### PR TITLE
Силы зла теперь рекастуемые

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3308,6 +3308,8 @@ int mag_affects(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int
 
 		to_vict = "Вы почувствовали себя отравленным.";
 		to_room = "$n позеленел$g от действия яда.";
+		victim->Poisoner = GET_ID(ch);
+
 		break;
 
 	case SPELL_PROT_FROM_EVIL:
@@ -3674,6 +3676,10 @@ int mag_affects(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int
 		break;
 
 	case SPELL_EVILESS:
+		if (!IS_NPC(victim) || victim->get_master() != ch || !MOB_FLAGGED(victim, MOB_CORPSE)) {
+			//тихо уходим, т.к. заклинание массовое
+			break;
+		}
 		af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
 		af[0].location = APPLY_DAMROLL;
 		af[0].modifier = 15 + (GET_REMORT(ch) > 8 ? (GET_REMORT(ch) - 8) : 0);
@@ -3684,8 +3690,21 @@ int mag_affects(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int
 		af[1].bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
 		af[2].duration = af[0].duration;
 		af[2].location = APPLY_HIT;
-		af[2].modifier = GET_REAL_MAX_HIT(victim);
 		af[2].bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
+
+		// иначе, при рекасте, модификатор суммируется с текущим аффектом.
+		if (!AFF_FLAGGED(victim, EAffectFlag::AFF_EVILESS)){
+			af[2].modifier = GET_REAL_MAX_HIT(victim);
+			// не очень красивый способ передать сигнал на лечение в mag_points
+			AFFECT_DATA<EApplyLocation> tmpaf;
+			tmpaf.type = SPELL_EVILESS;
+			tmpaf.duration = 1;
+			tmpaf.modifier = 0;
+			tmpaf.location = EApplyLocation::APPLY_NONE;
+			tmpaf.battleflag = 0;
+			tmpaf.bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
+			affect_to_char(ch, tmpaf);			
+		}
 		to_vict = "Черное облако покрыло вас.";
 		to_room = "Черное облако покрыло $n3 с головы до пят.";
 		break;
@@ -4251,16 +4270,13 @@ int mag_affects(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int
 		}
 	}
 
-	/*
-	 * If this is a mob that has this affect set in its mob file, do not
-	 * perform the affect.  This prevents people from un-sancting mobs
-	 * by sancting them and waiting for it to fade, for example.
-	 */
+	//проверка на обкаст мобов, имеющих от рождения встроенный аффкект
+	//чтобы этот аффект не очистился, со временем
 	if (IS_NPC(victim) && success)
 	{
 		for (i = 0; i < MAX_SPELL_AFFECTS && success; i++)
 		{
-			if (AFF_FLAGGED(victim, static_cast<EAffectFlag>(af[i].bitvector)))
+			if (AFF_FLAGGED(&mob_proto[victim->get_rnum()], static_cast<EAffectFlag>(af[i].bitvector)))
 			{
 				if (ch->in_room == IN_ROOM(victim))
 				{
@@ -4270,16 +4286,12 @@ int mag_affects(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int
 			}
 		}
 	}
-
-	// * If the victim is already affected by this spell
-
-	// Если прошло, и спелл дружествееный - то снять его нафиг чтобы обновить
+	
 	if (!SpINFO.violent && affected_by_spell(victim, spellnum) && success)
 	{
-//    affect_from_char(victim,spellnum);
 		update_spell = TRUE;
 	}
-
+	// вот такой оригинальный способ запретить рекасты оффенсивных аффектов - через флаг апдейта
 	if ((ch != victim) && affected_by_spell(victim, spellnum) && success && (!update_spell))
 	{
 		if (ch->in_room == IN_ROOM(victim))
@@ -4306,13 +4318,6 @@ int mag_affects(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int
 
 	if (success)
 	{
-		if (spellnum == SPELL_POISON)
-			victim->Poisoner = GET_ID(ch);
-		if (spellnum == SPELL_EVILESS && (GET_HIT(victim) < GET_MAX_HIT(victim)))
-		{
-			GET_HIT(victim) = GET_MAX_HIT(victim); //Без этой строки update_pos еще не видит восстановленных ХП
-			update_pos(victim);
-		}
 		if (to_vict != nullptr)
 			act(to_vict, FALSE, victim, 0, ch, TO_CHAR);
 		if (to_room != nullptr)
@@ -4828,12 +4833,16 @@ int mag_summons(int level, CHAR_DATA * ch, OBJ_DATA * obj, int spellnum, int sav
 	return 1;
 }
 
-int mag_points(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int/* savetype*/)
+int mag_points(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int)
 {
-	int hit = 0, move = 0;
+	int hit = 0; //если выставить больше нуля, то лечит 
+	int move = 0; //если выставить больше нуля, то реген хп
+	bool extraHealing = false; //если true, то лечит сверх макс.хп
 
-	if (victim == nullptr)
-		return 0;
+	if (victim == nullptr)	{
+		log("MAG_POINTS: Ошибка! Не указана цель, спелл spellnum: %d!\r\n", spellnum);
+		return 0;		
+	}
 
 	switch (spellnum)
 	{
@@ -4851,24 +4860,35 @@ int mag_points(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int/
 		break;
 	case SPELL_HEAL:
 	case SPELL_GROUP_HEAL:
-//MZ.overflow_fix
 		hit = GET_REAL_MAX_HIT(victim) - GET_HIT(victim);
-//-MZ.overflow_fix
 		send_to_char("Вы почувствовали себя здоровым.\r\n", victim);
 		break;
 	case SPELL_PATRONAGE:
 		hit = (GET_LEVEL(victim) + GET_REMORT(victim)) * 2;
 		break;
-	case SPELL_REFRESH:
-	case SPELL_GROUP_REFRESH:
-//MZ.overflow_fix
-		move = GET_REAL_MAX_MOVE(victim) - GET_MOVE(victim);
-//-MZ.overflow_fix
-		send_to_char("Вы почувствовали себя полным сил.\r\n", victim);
+	case SPELL_WC_OF_POWER:
+		hit = MIN(200, (4 * ch->get_con() + ch->get_skill(SKILL_WARCRY)) / 2);
+		send_to_char("По вашему телу начала струиться живительная сила.\r\n", victim);
 		break;
 	case SPELL_EXTRA_HITS:
+		extraHealing = true;
 		hit = dice(10, level / 3) + level;
 		send_to_char("По вашему телу начала струиться живительная сила.\r\n", victim);
+		break;				
+	case SPELL_EVILESS:
+	//лечим только умертвия-чармисы
+		if (!IS_NPC(victim) || victim->get_master() != ch || !MOB_FLAGGED(victim, MOB_CORPSE))
+			return 1;
+	//при рекасте - не лечим		
+		if (AFF_FLAGGED(ch, EAffectFlag::AFF_EVILESS)){
+			hit = GET_REAL_MAX_HIT(victim) - GET_HIT(victim);
+			affect_from_char(ch, SPELL_EVILESS); //сбрасываем аффект с хозяина
+		}
+		break;		
+	case SPELL_REFRESH:
+	case SPELL_GROUP_REFRESH:
+		move = GET_REAL_MAX_MOVE(victim) - GET_MOVE(victim);
+		send_to_char("Вы почувствовали себя полным сил.\r\n", victim);
 		break;
 	case SPELL_FULL:
 	case SPELL_COMMON_MEAL:
@@ -4880,38 +4900,39 @@ int mag_points(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int/
 			send_to_char("Вы полностью насытились.\r\n", victim);
 		}
 		break;
-	case SPELL_WC_OF_POWER:
-		hit = (4 * ch->get_con() + ch->get_skill(SKILL_WARCRY)) / 2;
-		send_to_char("По вашему телу начала струиться живительная сила.\r\n", victim);
+	default:
+		log("MAG_POINTS: Ошибка! Передан не определенный лечащий спелл spellnum: %d!\r\n", spellnum);
+		return 0;
 		break;
 	}
 
 	hit = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_EFFECT, hit);
 
-	if (hit && victim->get_fighting() && ch != victim)
-	{
-
+	if (hit && victim->get_fighting() && ch != victim){
 		if (!pk_agro_action(ch, victim->get_fighting()))
 			return 0;
 	}
-
-	if ((spellnum == SPELL_EXTRA_HITS || spellnum == SPELL_PATRONAGE)
-			&& (GET_HIT(victim) < MAX_HITS))
-//MZ.extrahits_fix
-		if (GET_REAL_MAX_HIT(victim) <= 0)
-			GET_HIT(victim) = MAX(GET_HIT(victim), MIN(GET_HIT(victim) + hit, 1));
-		else
-			GET_HIT(victim) = MAX(GET_HIT(victim),
-								  MIN(GET_HIT(victim) + hit,
-									  GET_REAL_MAX_HIT(victim) + GET_REAL_MAX_HIT(victim) * 33 / 100));
-//-MZ.extrahits_fix
-	else if (GET_HIT(victim) < GET_REAL_MAX_HIT(victim))
-		GET_HIT(victim) = MIN(GET_HIT(victim) + hit, GET_REAL_MAX_HIT(victim));
-//MZ.overflow_fix
-	if (GET_MOVE(victim) < GET_REAL_MAX_MOVE(victim))
+	// лечение
+	if (GET_HIT(victim) < MAX_HITS && hit != 0) {
+		// просто лечим
+		if (!extraHealing  &&  GET_HIT(victim) < GET_REAL_MAX_HIT(victim))
+			GET_HIT(victim) = MIN(GET_HIT(victim) + hit, GET_REAL_MAX_HIT(victim));
+		// добавляем фикс.хиты сверх максимума
+		if (extraHealing) {
+			// если макс.хп отрицательные - доводим до 1
+			if (GET_REAL_MAX_HIT(victim) <= 0)
+				GET_HIT(victim) = MAX(GET_HIT(victim), MIN(GET_HIT(victim) + hit, 1));
+			else
+			// лимит в треть от макс.хп сверху
+				GET_HIT(victim) = MAX(GET_HIT(victim),
+									MIN(GET_HIT(victim) + hit,
+										GET_REAL_MAX_HIT(victim) + GET_REAL_MAX_HIT(victim) * 33 / 100));
+		}
+	}
+	if (move != 0 && GET_MOVE(victim) < GET_REAL_MAX_MOVE(victim))
 		GET_MOVE(victim) = MIN(GET_MOVE(victim) + move, GET_REAL_MAX_MOVE(victim));
-//-MZ.overflow_fix
 	update_pos(victim);
+
 	return 1;
 }
 
@@ -5378,9 +5399,6 @@ int mag_manual(int level, CHAR_DATA * caster, CHAR_DATA * cvict, OBJ_DATA * ovic
 		break;
 	case SPELL_TELEPORT:
 		MANUAL_SPELL(spell_teleport);
-		break;
-	case SPELL_EVILESS:
-		MANUAL_SPELL(spell_eviless);
 		break;
 	case SPELL_CONTROL_WEATHER:
 		MANUAL_SPELL(spell_control_weather);

--- a/src/spell_parser.cpp
+++ b/src/spell_parser.cpp
@@ -4962,8 +4962,8 @@ void mag_assign_spells(void)
 	spello(SPELL_PRISMATICAURA, "призматическая аура", "prismatic aura", 85, 70, 4,
 		   POS_FIGHTING, TAR_CHAR_ROOM | TAR_FIGHT_SELF, FALSE, MAG_AFFECTS | NPC_AFFECT_NPC, 1, STYPE_LIGHT);
 //139
-	spello(SPELL_EVILESS, "силы зла", "eviless", 150, 130, 5, POS_STANDING, TAR_IGNORE, FALSE, MAG_MANUAL,
-		   3, STYPE_DARK);
+	spello(SPELL_EVILESS, "силы зла", "eviless", 150, 130, 5, 
+		   POS_STANDING, TAR_IGNORE, FALSE, MAG_GROUPS | MAG_AFFECTS | MAG_POINTS, 3, STYPE_DARK);
 //140
 	spello(SPELL_AIR_AURA, "воздушная аура", "air aura",
 		   140, 120, 2, POS_FIGHTING, TAR_IGNORE, FALSE, MAG_GROUPS | MAG_AFFECTS | NPC_AFFECT_NPC, 0, STYPE_AIR);

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -2774,22 +2774,6 @@ void spell_sacrifice(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* 
 	}
 }
 
-void spell_eviless(int/* level*/, CHAR_DATA *ch, CHAR_DATA* /*victim*/, OBJ_DATA* /*obj*/)
-{
-	for (const auto tch : world[ch->in_room]->people)
-	{
-		if (IS_NPC(tch)
-			&& tch->get_master() == ch
-			&& MOB_FLAGGED(tch, MOB_CORPSE))
-		{
-			if (mag_affects(GET_LEVEL(ch), ch, tch, SPELL_EVILESS, SAVING_STABILITY))
-			{
-				GET_HIT(tch) = MAX(GET_HIT(tch), GET_REAL_MAX_HIT(tch));
-			}
-		}
-	}
-}
-
 void spell_holystrike(int/* level*/, CHAR_DATA *ch, CHAR_DATA* /*victim*/, OBJ_DATA* /*obj*/)
 {
 	const char *msg1 = "Земля под вами засветилась и всех поглотил плотный туман.";

--- a/src/spells.h
+++ b/src/spells.h
@@ -594,7 +594,6 @@ void spell_identify(int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj);
 void spell_enchant_weapon(int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj);
 void spell_control_weather(int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj);
 void spell_create_weapon(int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj);
-void spell_eviless(int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj);
 void spell_townportal(int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj);
 void spell_energydrain(int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj);
 void spell_fear(int level, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj);


### PR DESCRIPTION
Рекаст заклинания !силы зла!, поэтому:
1. Теперь все дружественные аффекты можно рекастить, если такового аффекта не было на прототипе моба.
2. Сам спелл !силы зла! теперь групповой и лечащий (был manual), аффекты вешает на своих умертвий
3. Убрал лишний код mag_manual.
4. Переформировал чутка код mag_points - чтобы было понятно чо лечит, а чо надувает.
5. Передача информации о том, что !СЗ! кастуется впервые и надо подлечить чармиса - через временный аффект
6. Соотвественно, в mag_points добавил логику "лечения" умертвия.

Closes #711