### PR TITLE
Поправил лоад именного жареного мяса на игроках

### DIFF
--- a/src/fight_stuff.cpp
+++ b/src/fight_stuff.cpp
@@ -708,20 +708,6 @@ void real_kill(CHAR_DATA *ch, CHAR_DATA *killer)
 		//scripting::on_npc_dead(ch, killer, corpse);
 #endif
 	}
-	
-	if (!IS_NPC(ch) && GET_REMORT(ch) > 7 && (GET_LEVEL(ch) == 29 || GET_LEVEL(ch) == 30))
-	{
-		// лоадим свиток с экспой
-		const auto rnum = real_object(100);
-		if (rnum >= 0)
-		{
-			const auto o = world_objects.create_from_prototype_by_rnum(rnum);
-			o->set_owner(GET_UNIQUE(ch));
-			obj_to_obj(o.get(), corpse);
-		}
-		
-	}
-
 	// Теперь реализация режимов "автограбеж" и "брать куны" происходит не в damage,
 	// а здесь, после создания соответствующего трупа. Кроме того,
 	// если убил чармис и хозяин в комнате, то автолут происходит хозяину


### PR DESCRIPTION
Фикс issue #309
Судя по комментарию, должен был лоадиться какой-то свиток, но VNUM стоит неправильный. Я не знаю, что там должно быть, пока просто закомментировал.
upd: обновил патч, код удалён