### PR TITLE
fix line width off-by-one error in paginator

### DIFF
--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -1379,7 +1379,7 @@ char *next_page(char *str, CHAR_DATA * ch)
 
 			// * We need to check here and see if we are over the page width,
 			// * and if so, compensate by going to the begining of the next line.
-			else if (STRING_LENGTH(ch) && col++ > STRING_LENGTH(ch))
+			else if (STRING_LENGTH(ch) && ++col > STRING_LENGTH(ch))
 			{
 				col = 1;
 				line++;


### PR DESCRIPTION
Мелкая ошибка в разбивке на стриницы. А вообще странный вообще paginator, строки не переносит, а "подразумевает", что в клиенте они будут переноситься. Я бы сделал явный перенос и по умолчанию явно отключил его (STRING_LENGTH(this) = 0).