### PR TITLE
fix bug: escaped ~ breaking the line

### DIFF
--- a/src/boot.data.files.cpp
+++ b/src/boot.data.files.cpp
@@ -195,8 +195,7 @@ char* DiscreteFile::fread_string()
 			{
 				if (isEscaped)
 					*to++ = c; // escape sequence ~~ replaced with single ~
-				else
-					isEscaped = 1;
+				isEscaped = !isEscaped;
 			}
 			else
 			{


### PR DESCRIPTION
Поправил ошибку, допущенную в #252.
Не снимался флаг isEscaped после последовательности ~~, и строка завершалась на этом месте.