### PR TITLE
fix shutdown leaks

### DIFF
--- a/src/boot.data.files.cpp
+++ b/src/boot.data.files.cpp
@@ -81,11 +81,9 @@ protected:
 	bool discrete_load(const EBootType mode);
 	virtual void read_next_line(const int nr);
 
-	/**
-	* Reads and allocates space for a '~'-terminated string from a given file
-	* '~' character might be escaped: double '~' will be substituted to a single '~'.
-	*/
-	char* fread_string();
+	// Allocates and reads a '~'-terminated string from the file.
+	// '~' character might be escaped: double '~' is replaced with a single '~'.
+	std::string fread_string();
 
 	char fread_letter(FILE * fp);
 
@@ -169,7 +167,7 @@ void DiscreteFile::read_next_line(const int nr)
 	}
 }
 
-char* DiscreteFile::fread_string()
+std::string DiscreteFile::fread_string(void)
 {
 	char bufferIn[MAX_RAW_INPUT_LENGTH];
 	char bufferOut[MAX_STRING_LENGTH];
@@ -217,7 +215,7 @@ char* DiscreteFile::fread_string()
 	}
 	*to = '\0';
 
-	return strdup(bufferOut);
+	return std::string(bufferOut);
 }
 
 char DiscreteFile::fread_letter(FILE * fp)
@@ -325,12 +323,12 @@ void TriggersFile::read_entry(const int nr)
 
 void TriggersFile::parse_trigger(int nr)
 {
-	int t[2], k, indlev;
+	int t[2], k;
 
-	char line[256], *cmds, flags[256], *s;
+	char line[256], flags[256];
 
 	sprintf(buf2, "trig vnum %d", nr);
-	const auto trigger_name = fread_string();
+	std::string name(fread_string());
 	get_line(file(), line);
 
 	int attach_type = 0;
@@ -348,29 +346,31 @@ void TriggersFile::parse_trigger(int nr)
 	asciiflag_conv(flags, &trigger_type);
 
 	const auto rnum = top_of_trigt;
-	TRIG_DATA *trig = new TRIG_DATA(rnum, trigger_name, static_cast<byte>(attach_type), trigger_type);
+	TRIG_DATA *trig = new TRIG_DATA(rnum, std::move(name), static_cast<byte>(attach_type), trigger_type);
 
 	trig->narg = (k == 3) ? t[0] : 0;
 	trig->arglist = fread_string();
-	s = cmds = fread_string();
 
-	trig->cmdlist->reset(new cmdlist_element());
-	const auto& cmdlist = *trig->cmdlist;
-	const auto cmd_token = strtok(s, "\n\r");
-	cmdlist->cmd = cmd_token ? cmd_token : "";
-
-	indlev = 0;
-	indent_trigger(cmdlist->cmd, &indlev);
-
-	auto cle = cmdlist;
-
-	while ((s = strtok(NULL, "\n\r")))
+	std::string cmds(fread_string());
+	std::size_t pos = 0;
+	int indlev = 0;
+	auto ptr = trig->cmdlist.get();
+	do
 	{
-		cle->next.reset(new cmdlist_element());
-		cle = cle->next;
-		cle->cmd = s;
-		indent_trigger(cle->cmd, &indlev);
-	}
+		std::size_t pos_end = cmds.find_first_of("\r\n", pos);
+		std::string line = cmds.substr(pos, (pos_end == std::string::npos) ? pos_end : pos_end - pos);
+		// exclude empty lines, but always include the last one to make sure the list is not empty
+		if (!line.empty() || pos_end == std::string::npos)
+		{
+			ptr->reset(new cmdlist_element());
+			indent_trigger(line, &indlev);
+			(*ptr)->cmd = line;
+			ptr = &(*ptr)->next;
+		}
+		if (pos_end != std::string::npos)
+			pos_end = pos_end + 1;
+		pos = pos_end;
+	} while (pos != std::string::npos);
 
 	if (indlev > 0)
 	{
@@ -379,8 +379,6 @@ void TriggersFile::parse_trigger(int nr)
 		log("%s", tmp);
 		Boards::dg_script_text += tmp + std::string("\r\n");
 	}
