### PR TITLE
fix exit description in rstat output

### DIFF
--- a/src/act.wizard.cpp
+++ b/src/act.wizard.cpp
@@ -1975,7 +1975,7 @@ void do_stat_room(CHAR_DATA * ch, const int rnum)
 					GET_ROOM_VNUM(rm->dir_option[i]->to_room()), CCNRM(ch, C_NRM));
 			sprintbit(rm->dir_option[i]->exit_info, exit_bits, buf2);
 			sprintf(buf,
-				"Выход %s%-5s%s:  Ведет в : [%s], Ключ: [%5d], Название: %s (%s), Тип: %s\r\n ",
+				"Выход %s%-5s%s:  Ведет в : [%s], Ключ: [%5d], Название: %s (%s), Тип: %s\r\n",
 				CCCYN(ch, C_NRM), dirs[i], CCNRM(ch, C_NRM), buf1,
 				rm->dir_option[i]->key,
 				rm->dir_option[i]->keyword ? rm->dir_option[i]->keyword : "Нет(дверь)",
@@ -1983,7 +1983,7 @@ void do_stat_room(CHAR_DATA * ch, const int rnum)
 			send_to_char(buf, ch);
 			if (!rm->dir_option[i]->general_description.empty())
 			{
-				strcpy(buf, rm->dir_option[i]->general_description.c_str());
+                                sprintf(buf, "  %s\r\n", rm->dir_option[i]->general_description.c_str());
 			}
 			else
 			{


### PR DESCRIPTION
Подправил описание выходов по rstat, не было переноса строки после описания.