### PR TITLE
исправил потенциальный бесконечный цикл при выходе

### DIFF
--- a/src/blocking.queue.hpp
+++ b/src/blocking.queue.hpp
@@ -100,7 +100,7 @@ bool BlockingQueue<MessageType>::pop(MessageType& result)
 		m_new_message.wait(lock);
 	}
 
-	if (m_destroying)
+	if (m_messages.empty())
 	{
 		return false;
 	}


### PR DESCRIPTION
После попыток исправить потерю строк в логе при завершении работы (см  #267) стал возможен бесконечный цикл. Это *не та* ошибка, которая описана в #255 (Мад зависает при ребуте) - та ошибка проявилась раньше изменений, которые привели к этой.