### PR TITLE
Issue.737 Теперь везде показываются метки в случае рассыпания шмоток

### DIFF
--- a/src/fight_stuff.cpp
+++ b/src/fight_stuff.cpp
@@ -1225,11 +1225,15 @@ void alterate_object(OBJ_DATA * obj, int dam, int chance)
 		{
 			if (obj->get_worn_by())
 			{
-				act("$o рассыпал$U, не выдержав повреждений.", FALSE, obj->get_worn_by(), obj, 0, TO_CHAR);
+				snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U, не выдержав повреждений.", 
+						char_get_custom_label(obj, obj->get_worn_by()).c_str());
+				act(buf, FALSE, obj->get_worn_by(), obj, 0, TO_CHAR);
 			}
 			else if (obj->get_carried_by())
 			{
-				act("$o рассыпал$U, не выдержав повреждений.", FALSE, obj->get_carried_by(), obj, 0, TO_CHAR);
+				snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U, не выдержав повреждений.",
+						 char_get_custom_label(obj, obj->get_carried_by()).c_str());
+				act(buf, FALSE, obj->get_carried_by(), obj, 0, TO_CHAR);
 			}
 			extract_obj(obj);
 		}

--- a/src/limits.cpp
+++ b/src/limits.cpp
@@ -1548,7 +1548,9 @@ void charmee_obj_decay_tell(CHAR_DATA *charmee, OBJ_DATA *obj, int where)
 	}
 	else if (where == 2 && obj->get_in_obj())
 	{
-		snprintf(buf1, 128, "в %s", obj->get_in_obj()->get_PName(5).c_str());
+		snprintf(buf1, 128, "в %s%s", 
+				obj->get_in_obj()->get_PName(5).c_str(),
+				char_get_custom_label(obj->get_in_obj(), charmee->get_master()).c_str());
 	}
 	else
 	{
@@ -1563,10 +1565,11 @@ void charmee_obj_decay_tell(CHAR_DATA *charmee, OBJ_DATA *obj, int where)
 	*/
 	std::string cap = obj->get_PName(0);
 	cap[0] = UPPER(cap[0]);
-	snprintf(buf, MAX_STRING_LENGTH, "%s сказал%s вам : '%s рассыпал%s %s...'",
+	snprintf(buf, MAX_STRING_LENGTH, "%s сказал%s вам : '%s%s рассыпал%s %s...'",
 		GET_NAME(charmee),
 		GET_CH_SUF_1(charmee),
 		cap.c_str(),
+		char_get_custom_label(obj, charmee->get_master()).c_str(),
 		GET_OBJ_SUF_2(obj),
 		buf1);
 	send_to_char(charmee->get_master(), "%s%s%s\r\n", CCICYN(charmee->get_master(), C_NRM), CAP(buf), CCNRM(charmee->get_master(), C_NRM));
@@ -1764,7 +1767,9 @@ void obj_point_update()
 						}
 						else
 						{
-							act("$o рассыпал$U в ваших руках...", FALSE, j->get_worn_by(), j.get(), 0, TO_CHAR);
+							snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U в ваших руках...",
+									 char_get_custom_label(j.get(), j->get_worn_by()).c_str());
+							act(buf, FALSE, j->get_worn_by(), j.get(), 0, TO_CHAR);
 						}
 						break;
 
@@ -1775,7 +1780,9 @@ void obj_point_update()
 						}
 						else
 						{
-							act("$o рассыпал$U прямо на вас...", FALSE, j->get_worn_by(), j.get(), 0, TO_CHAR);
+							snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U прямо на вас...",
+									 char_get_custom_label(j.get(), j->get_worn_by()).c_str());
+							act(buf, FALSE, j->get_worn_by(), j.get(), 0, TO_CHAR);
 						}
 						break;
 					}
