### PR TITLE
дать возможность иммам обходить кривые командные триггерны

### DIFF
--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1231,10 +1231,12 @@ void command_interpreter(CHAR_DATA * ch, char *argument)
 		*(argument + length - 1) = ' ';
 	}
 
-	if (!IS_NPC(ch)
-		&& !GET_MOB_HOLD(ch)
-		&& !AFF_FLAGGED(ch, EAffectFlag::AFF_STOPFIGHT)
-		&& !AFF_FLAGGED(ch, EAffectFlag::AFF_MAGICSTOPFIGHT))
+        if (!IS_NPC(ch)
+                && !GET_INVIS_LEV(ch)
+                && !GET_MOB_HOLD(ch)
+                && !AFF_FLAGGED(ch, EAffectFlag::AFF_STOPFIGHT)
+                && !AFF_FLAGGED(ch, EAffectFlag::AFF_MAGICSTOPFIGHT)
+                && !(IS_GOD(ch) && !strcmp(arg, "invis")))  // let immortals switch to wizinvis to avoid broken command triggers
 	{
 		int cont;	// continue the command checks
 		cont = command_wtrigger(ch, arg, line);


### PR DESCRIPTION
Сделал так, чтобы команда invis не проверялась интерпретаторами команд триггеров.
В виз-инвизе триггерные команды не проверяются (это и сейчас так).
Заодно добавил проверку на GET_INVIS_LEV(ch) непосредственно в интерпретаторе команд.
Сейчас эти проверки делаются отдельно в command_wtrigger(), command_mtrigger() и command_otrigger().