-
-	free(cmds);
 
 	add_trig_index_entry(nr, trig);
 }
@@ -446,33 +444,19 @@ void WorldFile::parse_room(int virtual_nr, const int virt)
 	world[room_nr]->number = virtual_nr;
 	if (virt)
 	{
-		world[room_nr]->name = str_dup("Виртуальная комната");
-		world[room_nr]->description_num = RoomDescription::add_desc("Похоже, здесь вам делать нечего.");
+		world[room_nr]->set_name(std::string("Виртуальная комната"));
+		world[room_nr]->description_num = RoomDescription::add_desc(std::string("Похоже, здесь вам делать нечего."));
 		world[room_nr]->clear_flags();
 		world[room_nr]->sector_type = SECT_SECRET;
 	}
 	else
 	{
-		// не ставьте тут конструкцию ? : , т.к. gcc >=4.х вызывает в ней fread_string два раза
-		world[room_nr]->name = fread_string();
-		if (!world[room_nr]->name)
-			world[room_nr]->name = str_dup("");
+		world[room_nr]->set_name(fread_string());
 
-		// тож временная галиматья
-		char * temp_buf = fread_string();
-		if (!temp_buf)
-		{
-			temp_buf = str_dup("");
-		}
-		else
-		{
-			std::string buffer(temp_buf);
-			boost::trim_right_if(buffer, boost::is_any_of(std::string(" _"))); //убираем пробелы в конце строки
-			RECREATE(temp_buf, buffer.length() + 1);
-			strcpy(temp_buf, buffer.c_str());
-		}
-		world[room_nr]->description_num = RoomDescription::add_desc(temp_buf);
-		free(temp_buf);
+		std::string desc = fread_string();
+		boost::trim_right_if(desc, boost::is_any_of(std::string(" _"))); //убираем пробелы в конце строки
+		desc.shrink_to_fit();
+		world[room_nr]->description_num = RoomDescription::add_desc(desc);
 
 		if (!get_line(file(), line))
 		{
@@ -541,8 +525,8 @@ void WorldFile::parse_room(int virtual_nr, const int virt)
 		case 'E':
 			{
 				const EXTRA_DESCR_DATA::shared_ptr new_descr(new EXTRA_DESCR_DATA);
-				new_descr->keyword = fread_string();
-				new_descr->description = fread_string();
+				new_descr->set_keyword(fread_string());
+				new_descr->set_description(fread_string());
 				if (new_descr->keyword && new_descr->description)
 				{
 					new_descr->next = world[room_nr]->ex_description;
@@ -601,27 +585,23 @@ void WorldFile::setup_dir(int room, unsigned dir)
 	sprintf(buf2, "room #%d, direction D%u", GET_ROOM_VNUM(room), dir);
 
 	world[room]->dir_option[dir].reset(new EXIT_DATA());
-	const std::shared_ptr<char> general_description(fread_string(), free);
-	world[room]->dir_option[dir]->general_description = general_description.get();
+	world[room]->dir_option[dir]->general_description = fread_string();
 
-	// парс строки алиаса двери на имя;вининельный падеж, если он есть
-	char *alias = fread_string();
-	if (alias && *alias)
+	// парс строки алиаса двери на имя; вининельный падеж, если он есть
+	std::string alias(fread_string());
+	if (!alias.empty())
 	{
-		std::string buffer(alias);
-		std::string::size_type i = buffer.find('|');
+		std::string::size_type i = alias.find('|');
+		world[room]->dir_option[dir]->set_keyword(alias.substr(0, i));
 		if (i != std::string::npos)
 		{
-			world[room]->dir_option[dir]->keyword = str_dup(buffer.substr(0, i).c_str());
-			world[room]->dir_option[dir]->vkeyword = str_dup(buffer.substr(++i).c_str());
+			world[room]->dir_option[dir]->set_vkeyword(alias.substr(++i));
 		}
 		else
 		{
-			world[room]->dir_option[dir]->keyword = str_dup(buffer.c_str());
-			world[room]->dir_option[dir]->vkeyword = str_dup(buffer.c_str());
+			world[room]->dir_option[dir]->set_vkeyword(alias);
 		}
 	}
-	free(alias);
 
 	if (!get_line(file(), line))
 	{
@@ -708,7 +688,6 @@ void ObjectFile::read_entry(const int nr)
 void ObjectFile::parse_object(const int nr)
 {
 	int t[10], j = 0;
-	char *tmpptr;
 	char f0[256], f1[256], f2[256];
 
 	OBJ_DATA *tobj = new OBJ_DATA(nr);
@@ -724,36 +703,25 @@ void ObjectFile::parse_object(const int nr)
 	sprintf(m_buffer, "object #%d", nr);
 
 	// *** string data ***
-	const char* aliases = fread_string();
-	if (aliases == nullptr)
+	std::string aliases(fread_string());
+	if (aliases.empty())
 	{
-		log("SYSERR: Null obj name or format error at or near %s", m_buffer);
+		log("SYSERR: Empty obj name or format error at or near %s", m_buffer);
 		exit(1);
 	}
-
 	tobj->set_aliases(aliases);
-	tmpptr = fread_string();
-//	*tmpptr = LOWER(*tmpptr);
-	tobj->set_short_description(colorLOW(tmpptr));
+	tobj->set_short_description(colorLOW(fread_string()));
 
 	strcpy(buf, tobj->get_short_description().c_str());
 	tobj->set_PName(0, colorLOW(buf)); //именительный падеж равен короткому описанию
 
 	for (j = 1; j < CObjectPrototype::NUM_PADS; j++)
 	{
-		char *str = fread_string();
-		tobj->set_PName(j, colorLOW(str));
+		tobj->set_PName(j, colorLOW(fread_string()));
 	}
 
-	tmpptr = fread_string();
-	if (tmpptr && *tmpptr)
-	{
-		colorCAP(tmpptr);
-	}
-	tobj->set_description(tmpptr ? tmpptr : "");
-
-	auto action_description = fread_string();
-	tobj->set_action_description(action_description ? action_description : "");
+	tobj->set_description(colorCAP(fread_string()));
+	tobj->set_action_description(fread_string());
 
 	if (!get_line(file(), m_line))
 	{
@@ -910,8 +878,8 @@ void ObjectFile::parse_object(const int nr)
 		case 'E':
 			{
 				const EXTRA_DESCR_DATA::shared_ptr new_descr(new EXTRA_DESCR_DATA());
-				new_descr->keyword = fread_string();
-				new_descr->description = fread_string();
+				new_descr->set_keyword(fread_string());
+				new_descr->set_description(fread_string());
 				if (new_descr->keyword && new_descr->description)
 				{
 					new_descr->next = tobj->get_ex_description();
@@ -1183,7 +1151,6 @@ void MobileFile::parse_mobile(const int nr)
 	int j, t[10];
 	char line[256], letter;
 	char f1[128], f2[128];
-	char *str;
 	mob_index[i].vnum = nr;
 	mob_index[i].number = 0;
 	mob_index[i].func = NULL;
@@ -1194,18 +1161,8 @@ void MobileFile::parse_mobile(const int nr)
 	mob_proto[i].player_specials = player_special_data::s_for_mobiles;
 
 	// **** String data
-	char *tmp_str = fread_string();
-	mob_proto[i].set_pc_name(tmp_str);
-	if (tmp_str)
-	{
-		free(tmp_str);
-	}
-	tmp_str = fread_string();
-	mob_proto[i].set_npc_name(tmp_str);
-	if (tmp_str)
-	{
-		free(tmp_str);
-	}
+	mob_proto[i].set_pc_name(fread_string());
+	mob_proto[i].set_npc_name(fread_string());
 
 	// real name
 	mob_proto[i].player_data.PNames[0] = mob_proto[i].get_npc_name();
@@ -1213,8 +1170,7 @@ void MobileFile::parse_mobile(const int nr)
 	{
 		mob_proto[i].player_data.PNames[j] = fread_string();
 	}
-	str = fread_string();
-	mob_proto[i].player_data.long_descr = colorCAP(str);
+	mob_proto[i].player_data.long_descr = colorCAP(fread_string());
 	mob_proto[i].player_data.description = fread_string();
 	mob_proto[i].mob_specials.Questor = NULL;
 	mob_proto[i].player_data.title = "";

--- a/src/char.hpp
+++ b/src/char.hpp
@@ -415,8 +415,12 @@ public:
 	void set_name(const char *name);
 	const std::string& get_pc_name() const { return name_; }
 	void set_pc_name(const char *name);
+	void set_pc_name(const std::string& name) {name_ = name; }
+	void set_pc_name(std::string&& name) {name_ = name; }
 	const std::string& get_npc_name() const { return short_descr_; }
 	void set_npc_name(const char *name);
+	void set_npc_name(const std::string& name) {short_descr_ = name; }
+	void set_npc_name(std::string&& name) {short_descr_ = name; }
 	const std::string & get_name_str() const;
 	const char* get_pad(unsigned pad) const;
 	void set_pad(unsigned pad, const char* s);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -6192,13 +6192,16 @@ void room_free(ROOM_DATA * room)
    ВНИМАНИЕ. Память самой структуры room_data не освобождается.
              Необходимо дополнительно использовать delete()
 --*/
+// TODO: move to ROOM_DATA destructor
 {
 	// Название и описание
+	/*
+	this is now freed in ROOM_DATA destructor
 	if (room->name)
 	{
 		free(room->name);
 	}
-
+	*/
 	if (room->temp_description)
 	{
 		free(room->temp_description);
@@ -6210,6 +6213,8 @@ void room_free(ROOM_DATA * room)
 	{
 		if (room->dir_option[i])
 		{
+			/*
+			this is now freed in ROOM_DATA destructor
 			if (room->dir_option[i]->keyword)
 			{
 				free(room->dir_option[i]->keyword);
@@ -6219,6 +6224,7 @@ void room_free(ROOM_DATA * room)
 			{
 				free(room->dir_option[i]->vkeyword);
 			}
+			*/
 
 			room->dir_option[i].reset();
 		}

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -6192,20 +6192,18 @@ void room_free(ROOM_DATA * room)
    ВНИМАНИЕ. Память самой структуры room_data не освобождается.
              Необходимо дополнительно использовать delete()
 --*/
-// TODO: move to ROOM_DATA destructor
 {
 	// Название и описание
-	/*
-	this is now freed in ROOM_DATA destructor
 	if (room->name)
 	{
 		free(room->name);
+		room->name = nullptr;
 	}
-	*/
+
 	if (room->temp_description)
 	{
 		free(room->temp_description);
-		room->temp_description = 0;
+		room->temp_description = nullptr;
 	}
 
 	// Выходы и входы
@@ -6213,18 +6211,17 @@ void room_free(ROOM_DATA * room)
 	{
 		if (room->dir_option[i])
 		{
-			/*
-			this is now freed in ROOM_DATA destructor
 			if (room->dir_option[i]->keyword)
 			{
 				free(room->dir_option[i]->keyword);
+				room->dir_option[i]->keyword = nullptr;
 			}
 
 			if (room->dir_option[i]->vkeyword)
 			{
 				free(room->dir_option[i]->vkeyword);
+				room->dir_option[i]->vkeyword = nullptr;
 			}
-			*/
 
 			room->dir_option[i].reset();
 		}

--- a/src/dg_scripts.cpp
+++ b/src/dg_scripts.cpp
@@ -6783,6 +6783,20 @@ TRIG_DATA::TRIG_DATA(const sh_int rnum, const char* name, const byte attach_type
 {
 }
 
+TRIG_DATA::TRIG_DATA(const sh_int rnum, std::string&& name, const byte attach_type, const long trigger_type) :
+	cmdlist(new cmdlist_element::shared_ptr()),
+	narg(0),
+	depth(0),
+	loops(-1),
+	wait_event(nullptr),
+	var_list(nullptr),
+	nr(rnum),
+	attach_type(attach_type),
+	name(name),
+	trigger_type(trigger_type)
+{
+}
+
 TRIG_DATA::TRIG_DATA(const sh_int rnum, const char* name, const long trigger_type) : TRIG_DATA(rnum, name, 0, trigger_type)
 {
 }

--- a/src/dg_scripts.h
+++ b/src/dg_scripts.h
@@ -148,6 +148,7 @@ public:
 	TRIG_DATA& operator=(const TRIG_DATA& right);
 	TRIG_DATA(const sh_int rnum, const char* name, const long trigger_type);
 	TRIG_DATA(const sh_int rnum, const char* name, const byte attach_type, const long trigger_type);
+	TRIG_DATA(const sh_int rnum, std::string&& name, const byte attach_type, const long trigger_type);
 
 	virtual ~TRIG_DATA() {}	// make constructor virtual to be able to create a mock for this class
 

--- a/src/room.cpp
+++ b/src/room.cpp
@@ -17,6 +17,28 @@ EXIT_DATA::EXIT_DATA(): keyword(nullptr),
 {
 }
 
+EXIT_DATA::~EXIT_DATA()
+{
+	if (keyword != nullptr)
+		free(keyword);
+	if (vkeyword != nullptr)
+		free(vkeyword);
+}
+
+void EXIT_DATA::set_keyword(std::string const& value)
+{
+	if (keyword != nullptr)
+		free(keyword);
+	keyword = strdup(value.c_str());
+}
+
+void EXIT_DATA::set_vkeyword(std::string const& value)
+{
+	if (vkeyword != nullptr)
+		free(vkeyword);
+	vkeyword = strdup(value.c_str());
+}
+
 room_rnum EXIT_DATA::to_room() const
 {
 	return m_to_room;
@@ -64,6 +86,12 @@ ROOM_DATA::ROOM_DATA(): number(0),
 	memset(&add_property, 0, sizeof(room_property_data));
 }
 
+ROOM_DATA::~ROOM_DATA()
+{
+	if (name != nullptr)
+		free(name);
+}
+
 CHAR_DATA* ROOM_DATA::first_character() const
 {
 	CHAR_DATA* first = people.empty() ? nullptr : *people.begin();
@@ -74,6 +102,13 @@ CHAR_DATA* ROOM_DATA::first_character() const
 void ROOM_DATA::cleanup_script()
 {
 	script->cleanup();
+}
+
+void ROOM_DATA::set_name(std::string const& value)
+{
+	if (name != nullptr)
+		free(name);
+	name = strdup(value.c_str());
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/room.hpp
+++ b/src/room.hpp
@@ -15,7 +15,10 @@ class EXIT_DATA
 {
 public:
 	EXIT_DATA();
+	~EXIT_DATA();
 
+	void set_keyword(std::string const& value);
+	void set_vkeyword(std::string const& value);
 	room_rnum to_room() const;
 	void to_room(const room_rnum _);
 
@@ -64,6 +67,7 @@ struct ROOM_DATA
 	using people_t = std::list<CHAR_DATA*>;
 
 	ROOM_DATA();
+	~ROOM_DATA();
 
 	room_vnum number;	// Rooms number  (vnum)                //
 	zone_rnum zone;		// Room zone (for resetting)          //
@@ -126,6 +130,7 @@ struct ROOM_DATA
 	CHAR_DATA* first_character() const;
 
 	void cleanup_script();
+	void set_name(std::string const& name);
 
 private:
 	FLAG_DATA m_room_flags;	// DEATH,DARK ... etc //

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -1223,6 +1223,20 @@ void DESCRIPTOR_DATA::string_to_client_encoding(const char* input, char* output)
 	}
 }
 
+void EXTRA_DESCR_DATA::set_keyword(std::string const& value)
+{
+	if (keyword != nullptr)
+		free(keyword);
+	keyword = str_dup(value.c_str());
+}
+
+void EXTRA_DESCR_DATA::set_description(std::string const& value)
+{
+	if (description != nullptr)
+		free(description);
+	description = str_dup(value.c_str());
+}
+
 EXTRA_DESCR_DATA::~EXTRA_DESCR_DATA()
 {
 	if (nullptr != keyword)

--- a/src/structs.h
+++ b/src/structs.h
@@ -1383,6 +1383,8 @@ struct EXTRA_DESCR_DATA
 	using shared_ptr = std::shared_ptr<EXTRA_DESCR_DATA>;
 	EXTRA_DESCR_DATA() : keyword(nullptr), description(nullptr), next(nullptr) {}
 	~EXTRA_DESCR_DATA();
+	void set_keyword(std::string const& keyword);
+	void set_description(std::string const& description);
 
 	char *keyword;		// Keyword in look/examine          //
 	char *description;	// What to see                      //

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -137,7 +137,7 @@ int MAX(int a, int b)
 	return (a > b ? a : b);
 }
 
-char* first_letter(char* txt)
+const char* first_letter(const char* txt)
 {
 	if (txt)
 	{
@@ -173,7 +173,7 @@ char* first_letter(char* txt)
 
 char *colorCAP(char *txt) 
 {
-	char* letter = first_letter(txt);
+	char* letter = const_cast<char *>(first_letter(txt));
 	if (letter && *letter)
 	{
 		*letter = UPPER(*letter);
@@ -181,14 +181,40 @@ char *colorCAP(char *txt)
 	return txt;
 }
 
+std::string& colorCAP(std::string& txt)
+{
+	size_t pos = first_letter(txt.c_str()) - txt.c_str();
+	txt[pos] = UPPER(txt[pos]);
+	return txt;
+}
+
+// rvalue variant
+std::string& colorCAP(std::string&& txt)
+{
+	return colorCAP(txt);
+}
+
 char *colorLOW(char *txt)
 {
-	char* letter = first_letter(txt);
+	char* letter = const_cast<char *>(first_letter(txt));
 	if (letter && *letter)
 	{
 		*letter = LOWER(*letter);
 	}
 	return txt;
+}
+
+std::string& colorLOW(std::string& txt)
+{
+	size_t pos = first_letter(txt.c_str()) - txt.c_str();
+	txt[pos] = LOWER(txt[pos]);
+	return txt;
+}
+
+// rvalue variant
+std::string& colorLOW(std::string&& txt)
+{
+	return colorLOW(txt);
 }
 
 char * CAP(char *txt)

--- a/src/utils.h
+++ b/src/utils.h
@@ -190,7 +190,11 @@ int MIN(int a, int b);
 #define MMAX(a,b) ((a<b)?b:a)
 
 char *colorLOW(char *txt);
+std::string& colorLOW(std::string& txt);
+std::string& colorLOW(std::string&& txt);
 char * colorCAP(char *txt);
+std::string& colorCAP(std::string& txt);
+std::string& colorCAP(std::string&& txt);
 char * CAP(char *txt);
 
 #define KtoW(c) ((ubyte)(c) < 128 ? (c) : KoiToWin[(ubyte)(c)-128])

--- a/src/zone.table.cpp
+++ b/src/zone.table.cpp
@@ -33,6 +33,31 @@ ZoneData::ZoneData() : name(nullptr),
 {
 }
 
+ZoneData::~ZoneData()
+{
+	if (name)
+		free(name);
+	if (comment)
+		free(comment);
+	if (author)
+		free(author);
+	if (location)
+		free(location);
+	if (description)
+		free(description);
+	
+	if (cmd)
+		free(cmd);
+
+	if (typeA_list)
+		free(typeA_list);
+
+	if (typeB_list)
+		free(typeB_list);
+	if (typeB_flag)
+		free(typeB_flag);
+}
+
 zone_table_t& zone_table = GlobalObjects::zone_table();	// zone table
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/zone.table.hpp
+++ b/src/zone.table.hpp
@@ -17,7 +17,7 @@ public:
 	ZoneData& operator=(const ZoneData&) = delete;
 	ZoneData& operator=(ZoneData&&) = default;
 
-	~ZoneData() = default;
+	~ZoneData();
 
 	char *name;		// назвение зоны
 	char *comment;


### PR DESCRIPTION
Исправил множество ликов, которые возникают при shutdown - т.е. какие-то объекты выделяются при инициализации игры, и не удаляются при завершении. В основном это строки, инициализируемые в boot.data.files.cpp с помощью fread_string().
Вывод ASAN при завершении теперь сократился до пары десятков мест, где течёт, около пары килобайт если запустить и сразу завершить игру.
see #330