@@ -1789,7 +1796,9 @@ void obj_point_update()
 					}
 					else
 					{
-						act("$o рассыпал$U в ваших руках...", FALSE, j->get_carried_by(), j.get(), 0, TO_CHAR);
+						snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U в ваших руках...",
+								 char_get_custom_label(j.get(), j->get_carried_by()).c_str());
+						act(buf, FALSE, j->get_carried_by(), j.get(), 0, TO_CHAR);
 					}
 					obj_from_char(j.get());
 				}
@@ -1827,7 +1836,10 @@ void obj_point_update()
 						else
 						{
 							char buf[MAX_STRING_LENGTH];
-							snprintf(buf, MAX_STRING_LENGTH, "$o рассыпал$U в %s...", j->get_in_obj()->get_PName(5).c_str());
+							snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U в %s%s...",
+									 char_get_custom_label(j.get(), cont_owner).c_str(),
+									 j->get_in_obj()->get_PName(5).c_str(),
+									 char_get_custom_label(j->get_in_obj(), cont_owner).c_str());
 							act(buf, FALSE, cont_owner, j.get(), 0, TO_CHAR);
 						}
 					}

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1273,7 +1273,9 @@ void extract_item(CHAR_DATA * ch, OBJ_DATA * obj, int spelltype)
 	{
 		if (spelltype == SPELL_RUNES)
 		{
-			act("$o рассыпал$U у вас в руках.", FALSE, ch, obj, 0, TO_CHAR);
+			snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U у вас в руках.",
+					 char_get_custom_label(obj, ch).c_str());
+			act(buf, FALSE, ch, obj, 0, TO_CHAR);
 		}
 		obj_from_char(obj);
 		extract_obj(obj);

--- a/src/objsave.cpp
+++ b/src/objsave.cpp
@@ -2373,8 +2373,11 @@ int Crash_load(CHAR_DATA * ch)
 		// Предмет разваливается от старости
 		if (obj->get_timer() <= 0)
 		{
-			sprintf(buf, "%s%s рассыпал%s от длительного использования.\r\n",
-				CCWHT(ch, C_NRM), cap.c_str(), GET_OBJ_SUF_2(obj));
+			snprintf(buf, MAX_STRING_LENGTH, "%s%s%s рассыпал%s от длительного использования.\r\n",
+					 CCWHT(ch, C_NRM), 
+					 cap.c_str(), 
+					 char_get_custom_label(obj.get(), ch).c_str(), 
+					 GET_OBJ_SUF_2(obj));
 			send_to_char(buf, ch);
 			extract_obj(obj.get());
 

--- a/src/oedit.cpp
+++ b/src/oedit.cpp
@@ -222,6 +222,17 @@ void olc_update_object(int robj_num, OBJ_DATA *obj, OBJ_DATA *olc_proto)
 	{
 		obj->set_extra_flag(EExtraFlag::ITEM_NAMED);//ставим флаг именной предмет
 	}
+	//восстанавливаем метки, если они были
+	if (tmp.get_custom_label()){  
+		obj->set_custom_label(new custom_label());
+		obj->get_custom_label()->label_text = str_dup(tmp.get_custom_label()->label_text);
+		obj->get_custom_label()->author = tmp.get_custom_label()->author;
+		if (tmp.get_custom_label()->clan != nullptr)
+		{
+			obj->get_custom_label()->clan = str_dup(tmp.get_custom_label()->clan);
+		}
+		obj->get_custom_label()->author_mail = str_dup(tmp.get_custom_label()->author_mail);
+	}
 }
 
 // * Обновление полей объектов при изменении их прототипа через олц.


### PR DESCRIPTION
Разбиваю оригинальный пул реквест на запчасти. 
Первая пошла - 
при правке в OLC метки не затираются
метки теперь показываются в случае дикея шмота при:
- разрушении в бою
- рассыпалось у чармиса (в сумке тоже)
- рассыпалось в инвентаре владельца
- рассыпалось прямо на владельце
- рассыпалось в сумке (указывается метка сумки)