### PR TITLE
Сброс сообщений лога при выходе по exit()

### DIFF
--- a/src/blocking.queue.hpp
+++ b/src/blocking.queue.hpp
@@ -25,7 +25,7 @@ private:
 
 	std::size_t m_max_size;
 
-	std::mutex m_messages_mutex;
+	mutable std::mutex m_messages_mutex;
 	std::condition_variable m_new_message;
 	std::condition_variable m_message_processed;
 	messages_t m_messages;

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -395,7 +395,7 @@ namespace
 
 void OutputThread::output_loop()
 {
-	while (!m_destroying)
+	while (!m_destroying && !m_output_queue.empty())
 	{
 		message_t message;
 		if (m_output_queue.pop(message))


### PR DESCRIPTION
См #267
Также починил empty() и full() в BlockingQueue  - они не должны быть const потому что косвено меняют m_messages_mutex.
UPD: обновил патч после замечания kvirund