### PR TITLE
add CR before LF in multiline data

### DIFF
--- a/src/boot.data.files.cpp
+++ b/src/boot.data.files.cpp
@@ -175,46 +175,51 @@ void DiscreteFile::read_next_line(const int nr)
 
 char* DiscreteFile::fread_string()
 {
-	char buffer[1 + MAX_STRING_LENGTH];
-	char* to = buffer;
-
+	char bufferIn[MAX_RAW_INPUT_LENGTH];
+	char bufferOut[MAX_STRING_LENGTH];
+	char* to = bufferOut;
+	const char* end = bufferOut + sizeof(bufferOut) - 1;
+	bool isEscaped = false;
 	bool done = false;
-	int remained = MAX_STRING_LENGTH;
-	const char* end = buffer + MAX_STRING_LENGTH;
+
+	*to = 0;
 	while (!done
-		&& fgets(to, remained, file()))
+		&& fgets(bufferIn, sizeof(bufferIn), file())
+		&& to < end)
 	{
-		const char* chunk_beginning = to;
-		const char* from = to;
-		while (end != from)
+		const char* from = bufferIn;
+		char c;
+
+		while ((c = *from++) && (to < end))
 		{
-			if ('~' == from[0])
+			if (c == '~')
 			{
-				if (1 + from != end
-					&& '~' == from[1])
-				{
-					++from;	//	skip escaped '~'
-				}
+				if (isEscaped)
+					*to++ = c; // escape sequence ~~ replaced with single ~
+				else
+					isEscaped = 1;
+			}
+			else
+			{
+				if (isEscaped)
+					done = true; // not escape sequence ~~
 				else
 				{
-					done = true;
-					break;
+					if ((c == '\n') && (*to != '\r')) // NL without preceding CR
+					{
+						if ((to+1) < end)
+							*to++ = '\r';
+						else
+							done = true; // not enough space for \r\n. Don't put \r without \n - terminate
+					}
+					*to++ = c;
 				}
 			}
-
-			const char c = *(from++);
-			if ('\0' == c)
-			{
-				break;
-			}
-			*(to++) = c;
 		}
-
-		remained -= to - chunk_beginning;
 	}
 	*to = '\0';
 
-	return strdup(buffer);
+	return strdup(bufferOut);
 }
 
 char DiscreteFile::fread_letter(FILE * fp)

--- a/src/boot.data.files.cpp
+++ b/src/boot.data.files.cpp
@@ -182,7 +182,6 @@ char* DiscreteFile::fread_string()
 	bool isEscaped = false;
 	bool done = false;
 
-	*to = 0;
 	while (!done
 		&& fgets(bufferIn, sizeof(bufferIn), file())
 		&& to < end)
@@ -202,17 +201,21 @@ char* DiscreteFile::fread_string()
 			else
 			{
 				if (isEscaped)
-					done = true; // not escape sequence ~~
+					done = true; // '~' followed by something else - terminate
 				else
 				{
-					if ((c == '\n') && (*to != '\r')) // NL without preceding CR
+					if ((c == '\n') && (to == bufferOut || *(to - 1) != '\r')) // NL without preceding CR
 					{
-						if ((to+1) < end)
+						if ((to + 1) < end)
+						{
 							*to++ = '\r';
+							*to++ = c;
+						}
 						else
-							done = true; // not enough space for \r\n. Don't put \r without \n - terminate
+							done = true; // not enough space for \r\n. Don't put \r or \n alone, terminate
 					}
-					*to++ = c;
+					else
+						*to++ = c;
 				}
 			}
 		}


### PR DESCRIPTION
По [RFC 854 (Telnet)](https://tools.ietf.org/html/rfc854.html) концы строк определяются как последовательность CR LF. В коде я вижу попытки последовательно использовать CR LF, но в некоторых местах строки шлются в том виде, как они есть в базе, а в базе они лежат либо с CR, либо без - в зависимости от платформы. Из-за этого в описании комнат и в списке мобов сервер не шлёт CR перед LF, ибо линукс.
В этом патче я переделал загрузку строк из файла DiscreteFile::fread_string(), добавляя CR перед каждым LF, если его не было.

UPD: соврал про "в зависимости от платформы". fgets() на текстовом файле всегда конвертирует концы строк в LF. То есть если компилировать под виндой, тоже будут слаться LF без CR в описаниях.