### PR TITLE
fix boad index renumbering issue #6

### DIFF
--- a/src/boards.cpp
+++ b/src/boards.cpp
@@ -112,6 +112,7 @@ namespace Boards
 		temp_message->level = 1;
 
 		(*board_it)->add_message(temp_message);
+		(*board_it)->renumerate_messages();
 	}
 
 	void dg_script_message()
@@ -1140,6 +1141,7 @@ void report_on_board(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
 	temp_message->date = time(0);
 
 	(*board)->add_message(temp_message);
+	(*board)->renumerate_messages();
 	send_to_char(ch,
 		"Текст сообщения:\r\n"
 		"%s\r\n\r\n"


### PR DESCRIPTION
see issue #6
Пока просто воткнул перенумерацию где её не хватало. Но надо менять сам подход - сообщения должны уникальным образом идентифицироваться, чтобы не возникало гонок при написании/удалении/чтении.