### PR TITLE
fixed riding in mob-obstructed directions

### DIFF
--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -638,8 +638,7 @@ int legal_dir(CHAR_DATA * ch, int dir, int need_specials_check, int show_msg)
 				&& CAN_SEE(tch, ch)
 				&& !AFF_FLAGGED(tch, EAffectFlag::AFF_CHARM)
 				&& !AFF_FLAGGED(tch, EAffectFlag::AFF_HOLD)
-				&& !IS_GRGOD(ch)
-				&& !on_horse(ch))
+				&& !IS_GRGOD(ch))
 			{
 				if (show_msg)
 				{


### PR DESCRIPTION
Убрал возможность проезжать и сбегать на лошади в направлениях, преграждаемых мобом.
Я так понимаю признано багом, см #260.
Потом добавлю сообщение при сбегании - сначала надо причесать код.