### PR TITLE
fix global objects init order; leaking room list

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -96,7 +96,7 @@ long beginning_of_time = -1561789232;
 long beginning_of_time = 650336715;
 #endif
 
-Rooms world;
+Rooms& world = GlobalObjects::world();
 
 room_rnum top_of_world = 0;	// ref to top element of world
 
@@ -124,7 +124,7 @@ int global_uid = 0;
 
 struct message_list fight_messages[MAX_MESSAGES];	// fighting messages
 extern int slot_for_char(CHAR_DATA * ch, int slot_num);
-PlayersIndex player_table;	// index to plr file
+PlayersIndex& player_table = GlobalObjects::player_table();	// index to plr file
 
 bool player_exists(const long id) { return player_table.player_exists(id); }
 
@@ -6581,6 +6581,12 @@ void load_class_limit()
 		if (val > 0)
 			class_stats_limit[id][5] = val;
 	}
+}
+
+Rooms::~Rooms()
+{
+	for (auto i = this->begin(); i != this->end(); ++i)
+		delete *i;
 }
 
 const std::size_t PlayersIndex::NOT_FOUND = ~static_cast<std::size_t>(0);

--- a/src/db.h
+++ b/src/db.h
@@ -300,9 +300,10 @@ class Rooms: public std::vector<ROOM_DATA *>
 {
 public:
 	static constexpr int UNDEFINED_ROOM_VNUM = -1;
+	~Rooms();
 };
 
-extern Rooms world;
+extern Rooms& world;
 
 extern INDEX_DATA *mob_index;
 extern mob_rnum top_of_mobt;
@@ -377,7 +378,7 @@ private:
 	free_names_t m_free_names;
 };
 
-extern PlayersIndex player_table;
+extern PlayersIndex& player_table;
 
 extern long top_idnum;
 

--- a/src/dg_db_scripts.cpp
+++ b/src/dg_db_scripts.cpp
@@ -149,6 +149,7 @@ void indent_trigger(std::string& cmd, int* level)
 	char* cmd_copy = str_dup(cmd.c_str());;
 	cmd_copy = dirty_indent_trigger(cmd_copy, level);
 	cmd = cmd_copy;
+	free(cmd_copy);
 }
 
 /*

--- a/src/global.objects.cpp
+++ b/src/global.objects.cpp
@@ -21,10 +21,12 @@ namespace
 		Celebrates::CelebrateObjs loaded_objs;
 
 		GlobalTriggersStorage trigger_list;
+		Rooms world;
 		BloodyInfoMap bloody_map;
 
 		WorldObjects world_objects;
 		ShopExt::ShopListType shop_list;
+		PlayersIndex player_table;
 		Characters characters;
 		ShutdownParameters shutdown_parameters;
 		speedwalks_t speedwalks;
@@ -164,6 +166,16 @@ GlobalTriggersStorage& GlobalObjects::trigger_list()
 BloodyInfoMap& GlobalObjects::bloody_map()
 {
 	return global_objects().bloody_map;
+}
+
+Rooms& GlobalObjects::world()
+{
+	return global_objects().world;
+}
+
+PlayersIndex& GlobalObjects::player_table()
+{
+	return global_objects().player_table;
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/global.objects.hpp
+++ b/src/global.objects.hpp
@@ -54,6 +54,8 @@ public:
 
 	static GlobalTriggersStorage& trigger_list();
 	static BloodyInfoMap& bloody_map();
+	static Rooms& world();
+	static PlayersIndex& player_table();
 };
 
 #endif // __GLOBAL_OBJECTS_HPP__


### PR DESCRIPTION
Занёс в структуру глобальных объектов 
Rooms world;
PlayersIndex player_table;

Добавил деструктор Rooms::~Rooms(), который проходит по своему списку указателей и удаляет ROOM_DATA.