### PR TITLE
fix spell names array initialization

### DIFF
--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -3926,7 +3926,6 @@ void init_ESpell_ITEM_NAMES()
 	ESpell_name_by_value[ESpell::SPELL_ARROWS_EARTH] = "SPELL_ARROWS_EARTH";
 	ESpell_name_by_value[ESpell::SPELL_ARROWS_AIR] = "SPELL_ARROWS_AIR";
 	ESpell_name_by_value[ESpell::SPELL_ARROWS_DEATH] = "SPELL_ARROWS_DEATH";
-	ESpell_name_by_value[ESpell::SPELLS_COUNT] = "SPELLS_COUNT";
 
 	for (const auto& i : ESpell_name_by_value)
 	{


### PR DESCRIPTION
SPELLS_COUNT = SPELL_ARROWS_DEATH, поэтому
ESpell_name_by_value[ESpell::SPELLS_COUNT] = "SPELLS_COUNT";
перезаписывает значение, которое было инициализировано предыдущей строкой
ESpell_name_by_value[ESpell::SPELL_ARROWS_DEATH] = "SPELL_ARROWS_DEATH";