### PR TITLE
Level check for groupmates disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ set(SOURCES
 		src/skills/manadrain.cpp
 		src/skills/warcry.cpp
 		src/skills/identify.cpp
+		src/skills/relocate.cpp
 		src/chars/mount.cpp
 		src/fightsystem/assist.cpp
 		src/fightsystem/start.fight.cpp
@@ -258,6 +259,7 @@ set(HEADERS
 		src/skills/disarm.h
 		src/skills/warcry.h
 		src/skills/identify.h
+		src/skills/relocate.h
 		src/act.movement.hpp
 		src/strengthening.hpp
 		src/ability.constants.hpp

--- a/src/cmd.wiz/godtest.cpp
+++ b/src/cmd.wiz/godtest.cpp
@@ -5,18 +5,11 @@
 #include <iomanip>
 #include "../modify.h"
 
-#include "../magic.utils.hpp"
 
 // This is test command for different testings
 void do_godtest(CHAR_DATA *ch, char* /*argument*/, int /* cmd */, int /* subcmd */) {
-	//send_to_char("В настоящий момент процiдурка пуста.\r\nЕсли вам хочется что-то godtest, придется ее реализовать.\r\n", ch);
 	std::stringstream buffer;
-	int required_level = 0;
-	for (int i = 0; i < 31; i++) {
-		required_level -= MIN(8, MAX(0, ((i - 8)/3)*2 + (i > 7 && i < 11 ? 1 : 0)));
-		buffer <<  "Remort: " << i << "   Spell create bonus: " << required_level << std::endl;
-		required_level = 0;
-	}
+	buffer << "В настоящий момент процiдурка пуста.\r\nЕсли вам хочется что-то godtest, придется ее реализовать." << std::endl;
 	page_string(ch->desc, buffer.str());
 }
 

--- a/src/features.cpp
+++ b/src/features.cpp
@@ -23,9 +23,7 @@
 #include "room.hpp"
 #include "screen.h"
 #include "fightsystem/pk.h"
-#include "dg_script/dg_scripts.h"
 #include "room.hpp"
-#include "house.h"
 #include "screen.h"
 #include "fightsystem/pk.h"
 #include "utils.h"
@@ -1335,129 +1333,6 @@ void do_spell_capable(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/
 	af.bitvector = 0;
 	affect_to_char(follower, af);
 	follower->mob_specials.capable_spell = spellnum;
-}
-
-void do_relocate(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	struct timed_type timed;
-
-	if (!can_use_feat(ch, RELOCATE_FEAT))
-	{
-		send_to_char("Вам это недоступно.\r\n", ch);
-		return;
-	}
-
-	if (timed_by_feat(ch, RELOCATE_FEAT)
-#ifdef TEST_BUILD
-		&& !IS_IMMORTAL(ch)
-#endif
-	  )
-	{
-		send_to_char("Невозможно использовать это так часто.\r\n", ch);
-		return;
-	}
-
-	room_rnum to_room, fnd_room;
-	one_argument(argument, arg);
-	if (!*arg)
-	{
-		send_to_char("Переместиться на кого?", ch);
-		return;
-	}
-
-	CHAR_DATA* victim = get_player_vis(ch, arg, FIND_CHAR_WORLD);
-	if (!victim)
-	{
-		send_to_char(NOPERSON, ch);
-		return;
-	}
-
-	// Если левел жертвы больше чем перемещяющегося - фейл
-	if (IS_NPC(victim) || (GET_LEVEL(victim) > GET_LEVEL(ch)) || IS_IMMORTAL(victim))
-	{
-		send_to_char("Попытка перемещения не удалась.\r\n", ch);
-		return;
-	}
-
-	// Для иммов обязательные для перемещения условия не существенны
-	if (!IS_GOD(ch))
-	{
-		// Нельзя перемещаться из клетки ROOM_NOTELEPORTOUT
-		if (ROOM_FLAGGED(ch->in_room, ROOM_NOTELEPORTOUT))
-		{
-			send_to_char("Попытка перемещения не удалась.\r\n", ch);
-			return;
-		}
-		// Нельзя перемещаться после того, как попал под заклинание "приковать противника".
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_NOTELEPORT))
-		{
-			send_to_char("Попытка перемещения не удалась.\r\n", ch);
-			return;
-		}
-	}
-
-	to_room = IN_ROOM(victim);
-
-	if (to_room == NOWHERE)
-	{
-		send_to_char("Попытка перемещения не удалась.\r\n", ch);
-		return;
-	}
-	// в случае, если жертва не может зайти в замок (по любой причине)
-	// прыжок в зону ближайшей ренты
-	if (!Clan::MayEnter(ch, to_room, HCE_PORTAL))
-		fnd_room = Clan::CloseRent(to_room);
-	else
-		fnd_room = to_room;
-
-	if (fnd_room != to_room && !IS_GOD(ch))
-	{
-		send_to_char("Попытка перемещения не удалась.\r\n", ch);
-		return;
-	}
-
-	if (!IS_GOD(ch) &&
-			(SECT(fnd_room) == SECT_SECRET ||
-			 ROOM_FLAGGED(fnd_room, ROOM_DEATH) ||
-			 ROOM_FLAGGED(fnd_room, ROOM_SLOWDEATH) ||
-			 ROOM_FLAGGED(fnd_room, ROOM_TUNNEL) ||
-			 ROOM_FLAGGED(fnd_room, ROOM_NORELOCATEIN) ||
-			 ROOM_FLAGGED(fnd_room, ROOM_ICEDEATH) || (ROOM_FLAGGED(fnd_room, ROOM_GODROOM) && !IS_IMMORTAL(ch))))
-	{
-		send_to_char("Попытка перемещения не удалась.\r\n", ch);
-		return;
-	}
-
-	timed.skill = RELOCATE_FEAT;
-	act("$n медленно исчез$q из виду.", TRUE, ch, 0, 0, TO_ROOM);
-	send_to_char("Лазурные сполохи пронеслись перед вашими глазами.\r\n", ch);
-	char_from_room(ch);
-	char_to_room(ch, fnd_room);
-    ch->dismount();
-	act("$n медленно появил$u откуда-то.", TRUE, ch, 0, 0, TO_ROOM);
-	if (!(PRF_FLAGGED(victim, PRF_SUMMONABLE) || same_group(ch, victim) || IS_IMMORTAL(ch) || ROOM_FLAGGED(fnd_room, ROOM_ARENA)))
-	{
-		send_to_char(ch, "%sВаш поступок был расценен как потенциально агрессивный.%s\r\n",
-			CCIRED(ch, C_NRM), CCINRM(ch, C_NRM));
-		pkPortal(ch);
-		timed.time = 18 - MIN(GET_REMORT(ch),15);
-		WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
-		//На время лага на чара нельзя ставить пенту
-		AFFECT_DATA<EApplyLocation> af;
-		af.duration = pc_duration(ch, 3, 0, 0, 0, 0);
-		af.bitvector = to_underlying(EAffectFlag::AFF_NOTELEPORT);
-		af.battleflag = AF_PULSEDEC;
-		affect_to_char(ch, af);
-	}
-	else
-	{
-		timed.time = 2;
-		WAIT_STATE(ch, PULSE_VIOLENCE);
-	}
-	timed_feat_to_char(ch, &timed);
-	look_at_room(ch, 0);
-	greet_mtrigger(ch, -1);
-	greet_otrigger(ch, -1);
 }
 
 void setFeaturesOfRace(CHAR_DATA *ch) {

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -90,6 +90,7 @@
 #include "skills/track.h"
 #include "skills/turnundead.h"
 #include "skills/warcry.h"
+#include "skills/relocate.h"
 #include "spells.h"
 #include "time.h"
 #include "title.hpp"

--- a/src/skills/relocate.cpp
+++ b/src/skills/relocate.cpp
@@ -1,0 +1,132 @@
+#include "relocate.h"
+
+#include "../features.hpp"
+#include "../chars/char.hpp"
+#include "../house.h"
+#include "../comm.h"
+#include "../screen.h"
+#include "../structs.h"
+#include "../handler.h"
+#include "../fightsystem/pk.h"
+#include "../dg_script/dg_scripts.h"
+
+void do_relocate(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
+{
+	struct timed_type timed;
+
+	if (!can_use_feat(ch, RELOCATE_FEAT))
+	{
+		send_to_char("Вам это недоступно.\r\n", ch);
+		return;
+	}
+
+	if (timed_by_feat(ch, RELOCATE_FEAT)
+#ifdef TEST_BUILD
+		&& !IS_IMMORTAL(ch)
+#endif
+	  )
+	{
+		send_to_char("Невозможно использовать это так часто.\r\n", ch);
+		return;
+	}
+
+	room_rnum to_room, fnd_room;
+	one_argument(argument, arg);
+	if (!*arg)
+	{
+		send_to_char("Переместиться на кого?", ch);
+		return;
+	}
+
+	CHAR_DATA* victim = get_player_vis(ch, arg, FIND_CHAR_WORLD);
+	if (!victim)
+	{
+		send_to_char(NOPERSON, ch);
+		return;
+	}
+
+	if (IS_NPC(victim)
+		|| (GET_LEVEL(victim) > GET_LEVEL(ch) && !same_group(ch, victim))
+		|| IS_IMMORTAL(victim))
+	{
+		send_to_char("Попытка перемещения не удалась.\r\n", ch);
+		return;
+	}
+
+	if (!IS_GOD(ch))
+	{
+		if (ROOM_FLAGGED(ch->in_room, ROOM_NOTELEPORTOUT))
+		{
+			send_to_char("Попытка перемещения не удалась.\r\n", ch);
+			return;
+		}
+		if (AFF_FLAGGED(ch, EAffectFlag::AFF_NOTELEPORT))
+		{
+			send_to_char("Попытка перемещения не удалась.\r\n", ch);
+			return;
+		}
+	}
+
+	to_room = IN_ROOM(victim);
+
+	if (to_room == NOWHERE)
+	{
+		send_to_char("Попытка перемещения не удалась.\r\n", ch);
+		return;
+	}
+
+	if (!Clan::MayEnter(ch, to_room, HCE_PORTAL))
+		fnd_room = Clan::CloseRent(to_room);
+	else
+		fnd_room = to_room;
+
+	if (fnd_room != to_room && !IS_GOD(ch))
+	{
+		send_to_char("Попытка перемещения не удалась.\r\n", ch);
+		return;
+	}
+
+	if (!IS_GOD(ch) &&
+			(SECT(fnd_room) == SECT_SECRET ||
+			 ROOM_FLAGGED(fnd_room, ROOM_DEATH) ||
+			 ROOM_FLAGGED(fnd_room, ROOM_SLOWDEATH) ||
+			 ROOM_FLAGGED(fnd_room, ROOM_TUNNEL) ||
+			 ROOM_FLAGGED(fnd_room, ROOM_NORELOCATEIN) ||
+			 ROOM_FLAGGED(fnd_room, ROOM_ICEDEATH) || (ROOM_FLAGGED(fnd_room, ROOM_GODROOM) && !IS_IMMORTAL(ch))))
+	{
+		send_to_char("Попытка перемещения не удалась.\r\n", ch);
+		return;
+	}
+
+	timed.skill = RELOCATE_FEAT;
+	act("$n медленно исчез$q из виду.", TRUE, ch, 0, 0, TO_ROOM);
+	send_to_char("Лазурные сполохи пронеслись перед вашими глазами.\r\n", ch);
+	char_from_room(ch);
+	char_to_room(ch, fnd_room);
+    ch->dismount();
+	act("$n медленно появил$u откуда-то.", TRUE, ch, 0, 0, TO_ROOM);
+	if (!(PRF_FLAGGED(victim, PRF_SUMMONABLE) || same_group(ch, victim) || IS_IMMORTAL(ch) || ROOM_FLAGGED(fnd_room, ROOM_ARENA)))
+	{
+		send_to_char(ch, "%sВаш поступок был расценен как потенциально агрессивный.%s\r\n",
+			CCIRED(ch, C_NRM), CCINRM(ch, C_NRM));
+		pkPortal(ch);
+		timed.time = 18 - MIN(GET_REMORT(ch),15);
+		WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
+		AFFECT_DATA<EApplyLocation> af;
+		af.duration = pc_duration(ch, 3, 0, 0, 0, 0);
+		af.bitvector = to_underlying(EAffectFlag::AFF_NOTELEPORT);
+		af.battleflag = AF_PULSEDEC;
+		affect_to_char(ch, af);
+	}
+	else
+	{
+		timed.time = 2;
+		WAIT_STATE(ch, PULSE_VIOLENCE);
+	}
+	timed_feat_to_char(ch, &timed);
+	look_at_room(ch, 0);
+	greet_mtrigger(ch, -1);
+	greet_otrigger(ch, -1);
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/skills/relocate.h
+++ b/src/skills/relocate.h
@@ -1,0 +1,10 @@
+#ifndef BYLINS_RELOCATE_H
+#define BYLINS_RELOCATE_H
+
+class CHAR_DATA;
+
+void do_relocate(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/);
+
+#endif //BYLINS_RELOCATE_H
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
Отключил в !переместиться! проверку на уровень цели, если кастер и цель в одной группе.