### PR TITLE
fix names for boot modes in log messages

### DIFF
--- a/src/boot.constants.cpp
+++ b/src/boot.constants.cpp
@@ -12,7 +12,7 @@ const char *boot_mode_name(EBootType mode)
 		case DB_BOOT_HLP:    return "HLP";
 		case DB_BOOT_TRG:    return "trg";
 		case DB_BOOT_SOCIAL: return "soc";
-		default: return "";
+		default: return "unknown";
 	}
 }
 

--- a/src/boot.constants.cpp
+++ b/src/boot.constants.cpp
@@ -1,5 +1,21 @@
 #include "boot.constants.hpp"
 
+const char *boot_mode_name(EBootType mode)
+{
+	switch (mode)
+	{
+		case DB_BOOT_WLD:    return "world";
+		case DB_BOOT_MOB:    return "mob";
+		case DB_BOOT_OBJ:    return "obj";
+		case DB_BOOT_ZON:    return "ZON";
+		//case DB_BOOT_SHP:    return "SHP";
+		case DB_BOOT_HLP:    return "HLP";
+		case DB_BOOT_TRG:    return "trg";
+		case DB_BOOT_SOCIAL: return "soc";
+		default: return "";
+	}
+}
+
 const std::string& FilesPrefixes::operator()(const EBootType mode) const
 {
 	const auto result = find(mode);

--- a/src/boot.constants.hpp
+++ b/src/boot.constants.hpp
@@ -178,6 +178,8 @@ private:
 
 extern FilesPrefixes prefixes;
 
+const char *boot_mode_name(EBootType mode);
+
 #define READ_SIZE 256
 
 #endif // __BOOT_CONSTANTS_HPP__

--- a/src/boot.data.files.cpp
+++ b/src/boot.data.files.cpp
@@ -97,12 +97,7 @@ protected:
 private:
 	virtual EBootType mode() const = 0;
 	virtual void read_entry(const int nr) = 0;
-
-	/// modes positions correspond to DB_BOOT_xxx in db.h
-	static const char *s_modes[];
 };
-
-const char *DiscreteFile::s_modes[] = { "world", "mob", "obj", "ZON", "SHP", "HLP", "trg" };
 
 bool DiscreteFile::discrete_load(const EBootType mode)
 {
@@ -127,7 +122,7 @@ bool DiscreteFile::discrete_load(const EBootType mode)
 			last = nr;
 			if (sscanf(m_line, "#%d", &nr) != 1)
 			{
-				log("SYSERR: Format error after %s #%d", s_modes[mode], last);
+				log("SYSERR: Format error after %s #%d", boot_mode_name(mode), last);
 				exit(1);
 			}
 
@@ -146,7 +141,7 @@ bool DiscreteFile::discrete_load(const EBootType mode)
 		}
 		else
 		{
-			log("SYSERR: Format error in %s file %s near %s #%d", s_modes[mode], file_name().c_str(), s_modes[mode], nr);
+			log("SYSERR: Format error in %s file %s near %s #%d", boot_mode_name(mode), file_name().c_str(), boot_mode_name(mode), nr);
 			log("SYSERR: ... offending line: '%s'", m_line);
 			exit(1);
 		}
@@ -161,14 +156,14 @@ void DiscreteFile::read_next_line(const int nr)
 	{
 		if (nr == -1)
 		{
-			log("SYSERR: %s file %s is empty!", s_modes[mode()], file_name().c_str());
+			log("SYSERR: %s file %s is empty!", boot_mode_name(mode()), file_name().c_str());
 		}
 		else
 		{
 			log("SYSERR: Format error in %s after %s #%d\n"
 				"...expecting a new %s, but file ended!\n"
 				"(maybe the file is not terminated with '$'?)", file_name().c_str(),
-				s_modes[mode()], nr, s_modes[mode()]);
+				boot_mode_name(mode()), nr, boot_mode_name(mode()));
 		}
 		exit(1);
 	}


### PR DESCRIPTION
по рабоче-крестьянски на C - во всяком случае так надёжнее чем было.