### PR TITLE
#488  фикс карты с тьмой у персонажа

### DIFF
--- a/src/char_obj_utils.inl
+++ b/src/char_obj_utils.inl
@@ -6,17 +6,17 @@
 #include "obj.hpp"
 #include "utils.h"
 
-inline bool INVIS_OK_OBJ(const CHAR_DATA* sub, const CObjectPrototype* obj)
+inline bool INVIS_OK_OBJ(const CHAR_DATA* sub, const OBJ_DATA* obj)
 {
 	return !obj->get_extra_flag(EExtraFlag::ITEM_INVISIBLE)
 		|| AFF_FLAGGED(sub, EAffectFlag::AFF_DETECT_INVIS);
 }
 
-inline bool MORT_CAN_SEE_OBJ(const CHAR_DATA* sub, const CObjectPrototype* obj)
+inline bool MORT_CAN_SEE_OBJ(const CHAR_DATA* sub, const OBJ_DATA* obj)
 {
 	return INVIS_OK_OBJ(sub, obj)
 		&& !AFF_FLAGGED(sub, EAffectFlag::AFF_BLIND)
-		&& (IS_LIGHT(sub->in_room)
+		&& (IS_LIGHT(obj->get_in_room())
 			|| OBJ_FLAGGED(obj, EExtraFlag::ITEM_GLOW)
 			|| (IS_CORPSE(obj)
 				&& AFF_FLAGGED(sub, EAffectFlag::AFF_INFRAVISION))


### PR DESCRIPTION
убрал непонятые приведения типов. добавил проверку на свет не от персонажа а от объекта что бы показывать на карте объекты нормально.