### PR TITLE
Решение для #554

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,7 +509,7 @@ set_target_properties(changelog PROPERTIES FOLDER "Utility targets")
 # Main library file.
 add_library(circle.library STATIC ${CIRCLE_FILES})
 if (UNIX OR CYGWIN)
-	add_definitions("--std=gnu++14")
+	add_definitions("--std=gnu++17")
 else ()
 	set_target_properties(circle.library PROPERTIES CXX_STANDARD 14)
 endif ()

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -3220,6 +3220,8 @@ void spell_mental_shadow(int/* level*/, CHAR_DATA* ch, CHAR_DATA* /*victim*/, OB
 	return;
 }
 
+const char* spell_wear_off_msg_t::DEFAULT_MESSAGE = "!нет сообщения при спадении аффекта под номером %d!";
+char spell_wear_off_msg_t::MESSAGE_BUFFER[spell_wear_off_msg_t::MESSAGE_BUFFER_LENGTH];
 const spell_wear_off_msg_t spell_wear_off_msg =
 {
 	"RESERVED DB.C",	// 0

--- a/src/spells.h
+++ b/src/spells.h
@@ -390,7 +390,29 @@ enum ESpell
 	SPELLS_COUNT = SPELL_GROUP_AWARNESS    // Counter corresponds to the last value because we count spells from 1.
 };
 
-typedef std::array<const char*, SPELLS_COUNT + 1> spell_wear_off_msg_t;
+class spell_wear_off_msg_t: public std::array<const char*, SPELLS_COUNT + 1>
+{
+	private:
+		static constexpr std::size_t MESSAGE_BUFFER_LENGTH = 128;
+		static char MESSAGE_BUFFER[MESSAGE_BUFFER_LENGTH];
+
+		using parent_t = std::array<const char*, SPELLS_COUNT + 1>;
+		using parent_t::operator[];
+
+	public:
+		const static char* DEFAULT_MESSAGE;
+
+		value_type operator[](size_type index) const
+		{
+			if (size() > index && nullptr != parent_t::operator[](index))
+			{
+				return parent_t::operator[](index);
+			}
+
+			::snprintf(MESSAGE_BUFFER, MESSAGE_BUFFER_LENGTH, DEFAULT_MESSAGE, index);
+			return MESSAGE_BUFFER;
+		}
+};
 extern const spell_wear_off_msg_t spell_wear_off_msg;
 
 typedef std::array<const char*, 2> cast_phrase_t;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ if (UNIX)
 endif ()
 
 set(TESTS
+		spell_wear_off_msg.wrapper.cpp
 		blocking.queue.cpp
 		boards.changelog.cpp
 		boards.news.cpp
@@ -86,7 +87,7 @@ source_group("Tests" FILES ${TESTS})
 source_group("Tests helpers" FILES ${UTILITIES})
 add_executable(tests main.cpp ${TESTS} ${UTILITIES} ${ADDITIONAL_FILES})
 
-set_target_properties(tests PROPERTIES CXX_STANDARD 14)
+set_target_properties(tests PROPERTIES CXX_STANDARD 17)
 target_link_libraries(tests circle.library ${GTEST_LIB})
 if (NOT WIN32)
 	target_link_libraries(tests pthread)

--- a/tests/spell_wear_off_msg.wrapper.cpp
+++ b/tests/spell_wear_off_msg.wrapper.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+
+#include <spells.h>
+
+namespace
+{
+	const spell_wear_off_msg_t test_array = {
+		"message 1",
+		"message 2",
+		nullptr,
+		"",
+		"message 3"
+	};
+
+	constexpr std::size_t BUFFER_LENGTH = 128;
+}
+
+TEST(spell_wear_off_msg_wrapper, GettingExisingIndex)
+{
+	ASSERT_STREQ(test_array[0], "message 1");
+	ASSERT_STREQ(test_array[1], "message 2");
+	ASSERT_STREQ(test_array[3], "");
+	ASSERT_STREQ(test_array[4], "message 3");
+}
+
+TEST(spell_wear_off_msg_wrapper, GettingOutOfBoundIndex)
+{
+	for (auto index = test_array.size(); index < test_array.size() + 2; ++index)
+	{
+		char expected[BUFFER_LENGTH] = {0};
+		::snprintf(expected, BUFFER_LENGTH, spell_wear_off_msg_t::DEFAULT_MESSAGE, index);
+
+		ASSERT_STREQ(test_array[index], expected);
+	}
+}
+
+TEST(spell_wear_off_msg_wrapper, GettingExistingIndexWithNullValue)
+{
+	const std::size_t index = 2;
+	char expected[BUFFER_LENGTH] = {0};
+	::snprintf(expected, BUFFER_LENGTH, spell_wear_off_msg_t::DEFAULT_MESSAGE, index);
+
+	ASSERT_STREQ(test_array[index], expected);
+}


### PR DESCRIPTION
Добавил обёртку для spell_wear_off_msg.
Добавил unit-тестов для обёртки.
Поднял используемый стандарт до `C++17`, т. к. более ранние стандарты не поддерживают инициализацию списком экземпляров классов дочерних от тех, которые таким образом инициализированы могли быть (`std::array`).

Требования описаны в #554.