### PR TITLE
Issue.928.weaponskillscap

### DIFF
--- a/lib.template/misc/skills.xml
+++ b/lib.template/misc/skills.xml
@@ -1,25 +1,25 @@
 <!--
-    В перспективе в этом файле должны описываться все параметры скиллов.
-    Это можно реализовать следующим образом:
-    1. В коде определяем обработчики _не привязанные_ к скиллу.
-    2. В самом скилле указываем, какой обработчик он должен вызвать и параметры для обработчика.
-    3. Елси применение скилла накладывает аффекты и флаги на персонажа или цель - тоже описываем через файл.
-    3.2. Собственно всякие флаги аля стопфайт тоже можно и даже логично представить в виде аффектов.
-    Так что в теории новый скилл можно даже сделать, просто дописав тут секцию.
-    Конечно, всякие "ручные" скиллы типа взлома все равно придется кодить, но
-    например оффенсивы вида "ударил на NbM+K урона с % шансом наложить аффект N"
-    добавляются через файл на счет "раз". А елси и аффекты из кода извлечь...
+    О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫.
+    О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫:
+    1. О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ _О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫_ О©╫ О©╫О©╫О©╫О©╫О©╫О©╫.
+    2. О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫, О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫.
+    3. О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫ - О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫.
+    3.2. О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫.
+    О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫, О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫.
+    О©╫О©╫О©╫О©╫О©╫О©╫О©╫, О©╫О©╫О©╫О©╫О©╫О©╫ "О©╫О©╫О©╫О©╫О©╫О©╫" О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫, О©╫О©╫
+    О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫ "О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ NbM+K О©╫О©╫О©╫О©╫О©╫ О©╫ % О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ N"
+    О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫ "О©╫О©╫О©╫". О©╫ О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫...
 
-    Но пока что скиллы у нас в коде и имеют фиксированный номер и здесь просто
-    устанавливается соответствие между идентифкаторами скиллов в конфигах
-    и номером скилла в коде.
+    О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫
+    О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫
+    О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫.
 
-    Описание формата:
-    Начало блока описания скилла.
-    <skill id="уникальный идентификатор скилла">
-        <number val="уникальный номер скилла" />
-        <name text="название скилла на русском языке со строчной буквы" />
-        <max_perxent val="максимальный процент (используется в формуле прокачки" />
+    О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫:
+    О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫.
+    <skill id="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫">
+        <number val="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <max_perxent val="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ (О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
     </skill>
 
 -->
@@ -27,436 +27,436 @@
 <skills>
 	<skill id="SKILL_PROTECT">
         <number val="1" />
-        <name text="прикрыть" />
-        <max_percent val="120" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="120" />
     </skill>
 	<skill id="SKILL_TOUCH">
         <number val="2" />
-        <name text="перехватить атаку" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_SHIT">
 	    <number val="3" />
-        <name text="удар левой рукой" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_MIGHTHIT">
 	    <number val="4" />
-        <name text="богатырский молот" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_STUPOR">
 	    <number val="5" />
-        <name text="оглушить" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_POISONED">
 	    <number val="6" />
-        <name text="отравить" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
     <skill id="SKILL_SENSE">
 	    <number val="7" />
-        <name text="найти" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_HORSE">
 	    <number val="8" />
-        <name text="сражение верхом" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_HIDETRACK">
 	    <number val="9" />
-        <name text="замести следы" />
-        <max_percent val="120" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="120" />
     </skill>
-    <!-- И щито это тут делает? Клевая реализация... -->
+    <!-- О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫? О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫... -->
     <skill id="SKILL_RELIGION">
 	    <number val="10" />
-        <name text="!молитва или жертва!" />
-        <max_percent val="100" />
+        <name text="!О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫!" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_MAKEFOOD">
 	    <number val="11" />
-        <name text="освежевать" />
-        <max_percent val="120" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="120" />
     </skill>
 	<skill id="SKILL_MULTYPARRY">
 	    <number val="12" />
-        <name text="веерная защита" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
 	<skill id="SKILL_TRANSFORMWEAPON">
 	    <number val="13" />
-        <name text="перековать" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
-    <!-- Тут почему то идет проскок номеров -->
+    <!-- О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ -->
     <skill id="SKILL_LEADERSHIP">
 	    <number val="20" />
-        <name text="лидерство" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_PUNCTUAL">
 	    <number val="21" />
-        <name text="точный стиль" />
-        <max_percent val="110" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="110" />
     </skill>
 	<skill id="SKILL_AWAKE">
 	    <number val="22" />
-        <name text="осторожный стиль" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_IDENTIFY">
 	    <number val="23" />
-        <name text="опознание" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_HEARING">
 	    <number val="24" />
-        <name text="прислушаться" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
-    <!-- Следующие три скилла на деле не реализованы, видимо остатки чьих-то прожектов -->
+    <!-- О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫, О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫-О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ -->
     <skill id="SKILL_CREATE_POTION">
 	    <number val="25" />
-        <name text="создать зелье" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_CREATE_SCROLL">
 	    <number val="26" />
-        <name text="создать свиток" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_CREATE_WAND">
 	    <number val="27" />
-        <name text="создать волшебную палочку" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
-    <!--  Конец прожектов -->
+    <!--  О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ -->
     <skill id="SKILL_LOOK_HIDE">
 	    <number val="28" />
-        <name text="подсмотреть" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_ARMORED">
 	    <number val="29" />
-        <name text="укрепить" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_DRUNKOFF">
 	    <number val="30" />
-        <name text="опохмелиться" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_AID">
 	    <number val="31" />
-        <name text="лечить" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_FIRE">
 	    <number val="32" />
-        <name text="разжечь костер" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
-    <!-- Тоже не реализован, но из кода недовыдран -->
+    <!-- О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫, О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ -->
 	<skill id="SKILL_CREATEBOW">
         <number val="33" />
         <name text="create bow" />
-        <max_percent val="140" />
+        <fail_percent val="140" />
     </skill>
-    <!-- Тут снова здоровенный проскок по нумерации непонятно почему -->
+    <!-- О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ -->
     <skill id="SKILL_THROW">
 	    <number val="130" />
-        <name text="метнуть" />
-        <max_percent val="150" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="150" />
     </skill>
 	<skill id="SKILL_BACKSTAB">
         <number val="131" />
-        <name text="заколоть" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
 	<skill id="SKILL_BASH">
         <number val="132" />
-        <name text="сбить" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
 	<skill id="SKILL_HIDE">
         <number val="133" />
-        <name text="спрятаться" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_KICK">
         <number val="134" />
-        <name text="пнуть" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_PICK_LOCK">
         <number val="135" />
-        <name text="взломать" />
-        <max_percent val="120" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="120" />
     </skill>
 	<skill id="SKILL_PUNCH">
         <number val="136" />
-        <name text="кулачный бой" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_RESCUE">
         <number val="137" />
-        <name text="спасти" />
-        <max_percent val="130" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="130" />
     </skill>
 	<skill id="SKILL_SNEAK">
         <number val="138" />
-        <name text="подкрасться" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_STEAL">
         <number val="139" />
-        <name text="украсть" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_TRACK">
         <number val="140" />
-        <name text="выследить" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_CLUBS">
 	    <number val="141" />
-        <name text="палицы и дубины" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
     <skill id="SKILL_AXES">
 	    <number val="142" />
-        <name text="секиры" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
 	<skill id="SKILL_LONGS">
 	    <number val="143" />
-        <name text="длинные лезвия" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
 	<skill id="SKILL_SHORTS">
 	    <number val="144" />
-        <name text="короткие лезвия" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
     <skill id="SKILL_NONSTANDART">
 	    <number val="145" />
-        <name text="иное оружие" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
     <skill id="SKILL_BOTHHANDS">
 	    <number val="146" />
-        <name text="двуручники" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
     <skill id="SKILL_PICK">
 	    <number val="147" />
-        <name text="проникающее оружие" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
     <skill id="SKILL_SPADES">
 	    <number val="148" />
-        <name text="копья и рогатины" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
     <skill id="SKILL_SATTACK">
 	    <number val="149" />
-        <name text="атака левой рукой" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_DISARM">
 	    <number val="150" />
-        <name text="обезоружить" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_PARRY">
         <number val="151" />
-        <name text="парировать" />
-        <max_percent val="120" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="120" />
     </skill>
 	<skill id="SKILL_HEAL">
 	    <number val="152" />
         <name text="!heal!" />
-        <max_percent val="100" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_TURN">
 	    <number val="153" />
         <name text="turn" />
-        <max_percent val="100" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_BOWS">
 	    <number val="154" />
-        <name text="луки" />
-        <max_percent val="160" />
+        <name text="О©╫О©╫О©╫О©╫" />
+        <fail_percent val="160" />
     </skill>
     <skill id="SKILL_ADDSHOT">
 	    <number val="155" />
-        <name text="дополнительный выстрел" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_CAMOUFLAGE">
 	    <number val="156" />
-        <name text="маскировка" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_DEVIATE">
 	    <number val="157" />
-        <name text="уклониться" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_BLOCK">
         <number val="158" />
-        <name text="блокировать щитом" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
     <skill id="SKILL_LOOKING">
 	    <number val="159" />
-        <name text="приглядеться" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_CHOPOFF">
 	    <number val="160" />
-        <name text="подножка" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_REPAIR">
 	    <number val="161" />
-        <name text="ремонт" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
-    <!-- И снова проскок на два номера -->
+    <!-- О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ -->
     <skill id="SKILL_UPGRADE">
 	    <number val="164" />
-        <name text="заточить" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_COURAGE">
 	    <number val="165" />
-        <name text="ярость" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_MANADRAIN">
 	    <number val="166" />
-        <name text="сглазить" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_NOPARRYHIT">
 	    <number val="167" />
-        <name text="скрытый удар" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_TOWNPORTAL">
 	    <number val="168" />
-        <name text="врата" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
-    <!-- Крафтовые скиллы, но реально из них реализован только крафт луков -->
+    <!-- О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫, О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫ О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ -->
     <skill id="SKILL_MAKE_STAFF">
 	    <number val="169" />
-        <name text="изготовить посох" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
     <skill id="SKILL_MAKE_BOW">
 	    <number val="170" />
-        <name text="смастерить лук" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
 	<skill id="SKILL_MAKE_WEAPON">
 	    <number val="171" />
-        <name text="выковать оружие" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
 	<skill id="SKILL_MAKE_ARMOR">
 	    <number val="172" />
-        <name text="выковать доспех" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
 	<skill id="SKILL_MAKE_WEAR">
 	    <number val="173" />
-        <name text="сшить одежду" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
 	<skill id="SKILL_MAKE_JEWEL">
 	    <number val="174" />
-        <name text="смастерить диковинку" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
     <skill id="SKILL_MAKE_POTION">
 	    <number val="175" />
-        <name text="смастерить диковинку" />
-        <max_percent val="140" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="140" />
     </skill>
-    <!-- Дальше снова рабочие скиллы  -->
+    <!-- О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫  -->
     <skill id="SKILL_DIG">
 	    <number val="176" />
-        <name text="горное дело" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_INSERTGEM">
 	    <number val="177" />
-        <name text="ювелир" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
     <skill id="SKILL_WARCRY">
 	    <number val="178" />
-        <name text="боевой клич" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_TURN_UNDEAD">
 	    <number val="179" />
-        <name text="изгнать нежить" />
-        <max_percent val="100" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="100" />
     </skill>
 	<skill id="SKILL_IRON_WIND">
 	    <number val="180" />
-        <name text="железный ветер" />
-        <max_percent val="150" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="150" />
     </skill>
 	<skill id="SKILL_STRANGLE">
 	    <number val="181" />
-        <name text="удавить" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_AIR_MAGIC">
 	    <number val="182" />
-        <name text="магия воздуха" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_FIRE_MAGIC">
 	    <number val="183" />
-        <name text="магия огня" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_WATER_MAGIC">
 	    <number val="184" />
-        <name text="магия воды" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_EARTH_MAGIC">
 	    <number val="185" />
-        <name text="магия земли" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_LIGHT_MAGIC">
 	    <number val="186" />
-        <name text="магия света" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_DARK_MAGIC">
 	    <number val="187" />
-        <name text="магия тьмы" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_MIND_MAGIC">
 	    <number val="188" />
-        <name text="магия разума" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 	<skill id="SKILL_LIFE_MAGIC">
 	    <number val="189" />
-        <name text="магия жизни" />
-        <max_percent val="200" />
+        <name text="О©╫О©╫О©╫О©╫О©╫ О©╫О©╫О©╫О©╫О©╫" />
+        <fail_percent val="200" />
     </skill>
 </skills>

--- a/src/ability.rollsystem.cpp
+++ b/src/ability.rollsystem.cpp
@@ -137,7 +137,7 @@ short AbilityRollType::calculateActorRating() {
 
 //TODO: убрать обертку после изменения системы прокачки скиллов
 void AgainstRivalRollType::trainBaseSkill(bool success) {
-  train_skill(_actor, _baseSkill, success, _rival);
+  TrainSkill(_actor, _baseSkill, success, _rival);
 };
 
 short AgainstRivalRollType::calculateTargetRating() {
@@ -146,7 +146,7 @@ short AgainstRivalRollType::calculateTargetRating() {
 
 //TODO: избавиться от target в calculate_skill и убрать обертку
 short AgainstRivalRollType::calculatBaseSkillRating() {
-  return (calculate_skill(_actor, _baseSkill, _rival) / SKILL_RATING_DIVIDER);
+  return (CalcCurrentSkill(_actor, _baseSkill, _rival) / SKILL_RATING_DIVIDER);
 };
 
 //TODO: Избавиться от таргета в ситуационном бонусе, он там не нужен

--- a/src/ability.rollsystem.cpp
+++ b/src/ability.rollsystem.cpp
@@ -11,233 +11,240 @@
 
 namespace AbilitySystem {
 
-	using namespace AbilitySystemConstants;
+using namespace AbilitySystemConstants;
 
-	void AgainstRivalRollType::initialize(CHAR_DATA *abilityActor, int usedAbility, CHAR_DATA *abilityVictim) {
-		_rival = abilityVictim;
-		AbilityRollType::initialize(abilityActor, usedAbility);
-	};
+void AgainstRivalRollType::initialize(CHAR_DATA *abilityActor, int usedAbility, CHAR_DATA *abilityVictim) {
+  _rival = abilityVictim;
+  AbilityRollType::initialize(abilityActor, usedAbility);
+};
 
-	void AbilityRollType::initialize(CHAR_DATA *abilityActor, int usedAbility) {
-		_actor = abilityActor;
-		_ability = &feat_info[usedAbility];
-		if (tryRevealWrongConditions()) {
-			_success = false;
-			return;
-		}
-		performAbilityTest();
-	};
+void AbilityRollType::initialize(CHAR_DATA *abilityActor, int usedAbility) {
+  _actor = abilityActor;
+  _ability = &feat_info[usedAbility];
+  if (tryRevealWrongConditions()) {
+    _success = false;
+    return;
+  }
+  performAbilityTest();
+};
 
-	//TODO добавить возможность прописывать автоуспех навыка
-	void AbilityRollType::performAbilityTest() {
-		_actorRating = calculateActorRating();
-		short targetRating = calculateTargetRating();
-		short diceRoll = number(1, MAIN_DICE_SIZE);
-		short difficulty = _actorRating - targetRating;
-		short rollResult = difficulty - diceRoll;
-		processingResult(rollResult, diceRoll);
-		if (PRF_FLAGGED(_actor, PRF_TESTER)) {
-			send_to_char(_actor, "&CНавык: %s, Рейтинг навыка: %d, Рейтинг цели: %d, Сложность: %d Бросок d100: %d, Итог: %d (%s)&n\r\n",
-					_ability->name, _actorRating, targetRating, difficulty, diceRoll, rollResult, _success ? "успех":"провал" );
-		}
-	};
+//TODO добавить возможность прописывать автоуспех навыка
+void AbilityRollType::performAbilityTest() {
+  _actorRating = calculateActorRating();
+  short targetRating = calculateTargetRating();
+  short diceRoll = number(1, MAIN_DICE_SIZE);
+  short difficulty = _actorRating - targetRating;
+  short rollResult = difficulty - diceRoll;
+  processingResult(rollResult, diceRoll);
+  if (PRF_FLAGGED(_actor, PRF_TESTER)) {
+    send_to_char(_actor,
+                 "&CНавык: %s, Рейтинг навыка: %d, Рейтинг цели: %d, Сложность: %d Бросок d100: %d, Итог: %d (%s)&n\r\n",
+                 _ability->name,
+                 _actorRating,
+                 targetRating,
+                 difficulty,
+                 diceRoll,
+                 rollResult,
+                 _success ? "успех" : "провал");
+  }
+};
 
-	// TODO Лобавить возмодность проверки вполнения "специальныз условимй" для конкретной абилки, а не только оружия
-	bool AbilityRollType::tryRevealWrongConditions() {
-		if (isActorCantUseAbility()) {
-			return true;
-		};
-		determineBaseSkill();
-		if (_baseSkill == SKILL_INVALID) {
-			return true;
-		};
-		return false;
-	};
+// TODO Лобавить возмодность проверки вполнения "специальныз условимй" для конкретной абилки, а не только оружия
+bool AbilityRollType::tryRevealWrongConditions() {
+  if (isActorCantUseAbility()) {
+    return true;
+  };
+  determineBaseSkill();
+  if (_baseSkill == SKILL_INVALID) {
+    return true;
+  };
+  return false;
+};
 
-	bool AbilityRollType::isActorCantUseAbility() {
-		if (!IS_IMPL(_actor) && !can_use_feat(_actor, _ability->ID)) {
-			_denyMessage = "Вы не можете использовать этот навык.\r\n";
-			_wrongConditions = true;
-		};
-		return _wrongConditions;
-	}
+bool AbilityRollType::isActorCantUseAbility() {
+  if (!IS_IMPL(_actor) && !can_use_feat(_actor, _ability->ID)) {
+    _denyMessage = "Вы не можете использовать этот навык.\r\n";
+    _wrongConditions = true;
+  };
+  return _wrongConditions;
+}
 
-	void AbilityRollType::determineBaseSkill() {
-		_baseSkill = _ability->baseSkill;
-	}
+void AbilityRollType::determineBaseSkill() {
+  _baseSkill = _ability->baseSkill;
+}
 
-	void AbilityRollType::sendDenyMessageToActor() {
-			send_to_char(_denyMessage, _actor);
-	};
+void AbilityRollType::sendDenyMessageToActor() {
+  send_to_char(_denyMessage, _actor);
+};
 
-	void AbilityRollType::processingResult(short result, short diceRoll) {
-		_success = (result >= SUCCESS_THRESHOLD);
-		_degreeOfSuccess = result/DEGREE_DIVIDER;
-		_degreeOfSuccess = MIN(_degreeOfSuccess, MAX_SUCCESS_DEGREE);
-		_degreeOfSuccess = MAX(_degreeOfSuccess, MAX_FAIL_DEGREE);
-		if (_success) {
-			_criticalSuccess =  revealCriticalSuccess(diceRoll);
-		} else {
-			_criticalFail =  revealCriticalFail(diceRoll);
-		}
-		// Идея была в том, чтобы прокачка шла только на провалах умения.
-		// Тогда она естественным образом замедлялась бы по мере роста умения, требуя находить другие источники улучшения.
-		// Но это требует выстоенного баланса которым и не пахнет, потому сделал прокачку в любом случае.
-		trainBaseSkill();
-	};
+void AbilityRollType::processingResult(short result, short diceRoll) {
+  _success = (result >= SUCCESS_THRESHOLD);
+  _degreeOfSuccess = result / DEGREE_DIVIDER;
+  _degreeOfSuccess = MIN(_degreeOfSuccess, MAX_SUCCESS_DEGREE);
+  _degreeOfSuccess = MAX(_degreeOfSuccess, MAX_FAIL_DEGREE);
+  if (_success) {
+    _criticalSuccess = revealCriticalSuccess(diceRoll);
+  } else {
+    _criticalFail = revealCriticalFail(diceRoll);
+  }
+  // Идея была в том, чтобы прокачка шла только на провалах умения.
+  // Тогда она естественным образом замедлялась бы по мере роста умения, требуя находить другие источники улучшения.
+  // Но это требует выстоенного баланса которым и не пахнет, потому сделал прокачку в любом случае.
+  trainBaseSkill(_success);
+};
 
-	bool AbilityRollType::revealCriticalSuccess(short diceRoll) {
-		if (diceRoll < _ability->criticalSuccessThreshold) {
-			return true;
-		}
-		return false;
-	};
+bool AbilityRollType::revealCriticalSuccess(short diceRoll) {
+  if (diceRoll < _ability->criticalSuccessThreshold) {
+    return true;
+  }
+  return false;
+};
 
-	bool AbilityRollType::revealCriticalFail(short diceRoll) {
-		if ((diceRoll > _ability->criticalFailThreshold) && isActorMoraleFailure()) {
-			return true;
-		}
-		return false;
-	};
+bool AbilityRollType::revealCriticalFail(short diceRoll) {
+  if ((diceRoll > _ability->criticalFailThreshold) && isActorMoraleFailure()) {
+    return true;
+  }
+  return false;
+};
 
-	bool AbilityRollType::isActorMoraleFailure() {
-		return true;
-	};
+bool AbilityRollType::isActorMoraleFailure() {
+  return true;
+};
 
-	// Костыльно-черновой учет морали
-	bool AgainstRivalRollType::isActorMoraleFailure() {
-		int actorMorale = _actor->calc_morale();
-		int rivalMorale = _rival->calc_morale();
-		if (actorMorale > 0 && rivalMorale > 0) {
-			return ((number(0, _actor->calc_morale()) - number(0, _rival->calc_morale())) < 0);
-		}
-		if (actorMorale <= 0 && rivalMorale <= 0) {
-			return (actorMorale < rivalMorale);
-		}
-		if (actorMorale <= 0 && rivalMorale >= 0) {
-			return true;
-		}
-		return false;
-	};
+// Костыльно-черновой учет морали
+bool AgainstRivalRollType::isActorMoraleFailure() {
+  int actorMorale = _actor->calc_morale();
+  int rivalMorale = _rival->calc_morale();
+  if (actorMorale > 0 && rivalMorale > 0) {
+    return ((number(0, _actor->calc_morale()) - number(0, _rival->calc_morale())) < 0);
+  }
+  if (actorMorale <= 0 && rivalMorale <= 0) {
+    return (actorMorale < rivalMorale);
+  }
+  if (actorMorale <= 0 && rivalMorale >= 0) {
+    return true;
+  }
+  return false;
+};
 
-	// TODO: переделать на static, чтобы иметь возможность считать рейтинги, к примеру, при наложении аффектов
-	short AbilityRollType::calculateActorRating() {
-		short baseSkillRating = calculatBaseSkillRating();
-		short baseParameterRating  = _ability->getBaseParameter(_actor)/PARAMETER_RATING_DIVIDER;
-		short dicerollBonus = calculateDicerollBonus();
-		return (baseSkillRating + baseParameterRating + dicerollBonus);
-	};
+// TODO: переделать на static, чтобы иметь возможность считать рейтинги, к примеру, при наложении аффектов
+short AbilityRollType::calculateActorRating() {
+  short baseSkillRating = calculatBaseSkillRating();
+  short baseParameterRating = _ability->getBaseParameter(_actor) / PARAMETER_RATING_DIVIDER;
+  short dicerollBonus = calculateDicerollBonus();
+  return (baseSkillRating + baseParameterRating + dicerollBonus);
+};
 
-	//TODO: убрать обертку после изменения системы прокачки скиллов
-	void AgainstRivalRollType::trainBaseSkill() {
-		train_skill(_actor, _baseSkill, skill_info[_baseSkill].max_percent, _rival);
-	};
+//TODO: убрать обертку после изменения системы прокачки скиллов
+void AgainstRivalRollType::trainBaseSkill(bool success) {
+  train_skill(_actor, _baseSkill, success, _rival);
+};
 
-	short AgainstRivalRollType::calculateTargetRating() {
-		return MAX(0, calculateSaving(_actor, _rival, _ability->oppositeSaving, 0));
-	};
+short AgainstRivalRollType::calculateTargetRating() {
+  return MAX(0, calculateSaving(_actor, _rival, _ability->oppositeSaving, 0));
+};
 
-	//TODO: избавиться от target в calculate_skill и убрать обертку
-	short AgainstRivalRollType::calculatBaseSkillRating() {
-		return (calculate_skill(_actor, _baseSkill, _rival)/SKILL_RATING_DIVIDER);
-	};
+//TODO: избавиться от target в calculate_skill и убрать обертку
+short AgainstRivalRollType::calculatBaseSkillRating() {
+  return (calculate_skill(_actor, _baseSkill, _rival) / SKILL_RATING_DIVIDER);
+};
 
-	//TODO: Избавиться от таргета в ситуационном бонусе, он там не нужен
-	short AgainstRivalRollType::calculateDicerollBonus() {
-		return (_ability->dicerollBonus + _ability->calculateSituationalRollBonus(_actor, _rival));
-	};
+//TODO: Избавиться от таргета в ситуационном бонусе, он там не нужен
+short AgainstRivalRollType::calculateDicerollBonus() {
+  return (_ability->dicerollBonus + _ability->calculateSituationalRollBonus(_actor, _rival));
+};
 
-	void TechniqueRollType::determineBaseSkill() {
-		if (checkTechniqueKit()) {
-			if (_baseSkill == SKILL_INVALID) {
-				_baseSkill = _ability->baseSkill;
-			}
-		} else {
-			_wrongConditions = true;
-			_denyMessage = "У вас нет подходящей экипировки.\r\n";
-		}
-	}
+void TechniqueRollType::determineBaseSkill() {
+  if (checkTechniqueKit()) {
+    if (_baseSkill == SKILL_INVALID) {
+      _baseSkill = _ability->baseSkill;
+    }
+  } else {
+    _wrongConditions = true;
+    _denyMessage = "У вас нет подходящей экипировки.\r\n";
+  }
+}
 
-	bool TechniqueRollType::checkTechniqueKit() {
-		//const TechniqueItemKitsGroupType &kitsGroup = _ability->techniqueItemKitsGroup;
-		if (_ability->techniqueItemKitsGroup.empty()) {
-			return true;
-		};
-		for (const auto &itemKit : _ability->techniqueItemKitsGroup) {
-			bool kitFit = true;
-			for (const auto &item : *itemKit) {
-				if (isSuitableItem(item)) {
-					continue;
-				};
-				kitFit = false;
-				break;
-			};
-			if (kitFit) {
-				return true;
-			};
-		};
-		return false;
-	};
+bool TechniqueRollType::checkTechniqueKit() {
+  //const TechniqueItemKitsGroupType &kitsGroup = _ability->techniqueItemKitsGroup;
+  if (_ability->techniqueItemKitsGroup.empty()) {
+    return true;
+  };
+  for (const auto &itemKit : _ability->techniqueItemKitsGroup) {
+    bool kitFit = true;
+    for (const auto &item : *itemKit) {
+      if (isSuitableItem(item)) {
+        continue;
+      };
+      kitFit = false;
+      break;
+    };
+    if (kitFit) {
+      return true;
+    };
+  };
+  return false;
+};
 
-	bool TechniqueRollType::isSuitableItem(const TechniqueItem &techniqueItem) {
-		OBJ_DATA *characterItem = GET_EQ(_actor, techniqueItem._wearPosition);
-		if (techniqueItem == characterItem) {
-			if (GET_OBJ_TYPE(characterItem) == OBJ_DATA::ITEM_WEAPON) {
-				_weaponEquipPosition = techniqueItem._wearPosition;
-				if (_ability->usesWeaponSkill) {
-					_baseSkill = static_cast<ESkill>GET_OBJ_SKILL(characterItem);
-				};
-			};
-			return true;
-		};
-		return false;
-	};
+bool TechniqueRollType::isSuitableItem(const TechniqueItem &techniqueItem) {
+  OBJ_DATA *characterItem = GET_EQ(_actor, techniqueItem._wearPosition);
+  if (techniqueItem == characterItem) {
+    if (GET_OBJ_TYPE(characterItem) == OBJ_DATA::ITEM_WEAPON) {
+      _weaponEquipPosition = techniqueItem._wearPosition;
+      if (_ability->usesWeaponSkill) {
+        _baseSkill = static_cast<ESkill>GET_OBJ_SKILL(characterItem);
+      };
+    };
+    return true;
+  };
+  return false;
+};
 
-	//	TODO: Привести подсчет дамага к одному знаменателю с несколькими возможными точками входа.
-	int AbilityRollType::calculateBaseDamage() {
-		short abilityBaseParameter = _ability->getBaseParameter(_actor);
-		short dicePool = GET_SKILL(_actor, _baseSkill)/DAMAGE_DICEPOOL_SKILL_DIVIDER;
-		dicePool = MIN(dicePool, abilityBaseParameter);
-		return dice(MAX(1, dicePool), DAMAGE_DICE_SIZE);
-	};
+//	TODO: Привести подсчет дамага к одному знаменателю с несколькими возможными точками входа.
+int AbilityRollType::calculateBaseDamage() {
+  short abilityBaseParameter = _ability->getBaseParameter(_actor);
+  short dicePool = GET_SKILL(_actor, _baseSkill) / DAMAGE_DICEPOOL_SKILL_DIVIDER;
+  dicePool = MIN(dicePool, abilityBaseParameter);
+  return dice(MAX(1, dicePool), DAMAGE_DICE_SIZE);
+};
 
-	int AbilityRollType::calculateAddDamage() {
-		short dicePool = _ability->getEffectParameter(_actor);
-		short diceSize = DAMAGE_DICE_SIZE;
-		return dice(dicePool, diceSize);
-	}
+int AbilityRollType::calculateAddDamage() {
+  short dicePool = _ability->getEffectParameter(_actor);
+  short diceSize = DAMAGE_DICE_SIZE;
+  return dice(dicePool, diceSize);
+}
 
-	int TechniqueRollType::calculateAddDamage() {
-		OBJ_DATA *weapon = GET_EQ(_actor, _weaponEquipPosition);
-		if (weapon) {
-			short dicePool = _ability->getEffectParameter(_actor) + GET_OBJ_VAL(weapon, 1);
-			short diceSize = GET_OBJ_VAL(weapon, 2);
-			return dice(dicePool, diceSize);
-		}
+int TechniqueRollType::calculateAddDamage() {
+  OBJ_DATA *weapon = GET_EQ(_actor, _weaponEquipPosition);
+  if (weapon) {
+    short dicePool = _ability->getEffectParameter(_actor) + GET_OBJ_VAL(weapon, 1);
+    short diceSize = GET_OBJ_VAL(weapon, 2);
+    return dice(dicePool, diceSize);
+  }
 
-		return AgainstRivalRollType::calculateAddDamage();
-	};
+  return AgainstRivalRollType::calculateAddDamage();
+};
 
-	inline float AbilityRollType::calculateAbilityDamageFactor() {
-		return _ability->baseDamageBonusPercent/100.0;
-	};
+inline float AbilityRollType::calculateAbilityDamageFactor() {
+  return _ability->baseDamageBonusPercent / 100.0;
+};
 
-	inline float AbilityRollType::calculateDegreeOfSuccessDamageFactor() {
-		return _degreeOfSuccess*_ability->degreeOfSuccessDamagePercent/100.0;
-	};
+inline float AbilityRollType::calculateDegreeOfSuccessDamageFactor() {
+  return _degreeOfSuccess * _ability->degreeOfSuccessDamagePercent / 100.0;
+};
 
-	inline float AbilityRollType::calculateSituationalDamageFactor() {
-		return _ability->calculateSituationalDamageFactor(_actor);
-	};
+inline float AbilityRollType::calculateSituationalDamageFactor() {
+  return _ability->calculateSituationalDamageFactor(_actor);
+};
 
-	int TechniqueRollType::calculateDamage() {
-		int damage = calculateBaseDamage() + calculateAddDamage();
-		float abilityFactor = calculateAbilityDamageFactor();
-		float degreeFactor = calculateDegreeOfSuccessDamageFactor();
-		float situationalFactor = calculateSituationalDamageFactor();
-		damage += damage*abilityFactor + damage*degreeFactor + damage*situationalFactor;
-		return damage;
-	};
+int TechniqueRollType::calculateDamage() {
+  int damage = calculateBaseDamage() + calculateAddDamage();
+  float abilityFactor = calculateAbilityDamageFactor();
+  float degreeFactor = calculateDegreeOfSuccessDamageFactor();
+  float situationalFactor = calculateSituationalDamageFactor();
+  damage += damage * abilityFactor + damage * degreeFactor + damage * situationalFactor;
+  return damage;
+};
 
 }; // namespace AbilitySystem
 

--- a/src/ability.rollsystem.hpp
+++ b/src/ability.rollsystem.hpp
@@ -62,7 +62,7 @@ namespace AbilitySystem {
 		virtual inline float calculateAbilityDamageFactor();
 		virtual inline float calculateDegreeOfSuccessDamageFactor();
 		virtual inline float calculateSituationalDamageFactor();
-		virtual void trainBaseSkill() = 0;
+		virtual void trainBaseSkill(bool success) = 0;
 
 	public:
 		bool isSuccess() {return _success;};
@@ -81,7 +81,7 @@ namespace AbilitySystem {
 	protected:
 		CHAR_DATA *_rival;
 
-		void trainBaseSkill();
+		void trainBaseSkill(bool success);
 		short calculateTargetRating();
 		short calculatBaseSkillRating();
 		short calculateDicerollBonus();

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -95,16 +95,16 @@ extern int nameserver_is_slow; //config.cpp
 extern std::vector<City> cities;
 // extern functions
 long find_class_bitvector(char arg);
-int level_exp(CHAR_DATA * ch, int level);
+int level_exp(CHAR_DATA *ch, int level);
 TIME_INFO_DATA *real_time_passed(time_t t2, time_t t1);
-int compute_armor_class(CHAR_DATA * ch);
-int pk_count(CHAR_DATA * ch);
+int compute_armor_class(CHAR_DATA *ch);
+int pk_count(CHAR_DATA *ch);
 // local functions
-const char *show_obj_to_char(OBJ_DATA * object, CHAR_DATA * ch, int mode, int show_state, int how);
-void list_obj_to_char(OBJ_DATA * list, CHAR_DATA * ch, int mode, int show);
-char *diag_obj_to_char(CHAR_DATA * i, OBJ_DATA * obj, int mode);
-const char *diag_obj_timer(const OBJ_DATA * obj);
-char *diag_timer_to_char(const OBJ_DATA* obj);
+const char *show_obj_to_char(OBJ_DATA *object, CHAR_DATA *ch, int mode, int show_state, int how);
+void list_obj_to_char(OBJ_DATA *list, CHAR_DATA *ch, int mode, int show);
+char *diag_obj_to_char(CHAR_DATA *i, OBJ_DATA *obj, int mode);
+const char *diag_obj_timer(const OBJ_DATA *obj);
+char *diag_timer_to_char(const OBJ_DATA *obj);
 int get_pick_chance(int skill_pick, int lock_complexity);
 int thaco(int class_num, int level);
 
@@ -120,8 +120,8 @@ void do_weather(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_who(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_users(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_gen_ps(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
-void perform_mortal_where(CHAR_DATA * ch, char *arg);
-void perform_immort_where(CHAR_DATA * ch, char *arg);
+void perform_mortal_where(CHAR_DATA *ch, char *arg);
+void perform_immort_where(CHAR_DATA *ch, char *arg);
 void do_where(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_levels(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_consider(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
@@ -134,27 +134,27 @@ void do_hearing(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_sides(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_quest(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_check(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
-void do_cities(CHAR_DATA *ch, char*, int, int);
-void diag_char_to_char(CHAR_DATA * i, CHAR_DATA * ch);
-void look_at_char(CHAR_DATA * i, CHAR_DATA * ch);
-void list_one_char(CHAR_DATA * i, CHAR_DATA * ch, int skill_mode);
-void list_char_to_char(const ROOM_DATA::people_t& list, CHAR_DATA* ch);
-void do_auto_exits(CHAR_DATA * ch);
+void do_cities(CHAR_DATA *ch, char *, int, int);
+void diag_char_to_char(CHAR_DATA *i, CHAR_DATA *ch);
+void look_at_char(CHAR_DATA *i, CHAR_DATA *ch);
+void list_one_char(CHAR_DATA *i, CHAR_DATA *ch, int skill_mode);
+void list_char_to_char(const ROOM_DATA::people_t &list, CHAR_DATA *ch);
+void do_auto_exits(CHAR_DATA *ch);
 void do_exits(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
-void look_in_direction(CHAR_DATA * ch, int dir, int info_is);
-void look_in_obj(CHAR_DATA * ch, char *arg);
-char *find_exdesc(char *word, const EXTRA_DESCR_DATA::shared_ptr& list);
-bool look_at_target(CHAR_DATA * ch, char *arg, int subcmd);
-void gods_day_now(CHAR_DATA * ch);
+void look_in_direction(CHAR_DATA *ch, int dir, int info_is);
+void look_in_obj(CHAR_DATA *ch, char *arg);
+char *find_exdesc(char *word, const EXTRA_DESCR_DATA::shared_ptr &list);
+bool look_at_target(CHAR_DATA *ch, char *arg, int subcmd);
+void gods_day_now(CHAR_DATA *ch);
 void do_blind_exits(CHAR_DATA *ch);
-const char *diag_liquid_timer(const OBJ_DATA * obj);
+const char *diag_liquid_timer(const OBJ_DATA *obj);
 #define EXIT_SHOW_WALL    (1 << 0)
 #define EXIT_SHOW_LOOKING (1 << 1)
 
-void do_quest(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
+void do_quest(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 
-	send_to_char("У Вас нет никаких ежедневных поручений.\r\nЧтобы взять новые, наберите &Wпоручения получить&n.\r\n", ch);
+  send_to_char("У Вас нет никаких ежедневных поручений.\r\nЧтобы взять новые, наберите &Wпоручения получить&n.\r\n",
+               ch);
 }
 
 /*
@@ -163,1673 +163,1381 @@ void do_quest(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
 
 int param_sort = 0;
 
-const char *Dirs[NUM_OF_DIRS + 1] = { "Север",
-									  "Восток",
-									  "Юг",
-									  "Запад",
-									  "Вверх",
-									  "Вниз",
-									  "\n"
-									};
+const char *Dirs[NUM_OF_DIRS + 1] = {"Север",
+                                     "Восток",
+                                     "Юг",
+                                     "Запад",
+                                     "Вверх",
+                                     "Вниз",
+                                     "\n"
+};
 
-const char *ObjState[8][2] = { {"рассыпается", "рассыпается"},
-	{"плачевно", "в плачевном состоянии"},
-	{"плохо", "в плохом состоянии"},
-	{"неплохо", "в неплохом состоянии"},
-	{"средне", "в рабочем состоянии"},
-	{"хорошо", "в хорошем состоянии"},
-	{"очень хорошо", "в очень хорошем состоянии"},
-	{"великолепно", "в великолепном состоянии"}
+const char *ObjState[8][2] = {{"рассыпается", "рассыпается"},
+                              {"плачевно", "в плачевном состоянии"},
+                              {"плохо", "в плохом состоянии"},
+                              {"неплохо", "в неплохом состоянии"},
+                              {"средне", "в рабочем состоянии"},
+                              {"хорошо", "в хорошем состоянии"},
+                              {"очень хорошо", "в очень хорошем состоянии"},
+                              {"великолепно", "в великолепном состоянии"}
 };
 
 const char *Locks[4][2] =
-{
-	{"%s Вы в жизни не видели подобного замка.%s\r\n", KIRED},
-	{"%s Замок очень сложный.%s\r\n", KIYEL},
-	{"%s Сложный замок. Как бы не сломать.%s\r\n", KIGRN},
-	{"%s Простой замок. Эка невидаль.%s\r\n", KGRN}
+    {
+        {"%s Вы в жизни не видели подобного замка.%s\r\n", KIRED},
+        {"%s Замок очень сложный.%s\r\n", KIYEL},
+        {"%s Сложный замок. Как бы не сломать.%s\r\n", KIGRN},
+        {"%s Простой замок. Эка невидаль.%s\r\n", KGRN}
+    };
+
+void do_check(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  if (!login_change_invoice(ch))
+    send_to_char("Проверка показала: новых сообщений нет.\r\n", ch);
+}
+
+char *diag_obj_to_char(CHAR_DATA *i, OBJ_DATA *obj, int mode) {
+  static char out_str[80] = "\0";
+  const char *color;
+  int percent;
+
+  if (GET_OBJ_MAX(obj) > 0)
+    percent = 100 * GET_OBJ_CUR(obj) / GET_OBJ_MAX(obj);
+  else
+    percent = -1;
+
+  if (percent >= 100) {
+    percent = 7;
+    color = CCWHT(i, C_NRM);
+  } else if (percent >= 90) {
+    percent = 6;
+    color = CCIGRN(i, C_NRM);
+  } else if (percent >= 75) {
+    percent = 5;
+    color = CCGRN(i, C_NRM);
+  } else if (percent >= 50) {
+    percent = 4;
+    color = CCIYEL(i, C_NRM);
+  } else if (percent >= 30) {
+    percent = 3;
+    color = CCIRED(i, C_NRM);
+  } else if (percent >= 15) {
+    percent = 2;
+    color = CCIRED(i, C_NRM);
+  } else if (percent > 0) {
+    percent = 1;
+    color = CCRED(i, C_NRM);
+  } else {
+    percent = 0;
+    color = CCINRM(i, C_NRM);
+  }
+
+  if (mode == 1)
+    sprintf(out_str, " %s<%s>%s", color, ObjState[percent][0], CCNRM(i, C_NRM));
+  else if (mode == 2)
+    strcpy(out_str, ObjState[percent][1]);
+  return out_str;
+}
+
+const char *weapon_class[] = {"луки",
+                              "короткие лезвия",
+                              "длинные лезвия",
+                              "секиры",
+                              "палицы и дубины",
+                              "иное оружие",
+                              "двуручники",
+                              "проникающее оружие",
+                              "копья и рогатины"
 };
 
-void do_check(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-    if (!login_change_invoice(ch))
-		send_to_char("Проверка показала: новых сообщений нет.\r\n", ch);
-}
+char *diag_weapon_to_char(const CObjectPrototype *obj, int show_wear) {
+  static char out_str[MAX_STRING_LENGTH];
+  int skill = 0;
+  int need_str = 0;
 
-char *diag_obj_to_char(CHAR_DATA* i, OBJ_DATA* obj, int mode)
-{
-	static char out_str[80] = "\0";
-	const char *color;
-	int percent;
-
-	if (GET_OBJ_MAX(obj) > 0)
-		percent = 100 * GET_OBJ_CUR(obj) / GET_OBJ_MAX(obj);
-	else
-		percent = -1;
-
-	if (percent >= 100)
-	{
-		percent = 7;
-		color = CCWHT(i, C_NRM);
-	}
-	else if (percent >= 90)
-	{
-		percent = 6;
-		color = CCIGRN(i, C_NRM);
-	}
-	else if (percent >= 75)
-	{
-		percent = 5;
-		color = CCGRN(i, C_NRM);
-	}
-	else if (percent >= 50)
-	{
-		percent = 4;
-		color = CCIYEL(i, C_NRM);
-	}
-	else if (percent >= 30)
-	{
-		percent = 3;
-		color = CCIRED(i, C_NRM);
-	}
-	else if (percent >= 15)
-	{
-		percent = 2;
-		color = CCIRED(i, C_NRM);
-	}
-	else if (percent > 0)
-	{
-		percent = 1;
-		color = CCRED(i, C_NRM);
-	}
-	else
-	{
-		percent = 0;
-		color = CCINRM(i, C_NRM);
-	}
-
-	if (mode == 1)
-		sprintf(out_str, " %s<%s>%s", color, ObjState[percent][0], CCNRM(i, C_NRM));
-	else if (mode == 2)
-		strcpy(out_str, ObjState[percent][1]);
-	return out_str;
-}
-
-
-const char *weapon_class[] = { "луки",
-							   "короткие лезвия",
-							   "длинные лезвия",
-							   "секиры",
-							   "палицы и дубины",
-							   "иное оружие",
-							   "двуручники",
-							   "проникающее оружие",
-							   "копья и рогатины"
-							 };
-
-char *diag_weapon_to_char(const CObjectPrototype* obj, int show_wear)
-{
-	static char out_str[MAX_STRING_LENGTH];
-	int skill = 0;
-	int need_str = 0;
-
-	*out_str = '\0';
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)
-	{
-		switch (GET_OBJ_SKILL(obj))
-		{
-			case SKILL_BOWS:
-				skill = 1;
-				break;
-			case SKILL_SHORTS:
-				skill = 2;
-				break;
-			case SKILL_LONGS:
-				skill = 3;
-				break;
-			case SKILL_AXES:
-				skill = 4;
-				break;
-			case SKILL_CLUBS:
-				skill = 5;
-				break;
-			case SKILL_NONSTANDART:
-				skill = 6;
-				break;
-			case SKILL_BOTHHANDS:
-				skill = 7;
-				break;
-			case SKILL_PICK:
-				skill = 8;
-				break;
-			case SKILL_SPADES:
-				skill = 9;
-				break;
-			default:
-				sprintf(out_str, "!! Не принадлежит к известным типам оружия - сообщите Богам !!\r\n");
-				break;
-		}
-		if (skill)
-		{
-			sprintf(out_str, "Принадлежит к классу \"%s\".\r\n", weapon_class[skill - 1]);
-		}
-	}
-	if (show_wear)
-	{
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FINGER))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на палец.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_NECK))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на шею.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на туловище.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на голову.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на ноги.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET))
-		{
-			sprintf(out_str + strlen(out_str), "Можно обуть.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на кисти.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на руки.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на плечи.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WAIST))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на пояс.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_QUIVER))
-		{
-			sprintf(out_str + strlen(out_str), "Можно использовать как колчан.\r\n");
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WRIST))
-		{
-			sprintf(out_str + strlen(out_str), "Можно надеть на запястья.\r\n");
-		}
-		if (show_wear > 1)
-		{
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_SHIELD))
-			{
-				need_str = MAX(0, calc_str_req((GET_OBJ_WEIGHT(obj)+1)/2, STR_HOLD_W));
-				sprintf(out_str + strlen(out_str), "Можно использовать как щит (требуется %d %s).\r\n", need_str, desc_count(need_str, WHAT_STR));
-			}
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD))
-			{
-				need_str = MAX(0, calc_str_req(GET_OBJ_WEIGHT(obj), STR_WIELD_W));
-				sprintf(out_str + strlen(out_str), "Можно взять в правую руку (требуется %d %s).\r\n", need_str, desc_count(need_str, WHAT_STR));
-			}
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD))
-			{
-				need_str = MAX(0, calc_str_req(GET_OBJ_WEIGHT(obj), STR_HOLD_W));
-				sprintf(out_str + strlen(out_str), "Можно взять в левую руку (требуется %d %s).\r\n", need_str, desc_count(need_str, WHAT_STR));
-			}
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS))
-			{
-				need_str = MAX(0, calc_str_req(GET_OBJ_WEIGHT(obj), STR_BOTH_W));
-				sprintf(out_str + strlen(out_str), "Можно взять в обе руки (требуется %d %s).\r\n", need_str, desc_count(need_str, WHAT_STR));
-			}
-		}
-		else
-		{
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_SHIELD))
-			{
-				sprintf(out_str + strlen(out_str), "Можно использовать как щит.\r\n");
-			}
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD))
-			{
-				sprintf(out_str + strlen(out_str), "Можно взять в правую руку.\r\n");
-			}
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD))
-			{
-				sprintf(out_str + strlen(out_str), "Можно взять в левую руку.\r\n");
-			}
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS))
-			{
-				sprintf(out_str + strlen(out_str), "Можно взять в обе руки.\r\n");
-			}
-		}
-	}
-	return (out_str);
+  *out_str = '\0';
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON) {
+    switch (GET_OBJ_SKILL(obj)) {
+      case SKILL_BOWS: skill = 1;
+        break;
+      case SKILL_SHORTS: skill = 2;
+        break;
+      case SKILL_LONGS: skill = 3;
+        break;
+      case SKILL_AXES: skill = 4;
+        break;
+      case SKILL_CLUBS: skill = 5;
+        break;
+      case SKILL_NONSTANDART: skill = 6;
+        break;
+      case SKILL_BOTHHANDS: skill = 7;
+        break;
+      case SKILL_PICK: skill = 8;
+        break;
+      case SKILL_SPADES: skill = 9;
+        break;
+      default: sprintf(out_str, "!! Не принадлежит к известным типам оружия - сообщите Богам !!\r\n");
+        break;
+    }
+    if (skill) {
+      sprintf(out_str, "Принадлежит к классу \"%s\".\r\n", weapon_class[skill - 1]);
+    }
+  }
+  if (show_wear) {
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FINGER)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на палец.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_NECK)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на шею.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на туловище.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на голову.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на ноги.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET)) {
+      sprintf(out_str + strlen(out_str), "Можно обуть.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на кисти.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на руки.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на плечи.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WAIST)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на пояс.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_QUIVER)) {
+      sprintf(out_str + strlen(out_str), "Можно использовать как колчан.\r\n");
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WRIST)) {
+      sprintf(out_str + strlen(out_str), "Можно надеть на запястья.\r\n");
+    }
+    if (show_wear > 1) {
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_SHIELD)) {
+        need_str = MAX(0, calc_str_req((GET_OBJ_WEIGHT(obj) + 1) / 2, STR_HOLD_W));
+        sprintf(out_str + strlen(out_str),
+                "Можно использовать как щит (требуется %d %s).\r\n",
+                need_str,
+                desc_count(need_str, WHAT_STR));
+      }
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD)) {
+        need_str = MAX(0, calc_str_req(GET_OBJ_WEIGHT(obj), STR_WIELD_W));
+        sprintf(out_str + strlen(out_str),
+                "Можно взять в правую руку (требуется %d %s).\r\n",
+                need_str,
+                desc_count(need_str, WHAT_STR));
+      }
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD)) {
+        need_str = MAX(0, calc_str_req(GET_OBJ_WEIGHT(obj), STR_HOLD_W));
+        sprintf(out_str + strlen(out_str),
+                "Можно взять в левую руку (требуется %d %s).\r\n",
+                need_str,
+                desc_count(need_str, WHAT_STR));
+      }
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)) {
+        need_str = MAX(0, calc_str_req(GET_OBJ_WEIGHT(obj), STR_BOTH_W));
+        sprintf(out_str + strlen(out_str),
+                "Можно взять в обе руки (требуется %d %s).\r\n",
+                need_str,
+                desc_count(need_str, WHAT_STR));
+      }
+    } else {
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_SHIELD)) {
+        sprintf(out_str + strlen(out_str), "Можно использовать как щит.\r\n");
+      }
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD)) {
+        sprintf(out_str + strlen(out_str), "Можно взять в правую руку.\r\n");
+      }
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD)) {
+        sprintf(out_str + strlen(out_str), "Можно взять в левую руку.\r\n");
+      }
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)) {
+        sprintf(out_str + strlen(out_str), "Можно взять в обе руки.\r\n");
+      }
+    }
+  }
+  return (out_str);
 }
 
 // Чтобы можно было получить только строку состяния
-const char *diag_obj_timer(const OBJ_DATA* obj)
-{
-	int prot_timer;
-	if (GET_OBJ_RNUM(obj) != NOTHING)
-	{
-		if (check_unlimited_timer(obj))
-		{
-			return "нерушимо";
-		}
+const char *diag_obj_timer(const OBJ_DATA *obj) {
+  int prot_timer;
+  if (GET_OBJ_RNUM(obj) != NOTHING) {
+    if (check_unlimited_timer(obj)) {
+      return "нерушимо";
+    }
 
-		if (GET_OBJ_CRAFTIMER(obj) > 0)
-		{
-			prot_timer = GET_OBJ_CRAFTIMER(obj);// если вещь скрафчена, смотрим ее таймер а не у прототипа
-		}
-		else
-		{
-			prot_timer = obj_proto[GET_OBJ_RNUM(obj)]->get_timer();
-		}
+    if (GET_OBJ_CRAFTIMER(obj) > 0) {
+      prot_timer = GET_OBJ_CRAFTIMER(obj);// если вещь скрафчена, смотрим ее таймер а не у прототипа
+    } else {
+      prot_timer = obj_proto[GET_OBJ_RNUM(obj)]->get_timer();
+    }
 
-		if (!prot_timer)
-		{
-			return "Прототип предмета имеет нулевой таймер!\r\n";
-		}
+    if (!prot_timer) {
+      return "Прототип предмета имеет нулевой таймер!\r\n";
+    }
 
-		const int tm = (obj->get_timer() * 100 / prot_timer); // если вещь скрафчена, смотрим ее таймер а не у прототипа
-		return print_obj_state(tm);
-	}
-	return "";
+    const int tm = (obj->get_timer() * 100 / prot_timer); // если вещь скрафчена, смотрим ее таймер а не у прототипа
+    return print_obj_state(tm);
+  }
+  return "";
 }
 
-
-
-char *diag_timer_to_char(const OBJ_DATA* obj)
-{
-	static char out_str[MAX_STRING_LENGTH];
-	*out_str = 0;
-	sprintf(out_str, "Состояние: %s.\r\n", diag_obj_timer(obj));
-	return (out_str);
+char *diag_timer_to_char(const OBJ_DATA *obj) {
+  static char out_str[MAX_STRING_LENGTH];
+  *out_str = 0;
+  sprintf(out_str, "Состояние: %s.\r\n", diag_obj_timer(obj));
+  return (out_str);
 }
 
-char *diag_uses_to_char(OBJ_DATA * obj, CHAR_DATA * ch)
-{
-	static char out_str[MAX_STRING_LENGTH];
+char *diag_uses_to_char(OBJ_DATA *obj, CHAR_DATA *ch) {
+  static char out_str[MAX_STRING_LENGTH];
 
-	*out_str = 0;
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT
-		&& IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_USES)
-		&& GET_CLASS(ch) == CLASS_DRUID)
-	{
-		int i = -1;
-		if ((i = real_object(GET_OBJ_VAL(obj, 1))) >= 0)
-		{
-			sprintf(out_str, "Прототип: %s%s%s.\r\n",
-				CCICYN(ch, C_NRM), obj_proto[i]->get_PName(0).c_str(), CCNRM(ch, C_NRM));
-		}
-		sprintf(out_str + strlen(out_str), "Осталось применений: %s%d&n.\r\n",
-			GET_OBJ_VAL(obj, 2) > 100 ? "&G" : "&R", GET_OBJ_VAL(obj, 2));
-	}
-	return (out_str);
+  *out_str = 0;
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT
+      && IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_USES)
+      && GET_CLASS(ch) == CLASS_DRUID) {
+    int i = -1;
+    if ((i = real_object(GET_OBJ_VAL(obj, 1))) >= 0) {
+      sprintf(out_str, "Прототип: %s%s%s.\r\n",
+              CCICYN(ch, C_NRM), obj_proto[i]->get_PName(0).c_str(), CCNRM(ch, C_NRM));
+    }
+    sprintf(out_str + strlen(out_str), "Осталось применений: %s%d&n.\r\n",
+            GET_OBJ_VAL(obj, 2) > 100 ? "&G" : "&R", GET_OBJ_VAL(obj, 2));
+  }
+  return (out_str);
 }
 
-char *diag_shot_to_char(OBJ_DATA * obj, CHAR_DATA * ch)
-{
-	static char out_str[MAX_STRING_LENGTH];
+char *diag_shot_to_char(OBJ_DATA *obj, CHAR_DATA *ch) {
+  static char out_str[MAX_STRING_LENGTH];
 
-	*out_str = 0;
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_MAGIC_CONTAINER
-		&& (GET_CLASS(ch) == CLASS_RANGER||GET_CLASS(ch) == CLASS_CHARMMAGE||GET_CLASS(ch) == CLASS_DRUID))
-	{
-		sprintf(out_str + strlen(out_str), "Осталось стрел: %s%d&n.\r\n",
-			GET_OBJ_VAL(obj, 2) > 3 ? "&G" : "&R", GET_OBJ_VAL(obj, 2));
-	}
-	return (out_str);
+  *out_str = 0;
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_MAGIC_CONTAINER
+      && (GET_CLASS(ch) == CLASS_RANGER || GET_CLASS(ch) == CLASS_CHARMMAGE || GET_CLASS(ch) == CLASS_DRUID)) {
+    sprintf(out_str + strlen(out_str), "Осталось стрел: %s%d&n.\r\n",
+            GET_OBJ_VAL(obj, 2) > 3 ? "&G" : "&R", GET_OBJ_VAL(obj, 2));
+  }
+  return (out_str);
 }
 
 /**
 * При чтении писем и осмотре чара в его описании подставляем в начало каждой строки пробел
 * (для дурных тригов), пользуясь случаем передаю привет проне!
 */
-std::string space_before_string(char const *text)
-{
-	if (text)
-	{
-		std::string tmp(" ");
-		tmp += text;
-		boost::replace_all(tmp, "\n", "\n ");
-		boost::trim_right_if(tmp, boost::is_any_of(std::string(" ")));
-		return tmp;
-	}
-	return "";
+std::string space_before_string(char const *text) {
+  if (text) {
+    std::string tmp(" ");
+    tmp += text;
+    boost::replace_all(tmp, "\n", "\n ");
+    boost::trim_right_if(tmp, boost::is_any_of(std::string(" ")));
+    return tmp;
+  }
+  return "";
 }
 
-std::string space_before_string(std::string text)
-{
-	if (text != "")
-	{
-		std::string tmp(" ");
-		tmp += text;
-		boost::replace_all(tmp, "\n", "\n ");
-		boost::trim_right_if(tmp, boost::is_any_of(std::string(" ")));
-		return tmp;
-	}
-	return "";
+std::string space_before_string(std::string text) {
+  if (text != "") {
+    std::string tmp(" ");
+    tmp += text;
+    boost::replace_all(tmp, "\n", "\n ");
+    boost::trim_right_if(tmp, boost::is_any_of(std::string(" ")));
+    return tmp;
+  }
+  return "";
 }
 
+namespace {
 
-namespace
-{
-
-std::string diag_armor_type_to_char(const OBJ_DATA *obj)
-{
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_ARMOR_LIGHT)
-	{
-		return "Легкий тип доспехов.\r\n";
-	}
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_ARMOR_MEDIAN)
-	{
-		return "Средний тип доспехов.\r\n";
-	}
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_ARMOR_HEAVY)
-	{
-		return "Тяжелый тип доспехов.\r\n";
-	}
-	return "";
+std::string diag_armor_type_to_char(const OBJ_DATA *obj) {
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_ARMOR_LIGHT) {
+    return "Легкий тип доспехов.\r\n";
+  }
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_ARMOR_MEDIAN) {
+    return "Средний тип доспехов.\r\n";
+  }
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_ARMOR_HEAVY) {
+    return "Тяжелый тип доспехов.\r\n";
+  }
+  return "";
 }
 
 } // namespace
 
 // для использования с чарами:
 // возвращает метки предмета, если они есть и смотрящий является их автором или является членом соотв. клана
-std::string char_get_custom_label(OBJ_DATA *obj, CHAR_DATA *ch)
-{
-	const char *delim_l = NULL;
-	const char *delim_r = NULL;
+std::string char_get_custom_label(OBJ_DATA *obj, CHAR_DATA *ch) {
+  const char *delim_l = NULL;
+  const char *delim_r = NULL;
 
-	// разные скобки для клановых и личных
-	if (obj->get_custom_label() && (ch->player_specials->clan && obj->get_custom_label()->clan != NULL &&
-	    !strcmp(obj->get_custom_label()->clan, ch->player_specials->clan->GetAbbrev())))
-	{
-		delim_l = " *";
-		delim_r = "*";
-	} else {
-		delim_l = " (";
-		delim_r = ")";
-	}
+  // разные скобки для клановых и личных
+  if (obj->get_custom_label() && (ch->player_specials->clan && obj->get_custom_label()->clan != NULL &&
+      !strcmp(obj->get_custom_label()->clan, ch->player_specials->clan->GetAbbrev()))) {
+    delim_l = " *";
+    delim_r = "*";
+  } else {
+    delim_l = " (";
+    delim_r = ")";
+  }
 
-	if (AUTH_CUSTOM_LABEL(obj, ch))
-	{
-		return boost::str(boost::format("%s%s%s") % delim_l % obj->get_custom_label()->label_text % delim_r);
-	}
+  if (AUTH_CUSTOM_LABEL(obj, ch)) {
+    return boost::str(boost::format("%s%s%s") % delim_l % obj->get_custom_label()->label_text % delim_r);
+  }
 
-	return "";
+  return "";
 }
 
 // mode 1 show_state 3 для хранилище (4 - хранилище ингров)
-const char *show_obj_to_char(OBJ_DATA * object, CHAR_DATA * ch, int mode, int show_state, int how)
-{
-	*buf = '\0';
-	if ((mode < 5) && PRF_FLAGGED(ch, PRF_ROOMFLAGS))
-		sprintf(buf, "[%5d] ", GET_OBJ_VNUM(object));
+const char *show_obj_to_char(OBJ_DATA *object, CHAR_DATA *ch, int mode, int show_state, int how) {
+  *buf = '\0';
+  if ((mode < 5) && PRF_FLAGGED(ch, PRF_ROOMFLAGS))
+    sprintf(buf, "[%5d] ", GET_OBJ_VNUM(object));
 
-	if (mode == 0
-		&& !object->get_description().empty())
-	{
-		strcat(buf, object->get_description().c_str());
-		strcat(buf, char_get_custom_label(object, ch).c_str());
-	}
-	else if (!object->get_short_description().empty() && ((mode == 1) || (mode == 2) || (mode == 3) || (mode == 4)))
-	{
-		strcat(buf, object->get_short_description().c_str());
-		strcat(buf, char_get_custom_label(object, ch).c_str());
-	}
-	else if (mode == 5)
-	{
-		if (GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_NOTE)
-		{
-			if (!object->get_action_description().empty())
-			{
-				strcpy(buf, "Вы прочитали следующее :\r\n\r\n");
-				strcat(buf, space_before_string(object->get_action_description().c_str()).c_str());
-				page_string(ch->desc, buf, 1);
-			}
-			else
-			{
-				send_to_char("Чисто.\r\n", ch);
-			}
-			return 0;
-		}
-		else if (GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_BANDAGE)
-		{
-			strcpy(buf, "Бинты для перевязки ран ('перевязать').\r\n");
-			snprintf(buf2, MAX_STRING_LENGTH, "Осталось применений: %d, восстановление: %d",
-				GET_OBJ_WEIGHT(object), GET_OBJ_VAL(object, 0) * 10);
-			strcat(buf, buf2);
-		}
-		else if (GET_OBJ_TYPE(object) != OBJ_DATA::ITEM_DRINKCON)
-		{
-			strcpy(buf, "Вы не видите ничего необычного.");
-		}
-		else		// ITEM_TYPE == ITEM_DRINKCON||FOUNTAIN
-		{
-			strcpy(buf, "Это емкость для жидкости.");
-		}
-	}
+  if (mode == 0
+      && !object->get_description().empty()) {
+    strcat(buf, object->get_description().c_str());
+    strcat(buf, char_get_custom_label(object, ch).c_str());
+  } else if (!object->get_short_description().empty() && ((mode == 1) || (mode == 2) || (mode == 3) || (mode == 4))) {
+    strcat(buf, object->get_short_description().c_str());
+    strcat(buf, char_get_custom_label(object, ch).c_str());
+  } else if (mode == 5) {
+    if (GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_NOTE) {
+      if (!object->get_action_description().empty()) {
+        strcpy(buf, "Вы прочитали следующее :\r\n\r\n");
+        strcat(buf, space_before_string(object->get_action_description().c_str()).c_str());
+        page_string(ch->desc, buf, 1);
+      } else {
+        send_to_char("Чисто.\r\n", ch);
+      }
+      return 0;
+    } else if (GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_BANDAGE) {
+      strcpy(buf, "Бинты для перевязки ран ('перевязать').\r\n");
+      snprintf(buf2, MAX_STRING_LENGTH, "Осталось применений: %d, восстановление: %d",
+               GET_OBJ_WEIGHT(object), GET_OBJ_VAL(object, 0) * 10);
+      strcat(buf, buf2);
+    } else if (GET_OBJ_TYPE(object) != OBJ_DATA::ITEM_DRINKCON) {
+      strcpy(buf, "Вы не видите ничего необычного.");
+    } else        // ITEM_TYPE == ITEM_DRINKCON||FOUNTAIN
+    {
+      strcpy(buf, "Это емкость для жидкости.");
+    }
+  }
 
-	if (show_state && show_state != 3 && show_state != 4)
-	{
-		*buf2 = '\0';
-		if (mode == 1 && how <= 1)
-		{
-			if (GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_LIGHT)
-			{
-				if (GET_OBJ_VAL(object, 2) == -1)
-					strcpy(buf2, " (вечный свет)");
-				else if (GET_OBJ_VAL(object, 2) == 0)
-					sprintf(buf2, " (погас%s)", GET_OBJ_SUF_4(object));
-				else
-					sprintf(buf2, " (%d %s)",
-							GET_OBJ_VAL(object, 2), desc_count(GET_OBJ_VAL(object, 2), WHAT_HOUR));
-			}
-			else
-			{
-				if (object->timed_spell().is_spell_poisoned() != -1)
-				{
-					sprintf(buf2, " %s*%s%s", CCGRN(ch, C_NRM),
-						CCNRM(ch, C_NRM), diag_obj_to_char(ch, object, 1));
-				}
-				else
-				{
-					sprintf(buf2, " %s", diag_obj_to_char(ch, object, 1));
-				}
-			}
-			if ((GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_CONTAINER) && !OBJVAL_FLAGGED(object, CONT_CLOSED)) // если закрыто, содержимое не показываем
-			{
-				if (object->get_contains())
-				{
-					strcat(buf2, " (есть содержимое)");
-				}
-				else
-				{
-					if (GET_OBJ_VAL(object, 3) < 1) // есть ключ для открытия, пустоту не показываем2
-						sprintf(buf2 + strlen(buf2), " (пуст%s)", GET_OBJ_SUF_6(object));
-				}
-			}
-		}
-		else if (mode >= 2 && how <= 1)
-		{
-			std::string obj_name = OBJN(object, ch, 0);
-			obj_name[0] = UPPER(obj_name[0]);
-			if (GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_LIGHT)
-			{
-				if (GET_OBJ_VAL(object, 2) == -1)
-				{
-					sprintf(buf2, "\r\n%s дает вечный свет.", obj_name.c_str());
-				}
-				else if (GET_OBJ_VAL(object, 2) == 0)
-				{
-					sprintf(buf2, "\r\n%s погас%s.", obj_name.c_str(), GET_OBJ_SUF_4(object));
-				}
-				else
-				{
-					sprintf(buf2, "\r\n%s будет светить %d %s.", obj_name.c_str(), GET_OBJ_VAL(object, 2),
-						desc_count(GET_OBJ_VAL(object, 2), WHAT_HOUR));
-				}
-			}
-			else if (GET_OBJ_CUR(object) < GET_OBJ_MAX(object))
-			{
-				sprintf(buf2, "\r\n%s %s.", obj_name.c_str(), diag_obj_to_char(ch, object, 2));
-			}
-		}
-		strcat(buf, buf2);
-	}
-	if (how > 1)
-	{
-		sprintf(buf + strlen(buf), " [%d]", how);
-	}
-	if (mode != 3 && how <= 1)
-	{
-		if (object->get_extra_flag(EExtraFlag::ITEM_INVISIBLE))
-		{
-			sprintf(buf2, " (невидим%s)", GET_OBJ_SUF_6(object));
-			strcat(buf, buf2);
-		}
-		if (object->get_extra_flag(EExtraFlag::ITEM_BLESS)
-				&& AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN))
-			strcat(buf, " ..голубая аура!");
-		if (object->get_extra_flag(EExtraFlag::ITEM_MAGIC)
-				&& AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC))
-			strcat(buf, " ..желтая аура!");
-		if (object->get_extra_flag(EExtraFlag::ITEM_POISONED)
-				&& AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_POISON))
-		{
-			sprintf(buf2, "..отравлен%s!", GET_OBJ_SUF_6(object));
-			strcat(buf, buf2);
-		}
-		if (object->get_extra_flag(EExtraFlag::ITEM_GLOW))
-			strcat(buf, " ..блестит!");
-		if (object->get_extra_flag(EExtraFlag::ITEM_HUM) && !AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
-			strcat(buf, " ..шумит!");
-		if (object->get_extra_flag(EExtraFlag::ITEM_FIRE))
-			strcat(buf, " ..горит!");
-		if (object->get_extra_flag(EExtraFlag::ITEM_BLOODY))
-		{
-			sprintf(buf2, " %s..покрыт%s кровью!%s", CCIRED(ch, C_NRM), GET_OBJ_SUF_6(object), CCNRM(ch, C_NRM));
-			strcat(buf, buf2);
-		}
-	}
+  if (show_state && show_state != 3 && show_state != 4) {
+    *buf2 = '\0';
+    if (mode == 1 && how <= 1) {
+      if (GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_LIGHT) {
+        if (GET_OBJ_VAL(object, 2) == -1)
+          strcpy(buf2, " (вечный свет)");
+        else if (GET_OBJ_VAL(object, 2) == 0)
+          sprintf(buf2, " (погас%s)", GET_OBJ_SUF_4(object));
+        else
+          sprintf(buf2, " (%d %s)",
+                  GET_OBJ_VAL(object, 2), desc_count(GET_OBJ_VAL(object, 2), WHAT_HOUR));
+      } else {
+        if (object->timed_spell().is_spell_poisoned() != -1) {
+          sprintf(buf2, " %s*%s%s", CCGRN(ch, C_NRM),
+                  CCNRM(ch, C_NRM), diag_obj_to_char(ch, object, 1));
+        } else {
+          sprintf(buf2, " %s", diag_obj_to_char(ch, object, 1));
+        }
+      }
+      if ((GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_CONTAINER)
+          && !OBJVAL_FLAGGED(object, CONT_CLOSED)) // если закрыто, содержимое не показываем
+      {
+        if (object->get_contains()) {
+          strcat(buf2, " (есть содержимое)");
+        } else {
+          if (GET_OBJ_VAL(object, 3) < 1) // есть ключ для открытия, пустоту не показываем2
+            sprintf(buf2 + strlen(buf2), " (пуст%s)", GET_OBJ_SUF_6(object));
+        }
+      }
+    } else if (mode >= 2 && how <= 1) {
+      std::string obj_name = OBJN(object, ch, 0);
+      obj_name[0] = UPPER(obj_name[0]);
+      if (GET_OBJ_TYPE(object) == OBJ_DATA::ITEM_LIGHT) {
+        if (GET_OBJ_VAL(object, 2) == -1) {
+          sprintf(buf2, "\r\n%s дает вечный свет.", obj_name.c_str());
+        } else if (GET_OBJ_VAL(object, 2) == 0) {
+          sprintf(buf2, "\r\n%s погас%s.", obj_name.c_str(), GET_OBJ_SUF_4(object));
+        } else {
+          sprintf(buf2, "\r\n%s будет светить %d %s.", obj_name.c_str(), GET_OBJ_VAL(object, 2),
+                  desc_count(GET_OBJ_VAL(object, 2), WHAT_HOUR));
+        }
+      } else if (GET_OBJ_CUR(object) < GET_OBJ_MAX(object)) {
+        sprintf(buf2, "\r\n%s %s.", obj_name.c_str(), diag_obj_to_char(ch, object, 2));
+      }
+    }
+    strcat(buf, buf2);
+  }
+  if (how > 1) {
+    sprintf(buf + strlen(buf), " [%d]", how);
+  }
+  if (mode != 3 && how <= 1) {
+    if (object->get_extra_flag(EExtraFlag::ITEM_INVISIBLE)) {
+      sprintf(buf2, " (невидим%s)", GET_OBJ_SUF_6(object));
+      strcat(buf, buf2);
+    }
+    if (object->get_extra_flag(EExtraFlag::ITEM_BLESS)
+        && AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN))
+      strcat(buf, " ..голубая аура!");
+    if (object->get_extra_flag(EExtraFlag::ITEM_MAGIC)
+        && AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC))
+      strcat(buf, " ..желтая аура!");
+    if (object->get_extra_flag(EExtraFlag::ITEM_POISONED)
+        && AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_POISON)) {
+      sprintf(buf2, "..отравлен%s!", GET_OBJ_SUF_6(object));
+      strcat(buf, buf2);
+    }
+    if (object->get_extra_flag(EExtraFlag::ITEM_GLOW))
+      strcat(buf, " ..блестит!");
+    if (object->get_extra_flag(EExtraFlag::ITEM_HUM) && !AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
+      strcat(buf, " ..шумит!");
+    if (object->get_extra_flag(EExtraFlag::ITEM_FIRE))
+      strcat(buf, " ..горит!");
+    if (object->get_extra_flag(EExtraFlag::ITEM_BLOODY)) {
+      sprintf(buf2, " %s..покрыт%s кровью!%s", CCIRED(ch, C_NRM), GET_OBJ_SUF_6(object), CCNRM(ch, C_NRM));
+      strcat(buf, buf2);
+    }
+  }
 
-	if (mode == 1)
-	{
-		// клан-сундук, выводим список разом постранично
-		if (show_state == 3)
-		{
-			sprintf(buf + strlen(buf), " [%d %s]\r\n",
-					GET_OBJ_RENTEQ(object) * CLAN_STOREHOUSE_COEFF / 100,
-					desc_count(GET_OBJ_RENTEQ(object) * CLAN_STOREHOUSE_COEFF / 100, WHAT_MONEYa));
-			return buf;
-		}
-		// ингры
-		else if (show_state == 4)
-		{
-			sprintf(buf + strlen(buf), " [%d %s]\r\n", GET_OBJ_RENT(object),
-					desc_count(GET_OBJ_RENT(object), WHAT_MONEYa));
-			return buf;
-		}
-	}
+  if (mode == 1) {
+    // клан-сундук, выводим список разом постранично
+    if (show_state == 3) {
+      sprintf(buf + strlen(buf), " [%d %s]\r\n",
+              GET_OBJ_RENTEQ(object) * CLAN_STOREHOUSE_COEFF / 100,
+              desc_count(GET_OBJ_RENTEQ(object) * CLAN_STOREHOUSE_COEFF / 100, WHAT_MONEYa));
+      return buf;
+    }
+      // ингры
+    else if (show_state == 4) {
+      sprintf(buf + strlen(buf), " [%d %s]\r\n", GET_OBJ_RENT(object),
+              desc_count(GET_OBJ_RENT(object), WHAT_MONEYa));
+      return buf;
+    }
+  }
 
-	strcat(buf, "\r\n");
-	if (mode >= 5)
-	{
-		strcat(buf, diag_weapon_to_char(object, TRUE));
-		strcat(buf, diag_armor_type_to_char(object).c_str());
-		strcat(buf, diag_timer_to_char(object));
-		//strcat(buf, diag_uses_to_char(object, ch)); // commented by WorM перенес в obj_info чтобы заряды рун было видно на базаре/ауке
-		strcat(buf, object->diag_ts_to_char(ch).c_str());
-	}
-	page_string(ch->desc, buf, TRUE);
-	return 0;
+  strcat(buf, "\r\n");
+  if (mode >= 5) {
+    strcat(buf, diag_weapon_to_char(object, TRUE));
+    strcat(buf, diag_armor_type_to_char(object).c_str());
+    strcat(buf, diag_timer_to_char(object));
+    //strcat(buf, diag_uses_to_char(object, ch)); // commented by WorM перенес в obj_info чтобы заряды рун было видно на базаре/ауке
+    strcat(buf, object->diag_ts_to_char(ch).c_str());
+  }
+  page_string(ch->desc, buf, TRUE);
+  return 0;
 }
 
-void do_cities(CHAR_DATA *ch, char*, int, int)
-{
-	send_to_char("Города на Руси:\r\n", ch);
-	for (unsigned int i = 0; i < cities.size(); i++)
-	{
-		sprintf(buf, "%3d.", i + 1);
-		if (IS_IMMORTAL(ch))
-		{
-			sprintf(buf1, " [VNUM: %d]", cities[i].rent_vnum);
-			strcat(buf, buf1);
-		}
-		sprintf(buf1, " %s: %s\r\n", cities[i].name.c_str(), (ch->check_city(i) ? "&gВы были там.&n" : "&rВы еще не были там.&n"));
-		strcat(buf, buf1);
-		send_to_char(buf, ch);
-	}
+void do_cities(CHAR_DATA *ch, char *, int, int) {
+  send_to_char("Города на Руси:\r\n", ch);
+  for (unsigned int i = 0; i < cities.size(); i++) {
+    sprintf(buf, "%3d.", i + 1);
+    if (IS_IMMORTAL(ch)) {
+      sprintf(buf1, " [VNUM: %d]", cities[i].rent_vnum);
+      strcat(buf, buf1);
+    }
+    sprintf(buf1,
+            " %s: %s\r\n",
+            cities[i].name.c_str(),
+            (ch->check_city(i) ? "&gВы были там.&n" : "&rВы еще не были там.&n"));
+    strcat(buf, buf1);
+    send_to_char(buf, ch);
+  }
 }
 
-
-bool quest_item(OBJ_DATA *obj)
-{
-	if ((OBJ_FLAGGED(obj, EExtraFlag::ITEM_NODECAY)) && (!(CAN_WEAR(obj, EWearFlag::ITEM_WEAR_TAKE))))
-	{
-		return true;
-	}
-	return false;
+bool quest_item(OBJ_DATA *obj) {
+  if ((OBJ_FLAGGED(obj, EExtraFlag::ITEM_NODECAY)) && (!(CAN_WEAR(obj, EWearFlag::ITEM_WEAR_TAKE)))) {
+    return true;
+  }
+  return false;
 }
 
-void list_obj_to_char(OBJ_DATA * list, CHAR_DATA * ch, int mode, int show)
-{
-	OBJ_DATA *i, *push = NULL;
-	bool found = FALSE;
-	int push_count = 0;
-	std::ostringstream buffer;
-	long count = 0, cost = 0;
+void list_obj_to_char(OBJ_DATA *list, CHAR_DATA *ch, int mode, int show) {
+  OBJ_DATA *i, *push = NULL;
+  bool found = FALSE;
+  int push_count = 0;
+  std::ostringstream buffer;
+  long count = 0, cost = 0;
 
-	bool clan_chest = false;
-	if (mode == 1 && (show == 3 || show == 4))
-	{
-		clan_chest = true;
-	}
+  bool clan_chest = false;
+  if (mode == 1 && (show == 3 || show == 4)) {
+    clan_chest = true;
+  }
 
-	for (i = list; i; i = i->get_next_content())
-	{
-		if (CAN_SEE_OBJ(ch, i))
-		{
-			if (!push)
-			{
-				push = i;
-				push_count = 1;
-			}
-			else if ((!equal_obj(i, push))
-				|| (quest_item(i)))
-			{
-				if (clan_chest)
-				{
-					buffer << show_obj_to_char(push, ch, mode, show, push_count);
-					count += push_count;
-					cost += GET_OBJ_RENTEQ(push) * push_count;
-				}
-				else
-					show_obj_to_char(push, ch, mode, show, push_count);
-				push = i;
-				push_count = 1;
-			}
-			else
-				push_count++;
-			found = TRUE;
-		}
-	}
-	if (push && push_count)
-	{
-		if (clan_chest)
-		{
-			buffer << show_obj_to_char(push, ch, mode, show, push_count);
-			count += push_count;
-			cost += GET_OBJ_RENTEQ(push) * push_count;
-		}
-		else
-			show_obj_to_char(push, ch, mode, show, push_count);
-	}
-	if (!found && show)
-	{
-		if (show == 1)
-			send_to_char(" Внутри ничего нет.\r\n", ch);
-		else if (show == 2)
-			send_to_char(" Вы ничего не несете.\r\n", ch);
-		else if (show == 3)
-		{
-			send_to_char(" Пусто...\r\n", ch);
-			return;
-		}
-	}
-	if (clan_chest)
-		page_string(ch->desc, buffer.str());
+  for (i = list; i; i = i->get_next_content()) {
+    if (CAN_SEE_OBJ(ch, i)) {
+      if (!push) {
+        push = i;
+        push_count = 1;
+      } else if ((!equal_obj(i, push))
+          || (quest_item(i))) {
+        if (clan_chest) {
+          buffer << show_obj_to_char(push, ch, mode, show, push_count);
+          count += push_count;
+          cost += GET_OBJ_RENTEQ(push) * push_count;
+        } else
+          show_obj_to_char(push, ch, mode, show, push_count);
+        push = i;
+        push_count = 1;
+      } else
+        push_count++;
+      found = TRUE;
+    }
+  }
+  if (push && push_count) {
+    if (clan_chest) {
+      buffer << show_obj_to_char(push, ch, mode, show, push_count);
+      count += push_count;
+      cost += GET_OBJ_RENTEQ(push) * push_count;
+    } else
+      show_obj_to_char(push, ch, mode, show, push_count);
+  }
+  if (!found && show) {
+    if (show == 1)
+      send_to_char(" Внутри ничего нет.\r\n", ch);
+    else if (show == 2)
+      send_to_char(" Вы ничего не несете.\r\n", ch);
+    else if (show == 3) {
+      send_to_char(" Пусто...\r\n", ch);
+      return;
+    }
+  }
+  if (clan_chest)
+    page_string(ch->desc, buffer.str());
 }
 
-void diag_char_to_char(CHAR_DATA * i, CHAR_DATA * ch)
-{
-	int percent;
+void diag_char_to_char(CHAR_DATA *i, CHAR_DATA *ch) {
+  int percent;
 
-	if (GET_REAL_MAX_HIT(i) > 0)
-		percent = (100 * GET_HIT(i)) / GET_REAL_MAX_HIT(i);
-	else
-		percent = -1;	// How could MAX_HIT be < 1??
+  if (GET_REAL_MAX_HIT(i) > 0)
+    percent = (100 * GET_HIT(i)) / GET_REAL_MAX_HIT(i);
+  else
+    percent = -1;    // How could MAX_HIT be < 1??
 
-	strcpy(buf, PERS(i, ch, 0));
-	CAP(buf);
+  strcpy(buf, PERS(i, ch, 0));
+  CAP(buf);
 
-	if (percent >= 100)
-	{
-		sprintf(buf2, " невредим%s", GET_CH_SUF_6(i));
-		strcat(buf, buf2);
-	}
-	else if (percent >= 90)
-	{
-		sprintf(buf2, " слегка поцарапан%s", GET_CH_SUF_6(i));
-		strcat(buf, buf2);
-	}
-	else if (percent >= 75)
-	{
-		sprintf(buf2, " легко ранен%s", GET_CH_SUF_6(i));
-		strcat(buf, buf2);
-	}
-	else if (percent >= 50)
-	{
-		sprintf(buf2, " ранен%s", GET_CH_SUF_6(i));
-		strcat(buf, buf2);
-	}
-	else if (percent >= 30)
-	{
-		sprintf(buf2, " тяжело ранен%s", GET_CH_SUF_6(i));
-		strcat(buf, buf2);
-	}
-	else if (percent >= 15)
-	{
-		sprintf(buf2, " смертельно ранен%s", GET_CH_SUF_6(i));
-		strcat(buf, buf2);
-	}
-	else if (percent >= 0)
-		strcat(buf, " в ужасном состоянии");
-	else
-		strcat(buf, " умирает");
+  if (percent >= 100) {
+    sprintf(buf2, " невредим%s", GET_CH_SUF_6(i));
+    strcat(buf, buf2);
+  } else if (percent >= 90) {
+    sprintf(buf2, " слегка поцарапан%s", GET_CH_SUF_6(i));
+    strcat(buf, buf2);
+  } else if (percent >= 75) {
+    sprintf(buf2, " легко ранен%s", GET_CH_SUF_6(i));
+    strcat(buf, buf2);
+  } else if (percent >= 50) {
+    sprintf(buf2, " ранен%s", GET_CH_SUF_6(i));
+    strcat(buf, buf2);
+  } else if (percent >= 30) {
+    sprintf(buf2, " тяжело ранен%s", GET_CH_SUF_6(i));
+    strcat(buf, buf2);
+  } else if (percent >= 15) {
+    sprintf(buf2, " смертельно ранен%s", GET_CH_SUF_6(i));
+    strcat(buf, buf2);
+  } else if (percent >= 0)
+    strcat(buf, " в ужасном состоянии");
+  else
+    strcat(buf, " умирает");
 
-	if (!i->ahorse())
-		switch (GET_POS(i))
-			{
-			case POS_MORTALLYW:
-				strcat(buf, ".");
-			break;
-			case POS_INCAP:
-				strcat(buf, IS_POLY(i) ? ", лежат без сознания." : ", лежит без сознания.");
-			break;
-			case POS_STUNNED:
-				strcat(buf, IS_POLY(i) ? ", лежат в обмороке." : ", лежит в обмороке.");
-			break;
-			case POS_SLEEPING:
-				strcat(buf, IS_POLY(i) ? ", спят." : ", спит.");
-			break;
-			case POS_RESTING:
-				strcat(buf, IS_POLY(i) ? ", отдыхают." : ", отдыхает.");
-			break;
-			case POS_SITTING:
-				strcat(buf, IS_POLY(i) ? ", сидят." : ", сидит.");
-			break;
-			case POS_STANDING:
-				strcat(buf, IS_POLY(i) ? ", стоят." : ", стоит.");
-			break;
-			case POS_FIGHTING:
-				if (i->get_fighting())
-					strcat(buf, IS_POLY(i) ? ", сражаются." : ", сражается.");
-				else
-					strcat(buf, IS_POLY(i) ? ", махают кулаками." : ", махает кулаками.");
-			break;
-			default:
-				return;
-			break;
-		}
-	else
-		strcat(buf, IS_POLY(i) ? ", сидят верхом." : ", сидит верхом.");
+  if (!i->ahorse())
+    switch (GET_POS(i)) {
+      case POS_MORTALLYW: strcat(buf, ".");
+        break;
+      case POS_INCAP: strcat(buf, IS_POLY(i) ? ", лежат без сознания." : ", лежит без сознания.");
+        break;
+      case POS_STUNNED: strcat(buf, IS_POLY(i) ? ", лежат в обмороке." : ", лежит в обмороке.");
+        break;
+      case POS_SLEEPING: strcat(buf, IS_POLY(i) ? ", спят." : ", спит.");
+        break;
+      case POS_RESTING: strcat(buf, IS_POLY(i) ? ", отдыхают." : ", отдыхает.");
+        break;
+      case POS_SITTING: strcat(buf, IS_POLY(i) ? ", сидят." : ", сидит.");
+        break;
+      case POS_STANDING: strcat(buf, IS_POLY(i) ? ", стоят." : ", стоит.");
+        break;
+      case POS_FIGHTING:
+        if (i->get_fighting())
+          strcat(buf, IS_POLY(i) ? ", сражаются." : ", сражается.");
+        else
+          strcat(buf, IS_POLY(i) ? ", махают кулаками." : ", махает кулаками.");
+        break;
+      default: return;
+        break;
+    }
+  else
+    strcat(buf, IS_POLY(i) ? ", сидят верхом." : ", сидит верхом.");
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_POISON))
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_POISON))
-		{
-			sprintf(buf2, " (отравлен%s)", GET_CH_SUF_6(i));
-			strcat(buf, buf2);
-		}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_POISON))
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_POISON)) {
+      sprintf(buf2, " (отравлен%s)", GET_CH_SUF_6(i));
+      strcat(buf, buf2);
+    }
 
-	strcat(buf, "\r\n");
-	send_to_char(buf, ch);
+  strcat(buf, "\r\n");
+  send_to_char(buf, ch);
 
 }
 
+void look_at_char(CHAR_DATA *i, CHAR_DATA *ch) {
+  int j, found, push_count = 0;
+  OBJ_DATA *tmp_obj, *push = NULL;
 
-void look_at_char(CHAR_DATA * i, CHAR_DATA * ch)
-{
-	int j, found, push_count = 0;
-	OBJ_DATA *tmp_obj, *push = NULL;
+  if (!ch->desc)
+    return;
 
-	if (!ch->desc)
-		return;
+  if (i->player_data.description != "") {
+    if (IS_NPC(i))
+      send_to_char(ch, " * %s", i->player_data.description.c_str());
+    else
+      send_to_char(ch, "*\r\n%s*\r\n", space_before_string(i->player_data.description).c_str());
+  } else if (!IS_NPC(i)) {
+    strcpy(buf, "\r\nЭто");
+    if (i->is_morphed())
+      strcat(buf, string(" " + i->get_morph_desc() + ".\r\n").c_str());
+    else if (IS_FEMALE(i)) {
+      if (GET_HEIGHT(i) <= 151) {
+        if (GET_WEIGHT(i) >= 140)
+          strcat(buf, " маленькая плотная дамочка.\r\n");
+        else if (GET_WEIGHT(i) >= 125)
+          strcat(buf, " маленькая женщина.\r\n");
+        else
+          strcat(buf, " миниатюрная дамочка.\r\n");
+      } else if (GET_HEIGHT(i) <= 159) {
+        if (GET_WEIGHT(i) >= 145)
+          strcat(buf, " невысокая плотная мадам.\r\n");
+        else if (GET_WEIGHT(i) >= 130)
+          strcat(buf, " невысокая женщина.\r\n");
+        else
+          strcat(buf, " изящная леди.\r\n");
+      } else if (GET_HEIGHT(i) <= 165) {
+        if (GET_WEIGHT(i) >= 145)
+          strcat(buf, " среднего роста женщина.\r\n");
+        else
+          strcat(buf, " среднего роста изящная красавица.\r\n");
+      } else if (GET_HEIGHT(i) <= 175) {
+        if (GET_WEIGHT(i) >= 150)
+          strcat(buf, " высокая дородная баба.\r\n");
+        else if (GET_WEIGHT(i) >= 135)
+          strcat(buf, " высокая стройная женщина.\r\n");
+        else
+          strcat(buf, " высокая изящная женщина.\r\n");
+      } else {
+        if (GET_WEIGHT(i) >= 155)
+          strcat(buf, " очень высокая крупная дама.\r\n");
+        else if (GET_WEIGHT(i) >= 140)
+          strcat(buf, " очень высокая стройная женщина.\r\n");
+        else
+          strcat(buf, " очень высокая худощавая женщина.\r\n");
+      }
+    } else {
+      if (GET_HEIGHT(i) <= 165) {
+        if (GET_WEIGHT(i) >= 170)
+          strcat(buf, " маленький, похожий на колобок, мужчина.\r\n");
+        else if (GET_WEIGHT(i) >= 150)
+          strcat(buf, " маленький плотный мужчина.\r\n");
+        else
+          strcat(buf, " маленький плюгавенький мужичонка.\r\n");
+      } else if (GET_HEIGHT(i) <= 175) {
+        if (GET_WEIGHT(i) >= 175)
+          strcat(buf, " невысокий коренастый крепыш.\r\n");
+        else if (GET_WEIGHT(i) >= 160)
+          strcat(buf, " невысокий крепкий мужчина.\r\n");
+        else
+          strcat(buf, " невысокий худощавый мужчина.\r\n");
+      } else if (GET_HEIGHT(i) <= 185) {
+        if (GET_WEIGHT(i) >= 180)
+          strcat(buf, " среднего роста коренастый мужчина.\r\n");
+        else if (GET_WEIGHT(i) >= 165)
+          strcat(buf, " среднего роста крепкий мужчина.\r\n");
+        else
+          strcat(buf, " среднего роста худощавый мужчина.\r\n");
+      } else if (GET_HEIGHT(i) <= 195) {
+        if (GET_WEIGHT(i) >= 185)
+          strcat(buf, " высокий крупный мужчина.\r\n");
+        else if (GET_WEIGHT(i) >= 170)
+          strcat(buf, " высокий стройный мужчина.\r\n");
+        else
+          strcat(buf, " длинный, худощавый мужчина.\r\n");
+      } else {
+        if (GET_WEIGHT(i) >= 190)
+          strcat(buf, " огромный мужик.\r\n");
+        else if (GET_WEIGHT(i) >= 180)
+          strcat(buf, " очень высокий, крупный амбал.\r\n");
+        else
+          strcat(buf, " длиннющий, похожий на жердь мужчина.\r\n");
+      }
+    }
+    send_to_char(buf, ch);
+  } else
+    act("\r\nНичего необычного в $n5 вы не заметили.", FALSE, i, 0, ch, TO_VICT);
 
-	if (i->player_data.description != "")
-	{
-		if (IS_NPC(i))
-			send_to_char(ch, " * %s", i->player_data.description.c_str());
-		else
-			send_to_char(ch, "*\r\n%s*\r\n", space_before_string(i->player_data.description).c_str());
-	}
-	else if (!IS_NPC(i))
-	{
-		strcpy(buf, "\r\nЭто");
-		if (i->is_morphed())
-			strcat(buf, string(" "+i->get_morph_desc()+".\r\n").c_str());
-		else
-		if (IS_FEMALE(i))
-		{
-			if (GET_HEIGHT(i) <= 151)
-			{
-				if (GET_WEIGHT(i) >= 140)
-					strcat(buf, " маленькая плотная дамочка.\r\n");
-				else if (GET_WEIGHT(i) >= 125)
-					strcat(buf, " маленькая женщина.\r\n");
-				else
-					strcat(buf, " миниатюрная дамочка.\r\n");
-			}
-			else if (GET_HEIGHT(i) <= 159)
-			{
-				if (GET_WEIGHT(i) >= 145)
-					strcat(buf, " невысокая плотная мадам.\r\n");
-				else if (GET_WEIGHT(i) >= 130)
-					strcat(buf, " невысокая женщина.\r\n");
-				else
-					strcat(buf, " изящная леди.\r\n");
-			}
-			else if (GET_HEIGHT(i) <= 165)
-			{
-				if (GET_WEIGHT(i) >= 145)
-					strcat(buf, " среднего роста женщина.\r\n");
-				else
-					strcat(buf, " среднего роста изящная красавица.\r\n");
-			}
-			else if (GET_HEIGHT(i) <= 175)
-			{
-				if (GET_WEIGHT(i) >= 150)
-					strcat(buf, " высокая дородная баба.\r\n");
-				else if (GET_WEIGHT(i) >= 135)
-					strcat(buf, " высокая стройная женщина.\r\n");
-				else
-					strcat(buf, " высокая изящная женщина.\r\n");
-			}
-			else
-			{
-				if (GET_WEIGHT(i) >= 155)
-					strcat(buf, " очень высокая крупная дама.\r\n");
-				else if (GET_WEIGHT(i) >= 140)
-					strcat(buf, " очень высокая стройная женщина.\r\n");
-				else
-					strcat(buf, " очень высокая худощавая женщина.\r\n");
-			}
-		}
-		else
-		{
-			if (GET_HEIGHT(i) <= 165)
-			{
-				if (GET_WEIGHT(i) >= 170)
-					strcat(buf, " маленький, похожий на колобок, мужчина.\r\n");
-				else if (GET_WEIGHT(i) >= 150)
-					strcat(buf, " маленький плотный мужчина.\r\n");
-				else
-					strcat(buf, " маленький плюгавенький мужичонка.\r\n");
-			}
-			else if (GET_HEIGHT(i) <= 175)
-			{
-				if (GET_WEIGHT(i) >= 175)
-					strcat(buf, " невысокий коренастый крепыш.\r\n");
-				else if (GET_WEIGHT(i) >= 160)
-					strcat(buf, " невысокий крепкий мужчина.\r\n");
-				else
-					strcat(buf, " невысокий худощавый мужчина.\r\n");
-			}
-			else if (GET_HEIGHT(i) <= 185)
-			{
-				if (GET_WEIGHT(i) >= 180)
-					strcat(buf, " среднего роста коренастый мужчина.\r\n");
-				else if (GET_WEIGHT(i) >= 165)
-					strcat(buf, " среднего роста крепкий мужчина.\r\n");
-				else
-					strcat(buf, " среднего роста худощавый мужчина.\r\n");
-			}
-			else if (GET_HEIGHT(i) <= 195)
-			{
-				if (GET_WEIGHT(i) >= 185)
-					strcat(buf, " высокий крупный мужчина.\r\n");
-				else if (GET_WEIGHT(i) >= 170)
-					strcat(buf, " высокий стройный мужчина.\r\n");
-				else
-					strcat(buf, " длинный, худощавый мужчина.\r\n");
-			}
-			else
-			{
-				if (GET_WEIGHT(i) >= 190)
-					strcat(buf, " огромный мужик.\r\n");
-				else if (GET_WEIGHT(i) >= 180)
-					strcat(buf, " очень высокий, крупный амбал.\r\n");
-				else
-					strcat(buf, " длиннющий, похожий на жердь мужчина.\r\n");
-			}
-		}
-		send_to_char(buf, ch);
-	}
-	else
-		act("\r\nНичего необычного в $n5 вы не заметили.", FALSE, i, 0, ch, TO_VICT);
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_CHARM)
+      && i->get_master() == ch) {
+    if (i->low_charm()) {
+      act("$n скоро перестанет следовать за вами.", FALSE, i, 0, ch, TO_VICT);
+    } else {
+      for (const auto &aff : i->affected) {
+        if (aff->type == SPELL_CHARM) {
+          sprintf(buf,
+                  IS_POLY(i) ? "$n будут слушаться вас еще %d %s." : "$n будет слушаться вас еще %d %s.",
+                  aff->duration / 2,
+                  desc_count(aff->duration / 2, 1));
+          act(buf, FALSE, i, 0, ch, TO_VICT);
+          break;
+        }
+      }
+    }
+  }
 
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_CHARM)
-		&& i->get_master() == ch)
-	{
-		if (i->low_charm())
-		{
-			act("$n скоро перестанет следовать за вами.", FALSE, i, 0, ch, TO_VICT);
-		}
-		else
-		{
-			for (const auto& aff : i->affected)
-			{
-				if (aff->type == SPELL_CHARM)
-				{
-					sprintf(buf, IS_POLY(i) ? "$n будут слушаться вас еще %d %s." : "$n будет слушаться вас еще %d %s.", aff->duration / 2, desc_count(aff->duration / 2, 1));
-					act(buf, FALSE, i, 0, ch, TO_VICT);
-					break;
-				}
-			}
-		}
-	}
+  if (IS_HORSE(i)
+      && i->get_master() == ch) {
+    strcpy(buf, "\r\nЭто ваш скакун. Он ");
+    if (GET_HORSESTATE(i) <= 0)
+      strcat(buf, "загнан.\r\n");
+    else if (GET_HORSESTATE(i) <= 20)
+      strcat(buf, "весь в мыле.\r\n");
+    else if (GET_HORSESTATE(i) <= 80)
+      strcat(buf, "в хорошем состоянии.\r\n");
+    else
+      strcat(buf, "выглядит совсем свежим.\r\n");
+    send_to_char(buf, ch);
+  };
 
-	if (IS_HORSE(i)
-		&& i->get_master() == ch)
-	{
-		strcpy(buf, "\r\nЭто ваш скакун. Он ");
-		if (GET_HORSESTATE(i) <= 0)
-			strcat(buf, "загнан.\r\n");
-		else if (GET_HORSESTATE(i) <= 20)
-			strcat(buf, "весь в мыле.\r\n");
-		else if (GET_HORSESTATE(i) <= 80)
-			strcat(buf, "в хорошем состоянии.\r\n");
-		else
-			strcat(buf, "выглядит совсем свежим.\r\n");
-		send_to_char(buf, ch);
-	};
+  diag_char_to_char(i, ch);
 
-	diag_char_to_char(i, ch);
+  if (i->is_morphed()) {
+    send_to_char("\r\n", ch);
+    std::string coverDesc = "$n покрыт$a " + i->get_cover_desc() + ".";
+    act(coverDesc.c_str(), FALSE, i, 0, ch, TO_VICT);
+    send_to_char("\r\n", ch);
+  } else {
+    found = FALSE;
+    for (j = 0; !found && j < NUM_WEARS; j++)
+      if (GET_EQ(i, j) && CAN_SEE_OBJ(ch, GET_EQ(i, j)))
+        found = TRUE;
 
-	if (i->is_morphed())
-	{
-		send_to_char("\r\n", ch);
-		std::string coverDesc = "$n покрыт$a " + i->get_cover_desc()+".";
-		act(coverDesc.c_str(), FALSE, i, 0, ch, TO_VICT);
-		send_to_char("\r\n", ch);
-	}
-	else
-	{
-		found = FALSE;
-		for (j = 0; !found && j < NUM_WEARS; j++)
-			if (GET_EQ(i, j) && CAN_SEE_OBJ(ch, GET_EQ(i, j)))
-				found = TRUE;
+    if (found) {
+      send_to_char("\r\n", ch);
+      act("$n одет$a :", FALSE, i, 0, ch, TO_VICT);
+      for (j = 0; j < NUM_WEARS; j++) {
+        if (GET_EQ(i, j) && CAN_SEE_OBJ(ch, GET_EQ(i, j))) {
+          send_to_char(where[j], ch);
+          if (i->has_master()
+              && IS_NPC(i)) {
+            show_obj_to_char(GET_EQ(i, j), ch, 1, ch == i->get_master(), 1);
+          } else {
+            show_obj_to_char(GET_EQ(i, j), ch, 1, ch == i, 1);
+          }
+        }
+      }
+    }
+  }
 
-		if (found)
-		{
-			send_to_char("\r\n", ch);
-			act("$n одет$a :", FALSE, i, 0, ch, TO_VICT);
-			for (j = 0; j < NUM_WEARS; j++)
-			{
-				if (GET_EQ(i, j) && CAN_SEE_OBJ(ch, GET_EQ(i, j)))
-				{
-					send_to_char(where[j], ch);
-					if (i->has_master()
-						&& IS_NPC(i))
-					{
-						show_obj_to_char(GET_EQ(i, j), ch, 1, ch == i->get_master(), 1);
-					}
-					else
-					{
-						show_obj_to_char(GET_EQ(i, j), ch, 1, ch == i, 1);
-					}
-				}
-			}
-		}
-	}
-
-	if (ch != i && (ch->get_skill(SKILL_LOOK_HIDE) || IS_IMMORTAL(ch)))
-	{
-		found = FALSE;
-		act("\r\nВы попытались заглянуть в $s ношу:", FALSE, i, 0, ch, TO_VICT);
-		for (tmp_obj = i->carrying; tmp_obj; tmp_obj = tmp_obj->get_next_content())
-		{
-			if (CAN_SEE_OBJ(ch, tmp_obj) && (number(0, 30) < GET_LEVEL(ch)))
-			{
-				if (!push)
-				{
-					push = tmp_obj;
-					push_count = 1;
-				}
-				else if (GET_OBJ_VNUM(push) != GET_OBJ_VNUM(tmp_obj)
-						 || GET_OBJ_VNUM(push) == -1)
-				{
-					show_obj_to_char(push, ch, 1, ch == i, push_count);
-					push = tmp_obj;
-					push_count = 1;
-				}
-				else
-					push_count++;
-				found = TRUE;
-			}
-		}
-		if (push && push_count)
-			show_obj_to_char(push, ch, 1, ch == i, push_count);
-		if (!found)
-			send_to_char("...и ничего не обнаружили.\r\n", ch);
-	}
+  if (ch != i && (ch->get_skill(SKILL_LOOK_HIDE) || IS_IMMORTAL(ch))) {
+    found = FALSE;
+    act("\r\nВы попытались заглянуть в $s ношу:", FALSE, i, 0, ch, TO_VICT);
+    for (tmp_obj = i->carrying; tmp_obj; tmp_obj = tmp_obj->get_next_content()) {
+      if (CAN_SEE_OBJ(ch, tmp_obj) && (number(0, 30) < GET_LEVEL(ch))) {
+        if (!push) {
+          push = tmp_obj;
+          push_count = 1;
+        } else if (GET_OBJ_VNUM(push) != GET_OBJ_VNUM(tmp_obj)
+            || GET_OBJ_VNUM(push) == -1) {
+          show_obj_to_char(push, ch, 1, ch == i, push_count);
+          push = tmp_obj;
+          push_count = 1;
+        } else
+          push_count++;
+        found = TRUE;
+      }
+    }
+    if (push && push_count)
+      show_obj_to_char(push, ch, 1, ch == i, push_count);
+    if (!found)
+      send_to_char("...и ничего не обнаружили.\r\n", ch);
+  }
 }
 
+void list_one_char(CHAR_DATA *i, CHAR_DATA *ch, int skill_mode) {
+  int sector = SECT_CITY;
+  int n;
+  char aura_txt[200];
+  const char *positions[] =
+      {
+          "лежит здесь, мертвый. ",
+          "лежит здесь, при смерти. ",
+          "лежит здесь, без сознания. ",
+          "лежит здесь, в обмороке. ",
+          "спит здесь. ",
+          "отдыхает здесь. ",
+          "сидит здесь. ",
+          "СРАЖАЕТСЯ! ",
+          "стоит здесь. "
+      };
 
-void list_one_char(CHAR_DATA * i, CHAR_DATA * ch, int skill_mode)
-{
-	int sector = SECT_CITY;
-	int n;
-	char aura_txt[200];
-	const char *positions[] =
-	{
-		"лежит здесь, мертвый. ",
-		"лежит здесь, при смерти. ",
-		"лежит здесь, без сознания. ",
-		"лежит здесь, в обмороке. ",
-		"спит здесь. ",
-		"отдыхает здесь. ",
-		"сидит здесь. ",
-		"СРАЖАЕТСЯ! ",
-		"стоит здесь. "
-	};
+  // Здесь и далее при использовании IS_POLY() - патч для отображения позиций мобов типа "они" -- Ковшегуб
+  const char *poly_positions[] =
+      {
+          "лежат здесь, мертвые. ",
+          "лежат здесь, при смерти. ",
+          "лежат здесь, без сознания. ",
+          "лежат здесь, в обмороке. ",
+          "спят здесь. ",
+          "отдыхают здесь. ",
+          "сидят здесь. ",
+          "СРАЖАЮТСЯ! ",
+          "стоят здесь. "
+      };
 
-	// Здесь и далее при использовании IS_POLY() - патч для отображения позиций мобов типа "они" -- Ковшегуб
-	const char *poly_positions[] =
-	{
-		"лежат здесь, мертвые. ",
-		"лежат здесь, при смерти. ",
-		"лежат здесь, без сознания. ",
-		"лежат здесь, в обмороке. ",
-		"спят здесь. ",
-		"отдыхают здесь. ",
-		"сидят здесь. ",
-		"СРАЖАЮТСЯ! ",
-		"стоят здесь. "
-	};
+  if (IS_HORSE(i) && i->get_master()->ahorse()) {
+    if (ch == i->get_master()) {
+      if (!IS_POLY(i)) {
+        act("$N несет вас на своей спине.", FALSE, ch, 0, i, TO_CHAR);
+      } else {
+        act("$N несут вас на своей спине.", FALSE, ch, 0, i, TO_CHAR);
+      }
+    }
 
-	if (IS_HORSE(i) && i->get_master()->ahorse())
-	{
-		if (ch == i->get_master())
-		{
-			if (!IS_POLY(i))
-			{
-				act("$N несет вас на своей спине.", FALSE, ch, 0, i, TO_CHAR);
-			}
-			else
-			{
-				act("$N несут вас на своей спине.", FALSE, ch, 0, i, TO_CHAR);
-			}
-		}
+    return;
+  }
 
-		return;
-	}
+  if (skill_mode == SKILL_LOOKING) {
+    if (HERE(i) && INVIS_OK(ch, i) && GET_REAL_LEVEL(ch) >= (IS_NPC(i) ? 0 : GET_INVIS_LEV(i))) {
+      if (GET_RACE(i) == NPC_RACE_THING && IS_IMMORTAL(ch)) {
+        sprintf(buf, "Вы разглядели %s.(предмет)\r\n", GET_PAD(i, 3));
+      } else {
+        sprintf(buf, "Вы разглядели %s.\r\n", GET_PAD(i, 3));
+      }
+      send_to_char(buf, ch);
+    }
+    return;
+  }
 
-	if (skill_mode == SKILL_LOOKING)
-	{
-		if (HERE(i) && INVIS_OK(ch, i) && GET_REAL_LEVEL(ch) >= (IS_NPC(i) ? 0 : GET_INVIS_LEV(i)))
-		{
-			if (GET_RACE(i)==NPC_RACE_THING && IS_IMMORTAL(ch)) {
-				sprintf(buf, "Вы разглядели %s.(предмет)\r\n", GET_PAD(i, 3));
-			} else {
-				sprintf(buf, "Вы разглядели %s.\r\n", GET_PAD(i, 3));
-			}
-			send_to_char(buf, ch);
-		}
-		return;
-	}
+  if (!CAN_SEE(ch, i)) {
+    skill_mode =
+        check_awake(i, ACHECK_AFFECTS | ACHECK_LIGHT | ACHECK_HUMMING | ACHECK_GLOWING | ACHECK_WEIGHT);
+    *buf = 0;
+    if (IS_SET(skill_mode, ACHECK_AFFECTS)) {
+      REMOVE_BIT(skill_mode, ACHECK_AFFECTS);
+      sprintf(buf + strlen(buf), "магический ореол%s", skill_mode ? ", " : " ");
+    }
+    if (IS_SET(skill_mode, ACHECK_LIGHT)) {
+      REMOVE_BIT(skill_mode, ACHECK_LIGHT);
+      sprintf(buf + strlen(buf), "яркий свет%s", skill_mode ? ", " : " ");
+    }
+    if (IS_SET(skill_mode, ACHECK_GLOWING)
+        && IS_SET(skill_mode, ACHECK_HUMMING)
+        && !AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS)) {
+      REMOVE_BIT(skill_mode, ACHECK_GLOWING);
+      REMOVE_BIT(skill_mode, ACHECK_HUMMING);
+      sprintf(buf + strlen(buf), "шум и блеск экипировки%s", skill_mode ? ", " : " ");
+    }
+    if (IS_SET(skill_mode, ACHECK_GLOWING)) {
+      REMOVE_BIT(skill_mode, ACHECK_GLOWING);
+      sprintf(buf + strlen(buf), "блеск экипировки%s", skill_mode ? ", " : " ");
+    }
+    if (IS_SET(skill_mode, ACHECK_HUMMING)
+        && !AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS)) {
+      REMOVE_BIT(skill_mode, ACHECK_HUMMING);
+      sprintf(buf + strlen(buf), "шум экипировки%s", skill_mode ? ", " : " ");
+    }
+    if (IS_SET(skill_mode, ACHECK_WEIGHT)
+        && !AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS)) {
+      REMOVE_BIT(skill_mode, ACHECK_WEIGHT);
+      sprintf(buf + strlen(buf), "бряцание металла%s", skill_mode ? ", " : " ");
+    }
+    strcat(buf, "выдает чье-то присутствие.\r\n");
+    send_to_char(CAP(buf), ch);
+    return;
+  }
 
-	if (!CAN_SEE(ch, i))
-	{
-		skill_mode =
-			check_awake(i, ACHECK_AFFECTS | ACHECK_LIGHT | ACHECK_HUMMING | ACHECK_GLOWING | ACHECK_WEIGHT);
-		*buf = 0;
-		if (IS_SET(skill_mode, ACHECK_AFFECTS))
-		{
-			REMOVE_BIT(skill_mode, ACHECK_AFFECTS);
-			sprintf(buf + strlen(buf), "магический ореол%s", skill_mode ? ", " : " ");
-		}
-		if (IS_SET(skill_mode, ACHECK_LIGHT))
-		{
-			REMOVE_BIT(skill_mode, ACHECK_LIGHT);
-			sprintf(buf + strlen(buf), "яркий свет%s", skill_mode ? ", " : " ");
-		}
-		if (IS_SET(skill_mode, ACHECK_GLOWING)
-				&& IS_SET(skill_mode, ACHECK_HUMMING)
-				&& !AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
-		{
-			REMOVE_BIT(skill_mode, ACHECK_GLOWING);
-			REMOVE_BIT(skill_mode, ACHECK_HUMMING);
-			sprintf(buf + strlen(buf), "шум и блеск экипировки%s", skill_mode ? ", " : " ");
-		}
-		if (IS_SET(skill_mode, ACHECK_GLOWING))
-		{
-			REMOVE_BIT(skill_mode, ACHECK_GLOWING);
-			sprintf(buf + strlen(buf), "блеск экипировки%s", skill_mode ? ", " : " ");
-		}
-		if (IS_SET(skill_mode, ACHECK_HUMMING)
-				&& !AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
-		{
-			REMOVE_BIT(skill_mode, ACHECK_HUMMING);
-			sprintf(buf + strlen(buf), "шум экипировки%s", skill_mode ? ", " : " ");
-		}
-		if (IS_SET(skill_mode, ACHECK_WEIGHT)
-				&& !AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
-		{
-			REMOVE_BIT(skill_mode, ACHECK_WEIGHT);
-			sprintf(buf + strlen(buf), "бряцание металла%s", skill_mode ? ", " : " ");
-		}
-		strcat(buf, "выдает чье-то присутствие.\r\n");
-		send_to_char(CAP(buf), ch);
-		return;
-	}
+  if (IS_NPC(i)
+      && i->player_data.long_descr != ""
+      && GET_POS(i) == GET_DEFAULT_POS(i)
+      && ch->in_room == i->in_room
+      && !AFF_FLAGGED(i, EAffectFlag::AFF_CHARM)
+      && !IS_HORSE(i)) {
+    *buf = '\0';
+    if (PRF_FLAGGED(ch, PRF_ROOMFLAGS)) {
+      sprintf(buf, "[%5d] ", GET_MOB_VNUM(i));
+    }
 
-	if (IS_NPC(i)
-		&& i->player_data.long_descr != ""
-		&& GET_POS(i) == GET_DEFAULT_POS(i)
-		&& ch->in_room == i->in_room
-		&& !AFF_FLAGGED(i, EAffectFlag::AFF_CHARM)
-		&& !IS_HORSE(i))
-	{
-		*buf = '\0';
-		if (PRF_FLAGGED(ch, PRF_ROOMFLAGS))
-		{
-			sprintf(buf, "[%5d] ", GET_MOB_VNUM(i));
-		}
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
+        && !AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN)) {
+      if (AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS)) {
+        strcat(buf, "(черная аура) ");
+      }
+    }
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN)) {
+      if (IS_NPC(i)) {
+        if (NPC_FLAGGED(i, NPC_AIRCREATURE))
+          sprintf(buf + strlen(buf), "%s(аура воздуха)%s ",
+                  CCIBLU(ch, C_CMP), CCIRED(ch, C_CMP));
+        else if (NPC_FLAGGED(i, NPC_WATERCREATURE))
+          sprintf(buf + strlen(buf), "%s(аура воды)%s ",
+                  CCICYN(ch, C_CMP), CCIRED(ch, C_CMP));
+        else if (NPC_FLAGGED(i, NPC_FIRECREATURE))
+          sprintf(buf + strlen(buf), "%s(аура огня)%s ",
+                  CCIMAG(ch, C_CMP), CCIRED(ch, C_CMP));
+        else if (NPC_FLAGGED(i, NPC_EARTHCREATURE))
+          sprintf(buf + strlen(buf), "%s(аура земли)%s ",
+                  CCIGRN(ch, C_CMP), CCIRED(ch, C_CMP));
+      }
+    }
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_INVISIBLE))
+      sprintf(buf + strlen(buf), "(невидим%s) ", GET_CH_SUF_6(i));
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_HIDE))
+      sprintf(buf + strlen(buf), "(спрятал%s) ", GET_CH_SUF_2(i));
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_CAMOUFLAGE))
+      sprintf(buf + strlen(buf), "(замаскировал%s) ", GET_CH_SUF_2(i));
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_FLY))
+      strcat(buf, IS_POLY(i) ? "(летят) " : "(летит) ");
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_HORSE))
+      strcat(buf, "(под седлом) ");
 
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
-			&& !AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN))
-		{
-			if (AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
-			{
-				strcat(buf, "(черная аура) ");
-			}
-		}
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN))
-		{
-			if (IS_NPC(i))
-			{
-				if (NPC_FLAGGED(i, NPC_AIRCREATURE))
-					sprintf(buf + strlen(buf), "%s(аура воздуха)%s ",
-							CCIBLU(ch, C_CMP), CCIRED(ch, C_CMP));
-				else if (NPC_FLAGGED(i, NPC_WATERCREATURE))
-					sprintf(buf + strlen(buf), "%s(аура воды)%s ",
-							CCICYN(ch, C_CMP), CCIRED(ch, C_CMP));
-				else if (NPC_FLAGGED(i, NPC_FIRECREATURE))
-					sprintf(buf + strlen(buf), "%s(аура огня)%s ",
-							CCIMAG(ch, C_CMP), CCIRED(ch, C_CMP));
-				else if (NPC_FLAGGED(i, NPC_EARTHCREATURE))
-					sprintf(buf + strlen(buf), "%s(аура земли)%s ",
-							CCIGRN(ch, C_CMP), CCIRED(ch, C_CMP));
-			}
-		}
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_INVISIBLE))
-			sprintf(buf + strlen(buf), "(невидим%s) ", GET_CH_SUF_6(i));
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_HIDE))
-			sprintf(buf + strlen(buf), "(спрятал%s) ", GET_CH_SUF_2(i));
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_CAMOUFLAGE))
-			sprintf(buf + strlen(buf), "(замаскировал%s) ", GET_CH_SUF_2(i));
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_FLY))
-			strcat(buf, IS_POLY(i) ? "(летят) " : "(летит) ");
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_HORSE))
-			strcat(buf, "(под седлом) ");
+    strcat(buf, i->player_data.long_descr.c_str());
+    send_to_char(buf, ch);
 
-		strcat(buf, i->player_data.long_descr.c_str());
-		send_to_char(buf, ch);
+    *aura_txt = '\0';
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_SHIELD)) {
+      strcat(aura_txt, "...окутан");
+      strcat(aura_txt, GET_CH_SUF_6(i));
+      strcat(aura_txt, " сверкающим коконом ");
+    }
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_SANCTUARY))
+      strcat(aura_txt, IS_POLY(i) ? "...светятся ярким сиянием " : "...светится ярким сиянием ");
+    else if (AFF_FLAGGED(i, EAffectFlag::AFF_PRISMATICAURA))
+      strcat(aura_txt, IS_POLY(i) ? "...переливаются всеми цветами " : "...переливается всеми цветами ");
+    act(aura_txt, FALSE, i, 0, ch, TO_VICT);
 
-		*aura_txt = '\0';
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_SHIELD))
-		{
-			strcat(aura_txt, "...окутан");
-			strcat(aura_txt, GET_CH_SUF_6(i));
-			strcat(aura_txt, " сверкающим коконом ");
-		}
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_SANCTUARY))
-			strcat(aura_txt, IS_POLY(i) ? "...светятся ярким сиянием " : "...светится ярким сиянием ");
-		else if (AFF_FLAGGED(i, EAffectFlag::AFF_PRISMATICAURA))
-			strcat(aura_txt, IS_POLY(i) ? "...переливаются всеми цветами " : "...переливается всеми цветами ");
-		act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+    *aura_txt = '\0';
+    n = 0;
+    strcat(aura_txt, "...окружен");
+    strcat(aura_txt, GET_CH_SUF_6(i));
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_AIRSHIELD)) {
+      strcat(aura_txt, " воздушным");
+      n++;
+    }
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_FIRESHIELD)) {
+      if (n > 0)
+        strcat(aura_txt, ", огненным");
+      else
+        strcat(aura_txt, " огненным");
+      n++;
+    }
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_ICESHIELD)) {
+      if (n > 0)
+        strcat(aura_txt, ", ледяным");
+      else
+        strcat(aura_txt, " ледяным");
+      n++;
+    }
+    if (n == 1)
+      strcat(aura_txt, " щитом ");
+    else if (n > 1)
+      strcat(aura_txt, " щитами ");
+    if (n > 0)
+      act(aura_txt, FALSE, i, 0, ch, TO_VICT);
 
-		*aura_txt = '\0';
-		n = 0;
-		strcat(aura_txt, "...окружен");
-		strcat(aura_txt, GET_CH_SUF_6(i));
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_AIRSHIELD))
-		{
-			strcat(aura_txt, " воздушным");
-			n++;
-		}
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_FIRESHIELD))
-		{
-			if (n > 0)
-				strcat(aura_txt, ", огненным");
-			else
-				strcat(aura_txt, " огненным");
-			n++;
-		}
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_ICESHIELD))
-		{
-			if (n > 0)
-				strcat(aura_txt, ", ледяным");
-			else
-				strcat(aura_txt, " ледяным");
-			n++;
-		}
-		if (n == 1)
-			strcat(aura_txt, " щитом ");
-		else if (n > 1)
-			strcat(aura_txt, " щитами ");
-		if (n > 0)
-			act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)) {
+      *aura_txt = '\0';
+      n = 0;
+      strcat(aura_txt, "...");
+      if (AFF_FLAGGED(i, EAffectFlag::AFF_MAGICGLASS)) {
+        if (n > 0)
+          strcat(aura_txt, ", серебристая");
+        else
+          strcat(aura_txt, "серебристая");
+        n++;
+      }
+      if (AFF_FLAGGED(i, EAffectFlag::AFF_BROKEN_CHAINS)) {
+        if (n > 0)
+          strcat(aura_txt, ", ярко-синяя");
+        else
+          strcat(aura_txt, "ярко-синяя");
+        n++;
+      }
+      if (AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS)) {
+        if (n > 0)
+          strcat(aura_txt, ", черная");
+        else
+          strcat(aura_txt, "черная");
+        n++;
+      }
+      if (n == 1)
+        strcat(aura_txt, " аура ");
+      else if (n > 1)
+        strcat(aura_txt, " ауры ");
 
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC))
-		{
-			*aura_txt = '\0';
-			n = 0;
-			strcat(aura_txt, "...");
-			if (AFF_FLAGGED(i, EAffectFlag::AFF_MAGICGLASS)) {
-				if (n > 0)
-					strcat(aura_txt, ", серебристая");
-				else
-					strcat(aura_txt, "серебристая");
-				n++;
-			}
-			if (AFF_FLAGGED(i, EAffectFlag::AFF_BROKEN_CHAINS)) {
-				if (n > 0)
-					strcat(aura_txt, ", ярко-синяя");
-				else
-					strcat(aura_txt, "ярко-синяя");
-				n++;
-			}
-			if (AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS)) {
-				if (n > 0)
-					strcat(aura_txt, ", черная");
-				else
-					strcat(aura_txt, "черная");
-				n++;
-			}
-			if (n == 1)
-				strcat(aura_txt, " аура ");
-			else if (n > 1)
-				strcat(aura_txt, " ауры ");
+      if (n > 0)
+        act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+    }
+    *aura_txt = '\0';
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)) {
+      if (AFF_FLAGGED(i, EAffectFlag::AFF_HOLD))
+        strcat(aura_txt, "...парализован$a");
+      if (AFF_FLAGGED(i, EAffectFlag::AFF_SILENCE))
+        strcat(aura_txt, "...нем$a");
+    }
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_BLIND))
+      strcat(aura_txt, "...слеп$a");
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_DEAFNESS))
+      strcat(aura_txt, "...глух$a");
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_STRANGLED))
+      strcat(aura_txt, "...задыхается.");
 
-			if (n > 0)
-				act(aura_txt, FALSE, i, 0, ch, TO_VICT);
-		}
-		*aura_txt = '\0';
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC))
-		{
-			if (AFF_FLAGGED(i, EAffectFlag::AFF_HOLD))
-				strcat(aura_txt, "...парализован$a");
-			if (AFF_FLAGGED(i, EAffectFlag::AFF_SILENCE))
-				strcat(aura_txt, "...нем$a");
-		}
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_BLIND))
-			strcat(aura_txt, "...слеп$a");
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_DEAFNESS))
-			strcat(aura_txt, "...глух$a");
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_STRANGLED))
-			strcat(aura_txt, "...задыхается.");
+    if (*aura_txt)
+      act(aura_txt, FALSE, i, 0, ch, TO_VICT);
 
-		if (*aura_txt)
-			act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+    return;
+  }
 
-		return;
-	}
+  if (IS_NPC(i)) {
+    strcpy(buf1, i->get_npc_name().c_str());
+    strcat(buf1, " ");
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_HORSE))
+      strcat(buf1, "(под седлом) ");
+    CAP(buf1);
+  } else {
+    sprintf(buf1, "%s%s ", i->get_morphed_title().c_str(), PLR_FLAGGED(i, PLR_KILLER) ? " <ДУШЕГУБ>" : "");
+  }
 
-	if (IS_NPC(i))
-	{
-		strcpy(buf1, i->get_npc_name().c_str());
-		strcat(buf1, " ");
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_HORSE))
-			strcat(buf1, "(под седлом) ");
-		CAP(buf1);
-	}
-	else
-	{
-		sprintf(buf1, "%s%s ", i->get_morphed_title().c_str(), PLR_FLAGGED(i, PLR_KILLER) ? " <ДУШЕГУБ>" : "");
-	}
+  sprintf(buf, "%s%s", AFF_FLAGGED(i, EAffectFlag::AFF_CHARM) ? "*" : "", buf1);
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_INVISIBLE))
+    sprintf(buf + strlen(buf), "(невидим%s) ", GET_CH_SUF_6(i));
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_HIDE))
+    sprintf(buf + strlen(buf), "(спрятал%s) ", GET_CH_SUF_2(i));
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_CAMOUFLAGE))
+    sprintf(buf + strlen(buf), "(замаскировал%s) ", GET_CH_SUF_2(i));
+  if (!IS_NPC(i) && !i->desc)
+    sprintf(buf + strlen(buf), "(потерял%s связь) ", GET_CH_SUF_1(i));
+  if (!IS_NPC(i) && PLR_FLAGGED(i, PLR_WRITING))
+    strcat(buf, "(пишет) ");
 
-	sprintf(buf, "%s%s", AFF_FLAGGED(i, EAffectFlag::AFF_CHARM) ? "*" : "", buf1);
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_INVISIBLE))
-		sprintf(buf + strlen(buf), "(невидим%s) ", GET_CH_SUF_6(i));
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_HIDE))
-		sprintf(buf + strlen(buf), "(спрятал%s) ", GET_CH_SUF_2(i));
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_CAMOUFLAGE))
-		sprintf(buf + strlen(buf), "(замаскировал%s) ", GET_CH_SUF_2(i));
-	if (!IS_NPC(i) && !i->desc)
-		sprintf(buf + strlen(buf), "(потерял%s связь) ", GET_CH_SUF_1(i));
-	if (!IS_NPC(i) && PLR_FLAGGED(i, PLR_WRITING))
-		strcat(buf, "(пишет) ");
+  if (GET_POS(i) != POS_FIGHTING) {
+    if (i->ahorse()) {
+      CHAR_DATA *horse = i->get_horse();
+      if (horse) {
+        const char *msg =
+            AFF_FLAGGED(horse, EAffectFlag::AFF_FLY) ? "летает" : "сидит";
+        sprintf(buf + strlen(buf), "%s здесь верхом на %s. ",
+                msg, PERS(horse, ch, 5));
+      }
+    } else if (IS_HORSE(i) && AFF_FLAGGED(i, EAffectFlag::AFF_TETHERED))
+      sprintf(buf + strlen(buf), "привязан%s здесь. ", GET_CH_SUF_6(i));
+    else if ((sector = real_sector(i->in_room)) == SECT_FLYING)
+      strcat(buf, IS_POLY(i) ? "летают здесь. " : "летает здесь. ");
+    else if (sector == SECT_UNDERWATER)
+      strcat(buf, IS_POLY(i) ? "плавают здесь. " : "плавает здесь. ");
+    else if (GET_POS(i) > POS_SLEEPING && AFF_FLAGGED(i, EAffectFlag::AFF_FLY))
+      strcat(buf, IS_POLY(i) ? "летают здесь. " : "летает здесь. ");
+    else if (sector == SECT_WATER_SWIM || sector == SECT_WATER_NOSWIM)
+      strcat(buf, IS_POLY(i) ? "плавают здесь. " : "плавает здесь. ");
+    else
+      strcat(buf, IS_POLY(i) ? poly_positions[static_cast<int>(GET_POS(i))] : positions[static_cast<int>(GET_POS(i))]);
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC) && IS_NPC(i) && affected_by_spell(i, SPELL_CAPABLE))
+      sprintf(buf + strlen(buf), "(аура магии) ");
+  } else {
+    if (i->get_fighting()) {
+      strcat(buf, IS_POLY(i) ? "сражаются с " : "сражается с ");
+      if (i->in_room != i->get_fighting()->in_room)
+        strcat(buf, "чьей-то тенью");
+      else if (i->get_fighting() == ch)
+        strcat(buf, "ВАМИ");
+      else
+        strcat(buf, GET_PAD(i->get_fighting(), 4));
+      if (i->ahorse())
+        sprintf(buf + strlen(buf), ", сидя верхом на %s! ", PERS(i->get_horse(), ch, 5));
+      else
+        strcat(buf, "! ");
+    } else        // NIL fighting pointer
+    {
+      strcat(buf, IS_POLY(i) ? "колотят по воздуху" : "колотит по воздуху");
+      if (i->ahorse())
+        sprintf(buf + strlen(buf), ", сидя верхом на %s. ", PERS(i->get_horse(), ch, 5));
+      else
+        strcat(buf, ". ");
+    }
+  }
 
-	if (GET_POS(i) != POS_FIGHTING)
-	{
-		if (i->ahorse())
-		{
-			CHAR_DATA *horse = i->get_horse();
-			if (horse)
-			{
-				const char *msg =
-					AFF_FLAGGED(horse, EAffectFlag::AFF_FLY) ? "летает" : "сидит";
-				sprintf(buf + strlen(buf), "%s здесь верхом на %s. ",
-					msg, PERS(horse, ch, 5));
-			}
-		}
-		else if (IS_HORSE(i) && AFF_FLAGGED(i, EAffectFlag::AFF_TETHERED))
-			sprintf(buf + strlen(buf), "привязан%s здесь. ", GET_CH_SUF_6(i));
-		else if ((sector = real_sector(i->in_room)) == SECT_FLYING)
-			strcat(buf, IS_POLY(i) ? "летают здесь. " : "летает здесь. ");
-		else if (sector == SECT_UNDERWATER)
-			strcat(buf, IS_POLY(i) ? "плавают здесь. " : "плавает здесь. ");
-		else if (GET_POS(i) > POS_SLEEPING && AFF_FLAGGED(i, EAffectFlag::AFF_FLY))
-			strcat(buf, IS_POLY(i) ? "летают здесь. " : "летает здесь. ");
-		else if (sector == SECT_WATER_SWIM || sector == SECT_WATER_NOSWIM)
-			strcat(buf, IS_POLY(i) ? "плавают здесь. " : "плавает здесь. ");
-		else
-			strcat(buf, IS_POLY(i) ? poly_positions[static_cast<int>(GET_POS(i))] : positions[static_cast<int>(GET_POS(i))]);
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC) && IS_NPC(i) && affected_by_spell(i, SPELL_CAPABLE))
-			sprintf(buf + strlen(buf), "(аура магии) ");
-	}
-	else
-	{
-		if (i->get_fighting())
-		{
-			strcat(buf, IS_POLY(i) ? "сражаются с " : "сражается с ");
-			if (i->in_room != i->get_fighting()->in_room)
-				strcat(buf, "чьей-то тенью");
-			else if (i->get_fighting() == ch)
-				strcat(buf, "ВАМИ");
-			else
-				strcat(buf, GET_PAD(i->get_fighting(), 4));
-			if (i->ahorse())
-				sprintf(buf + strlen(buf), ", сидя верхом на %s! ", PERS(i->get_horse(), ch, 5));
-			else
-				strcat(buf, "! ");
-		}
-		else		// NIL fighting pointer
-		{
-			strcat(buf, IS_POLY(i) ? "колотят по воздуху" : "колотит по воздуху");
-			if (i->ahorse())
-				sprintf(buf + strlen(buf), ", сидя верхом на %s. ", PERS(i->get_horse(), ch, 5));
-			else
-				strcat(buf, ". ");
-		}
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
+      && !AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN)) {
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
+      strcat(buf, "(черная аура) ");
+  }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN)) {
+    if (IS_NPC(i)) {
+      if (IS_EVIL(i)) {
+        if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
+            && AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
+          strcat(buf, "(иссиня-черная аура) ");
+        else
+          strcat(buf, "(темная аура) ");
+      } else if (IS_GOOD(i)) {
+        if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
+            && AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
+          strcat(buf, "(серая аура) ");
+        else
+          strcat(buf, "(светлая аура) ");
+      } else {
+        if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
+            && AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
+          strcat(buf, "(черная аура) ");
+      }
+    } else {
+      aura(ch, C_CMP, i, aura_txt);
+      strcat(buf, aura_txt);
+      strcat(buf, " ");
+    }
+  }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_POISON))
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_POISON))
+      sprintf(buf + strlen(buf), "(отравлен%s) ", GET_CH_SUF_6(i));
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
-			&& !AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN))
-	{
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
-			strcat(buf, "(черная аура) ");
-	}
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN))
-	{
-		if (IS_NPC(i))
-		{
-			if (IS_EVIL(i))
-			{
-				if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
-						&& AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
-					strcat(buf, "(иссиня-черная аура) ");
-				else
-					strcat(buf, "(темная аура) ");
-			}
-			else if (IS_GOOD(i))
-			{
-				if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
-						&& AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
-					strcat(buf, "(серая аура) ");
-				else
-					strcat(buf, "(светлая аура) ");
-			}
-			else
-			{
-				if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
-						&& AFF_FLAGGED(i, EAffectFlag::AFF_EVILESS))
-					strcat(buf, "(черная аура) ");
-			}
-		}
-		else
-		{
-			aura(ch, C_CMP, i, aura_txt);
-			strcat(buf, aura_txt);
-			strcat(buf, " ");
-		}
-	}
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_POISON))
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_POISON))
-			sprintf(buf + strlen(buf), "(отравлен%s) ", GET_CH_SUF_6(i));
+  strcat(buf, "\r\n");
+  send_to_char(buf, ch);
 
-	strcat(buf, "\r\n");
-	send_to_char(buf, ch);
+  *aura_txt = '\0';
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_SHIELD)) {
+    strcat(aura_txt, "...окутан");
+    strcat(aura_txt, GET_CH_SUF_6(i));
+    strcat(aura_txt, " сверкающим коконом ");
+  }
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_SANCTUARY))
+    strcat(aura_txt, IS_POLY(i) ? "...светятся ярким сиянием " : "...светится ярким сиянием ");
+  else if (AFF_FLAGGED(i, EAffectFlag::AFF_PRISMATICAURA))
+    strcat(aura_txt, IS_POLY(i) ? "...переливаются всеми цветами " : "...переливается всеми цветами ");
+  act(aura_txt, FALSE, i, 0, ch, TO_VICT);
 
-	*aura_txt = '\0';
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_SHIELD))
-	{
-		strcat(aura_txt, "...окутан");
-		strcat(aura_txt, GET_CH_SUF_6(i));
-		strcat(aura_txt, " сверкающим коконом ");
-	}
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_SANCTUARY))
-		strcat(aura_txt, IS_POLY(i) ? "...светятся ярким сиянием " : "...светится ярким сиянием ");
-	else if (AFF_FLAGGED(i, EAffectFlag::AFF_PRISMATICAURA))
-		strcat(aura_txt, IS_POLY(i) ? "...переливаются всеми цветами " : "...переливается всеми цветами ");
-	act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+  *aura_txt = '\0';
+  n = 0;
+  strcat(aura_txt, "...окружен");
+  strcat(aura_txt, GET_CH_SUF_6(i));
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_AIRSHIELD)) {
+    strcat(aura_txt, " воздушным");
+    n++;
+  }
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_FIRESHIELD)) {
+    if (n > 0)
+      strcat(aura_txt, ", огненным");
+    else
+      strcat(aura_txt, " огненным");
+    n++;
+  }
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_ICESHIELD)) {
+    if (n > 0)
+      strcat(aura_txt, ", ледяным");
+    else
+      strcat(aura_txt, " ледяным");
+    n++;
+  }
+  if (n == 1)
+    strcat(aura_txt, " щитом ");
+  else if (n > 1)
+    strcat(aura_txt, " щитами ");
+  if (n > 0)
+    act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN)) {
+    *aura_txt = '\0';
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_COMMANDER))
+      strcat(aura_txt, "... реет стяг над головой ");
+    if (*aura_txt)
+      act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+  }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)) {
+    *aura_txt = '\0';
+    n = 0;
+    strcat(aura_txt, " ..");
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_MAGICGLASS)) {
+      if (n > 0)
+        strcat(aura_txt, ", серебристая");
+      else
+        strcat(aura_txt, "серебристая");
+      n++;
+    }
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_BROKEN_CHAINS)) {
+      if (n > 0)
+        strcat(aura_txt, ", ярко-синяя");
+      else
+        strcat(aura_txt, "ярко-синяя");
+      n++;
+    }
+    if (n == 1)
+      strcat(aura_txt, " аура ");
+    else if (n > 1)
+      strcat(aura_txt, " ауры ");
 
-	*aura_txt = '\0';
-	n = 0;
-	strcat(aura_txt, "...окружен");
-	strcat(aura_txt, GET_CH_SUF_6(i));
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_AIRSHIELD))
-	{
-		strcat(aura_txt, " воздушным");
-		n++;
-	}
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_FIRESHIELD))
-	{
-		if (n > 0)
-			strcat(aura_txt, ", огненным");
-		else
-			strcat(aura_txt, " огненным");
-		n++;
-	}
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_ICESHIELD))
-	{
-		if (n > 0)
-			strcat(aura_txt, ", ледяным");
-		else
-			strcat(aura_txt, " ледяным");
-		n++;
-	}
-	if (n == 1)
-		strcat(aura_txt, " щитом ");
-	else if (n > 1)
-		strcat(aura_txt, " щитами ");
-	if (n > 0)
-		act(aura_txt, FALSE, i, 0, ch, TO_VICT);
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_ALIGN))
-	{
-	*aura_txt = '\0';
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_COMMANDER))
-		strcat(aura_txt, "... реет стяг над головой ");
-	if (*aura_txt)
-		act(aura_txt, FALSE, i, 0, ch, TO_VICT);
-	}
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC))
-	{
-		*aura_txt = '\0';
-		n = 0;
-		strcat(aura_txt, " ..");
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_MAGICGLASS))
-		{
-			if (n > 0)
-				strcat(aura_txt, ", серебристая");
-			else
-				strcat(aura_txt, "серебристая");
-			n++;
-		}
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_BROKEN_CHAINS))
-		{
-			if (n > 0)
-				strcat(aura_txt, ", ярко-синяя");
-			else
-				strcat(aura_txt, "ярко-синяя");
-			n++;
-		}
-		if (n == 1)
-			strcat(aura_txt, " аура ");
-		else if (n > 1)
-			strcat(aura_txt, " ауры ");
-
-		if (n > 0)
-			act(aura_txt, FALSE, i, 0, ch, TO_VICT);
-	}
-	*aura_txt = '\0';
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC))
-	{
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_HOLD))
-			strcat(aura_txt, " ...парализован$a");
-		if (AFF_FLAGGED(i, EAffectFlag::AFF_SILENCE))
-			strcat(aura_txt, " ...нем$a");
-	}
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_BLIND))
-		strcat(aura_txt, " ...слеп$a");
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_DEAFNESS))
-		strcat(aura_txt, " ...глух$a");
-	if (AFF_FLAGGED(i, EAffectFlag::AFF_STRANGLED))
-		strcat(aura_txt, " ...задыхается");
-	if (*aura_txt)
-		act(aura_txt, FALSE, i, 0, ch, TO_VICT);
-	if (IS_MANA_CASTER(i))
-		{
-			*aura_txt = '\0';
-			if (i->get_trained_skill(SKILL_DARK_MAGIC) > 0)
-				strcat(aura_txt,  "...все сферы магии кружатся над головой");
-			else if (i->get_trained_skill(SKILL_AIR_MAGIC) > 0)
-				strcat(aura_txt, "...сферы четырех магий кружатся над головой");
-			else if (i->get_trained_skill(SKILL_EARTH_MAGIC) > 0)
-				strcat(aura_txt, "...сферы трех магий кружатся над головой");
-			else if  (i->get_trained_skill(SKILL_WATER_MAGIC) > 0)
-				strcat(aura_txt, "...сферы двух магий кружатся над головой");
-			else if (i->get_trained_skill(SKILL_FIRE_MAGIC) > 0)
-				strcat(aura_txt, "...сфера огня кружит над головой");
-			if (*aura_txt)
-				act(aura_txt, FALSE, i, 0, ch, TO_VICT);
-		}
+    if (n > 0)
+      act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+  }
+  *aura_txt = '\0';
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)) {
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_HOLD))
+      strcat(aura_txt, " ...парализован$a");
+    if (AFF_FLAGGED(i, EAffectFlag::AFF_SILENCE))
+      strcat(aura_txt, " ...нем$a");
+  }
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_BLIND))
+    strcat(aura_txt, " ...слеп$a");
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_DEAFNESS))
+    strcat(aura_txt, " ...глух$a");
+  if (AFF_FLAGGED(i, EAffectFlag::AFF_STRANGLED))
+    strcat(aura_txt, " ...задыхается");
+  if (*aura_txt)
+    act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+  if (IS_MANA_CASTER(i)) {
+    *aura_txt = '\0';
+    if (i->get_trained_skill(SKILL_DARK_MAGIC) > 0)
+      strcat(aura_txt, "...все сферы магии кружатся над головой");
+    else if (i->get_trained_skill(SKILL_AIR_MAGIC) > 0)
+      strcat(aura_txt, "...сферы четырех магий кружатся над головой");
+    else if (i->get_trained_skill(SKILL_EARTH_MAGIC) > 0)
+      strcat(aura_txt, "...сферы трех магий кружатся над головой");
+    else if (i->get_trained_skill(SKILL_WATER_MAGIC) > 0)
+      strcat(aura_txt, "...сферы двух магий кружатся над головой");
+    else if (i->get_trained_skill(SKILL_FIRE_MAGIC) > 0)
+      strcat(aura_txt, "...сфера огня кружит над головой");
+    if (*aura_txt)
+      act(aura_txt, FALSE, i, 0, ch, TO_VICT);
+  }
 
 }
 
-void list_char_to_char(const ROOM_DATA::people_t& list, CHAR_DATA* ch)
-{
-	for (const auto i : list)
-	{
-		if (ch != i)
-		{
-			if (HERE(i) && (GET_RACE(i) != NPC_RACE_THING)
-				&& (CAN_SEE(ch, i)
-					|| awaking(i, AW_HIDE | AW_INVIS | AW_CAMOUFLAGE)))
-			{
-				list_one_char(i, ch, 0);
-			}
-			else if (IS_DARK(i->in_room)
-				&& i->in_room == ch->in_room
-				&& !CAN_SEE_IN_DARK(ch)
-				&& AFF_FLAGGED(i, EAffectFlag::AFF_INFRAVISION))
-			{
-				send_to_char("Пара светящихся глаз смотрит на вас.\r\n", ch);
-			}
-		}
-	}
+void list_char_to_char(const ROOM_DATA::people_t &list, CHAR_DATA *ch) {
+  for (const auto i : list) {
+    if (ch != i) {
+      if (HERE(i) && (GET_RACE(i) != NPC_RACE_THING)
+          && (CAN_SEE(ch, i)
+              || awaking(i, AW_HIDE | AW_INVIS | AW_CAMOUFLAGE))) {
+        list_one_char(i, ch, 0);
+      } else if (IS_DARK(i->in_room)
+          && i->in_room == ch->in_room
+          && !CAN_SEE_IN_DARK(ch)
+          && AFF_FLAGGED(i, EAffectFlag::AFF_INFRAVISION)) {
+        send_to_char("Пара светящихся глаз смотрит на вас.\r\n", ch);
+      }
+    }
+  }
 }
-void list_char_to_char_thing(const ROOM_DATA::people_t& list, CHAR_DATA* ch)   //мобы рассы предмет будем выводить вместе с предметами желтеньким
+void list_char_to_char_thing(const ROOM_DATA::people_t &list,
+                             CHAR_DATA *ch)   //мобы рассы предмет будем выводить вместе с предметами желтеньким
 {
-	for (const auto i : list)
-	{
-		if (ch != i)
-		{
-			if (GET_RACE(i) == NPC_RACE_THING)
-			{
-				list_one_char(i, ch, 0);
-			}
-		}
-	}
+  for (const auto i : list) {
+    if (ch != i) {
+      if (GET_RACE(i) == NPC_RACE_THING) {
+        list_one_char(i, ch, 0);
+      }
+    }
+  }
 }
 
-void do_auto_exits(CHAR_DATA * ch)
-{
-	int door, slen = 0;
+void do_auto_exits(CHAR_DATA *ch) {
+  int door, slen = 0;
 
-	*buf = '\0';
+  *buf = '\0';
 
-	for (door = 0; door < NUM_OF_DIRS; door++)
-	{
-		// Наконец-то добавлена отрисовка в автовыходах закрытых дверей
-		if (EXIT(ch, door) && EXIT(ch, door)->to_room() != NOWHERE)
-		{
-			if (EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED))
-			{
-				slen += sprintf(buf + slen, "(%c) ", LOWER(*dirs[door]));
-			}
-			else if (!EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN))
-			{
-				if (world[EXIT(ch, door)->to_room()]->zone == world[ch->in_room]->zone)
-				{
-					slen += sprintf(buf + slen, "%c ", LOWER(*dirs[door]));
-				}
-				else
-				{
-					slen += sprintf(buf + slen, "%c ", UPPER(*dirs[door]));
-				}
-			}
-		}
-	}
-	sprintf(buf2, "%s[ Exits: %s]%s\r\n", CCCYN(ch, C_NRM), *buf ? buf : "None! ", CCNRM(ch, C_NRM));
+  for (door = 0; door < NUM_OF_DIRS; door++) {
+    // Наконец-то добавлена отрисовка в автовыходах закрытых дверей
+    if (EXIT(ch, door) && EXIT(ch, door)->to_room() != NOWHERE) {
+      if (EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED)) {
+        slen += sprintf(buf + slen, "(%c) ", LOWER(*dirs[door]));
+      } else if (!EXIT_FLAGGED(EXIT(ch, door), EX_HIDDEN)) {
+        if (world[EXIT(ch, door)->to_room()]->zone == world[ch->in_room]->zone) {
+          slen += sprintf(buf + slen, "%c ", LOWER(*dirs[door]));
+        } else {
+          slen += sprintf(buf + slen, "%c ", UPPER(*dirs[door]));
+        }
+      }
+    }
+  }
+  sprintf(buf2, "%s[ Exits: %s]%s\r\n", CCCYN(ch, C_NRM), *buf ? buf : "None! ", CCNRM(ch, C_NRM));
 
-	send_to_char(buf2, ch);
+  send_to_char(buf2, ch);
 }
 
-void do_exits(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int door;
+void do_exits(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int door;
 
-	*buf = '\0';
+  *buf = '\0';
 
-	if (PRF_FLAGGED(ch, PRF_BLIND))
-	{
-		do_blind_exits(ch);
-		return;
-	}
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-	{
-		send_to_char("Вы слепы, как котенок!\r\n", ch);
-		return;
-	}
-	for (door = 0; door < NUM_OF_DIRS; door++)
-		if (EXIT(ch, door) && EXIT(ch, door)->to_room() != NOWHERE && !EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED))
-		{
-			if (IS_GOD(ch))
-				sprintf(buf2, "%-5s - [%5d] %s\r\n", Dirs[door],
-						GET_ROOM_VNUM(EXIT(ch, door)->to_room()), world[EXIT(ch, door)->to_room()]->name);
-			else
-			{
-				sprintf(buf2, "%-5s - ", Dirs[door]);
-				if (IS_DARK(EXIT(ch, door)->to_room()) && !CAN_SEE_IN_DARK(ch))
-					strcat(buf2, "слишком темно\r\n");
-				else
-				{
-					strcat(buf2, world[EXIT(ch, door)->to_room()]->name);
-					strcat(buf2, "\r\n");
-				}
-			}
-			strcat(buf, CAP(buf2));
-		}
-	send_to_char("Видимые выходы:\r\n", ch);
-	if (*buf)
-		send_to_char(buf, ch);
-	else
-		send_to_char(" Замуровали, ДЕМОНЫ!\r\n", ch);
+  if (PRF_FLAGGED(ch, PRF_BLIND)) {
+    do_blind_exits(ch);
+    return;
+  }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    send_to_char("Вы слепы, как котенок!\r\n", ch);
+    return;
+  }
+  for (door = 0; door < NUM_OF_DIRS; door++)
+    if (EXIT(ch, door) && EXIT(ch, door)->to_room() != NOWHERE && !EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED)) {
+      if (IS_GOD(ch))
+        sprintf(buf2, "%-5s - [%5d] %s\r\n", Dirs[door],
+                GET_ROOM_VNUM(EXIT(ch, door)->to_room()), world[EXIT(ch, door)->to_room()]->name);
+      else {
+        sprintf(buf2, "%-5s - ", Dirs[door]);
+        if (IS_DARK(EXIT(ch, door)->to_room()) && !CAN_SEE_IN_DARK(ch))
+          strcat(buf2, "слишком темно\r\n");
+        else {
+          strcat(buf2, world[EXIT(ch, door)->to_room()]->name);
+          strcat(buf2, "\r\n");
+        }
+      }
+      strcat(buf, CAP(buf2));
+    }
+  send_to_char("Видимые выходы:\r\n", ch);
+  if (*buf)
+    send_to_char(buf, ch);
+  else
+    send_to_char(" Замуровали, ДЕМОНЫ!\r\n", ch);
 }
-void do_blind_exits(CHAR_DATA *ch)
-{
-	int door;
+void do_blind_exits(CHAR_DATA *ch) {
+  int door;
 
-	*buf = '\0';
+  *buf = '\0';
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-	{
-		send_to_char("Вы слепы, как котенок!\r\n", ch);
-		return;
-	}
-	for (door = 0; door < NUM_OF_DIRS; door++)
-		if (EXIT(ch, door) && EXIT(ch, door)->to_room() != NOWHERE && !EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED))
-		{
-			if (IS_GOD(ch))
-				sprintf(buf2, "&W%-5s - [%5d] %s ", Dirs[door],
-						GET_ROOM_VNUM(EXIT(ch, door)->to_room()), world[EXIT(ch, door)->to_room()]->name);
-			else
-			{
-				sprintf(buf2, "&W%-5s - ", Dirs[door]);
-				if (IS_DARK(EXIT(ch, door)->to_room()) && !CAN_SEE_IN_DARK(ch))
-					strcat(buf2, "слишком темно");
-				else
-				{
-					strcat(buf2, world[EXIT(ch, door)->to_room()]->name);
-					strcat(buf2, "");
-				}
-			}
-			strcat(buf, CAP(buf2));
-		}
-	send_to_char("Видимые выходы:\r\n", ch);
-	if (*buf)
-		send_to_char(ch, "%s&n\r\n", buf);
-	else
-		send_to_char("&W Замуровали, ДЕМОНЫ!&n\r\n", ch);
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    send_to_char("Вы слепы, как котенок!\r\n", ch);
+    return;
+  }
+  for (door = 0; door < NUM_OF_DIRS; door++)
+    if (EXIT(ch, door) && EXIT(ch, door)->to_room() != NOWHERE && !EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED)) {
+      if (IS_GOD(ch))
+        sprintf(buf2, "&W%-5s - [%5d] %s ", Dirs[door],
+                GET_ROOM_VNUM(EXIT(ch, door)->to_room()), world[EXIT(ch, door)->to_room()]->name);
+      else {
+        sprintf(buf2, "&W%-5s - ", Dirs[door]);
+        if (IS_DARK(EXIT(ch, door)->to_room()) && !CAN_SEE_IN_DARK(ch))
+          strcat(buf2, "слишком темно");
+        else {
+          strcat(buf2, world[EXIT(ch, door)->to_room()]->name);
+          strcat(buf2, "");
+        }
+      }
+      strcat(buf, CAP(buf2));
+    }
+  send_to_char("Видимые выходы:\r\n", ch);
+  if (*buf)
+    send_to_char(ch, "%s&n\r\n", buf);
+  else
+    send_to_char("&W Замуровали, ДЕМОНЫ!&n\r\n", ch);
 }
 
 #define MAX_FIRES 6
-const char *Fires[MAX_FIRES] = { "тлеет небольшая кучка угольков",
-								 "тлеет небольшая кучка угольков",
-								 "еле-еле теплится огонек",
-								 "догорает небольшой костер",
-								 "весело трещит костер",
-								 "ярко пылает костер"
-							   };
+const char *Fires[MAX_FIRES] = {"тлеет небольшая кучка угольков",
+                                "тлеет небольшая кучка угольков",
+                                "еле-еле теплится огонек",
+                                "догорает небольшой костер",
+                                "весело трещит костер",
+                                "ярко пылает костер"
+};
 
 #define TAG_NIGHT       "<night>"
 #define TAG_DAY         "<day>"
@@ -1842,971 +1550,798 @@ const char *Fires[MAX_FIRES] = { "тлеет небольшая кучка уг�
 #define TAG_AUTUMNNIGHT "<autumnnight>"
 #define TAG_AUTUMNDAY   "<autumnday>"
 
-int paste_description(char *string, const char *tag, int need)
-{
-	if (!*string || !*tag)
-	{
-		return (FALSE);
-	}
+int paste_description(char *string, const char *tag, int need) {
+  if (!*string || !*tag) {
+    return (FALSE);
+  }
 
-	const char *pos = str_str(string, tag);
-	if (!pos)
-	{
-		return FALSE;
-	}
+  const char *pos = str_str(string, tag);
+  if (!pos) {
+    return FALSE;
+  }
 
-	if (!need)
-	{
-		const size_t offset = pos - string;
-		string[offset] = '\0';
-		pos = str_str(pos + 1, tag);
-		if (pos)
-		{
-			auto to_pos = string + offset;
-			auto from_pos = pos + strlen(tag);
-			while ((*(to_pos++) = *(from_pos++)));
-		}
-		return FALSE;
-	}
+  if (!need) {
+    const size_t offset = pos - string;
+    string[offset] = '\0';
+    pos = str_str(pos + 1, tag);
+    if (pos) {
+      auto to_pos = string + offset;
+      auto from_pos = pos + strlen(tag);
+      while ((*(to_pos++) = *(from_pos++)));
+    }
+    return FALSE;
+  }
 
-	for (; *pos && *pos != '>'; pos++);
+  for (; *pos && *pos != '>'; pos++);
 
-	if (*pos)
-	{
-		pos++;
-	}
+  if (*pos) {
+    pos++;
+  }
 
-	if (*pos == 'R')
-	{
-		pos++;
-		buf[0] = '\0';
-	}
+  if (*pos == 'R') {
+    pos++;
+    buf[0] = '\0';
+  }
 
-	strcat(buf, pos);
-	pos = str_str(buf, tag);
-	if (pos)
-	{
-		const size_t offset = pos - buf;
-		buf[offset] = '\0';
-	}
+  strcat(buf, pos);
+  pos = str_str(buf, tag);
+  if (pos) {
+    const size_t offset = pos - buf;
+    buf[offset] = '\0';
+  }
 
-	return (TRUE);
+  return (TRUE);
 }
 
+void show_extend_room(const char *const description, CHAR_DATA *ch) {
+  int found = FALSE;
+  char string[MAX_STRING_LENGTH], *pos;
 
-void show_extend_room(const char * const description, CHAR_DATA * ch)
-{
-	int found = FALSE;
-	char string[MAX_STRING_LENGTH], *pos;
+  if (!description || !*description)
+    return;
 
-	if (!description || !*description)
-		return;
+  strcpy(string, description);
+  if ((pos = strchr(string, '<')))
+    *pos = '\0';
+  strcpy(buf, string);
+  if (pos)
+    *pos = '<';
 
-	strcpy(string, description);
-	if ((pos = strchr(string, '<')))
-		* pos = '\0';
-	strcpy(buf, string);
-	if (pos)
-		*pos = '<';
+  found = found || paste_description(string, TAG_WINTERNIGHT,
+                                     (weather_info.season == SEASON_WINTER
+                                         && (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK)));
+  found = found || paste_description(string, TAG_WINTERDAY,
+                                     (weather_info.season == SEASON_WINTER
+                                         && (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT)));
+  found = found || paste_description(string, TAG_SPRINGNIGHT,
+                                     (weather_info.season == SEASON_SPRING
+                                         && (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK)));
+  found = found || paste_description(string, TAG_SPRINGDAY,
+                                     (weather_info.season == SEASON_SPRING
+                                         && (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT)));
+  found = found || paste_description(string, TAG_SUMMERNIGHT,
+                                     (weather_info.season == SEASON_SUMMER
+                                         && (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK)));
+  found = found || paste_description(string, TAG_SUMMERDAY,
+                                     (weather_info.season == SEASON_SUMMER
+                                         && (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT)));
+  found = found || paste_description(string, TAG_AUTUMNNIGHT,
+                                     (weather_info.season == SEASON_AUTUMN
+                                         && (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK)));
+  found = found || paste_description(string, TAG_AUTUMNDAY,
+                                     (weather_info.season == SEASON_AUTUMN
+                                         && (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT)));
+  found = found || paste_description(string, TAG_NIGHT,
+                                     (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK));
+  found = found || paste_description(string, TAG_DAY,
+                                     (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT));
 
-	found = found || paste_description(string, TAG_WINTERNIGHT,
-									   (weather_info.season == SEASON_WINTER
-										&& (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK)));
-	found = found || paste_description(string, TAG_WINTERDAY,
-									   (weather_info.season == SEASON_WINTER
-										&& (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT)));
-	found = found || paste_description(string, TAG_SPRINGNIGHT,
-									   (weather_info.season == SEASON_SPRING
-										&& (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK)));
-	found = found || paste_description(string, TAG_SPRINGDAY,
-									   (weather_info.season == SEASON_SPRING
-										&& (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT)));
-	found = found || paste_description(string, TAG_SUMMERNIGHT,
-									   (weather_info.season == SEASON_SUMMER
-										&& (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK)));
-	found = found || paste_description(string, TAG_SUMMERDAY,
-									   (weather_info.season == SEASON_SUMMER
-										&& (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT)));
-	found = found || paste_description(string, TAG_AUTUMNNIGHT,
-									   (weather_info.season == SEASON_AUTUMN
-										&& (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK)));
-	found = found || paste_description(string, TAG_AUTUMNDAY,
-									   (weather_info.season == SEASON_AUTUMN
-										&& (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT)));
-	found = found || paste_description(string, TAG_NIGHT,
-									   (weather_info.sunlight == SUN_SET || weather_info.sunlight == SUN_DARK));
-	found = found || paste_description(string, TAG_DAY,
-									   (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT));
+  // Trim any LF/CRLF at the end of description
+  pos = buf + strlen(buf);
+  while (pos > buf && *--pos == '\n') {
+    *pos = '\0';
+    if (pos > buf && *(pos - 1) == '\r')
+      *--pos = '\0';
+  }
 
-	// Trim any LF/CRLF at the end of description
-	pos = buf + strlen(buf);
-	while (pos > buf && *--pos == '\n')
-	{
-		*pos = '\0';
-		if (pos > buf && *(pos - 1) == '\r')
-			*--pos = '\0';
-	}
-
-	send_to_char(buf, ch);
-	send_to_char("\r\n", ch);
+  send_to_char(buf, ch);
+  send_to_char("\r\n", ch);
 }
 
-bool put_delim(std::stringstream &out, bool delim)
-{
-	if (!delim)
-	{
-		out << " (";
-	}
-	else
-	{
-		out << ", ";
-	}
-	return true;
+bool put_delim(std::stringstream &out, bool delim) {
+  if (!delim) {
+    out << " (";
+  } else {
+    out << ", ";
+  }
+  return true;
 }
 
-void print_zone_info(CHAR_DATA *ch)
-{
-	ZoneData *zone = &zone_table[world[ch->in_room]->zone];
-	std::stringstream out;
-	out << "\r\n" << zone->name;
+void print_zone_info(CHAR_DATA *ch) {
+  ZoneData *zone = &zone_table[world[ch->in_room]->zone];
+  std::stringstream out;
+  out << "\r\n" << zone->name;
 
-	bool delim = false;
-	if (!zone->is_town)
-	{
-		delim = put_delim(out, delim);
-		out << "средний уровень: " << zone->mob_level;
-	}
-	if (zone->group > 1)
-	{
-		delim = put_delim(out, delim);
-		out << "групповая на " << zone->group
-			<< " " << desc_count(zone->group, WHAT_PEOPLE);
-	}
-	if (delim)
-	{
-		out << ")";
-	}
-	out << ".\r\n";
+  bool delim = false;
+  if (!zone->is_town) {
+    delim = put_delim(out, delim);
+    out << "средний уровень: " << zone->mob_level;
+  }
+  if (zone->group > 1) {
+    delim = put_delim(out, delim);
+    out << "групповая на " << zone->group
+        << " " << desc_count(zone->group, WHAT_PEOPLE);
+  }
+  if (delim) {
+    out << ")";
+  }
+  out << ".\r\n";
 
-	send_to_char(out.str(), ch);
+  send_to_char(out.str(), ch);
 }
 
-void show_glow_objs(CHAR_DATA *ch)
-{
-	unsigned cnt = 0;
-	for (OBJ_DATA *obj = world[ch->in_room]->contents;
-		obj; obj = obj->get_next_content())
-	{
-		if (obj->get_extra_flag(EExtraFlag::ITEM_GLOW))
-		{
-			++cnt;
-			if (cnt > 1)
-			{
-				break;
-			}
-		}
-	}
-	if (!cnt) return;
+void show_glow_objs(CHAR_DATA *ch) {
+  unsigned cnt = 0;
+  for (OBJ_DATA *obj = world[ch->in_room]->contents;
+       obj; obj = obj->get_next_content()) {
+    if (obj->get_extra_flag(EExtraFlag::ITEM_GLOW)) {
+      ++cnt;
+      if (cnt > 1) {
+        break;
+      }
+    }
+  }
+  if (!cnt) return;
 
-	const char *str = cnt > 1 ?
-		"Вы видите очертания каких-то блестящих предметов.\r\n" :
-		"Вы видите очертания какого-то блестящего предмета.\r\n";
-	send_to_char(str, ch);
+  const char *str = cnt > 1 ?
+                    "Вы видите очертания каких-то блестящих предметов.\r\n" :
+                    "Вы видите очертания какого-то блестящего предмета.\r\n";
+  send_to_char(str, ch);
 }
 
-void show_room_affects(CHAR_DATA* ch, const char* name_affects[], const char* name_self_affects[])
-{
-	bitvector_t bitvector = 0;
-	std::ostringstream buffer;
+void show_room_affects(CHAR_DATA *ch, const char *name_affects[], const char *name_self_affects[]) {
+  bitvector_t bitvector = 0;
+  std::ostringstream buffer;
 
-	for (const auto& af : world[ch->in_room]->affected)
-	{
-		switch (af->bitvector)
-		{
-		case AFF_ROOM_LIGHT:					// 1 << 0
-			if (!IS_SET(bitvector, AFF_ROOM_LIGHT))
-			{
-				if (af->caster_id == ch->id && *name_self_affects[0] != '\0')
-				{
-					buffer << name_self_affects[0] << "\r\n";
-				}
-				else if(*name_affects[0] != '\0')
-				{
-					buffer << name_affects[0] << "\r\n";
-				}
+  for (const auto &af : world[ch->in_room]->affected) {
+    switch (af->bitvector) {
+      case AFF_ROOM_LIGHT:                    // 1 << 0
+        if (!IS_SET(bitvector, AFF_ROOM_LIGHT)) {
+          if (af->caster_id == ch->id && *name_self_affects[0] != '\0') {
+            buffer << name_self_affects[0] << "\r\n";
+          } else if (*name_affects[0] != '\0') {
+            buffer << name_affects[0] << "\r\n";
+          }
 
-				SET_BIT(bitvector, AFF_ROOM_LIGHT);
-			}
-			break;
-		case AFF_ROOM_FOG:						// 1 << 1
-			if (!IS_SET(bitvector, AFF_ROOM_FOG))
-			{
-				if (af->caster_id == ch->id && *name_self_affects[1] != '\0')
-				{
-					buffer << name_self_affects[1] << "\r\n";
-				}
-				else if (*name_affects[1] != '\0')
-				{
-					buffer << name_affects[1] << "\r\n";
-				}
+          SET_BIT(bitvector, AFF_ROOM_LIGHT);
+        }
+        break;
+      case AFF_ROOM_FOG:                        // 1 << 1
+        if (!IS_SET(bitvector, AFF_ROOM_FOG)) {
+          if (af->caster_id == ch->id && *name_self_affects[1] != '\0') {
+            buffer << name_self_affects[1] << "\r\n";
+          } else if (*name_affects[1] != '\0') {
+            buffer << name_affects[1] << "\r\n";
+          }
 
-				SET_BIT(bitvector, AFF_ROOM_FOG);
-			}
-			break;
-		case AFF_ROOM_RUNE_LABEL:				// 1 << 2
-			if (af->caster_id == ch->id && *name_self_affects[2] != '\0')
-			{
-				buffer << name_self_affects[2] << "\r\n";
-			}
-			else if (*name_affects[2] != '\0')
-			{
-				buffer << name_affects[2] << "\r\n";
-			}
-			break;
-		case AFF_ROOM_FORBIDDEN:				// 1 << 3
-			if (!IS_SET(bitvector, AFF_ROOM_FORBIDDEN))
-			{
-				if (af->caster_id == ch->id && *name_self_affects[3] != '\0')
-				{
-					buffer << name_self_affects[3] << "\r\n";
-				}
-				else if (*name_affects[3] != '\0')
-				{
-					buffer << name_affects[3] << "\r\n";
-				}
+          SET_BIT(bitvector, AFF_ROOM_FOG);
+        }
+        break;
+      case AFF_ROOM_RUNE_LABEL:                // 1 << 2
+        if (af->caster_id == ch->id && *name_self_affects[2] != '\0') {
+          buffer << name_self_affects[2] << "\r\n";
+        } else if (*name_affects[2] != '\0') {
+          buffer << name_affects[2] << "\r\n";
+        }
+        break;
+      case AFF_ROOM_FORBIDDEN:                // 1 << 3
+        if (!IS_SET(bitvector, AFF_ROOM_FORBIDDEN)) {
+          if (af->caster_id == ch->id && *name_self_affects[3] != '\0') {
+            buffer << name_self_affects[3] << "\r\n";
+          } else if (*name_affects[3] != '\0') {
+            buffer << name_affects[3] << "\r\n";
+          }
 
-				SET_BIT(bitvector, AFF_ROOM_FORBIDDEN);
-			}
-			break;
-		case AFF_ROOM_HYPNOTIC_PATTERN:			// 1 << 4
-			if (!IS_SET(bitvector, AFF_ROOM_HYPNOTIC_PATTERN))
-			{
-				if (af->caster_id == ch->id && *name_self_affects[4] != '\0')
-				{
-					buffer << name_self_affects[4] << "\r\n";
-				}
-				else if (*name_affects[4] != '\0')
-				{
-					buffer << name_affects[4] << "\r\n";
-				}
+          SET_BIT(bitvector, AFF_ROOM_FORBIDDEN);
+        }
+        break;
+      case AFF_ROOM_HYPNOTIC_PATTERN:            // 1 << 4
+        if (!IS_SET(bitvector, AFF_ROOM_HYPNOTIC_PATTERN)) {
+          if (af->caster_id == ch->id && *name_self_affects[4] != '\0') {
+            buffer << name_self_affects[4] << "\r\n";
+          } else if (*name_affects[4] != '\0') {
+            buffer << name_affects[4] << "\r\n";
+          }
 
-				SET_BIT(bitvector, AFF_ROOM_HYPNOTIC_PATTERN);
-			}
-			break;
-		case AFF_ROOM_EVARDS_BLACK_TENTACLES:	// 1 << 5
-			if (!IS_SET(bitvector, AFF_ROOM_EVARDS_BLACK_TENTACLES))
-			{
-				if (af->caster_id == ch->id && *name_self_affects[5] != '\0')
-				{
-					buffer << name_self_affects[5] << "\r\n";
-				}
-				else if (*name_affects[5] != '\0')
-				{
-					buffer << name_affects[5] << "\r\n";
-				}
+          SET_BIT(bitvector, AFF_ROOM_HYPNOTIC_PATTERN);
+        }
+        break;
+      case AFF_ROOM_EVARDS_BLACK_TENTACLES:    // 1 << 5
+        if (!IS_SET(bitvector, AFF_ROOM_EVARDS_BLACK_TENTACLES)) {
+          if (af->caster_id == ch->id && *name_self_affects[5] != '\0') {
+            buffer << name_self_affects[5] << "\r\n";
+          } else if (*name_affects[5] != '\0') {
+            buffer << name_affects[5] << "\r\n";
+          }
 
-				SET_BIT(bitvector, AFF_ROOM_EVARDS_BLACK_TENTACLES);
-			}
-			break;
-		case AFF_ROOM_METEORSTORM:				// 1 << 6
-			if (!IS_SET(bitvector, AFF_ROOM_METEORSTORM))
-			{
-				if (af->caster_id == ch->id && *name_self_affects[6] != '\0')
-				{
-					buffer << name_self_affects[6] << "\r\n";
-				}
-				else if (*name_affects[6] != '\0')
-				{
-					buffer << name_affects[6] << "\r\n";
-				}
+          SET_BIT(bitvector, AFF_ROOM_EVARDS_BLACK_TENTACLES);
+        }
+        break;
+      case AFF_ROOM_METEORSTORM:                // 1 << 6
+        if (!IS_SET(bitvector, AFF_ROOM_METEORSTORM)) {
+          if (af->caster_id == ch->id && *name_self_affects[6] != '\0') {
+            buffer << name_self_affects[6] << "\r\n";
+          } else if (*name_affects[6] != '\0') {
+            buffer << name_affects[6] << "\r\n";
+          }
 
-				SET_BIT(bitvector, AFF_ROOM_METEORSTORM);
-			}
-			break;
-		case AFF_ROOM_THUNDERSTORM:				// 1 << 7
-			if (!IS_SET(bitvector, AFF_ROOM_THUNDERSTORM))
-			{
-				if (af->caster_id == ch->id && *name_self_affects[7] != '\0')
-				{
-					buffer << name_self_affects[7] << "\r\n";
-				}
-				else if (*name_affects[7] != '\0')
-				{
-					buffer << name_affects[7] << "\r\n";
-				}
+          SET_BIT(bitvector, AFF_ROOM_METEORSTORM);
+        }
+        break;
+      case AFF_ROOM_THUNDERSTORM:                // 1 << 7
+        if (!IS_SET(bitvector, AFF_ROOM_THUNDERSTORM)) {
+          if (af->caster_id == ch->id && *name_self_affects[7] != '\0') {
+            buffer << name_self_affects[7] << "\r\n";
+          } else if (*name_affects[7] != '\0') {
+            buffer << name_affects[7] << "\r\n";
+          }
 
-				SET_BIT(bitvector, AFF_ROOM_THUNDERSTORM);
-			}
-			break;
-		default:
-			log("SYSERR: Unknown room affect: %d", af->type);
-		}
-	}
+          SET_BIT(bitvector, AFF_ROOM_THUNDERSTORM);
+        }
+        break;
+      default: log("SYSERR: Unknown room affect: %d", af->type);
+    }
+  }
 
-	auto affects = buffer.str();
-	if (!affects.empty())
-	{
-		affects.append("\r\n");
-		send_to_char(affects.c_str(), ch);
-	}
+  auto affects = buffer.str();
+  if (!affects.empty()) {
+    affects.append("\r\n");
+    send_to_char(affects.c_str(), ch);
+  }
 }
 
-void look_at_room(CHAR_DATA * ch, int ignore_brief)
-{
-	if (!ch->desc)
-		return;
+void look_at_room(CHAR_DATA *ch, int ignore_brief) {
+  if (!ch->desc)
+    return;
 
-	if (IS_DARK(ch->in_room) && !CAN_SEE_IN_DARK(ch) && !can_use_feat(ch, DARK_READING_FEAT))
-	{
-		send_to_char("Слишком темно...\r\n", ch);
-		show_glow_objs(ch);
-		return;
-	}
-	else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-	{
-		send_to_char("Вы все еще слепы...\r\n", ch);
-		return;
-	}
-	else if (GET_POS(ch) < POS_SLEEPING)
-	{
-		return;
-	}
+  if (IS_DARK(ch->in_room) && !CAN_SEE_IN_DARK(ch) && !can_use_feat(ch, DARK_READING_FEAT)) {
+    send_to_char("Слишком темно...\r\n", ch);
+    show_glow_objs(ch);
+    return;
+  } else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    send_to_char("Вы все еще слепы...\r\n", ch);
+    return;
+  } else if (GET_POS(ch) < POS_SLEEPING) {
+    return;
+  }
 
-	if (PRF_FLAGGED(ch, PRF_DRAW_MAP) && !PRF_FLAGGED(ch, PRF_BLIND))
-	{
-		MapSystem::print_map(ch);
-	}
-	else if (ch->desc->snoop_by
-		&& ch->desc->snoop_by->snoop_with_map
-		&& ch->desc->snoop_by->character)
-	{
-		ch->map_print_to_snooper(ch->desc->snoop_by->character.get());
-	}
+  if (PRF_FLAGGED(ch, PRF_DRAW_MAP) && !PRF_FLAGGED(ch, PRF_BLIND)) {
+    MapSystem::print_map(ch);
+  } else if (ch->desc->snoop_by
+      && ch->desc->snoop_by->snoop_with_map
+      && ch->desc->snoop_by->character) {
+    ch->map_print_to_snooper(ch->desc->snoop_by->character.get());
+  }
 
-	send_to_char(CCICYN(ch, C_NRM), ch);
+  send_to_char(CCICYN(ch, C_NRM), ch);
 
-	if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_ROOMFLAGS)) {
-		// иммам рандомная * во флагах ломает мапер грят
-		const bool has_flag = ROOM_FLAGGED(ch->in_room, ROOM_BFS_MARK) ? true : false;
-		GET_ROOM(ch->in_room)->unset_flag(ROOM_BFS_MARK);
+  if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_ROOMFLAGS)) {
+    // иммам рандомная * во флагах ломает мапер грят
+    const bool has_flag = ROOM_FLAGGED(ch->in_room, ROOM_BFS_MARK) ? true : false;
+    GET_ROOM(ch->in_room)->unset_flag(ROOM_BFS_MARK);
 
-		GET_ROOM(ch->in_room)->flags_sprint(buf, ";");
-		snprintf(buf2, MAX_STRING_LENGTH, "[%5d] %s [%s]", GET_ROOM_VNUM(ch->in_room), world[ch->in_room]->name, buf);
-		send_to_char(buf2, ch);
+    GET_ROOM(ch->in_room)->flags_sprint(buf, ";");
+    snprintf(buf2, MAX_STRING_LENGTH, "[%5d] %s [%s]", GET_ROOM_VNUM(ch->in_room), world[ch->in_room]->name, buf);
+    send_to_char(buf2, ch);
 
-		if (has_flag)
-		{
-			GET_ROOM(ch->in_room)->set_flag(ROOM_BFS_MARK);
-		}
-	}
-	else
-	{
-		if (PRF_FLAGGED(ch, PRF_MAPPER) && !PLR_FLAGGED(ch, PLR_SCRIPTWRITER) && !ROOM_FLAGGED(ch->in_room, ROOM_NOMAPPER))
-		{
-			sprintf(buf2, "%s [%d]", world[ch->in_room]->name, GET_ROOM_VNUM(ch->in_room));
-			send_to_char(buf2, ch);
-		}
-		else
-			send_to_char(world[ch->in_room]->name, ch);
-	}
+    if (has_flag) {
+      GET_ROOM(ch->in_room)->set_flag(ROOM_BFS_MARK);
+    }
+  } else {
+    if (PRF_FLAGGED(ch, PRF_MAPPER) && !PLR_FLAGGED(ch, PLR_SCRIPTWRITER)
+        && !ROOM_FLAGGED(ch->in_room, ROOM_NOMAPPER)) {
+      sprintf(buf2, "%s [%d]", world[ch->in_room]->name, GET_ROOM_VNUM(ch->in_room));
+      send_to_char(buf2, ch);
+    } else
+      send_to_char(world[ch->in_room]->name, ch);
+  }
 
-	send_to_char(CCNRM(ch, C_NRM), ch);
-	send_to_char("\r\n", ch);
+  send_to_char(CCNRM(ch, C_NRM), ch);
+  send_to_char("\r\n", ch);
 
-	if (IS_DARK(ch->in_room) && !PRF_FLAGGED(ch, PRF_HOLYLIGHT))
-	{
-		send_to_char("Слишком темно...\r\n", ch);
-	}
-	else if ((!IS_NPC(ch) && !PRF_FLAGGED(ch, PRF_BRIEF)) || ignore_brief || ROOM_FLAGGED(ch->in_room, ROOM_DEATH))
-	{
-		show_extend_room(RoomDescription::show_desc(world[ch->in_room]->description_num).c_str(), ch);
-	}
+  if (IS_DARK(ch->in_room) && !PRF_FLAGGED(ch, PRF_HOLYLIGHT)) {
+    send_to_char("Слишком темно...\r\n", ch);
+  } else if ((!IS_NPC(ch) && !PRF_FLAGGED(ch, PRF_BRIEF)) || ignore_brief || ROOM_FLAGGED(ch->in_room, ROOM_DEATH)) {
+    show_extend_room(RoomDescription::show_desc(world[ch->in_room]->description_num).c_str(), ch);
+  }
 
-	// autoexits
-	if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_AUTOEXIT) && !PLR_FLAGGED(ch, PLR_SCRIPTWRITER))
-	{
-		do_auto_exits(ch);
-	}
+  // autoexits
+  if (!IS_NPC(ch) && PRF_FLAGGED(ch, PRF_AUTOEXIT) && !PLR_FLAGGED(ch, PLR_SCRIPTWRITER)) {
+    do_auto_exits(ch);
+  }
 
-	// Отображаем аффекты комнаты. После автовыходов чтобы не ломать популярный маппер.
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC) || IS_IMMORTAL(ch))
-	{
-		show_room_affects(ch, room_aff_invis_bits, room_self_aff_invis_bits);
-	}
-	else
-	{
-		show_room_affects(ch, room_aff_visib_bits, room_aff_visib_bits);
-	}
+  // Отображаем аффекты комнаты. После автовыходов чтобы не ломать популярный маппер.
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC) || IS_IMMORTAL(ch)) {
+    show_room_affects(ch, room_aff_invis_bits, room_self_aff_invis_bits);
+  } else {
+    show_room_affects(ch, room_aff_visib_bits, room_aff_visib_bits);
+  }
 
-	// now list characters & objects
-	if (world[ch->in_room]->fires)
-	{
-		sprintf(buf, "%sВ центре %s.%s\r\n",
-				CCRED(ch, C_NRM), Fires[MIN(world[ch->in_room]->fires, MAX_FIRES - 1)], CCNRM(ch, C_NRM));
-		send_to_char(buf, ch);
-	}
+  // now list characters & objects
+  if (world[ch->in_room]->fires) {
+    sprintf(buf, "%sВ центре %s.%s\r\n",
+            CCRED(ch, C_NRM), Fires[MIN(world[ch->in_room]->fires, MAX_FIRES - 1)], CCNRM(ch, C_NRM));
+    send_to_char(buf, ch);
+  }
 
-	if (world[ch->in_room]->portal_time)
-	{
-		if (world[ch->in_room]->pkPenterUnique)
-		{
-			sprintf(buf, "%sЛазурная пентаграмма %sс кровавым отблеском%s ярко сверкает здесь.%s\r\n",
-				CCIBLU(ch, C_NRM), CCIRED(ch, C_NRM), CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
-		}
-		else
-		{
-			sprintf(buf, "%sЛазурная пентаграмма ярко сверкает здесь.%s\r\n",
-				CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
-		}
+  if (world[ch->in_room]->portal_time) {
+    if (world[ch->in_room]->pkPenterUnique) {
+      sprintf(buf, "%sЛазурная пентаграмма %sс кровавым отблеском%s ярко сверкает здесь.%s\r\n",
+              CCIBLU(ch, C_NRM), CCIRED(ch, C_NRM), CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
+    } else {
+      sprintf(buf, "%sЛазурная пентаграмма ярко сверкает здесь.%s\r\n",
+              CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
+    }
 
-		send_to_char(buf, ch);
-	}
+    send_to_char(buf, ch);
+  }
 
-	if (world[ch->in_room]->holes)
-	{
-		const int ar = roundup(world[ch->in_room]->holes / HOLES_TIME);
-		sprintf(buf, "%sЗдесь выкопана ямка глубиной примерно в %i аршин%s.%s\r\n",
-			CCYEL(ch, C_NRM), ar, (ar == 1 ? "" : (ar < 5 ? "а" : "ов")), (CCNRM(ch, C_NRM)));
-		send_to_char(buf, ch);
-	}
+  if (world[ch->in_room]->holes) {
+    const int ar = roundup(world[ch->in_room]->holes / HOLES_TIME);
+    sprintf(buf, "%sЗдесь выкопана ямка глубиной примерно в %i аршин%s.%s\r\n",
+            CCYEL(ch, C_NRM), ar, (ar == 1 ? "" : (ar < 5 ? "а" : "ов")), (CCNRM(ch, C_NRM)));
+    send_to_char(buf, ch);
+  }
 
-	if (ch->in_room != NOWHERE && !ROOM_FLAGGED(ch->in_room, ROOM_NOWEATHER) && !ROOM_FLAGGED(ch->in_room, ROOM_INDOORS))
-	{
-		*buf = '\0';
-		switch (real_sector(ch->in_room))
-		{
-		case SECT_FIELD_SNOW:
-		case SECT_FOREST_SNOW:
-		case SECT_HILLS_SNOW:
-		case SECT_MOUNTAIN_SNOW:
-			sprintf(buf, "%sСнежный ковер лежит у вас под ногами.%s\r\n",
-				CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
-			break;
-		case SECT_FIELD_RAIN:
-		case SECT_FOREST_RAIN:
-		case SECT_HILLS_RAIN:
-			sprintf(buf, "%sВы просто увязаете в грязи.%s\r\n", CCIWHT(ch, C_NRM), CCNRM(ch, C_NRM));
-			break;
-		case SECT_THICK_ICE:
-			sprintf(buf, "%sУ вас под ногами толстый лед.%s\r\n", CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
-			break;
-		case SECT_NORMAL_ICE:
-			sprintf(buf, "%sУ вас под ногами достаточно толстый лед.%s\r\n",
-				CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
-			break;
-		case SECT_THIN_ICE:
-			sprintf(buf, "%sТоненький ледок вот-вот проломится под вами.%s\r\n",
-				CCICYN(ch, C_NRM), CCNRM(ch, C_NRM));
-			break;
-		};
-		if (*buf)
-		{
-			send_to_char(buf, ch);
-		}
-	}
-	send_to_char("&Y&q", ch);
-	if (ch->get_skill(SKILL_TOWNPORTAL)) {
-		if (find_portal_by_vnum(GET_ROOM_VNUM(ch->in_room))) {
-			send_to_char("Рунный камень с изображением пентаграммы немного выступает из земли.\r\n", ch);
-		}
-	}
-	list_obj_to_char(world[ch->in_room]->contents, ch, 0, FALSE);
-	list_char_to_char_thing(world[ch->in_room]->people, ch);  //добавим отдельный вызов если моб типа предмет выводим желтым
-	send_to_char("&R&q", ch);
-	list_char_to_char(world[ch->in_room]->people, ch);
-	send_to_char("&Q&n", ch);
+  if (ch->in_room != NOWHERE && !ROOM_FLAGGED(ch->in_room, ROOM_NOWEATHER)
+      && !ROOM_FLAGGED(ch->in_room, ROOM_INDOORS)) {
+    *buf = '\0';
+    switch (real_sector(ch->in_room)) {
+      case SECT_FIELD_SNOW:
+      case SECT_FOREST_SNOW:
+      case SECT_HILLS_SNOW:
+      case SECT_MOUNTAIN_SNOW:
+        sprintf(buf, "%sСнежный ковер лежит у вас под ногами.%s\r\n",
+                CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
+        break;
+      case SECT_FIELD_RAIN:
+      case SECT_FOREST_RAIN:
+      case SECT_HILLS_RAIN: sprintf(buf, "%sВы просто увязаете в грязи.%s\r\n", CCIWHT(ch, C_NRM), CCNRM(ch, C_NRM));
+        break;
+      case SECT_THICK_ICE: sprintf(buf, "%sУ вас под ногами толстый лед.%s\r\n", CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
+        break;
+      case SECT_NORMAL_ICE:
+        sprintf(buf, "%sУ вас под ногами достаточно толстый лед.%s\r\n",
+                CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
+        break;
+      case SECT_THIN_ICE:
+        sprintf(buf, "%sТоненький ледок вот-вот проломится под вами.%s\r\n",
+                CCICYN(ch, C_NRM), CCNRM(ch, C_NRM));
+        break;
+    };
+    if (*buf) {
+      send_to_char(buf, ch);
+    }
+  }
+  send_to_char("&Y&q", ch);
+  if (ch->get_skill(SKILL_TOWNPORTAL)) {
+    if (find_portal_by_vnum(GET_ROOM_VNUM(ch->in_room))) {
+      send_to_char("Рунный камень с изображением пентаграммы немного выступает из земли.\r\n", ch);
+    }
+  }
+  list_obj_to_char(world[ch->in_room]->contents, ch, 0, FALSE);
+  list_char_to_char_thing(world[ch->in_room]->people,
+                          ch);  //добавим отдельный вызов если моб типа предмет выводим желтым
+  send_to_char("&R&q", ch);
+  list_char_to_char(world[ch->in_room]->people, ch);
+  send_to_char("&Q&n", ch);
 
-	// вход в новую зону
-	if (!IS_NPC(ch)) {
-		zone_rnum inroom = world[ch->in_room]->zone;
-		if (zone_table[world[ch->get_from_room()]->zone].number != zone_table[inroom].number) {
-			if (PRF_FLAGGED(ch, PRF_ENTER_ZONE))
-				print_zone_info(ch);
-			if ((ch->get_level() < LVL_IMMORT) && !ch->get_master())
-				++zone_table[inroom].traffic;
-		}
-	}
+  // вход в новую зону
+  if (!IS_NPC(ch)) {
+    zone_rnum inroom = world[ch->in_room]->zone;
+    if (zone_table[world[ch->get_from_room()]->zone].number != zone_table[inroom].number) {
+      if (PRF_FLAGGED(ch, PRF_ENTER_ZONE))
+        print_zone_info(ch);
+      if ((ch->get_level() < LVL_IMMORT) && !ch->get_master())
+        ++zone_table[inroom].traffic;
+    }
+  }
 }
 
-int get_pick_chance(int skill_pick, int lock_complexity)
-{
-	return (MIN(5, MAX(-5, skill_pick - lock_complexity)) + 5);
+int get_pick_chance(int skill_pick, int lock_complexity) {
+  return (MIN(5, MAX(-5, skill_pick - lock_complexity)) + 5);
 }
 
-void look_in_direction(CHAR_DATA * ch, int dir, int info_is)
-{
-	int count = 0, probe, percent;
-	ROOM_DATA::exit_data_ptr rdata;
+void look_in_direction(CHAR_DATA *ch, int dir, int info_is) {
+  int count = 0, probe, percent;
+  ROOM_DATA::exit_data_ptr rdata;
 
-	if (CAN_GO(ch, dir)
-		|| (EXIT(ch, dir)
-			&& EXIT(ch, dir)->to_room() != NOWHERE))
-	{
-		rdata = EXIT(ch, dir);
-		count += sprintf(buf, "%s%s:%s ", CCYEL(ch, C_NRM), Dirs[dir], CCNRM(ch, C_NRM));
-		if (EXIT_FLAGGED(rdata, EX_CLOSED))
-		{
-			if (rdata->keyword)
-			{
-				count += sprintf(buf + count, " закрыто (%s).\r\n", rdata->keyword);
-			}
-			else
-			{
-				count += sprintf(buf + count, " закрыто (вероятно дверь).\r\n");
-			}
+  if (CAN_GO(ch, dir)
+      || (EXIT(ch, dir)
+          && EXIT(ch, dir)->to_room() != NOWHERE)) {
+    rdata = EXIT(ch, dir);
+    count += sprintf(buf, "%s%s:%s ", CCYEL(ch, C_NRM), Dirs[dir], CCNRM(ch, C_NRM));
+    if (EXIT_FLAGGED(rdata, EX_CLOSED)) {
+      if (rdata->keyword) {
+        count += sprintf(buf + count, " закрыто (%s).\r\n", rdata->keyword);
+      } else {
+        count += sprintf(buf + count, " закрыто (вероятно дверь).\r\n");
+      }
 
-			const int skill_pick = ch->get_skill(SKILL_PICK_LOCK) ;
-			if (EXIT_FLAGGED(rdata, EX_LOCKED) && skill_pick)
-			{
-				if (EXIT_FLAGGED(rdata, EX_PICKPROOF))
-				{
-					count += sprintf(buf+count-2, "%s вы никогда не сможете ЭТО взломать!%s\r\n", CCICYN(ch, C_NRM), CCNRM(ch, C_NRM));
-				}
-				else if (EXIT_FLAGGED(rdata, EX_BROKEN))
-				{
-					count += sprintf(buf+count-2, "%s Замок сломан... %s\r\n", CCRED(ch, C_NRM), CCNRM(ch, C_NRM));
-				}
-				else
-				{
-					const int chance = get_pick_chance(skill_pick, rdata->lock_complexity);
-					const int index = chance ? chance/5 + 1 : 0;
+      const int skill_pick = ch->get_skill(SKILL_PICK_LOCK);
+      if (EXIT_FLAGGED(rdata, EX_LOCKED) && skill_pick) {
+        if (EXIT_FLAGGED(rdata, EX_PICKPROOF)) {
+          count += sprintf(buf + count - 2,
+                           "%s вы никогда не сможете ЭТО взломать!%s\r\n",
+                           CCICYN(ch, C_NRM),
+                           CCNRM(ch, C_NRM));
+        } else if (EXIT_FLAGGED(rdata, EX_BROKEN)) {
+          count += sprintf(buf + count - 2, "%s Замок сломан... %s\r\n", CCRED(ch, C_NRM), CCNRM(ch, C_NRM));
+        } else {
+          const int chance = get_pick_chance(skill_pick, rdata->lock_complexity);
+          const int index = chance ? chance / 5 + 1 : 0;
 
-					std::string color = Locks[index][1];
-					if (abs(skill_pick - rdata->lock_complexity)>10)
-					{
-						color = KIDRK;
-					}
-					if (COLOR_LEV(ch)>C_NRM)
-					{
-						count += sprintf(buf + count - 2, Locks[index][0], color.c_str(), KNRM);
-					}
-					else
-					{
-						count += sprintf(buf + count - 2, Locks[index][0], KNUL, KNUL);
-					}
-				}
-			}
+          std::string color = Locks[index][1];
+          if (abs(skill_pick - rdata->lock_complexity) > 10) {
+            color = KIDRK;
+          }
+          if (COLOR_LEV(ch) > C_NRM) {
+            count += sprintf(buf + count - 2, Locks[index][0], color.c_str(), KNRM);
+          } else {
+            count += sprintf(buf + count - 2, Locks[index][0], KNUL, KNUL);
+          }
+        }
+      }
 
-			send_to_char(buf, ch);
-			return;
-		}
+      send_to_char(buf, ch);
+      return;
+    }
 
-		if (IS_TIMEDARK(rdata->to_room()))
-		{
-			count += sprintf(buf + count, " слишком темно.\r\n");
-			send_to_char(buf, ch);
-			if (info_is & EXIT_SHOW_LOOKING)
-			{
-				send_to_char("&R&q", ch);
-				count = 0;
-				for (const auto tch : world[rdata->to_room()]->people)
-				{
-					percent = number(1, skill_info[SKILL_LOOKING].max_percent);
-					probe =
-						train_skill(ch, SKILL_LOOKING, skill_info[SKILL_LOOKING].max_percent, tch);
-					if (HERE(tch) && INVIS_OK(ch, tch) && probe >= percent
-							&& (percent < 100 || IS_IMMORTAL(ch)))
-					{
-						// Если моб не вещь и смотрящий не им
-						if ( GET_RACE(tch) != NPC_RACE_THING || IS_IMMORTAL(ch) ) {
-							list_one_char(tch, ch, SKILL_LOOKING);
-							count++;
-						}
-					}
-				}
+    if (IS_TIMEDARK(rdata->to_room())) {
+      count += sprintf(buf + count, " слишком темно.\r\n");
+      send_to_char(buf, ch);
+      if (info_is & EXIT_SHOW_LOOKING) {
+        send_to_char("&R&q", ch);
+        count = 0;
+        for (const auto tch : world[rdata->to_room()]->people) {
+          percent = number(1, skill_info[SKILL_LOOKING].max_percent);
+          probe = calculate_skill(ch, SKILL_LOOKING, tch);
+          train_skill(ch, SKILL_LOOKING, probe >= percent, tch);
+          if (HERE(tch) && INVIS_OK(ch, tch) && probe >= percent
+              && (percent < 100 || IS_IMMORTAL(ch))) {
+            // Если моб не вещь и смотрящий не им
+            if (GET_RACE(tch) != NPC_RACE_THING || IS_IMMORTAL(ch)) {
+              list_one_char(tch, ch, SKILL_LOOKING);
+              count++;
+            }
+          }
+        }
 
-				if (!count)
-				{
-					send_to_char("Вы ничего не смогли разглядеть!\r\n", ch);
-				}
-				send_to_char("&Q&n", ch);
-			}
-		}
-		else
-		{
-			if (!rdata->general_description.empty())
-			{
-				count += sprintf(buf + count, "%s\r\n", rdata->general_description.c_str());
-			}
-			else
-			{
-				count += sprintf(buf + count, "%s\r\n", world[rdata->to_room()]->name);
-			}
-			send_to_char(buf, ch);
-			send_to_char("&R&q", ch);
-			list_char_to_char(world[rdata->to_room()]->people, ch);
-			send_to_char("&Q&n", ch);
-		}
-	}
-	else if (info_is & EXIT_SHOW_WALL)
-		send_to_char("И что вы там мечтаете увидеть?\r\n", ch);
+        if (!count) {
+          send_to_char("Вы ничего не смогли разглядеть!\r\n", ch);
+        }
+        send_to_char("&Q&n", ch);
+      }
+    } else {
+      if (!rdata->general_description.empty()) {
+        count += sprintf(buf + count, "%s\r\n", rdata->general_description.c_str());
+      } else {
+        count += sprintf(buf + count, "%s\r\n", world[rdata->to_room()]->name);
+      }
+      send_to_char(buf, ch);
+      send_to_char("&R&q", ch);
+      list_char_to_char(world[rdata->to_room()]->people, ch);
+      send_to_char("&Q&n", ch);
+    }
+  } else if (info_is & EXIT_SHOW_WALL)
+    send_to_char("И что вы там мечтаете увидеть?\r\n", ch);
 }
 
-void hear_in_direction(CHAR_DATA * ch, int dir, int info_is)
-{
-	int count = 0, percent = 0, probe = 0;
-	ROOM_DATA::exit_data_ptr rdata;
-	int fight_count = 0;
-	string tmpstr = "";
+void hear_in_direction(CHAR_DATA *ch, int dir, int info_is) {
+  int count = 0, percent = 0, probe = 0;
+  ROOM_DATA::exit_data_ptr rdata;
+  int fight_count = 0;
+  string tmpstr = "";
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
-	{
-		send_to_char("Вы забыли, что вы глухи?\r\n", ch);
-		return;
-	}
-	if (CAN_GO(ch, dir)
-		|| (EXIT(ch, dir)
-		&& EXIT(ch, dir)->to_room() != NOWHERE))
-	{
-		rdata = EXIT(ch, dir);
-		count += sprintf(buf, "%s%s:%s ", CCYEL(ch, C_NRM), Dirs[dir], CCNRM(ch, C_NRM));
-		count += sprintf(buf + count, "\r\n%s", CCGRN(ch, C_NRM));
-		send_to_char(buf, ch);
-		count = 0;
-		for (const auto tch : world[rdata->to_room()]->people)
-		{
-			percent = number(1, skill_info[SKILL_HEARING].max_percent);
-			probe = train_skill(ch, SKILL_HEARING, skill_info[SKILL_HEARING].max_percent, tch);
-			// Если сражаются то слышем только борьбу.
-			if (tch->get_fighting())
-			{
-				if (IS_NPC(tch))
-				{
-					tmpstr += " Вы слышите шум чьей-то борьбы.\r\n";
-				}
-				else
-				{
-					tmpstr += " Вы слышите звуки чьих-то ударов.\r\n";
-				}
-				fight_count++;
-				continue;
-			}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS)) {
+    send_to_char("Вы забыли, что вы глухи?\r\n", ch);
+    return;
+  }
+  if (CAN_GO(ch, dir)
+      || (EXIT(ch, dir)
+          && EXIT(ch, dir)->to_room() != NOWHERE)) {
+    rdata = EXIT(ch, dir);
+    count += sprintf(buf, "%s%s:%s ", CCYEL(ch, C_NRM), Dirs[dir], CCNRM(ch, C_NRM));
+    count += sprintf(buf + count, "\r\n%s", CCGRN(ch, C_NRM));
+    send_to_char(buf, ch);
+    count = 0;
+    for (const auto tch : world[rdata->to_room()]->people) {
+      percent = number(1, skill_info[SKILL_HEARING].max_percent);
+      probe = calculate_skill(ch, SKILL_HEARING, tch);
+      train_skill(ch, SKILL_HEARING, probe >= percent, tch);
+      // Если сражаются то слышем только борьбу.
+      if (tch->get_fighting()) {
+        if (IS_NPC(tch)) {
+          tmpstr += " Вы слышите шум чьей-то борьбы.\r\n";
+        } else {
+          tmpstr += " Вы слышите звуки чьих-то ударов.\r\n";
+        }
+        fight_count++;
+        continue;
+      }
 
-			if ((probe >= percent || ((!AFF_FLAGGED(tch, EAffectFlag::AFF_SNEAK) || !AFF_FLAGGED(tch, EAffectFlag::AFF_HIDE)) && (probe > percent * 2)))
-					&& (percent < 100 || IS_IMMORTAL(ch))
-					&& !fight_count)
-			{
-				if (IS_NPC(tch))
-				{
-					if (GET_RACE(tch)==NPC_RACE_THING) {
-						if (GET_LEVEL(tch) < 5)
-							tmpstr += " Вы слышите чье-то тихое поскрипывание.\r\n";
-						else if (GET_LEVEL(tch) < 15)
-							tmpstr += " Вы слышите чей-то скрип.\r\n";
-						else if (GET_LEVEL(tch) < 25)
-							tmpstr += " Вы слышите чей-то громкий скрип.\r\n";
-						else
-							tmpstr += " Вы слышите чей-то грозный скрип.\r\n";
-					}
-					else if (real_sector(ch->in_room) != SECT_UNDERWATER)
-					{
-						if (GET_LEVEL(tch) < 5)
-							tmpstr += " Вы слышите чью-то тихую возню.\r\n";
-						else if (GET_LEVEL(tch) < 15)
-							tmpstr += " Вы слышите чье-то сопение.\r\n";
-						else if (GET_LEVEL(tch) < 25)
-							tmpstr += " Вы слышите чье-то громкое дыхание.\r\n";
-						else
-							tmpstr += " Вы слышите чье-то грозное дыхание.\r\n";
-					}
-					else
-					{
-						if (GET_LEVEL(tch) < 5)
-							tmpstr += " Вы слышите тихое бульканье.\r\n";
-						else if (GET_LEVEL(tch) < 15)
-							tmpstr += " Вы слышите бульканье.\r\n";
-						else if (GET_LEVEL(tch) < 25)
-							tmpstr += " Вы слышите громкое бульканье.\r\n";
-						else
-							tmpstr += " Вы слышите грозное пузырение.\r\n";
-					}
-				}
-				else
-				{
-					tmpstr += " Вы слышите чье-то присутствие.\r\n";
-				}
-				count++;
-			}
-		}
+      if ((probe >= percent || ((!AFF_FLAGGED(tch, EAffectFlag::AFF_SNEAK) || !AFF_FLAGGED(tch, EAffectFlag::AFF_HIDE))
+          && (probe > percent * 2)))
+          && (percent < 100 || IS_IMMORTAL(ch))
+          && !fight_count) {
+        if (IS_NPC(tch)) {
+          if (GET_RACE(tch) == NPC_RACE_THING) {
+            if (GET_LEVEL(tch) < 5)
+              tmpstr += " Вы слышите чье-то тихое поскрипывание.\r\n";
+            else if (GET_LEVEL(tch) < 15)
+              tmpstr += " Вы слышите чей-то скрип.\r\n";
+            else if (GET_LEVEL(tch) < 25)
+              tmpstr += " Вы слышите чей-то громкий скрип.\r\n";
+            else
+              tmpstr += " Вы слышите чей-то грозный скрип.\r\n";
+          } else if (real_sector(ch->in_room) != SECT_UNDERWATER) {
+            if (GET_LEVEL(tch) < 5)
+              tmpstr += " Вы слышите чью-то тихую возню.\r\n";
+            else if (GET_LEVEL(tch) < 15)
+              tmpstr += " Вы слышите чье-то сопение.\r\n";
+            else if (GET_LEVEL(tch) < 25)
+              tmpstr += " Вы слышите чье-то громкое дыхание.\r\n";
+            else
+              tmpstr += " Вы слышите чье-то грозное дыхание.\r\n";
+          } else {
+            if (GET_LEVEL(tch) < 5)
+              tmpstr += " Вы слышите тихое бульканье.\r\n";
+            else if (GET_LEVEL(tch) < 15)
+              tmpstr += " Вы слышите бульканье.\r\n";
+            else if (GET_LEVEL(tch) < 25)
+              tmpstr += " Вы слышите громкое бульканье.\r\n";
+            else
+              tmpstr += " Вы слышите грозное пузырение.\r\n";
+          }
+        } else {
+          tmpstr += " Вы слышите чье-то присутствие.\r\n";
+        }
+        count++;
+      }
+    }
 
-		if ((!count) && (!fight_count))
-		{
-			send_to_char(" Тишина и покой.\r\n", ch);
-		}
-		else
-		{
-			send_to_char(tmpstr.c_str(), ch);
-		}
+    if ((!count) && (!fight_count)) {
+      send_to_char(" Тишина и покой.\r\n", ch);
+    } else {
+      send_to_char(tmpstr.c_str(), ch);
+    }
 
-		send_to_char(CCNRM(ch, C_NRM), ch);
-	}
-	else
-	{
-		if (info_is & EXIT_SHOW_WALL)
-		{
-			send_to_char("И что вы там хотите услышать?\r\n", ch);
-		}
-	}
+    send_to_char(CCNRM(ch, C_NRM), ch);
+  } else {
+    if (info_is & EXIT_SHOW_WALL) {
+      send_to_char("И что вы там хотите услышать?\r\n", ch);
+    }
+  }
 }
 
-void look_in_obj(CHAR_DATA * ch, char *arg)
-{
-	OBJ_DATA *obj = NULL;
-	CHAR_DATA *dummy = NULL;
-	char whatp[MAX_INPUT_LENGTH], where[MAX_INPUT_LENGTH];
-	int amt, bits;
-	int where_bits = FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP;
+void look_in_obj(CHAR_DATA *ch, char *arg) {
+  OBJ_DATA *obj = NULL;
+  CHAR_DATA *dummy = NULL;
+  char whatp[MAX_INPUT_LENGTH], where[MAX_INPUT_LENGTH];
+  int amt, bits;
+  int where_bits = FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP;
 
-	if (!*arg)
-		send_to_char("Смотреть во что?\r\n", ch);
-	else
-		half_chop(arg, whatp, where);
+  if (!*arg)
+    send_to_char("Смотреть во что?\r\n", ch);
+  else
+    half_chop(arg, whatp, where);
 
-	if (isname(where, "земля комната room ground"))
-		where_bits = FIND_OBJ_ROOM;
-	else if (isname(where, "инвентарь inventory"))
-		where_bits = FIND_OBJ_INV;
-	else if (isname(where, "экипировка equipment"))
-		where_bits = FIND_OBJ_EQUIP;
+  if (isname(where, "земля комната room ground"))
+    where_bits = FIND_OBJ_ROOM;
+  else if (isname(where, "инвентарь inventory"))
+    where_bits = FIND_OBJ_INV;
+  else if (isname(where, "экипировка equipment"))
+    where_bits = FIND_OBJ_EQUIP;
 
-	bits = generic_find(arg, where_bits, ch, &dummy, &obj);
+  bits = generic_find(arg, where_bits, ch, &dummy, &obj);
 
-	if ((obj == NULL) || !bits)
-	{
-		sprintf(buf, "Вы не видите здесь '%s'.\r\n", arg);
-		send_to_char(buf, ch);
-	}
-	else if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_DRINKCON
-		&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_FOUNTAIN
-		&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_CONTAINER)
-	{
-		send_to_char("Ничего в нем нет!\r\n", ch);
-	}
-	else
-	{
-		if (Clan::ChestShow(obj, ch))
-		{
-			return;
-		}
-		if (ClanSystem::show_ingr_chest(obj, ch))
-		{
-			return;
-		}
-		if (Depot::is_depot(obj))
-		{
-			Depot::show_depot(ch);
-			return;
-		}
+  if ((obj == NULL) || !bits) {
+    sprintf(buf, "Вы не видите здесь '%s'.\r\n", arg);
+    send_to_char(buf, ch);
+  } else if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_DRINKCON
+      && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_FOUNTAIN
+      && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_CONTAINER) {
+    send_to_char("Ничего в нем нет!\r\n", ch);
+  } else {
+    if (Clan::ChestShow(obj, ch)) {
+      return;
+    }
+    if (ClanSystem::show_ingr_chest(obj, ch)) {
+      return;
+    }
+    if (Depot::is_depot(obj)) {
+      Depot::show_depot(ch);
+      return;
+    }
 
-		if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_CONTAINER)
-		{
-			if (OBJVAL_FLAGGED(obj, CONT_CLOSED))
-			{
-				act("Закрыт$A.", FALSE, ch, obj, 0, TO_CHAR);
-				const int skill_pick = ch->get_skill(SKILL_PICK_LOCK) ;
-				int count = sprintf(buf, "Заперт%s.", GET_OBJ_SUF_6(obj));
-				if (OBJVAL_FLAGGED(obj, CONT_LOCKED) && skill_pick)
-				{
-					if (OBJVAL_FLAGGED(obj, CONT_PICKPROOF))
-						count += sprintf(buf+count, "%s Вы никогда не сможете ЭТО взломать!%s\r\n", CCICYN(ch, C_NRM), CCNRM(ch, C_NRM));
-					else if (OBJVAL_FLAGGED(obj, CONT_BROKEN))
-						count += sprintf(buf+count, "%s Замок сломан... %s\r\n", CCRED(ch, C_NRM), CCNRM(ch, C_NRM));
-					else
-					{
-						const int chance = get_pick_chance(skill_pick, GET_OBJ_VAL(obj, 3));
-						const int index = chance ? chance/5 + 1 : 0;
-						std::string color = Locks[index][1];
-						if (abs(skill_pick - GET_OBJ_VAL(obj, 3))>10)
-							color = KIDRK;
+    if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_CONTAINER) {
+      if (OBJVAL_FLAGGED(obj, CONT_CLOSED)) {
+        act("Закрыт$A.", FALSE, ch, obj, 0, TO_CHAR);
+        const int skill_pick = ch->get_skill(SKILL_PICK_LOCK);
+        int count = sprintf(buf, "Заперт%s.", GET_OBJ_SUF_6(obj));
+        if (OBJVAL_FLAGGED(obj, CONT_LOCKED) && skill_pick) {
+          if (OBJVAL_FLAGGED(obj, CONT_PICKPROOF))
+            count += sprintf(buf + count,
+                             "%s Вы никогда не сможете ЭТО взломать!%s\r\n",
+                             CCICYN(ch, C_NRM),
+                             CCNRM(ch, C_NRM));
+          else if (OBJVAL_FLAGGED(obj, CONT_BROKEN))
+            count += sprintf(buf + count, "%s Замок сломан... %s\r\n", CCRED(ch, C_NRM), CCNRM(ch, C_NRM));
+          else {
+            const int chance = get_pick_chance(skill_pick, GET_OBJ_VAL(obj, 3));
+            const int index = chance ? chance / 5 + 1 : 0;
+            std::string color = Locks[index][1];
+            if (abs(skill_pick - GET_OBJ_VAL(obj, 3)) > 10)
+              color = KIDRK;
 
-						if (COLOR_LEV(ch)>C_NRM)
-							count += sprintf(buf + count, Locks[index][0], color.c_str(), KNRM);
-						else
-							count += sprintf(buf + count, Locks[index][0], KNUL, KNUL);
-					}
-					send_to_char(buf, ch);
-				}
-			}
-			else
-			{
-				send_to_char(OBJN(obj, ch, 0), ch);
-				switch (bits)
-				{
-				case FIND_OBJ_INV:
-					send_to_char("(в руках)\r\n", ch);
-					break;
-				case FIND_OBJ_ROOM:
-					send_to_char("(на земле)\r\n", ch);
-					break;
-				case FIND_OBJ_EQUIP:
-					send_to_char("(в амуниции)\r\n", ch);
-					break;
-				}
-				if (!obj->get_contains())
-					send_to_char(" Внутри ничего нет.\r\n", ch);
-				else
-				{
-					if (GET_OBJ_VAL(obj, 0) > 0 && bits != FIND_OBJ_ROOM) {
-						/* amt - индекс массива из 6 элементов (0..5) с описанием наполненности
+            if (COLOR_LEV(ch) > C_NRM)
+              count += sprintf(buf + count, Locks[index][0], color.c_str(), KNRM);
+            else
+              count += sprintf(buf + count, Locks[index][0], KNUL, KNUL);
+          }
+          send_to_char(buf, ch);
+        }
+      } else {
+        send_to_char(OBJN(obj, ch, 0), ch);
+        switch (bits) {
+          case FIND_OBJ_INV: send_to_char("(в руках)\r\n", ch);
+            break;
+          case FIND_OBJ_ROOM: send_to_char("(на земле)\r\n", ch);
+            break;
+          case FIND_OBJ_EQUIP: send_to_char("(в амуниции)\r\n", ch);
+            break;
+        }
+        if (!obj->get_contains())
+          send_to_char(" Внутри ничего нет.\r\n", ch);
+        else {
+          if (GET_OBJ_VAL(obj, 0) > 0 && bits != FIND_OBJ_ROOM) {
+            /* amt - индекс массива из 6 элементов (0..5) с описанием наполненности
 						   с помощью нехитрых мат. преобразований мы получаем соотношение веса и максимального объема контейнера,
 						   выраженные числами от 0 до 5. (причем 5 будет лишь при полностью полном контейнере)
 						*/
-						amt = MAX(0, MIN(5, (GET_OBJ_WEIGHT(obj) * 100) / (GET_OBJ_VAL(obj, 0) *  20)));
-						//sprintf(buf, "DEBUG 1: %d 2: %d 3: %d.\r\n", GET_OBJ_WEIGHT(obj), GET_OBJ_VAL(obj, 0), amt);
-						//send_to_char(buf, ch);
-						sprintf(buf, "Заполнен%s содержимым %s:\r\n", GET_OBJ_SUF_6(obj), fullness[amt]);
-						send_to_char(buf, ch);
-					}
-					list_obj_to_char(obj->get_contains(), ch, 1, bits != FIND_OBJ_ROOM);
-				}
-			}
-		}
-		else  	// item must be a fountain or drink container
-		{
-			if (GET_OBJ_VAL(obj, 1) <= 0)
-				send_to_char("Пусто.\r\n", ch);
-			else
-			{
-				if (GET_OBJ_VAL(obj, 0) <= 0 || GET_OBJ_VAL(obj, 1) > GET_OBJ_VAL(obj, 0))
-				{
-					sprintf(buf, "Заполнен%s вакуумом?!\r\n", GET_OBJ_SUF_6(obj));	// BUG
-				}
-				else
-				{
-					const char* msg = AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_POISON)
-						&& obj->get_val(3) == 1 ? "(отравленной)" : "";
-					amt = (GET_OBJ_VAL(obj, 1) * 5) / GET_OBJ_VAL(obj, 0);
-					sprinttype(GET_OBJ_VAL(obj, 2), color_liquid, buf2);
-					snprintf(buf, MAX_STRING_LENGTH, "Наполнен%s %s%s%s жидкостью.\r\n", GET_OBJ_SUF_6(obj), fullness[amt], buf2, msg);
-				}
-				send_to_char(buf, ch);
-			}
-		}
-	}
+            amt = MAX(0, MIN(5, (GET_OBJ_WEIGHT(obj) * 100) / (GET_OBJ_VAL(obj, 0) * 20)));
+            //sprintf(buf, "DEBUG 1: %d 2: %d 3: %d.\r\n", GET_OBJ_WEIGHT(obj), GET_OBJ_VAL(obj, 0), amt);
+            //send_to_char(buf, ch);
+            sprintf(buf, "Заполнен%s содержимым %s:\r\n", GET_OBJ_SUF_6(obj), fullness[amt]);
+            send_to_char(buf, ch);
+          }
+          list_obj_to_char(obj->get_contains(), ch, 1, bits != FIND_OBJ_ROOM);
+        }
+      }
+    } else    // item must be a fountain or drink container
+    {
+      if (GET_OBJ_VAL(obj, 1) <= 0)
+        send_to_char("Пусто.\r\n", ch);
+      else {
+        if (GET_OBJ_VAL(obj, 0) <= 0 || GET_OBJ_VAL(obj, 1) > GET_OBJ_VAL(obj, 0)) {
+          sprintf(buf, "Заполнен%s вакуумом?!\r\n", GET_OBJ_SUF_6(obj));    // BUG
+        } else {
+          const char *msg = AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_POISON)
+                                && obj->get_val(3) == 1 ? "(отравленной)" : "";
+          amt = (GET_OBJ_VAL(obj, 1) * 5) / GET_OBJ_VAL(obj, 0);
+          sprinttype(GET_OBJ_VAL(obj, 2), color_liquid, buf2);
+          snprintf(buf,
+                   MAX_STRING_LENGTH,
+                   "Наполнен%s %s%s%s жидкостью.\r\n",
+                   GET_OBJ_SUF_6(obj),
+                   fullness[amt],
+                   buf2,
+                   msg);
+        }
+        send_to_char(buf, ch);
+      }
+    }
+  }
 }
 
-char *find_exdesc(char *word, const EXTRA_DESCR_DATA::shared_ptr& list)
-{
-	for (auto i = list; i; i = i->next)
-	{
-		if (isname(word, i->keyword))
-		{
-			return i->description;
-		}
-	}
+char *find_exdesc(char *word, const EXTRA_DESCR_DATA::shared_ptr &list) {
+  for (auto i = list; i; i = i->next) {
+    if (isname(word, i->keyword)) {
+      return i->description;
+    }
+  }
 
-	return nullptr;
+  return nullptr;
 }
-const char *diag_liquid_timer(const OBJ_DATA* obj)
-{	int tm;
-	if (GET_OBJ_VAL(obj, 3) == 1)
-		return "испортилось!";
-	if (GET_OBJ_VAL(obj, 3) == 0)
-		return "идеальное.";
-	tm = (GET_OBJ_VAL(obj, 3));
-	if (tm < 1440) // сутки
-		return "скоро испортится!";
-	else if (tm < 10080) //неделя
-		return "сомнительное.";
-	else if (tm < 20160) // 2 недели
-		return "выглядит свежим.";
-	else if (tm < 30240) // 3 недели
-		return "свежее.";
-	return "идеальное.";
+const char *diag_liquid_timer(const OBJ_DATA *obj) {
+  int tm;
+  if (GET_OBJ_VAL(obj, 3) == 1)
+    return "испортилось!";
+  if (GET_OBJ_VAL(obj, 3) == 0)
+    return "идеальное.";
+  tm = (GET_OBJ_VAL(obj, 3));
+  if (tm < 1440) // сутки
+    return "скоро испортится!";
+  else if (tm < 10080) //неделя
+    return "сомнительное.";
+  else if (tm < 20160) // 2 недели
+    return "выглядит свежим.";
+  else if (tm < 30240) // 3 недели
+    return "свежее.";
+  return "идеальное.";
 }
 
 //ф-ция вывода доп инфы об объекте
 //buf это буфер в который дописывать инфу, в нем уже может быть что-то иначе надо перед вызовом присвоить *buf='\0'
-void obj_info(CHAR_DATA * ch, OBJ_DATA *obj, char buf[MAX_STRING_LENGTH])
-{
-	int j;
-		if (can_use_feat(ch, SKILLED_TRADER_FEAT) || PRF_FLAGGED(ch, PRF_HOLYLIGHT)|| ch->get_skill(SKILL_INSERTGEM))
-		{
-			sprintf(buf+strlen(buf), "Материал : %s", CCCYN(ch, C_NRM));
-			sprinttype(obj->get_material(), material_name, buf+strlen(buf));
-			sprintf(buf+strlen(buf), "\r\n%s", CCNRM(ch, C_NRM));
-		}
+void obj_info(CHAR_DATA *ch, OBJ_DATA *obj, char buf[MAX_STRING_LENGTH]) {
+  int j;
+  if (can_use_feat(ch, SKILLED_TRADER_FEAT) || PRF_FLAGGED(ch, PRF_HOLYLIGHT) || ch->get_skill(SKILL_INSERTGEM)) {
+    sprintf(buf + strlen(buf), "Материал : %s", CCCYN(ch, C_NRM));
+    sprinttype(obj->get_material(), material_name, buf + strlen(buf));
+    sprintf(buf + strlen(buf), "\r\n%s", CCNRM(ch, C_NRM));
+  }
 
-		if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_MING
-			&& (can_use_feat(ch, BREW_POTION_FEAT)
-				|| PRF_FLAGGED(ch, PRF_HOLYLIGHT)))
-		{
-			for (j = 0; imtypes[j].id != GET_OBJ_VAL(obj, IM_TYPE_SLOT) && j <= top_imtypes;)
-			{
-				j++;
-			}
-			sprintf(buf+strlen(buf), "Это ингредиент вида '%s'.\r\n", imtypes[j].name);
-			const int imquality = GET_OBJ_VAL(obj, IM_POWER_SLOT);
-			if (GET_LEVEL(ch) >= imquality)
-			{
-				sprintf(buf+strlen(buf), "Качество ингредиента ");
-				if (imquality > 25)
-					strcat(buf+strlen(buf), "наилучшее.\r\n");
-				else if (imquality > 20)
-					strcat(buf+strlen(buf), "отличное.\r\n");
-				else if (imquality > 15)
-					strcat(buf+strlen(buf), "очень хорошее.\r\n");
-				else if (imquality > 10)
-					strcat(buf+strlen(buf), "выше среднего.\r\n");
-				else if (imquality > 5)
-					strcat(buf+strlen(buf), "весьма посредственное.\r\n");
-				else
-					strcat(buf+strlen(buf), "хуже не бывает.\r\n");
-			}
-			else
-			{
-				strcat(buf+strlen(buf), "Вы не в состоянии определить качество этого ингредиента.\r\n");
-			}
-		}
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_MING
+      && (can_use_feat(ch, BREW_POTION_FEAT)
+          || PRF_FLAGGED(ch, PRF_HOLYLIGHT))) {
+    for (j = 0; imtypes[j].id != GET_OBJ_VAL(obj, IM_TYPE_SLOT) && j <= top_imtypes;) {
+      j++;
+    }
+    sprintf(buf + strlen(buf), "Это ингредиент вида '%s'.\r\n", imtypes[j].name);
+    const int imquality = GET_OBJ_VAL(obj, IM_POWER_SLOT);
+    if (GET_LEVEL(ch) >= imquality) {
+      sprintf(buf + strlen(buf), "Качество ингредиента ");
+      if (imquality > 25)
+        strcat(buf + strlen(buf), "наилучшее.\r\n");
+      else if (imquality > 20)
+        strcat(buf + strlen(buf), "отличное.\r\n");
+      else if (imquality > 15)
+        strcat(buf + strlen(buf), "очень хорошее.\r\n");
+      else if (imquality > 10)
+        strcat(buf + strlen(buf), "выше среднего.\r\n");
+      else if (imquality > 5)
+        strcat(buf + strlen(buf), "весьма посредственное.\r\n");
+      else
+        strcat(buf + strlen(buf), "хуже не бывает.\r\n");
+    } else {
+      strcat(buf + strlen(buf), "Вы не в состоянии определить качество этого ингредиента.\r\n");
+    }
+  }
 
- 		//|| PRF_FLAGGED(ch, PRF_HOLYLIGHT)
-		if (can_use_feat(ch, MASTER_JEWELER_FEAT))
-		{
-			sprintf(buf+strlen(buf), "Слоты : %s", CCCYN(ch, C_NRM));
-			if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_WITH3SLOTS))
-			{
-				strcat(buf, "доступно 3 слота\r\n");
-			}
-			else if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_WITH2SLOTS))
-			{
-				strcat(buf, "доступно 2 слота\r\n");
-			}
-			else if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_WITH1SLOT))
-			{
-				strcat(buf, "доступен 1 слот\r\n");
-			}
-			else
-			{
-				strcat(buf, "нет слотов\r\n");
-			}
-			sprintf(buf+strlen(buf), "\r\n%s", CCNRM(ch, C_NRM));
-		}
-		if (AUTH_CUSTOM_LABEL(obj, ch) && obj->get_custom_label()->label_text)
-		{
-			if (obj->get_custom_label()->clan)
-			{
-				strcat(buf, "Метки дружины: ");
-			}
-			else
-			{
-				strcat(buf, "Ваши метки: ");
-			}
-			sprintf(buf + strlen(buf), "%s\r\n", obj->get_custom_label()->label_text);
-		}
-		sprintf(buf+strlen(buf), "%s", diag_uses_to_char(obj, ch));
-		sprintf(buf+strlen(buf), "%s", diag_shot_to_char(obj, ch));
-		if (GET_OBJ_VNUM(obj) >= DUPLICATE_MINI_SET_VNUM)
-		{
-			sprintf(buf + strlen(buf), "Светится белым сиянием.\r\n");
-		}
+  //|| PRF_FLAGGED(ch, PRF_HOLYLIGHT)
+  if (can_use_feat(ch, MASTER_JEWELER_FEAT)) {
+    sprintf(buf + strlen(buf), "Слоты : %s", CCCYN(ch, C_NRM));
+    if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_WITH3SLOTS)) {
+      strcat(buf, "доступно 3 слота\r\n");
+    } else if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_WITH2SLOTS)) {
+      strcat(buf, "доступно 2 слота\r\n");
+    } else if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_WITH1SLOT)) {
+      strcat(buf, "доступен 1 слот\r\n");
+    } else {
+      strcat(buf, "нет слотов\r\n");
+    }
+    sprintf(buf + strlen(buf), "\r\n%s", CCNRM(ch, C_NRM));
+  }
+  if (AUTH_CUSTOM_LABEL(obj, ch) && obj->get_custom_label()->label_text) {
+    if (obj->get_custom_label()->clan) {
+      strcat(buf, "Метки дружины: ");
+    } else {
+      strcat(buf, "Ваши метки: ");
+    }
+    sprintf(buf + strlen(buf), "%s\r\n", obj->get_custom_label()->label_text);
+  }
+  sprintf(buf + strlen(buf), "%s", diag_uses_to_char(obj, ch));
+  sprintf(buf + strlen(buf), "%s", diag_shot_to_char(obj, ch));
+  if (GET_OBJ_VNUM(obj) >= DUPLICATE_MINI_SET_VNUM) {
+    sprintf(buf + strlen(buf), "Светится белым сиянием.\r\n");
+  }
 
-		if (((GET_OBJ_TYPE(obj) == CObjectPrototype::ITEM_DRINKCON)
-			&& (GET_OBJ_VAL(obj, 1) > 0))
-			|| (GET_OBJ_TYPE(obj) == CObjectPrototype::ITEM_FOOD))
-		{
-			sprintf(buf1, "Качество: %s\r\n", diag_liquid_timer(obj));
-			strcat(buf, buf1);
-		}
+  if (((GET_OBJ_TYPE(obj) == CObjectPrototype::ITEM_DRINKCON)
+      && (GET_OBJ_VAL(obj, 1) > 0))
+      || (GET_OBJ_TYPE(obj) == CObjectPrototype::ITEM_FOOD)) {
+    sprintf(buf1, "Качество: %s\r\n", diag_liquid_timer(obj));
+    strcat(buf, buf1);
+  }
 }
 
 /*
@@ -2818,956 +2353,874 @@ void obj_info(CHAR_DATA * ch, OBJ_DATA *obj, char buf[MAX_STRING_LENGTH])
  * suggested fix to this problem.
  * \return флаг если смотрим в клан-сундук, чтобы после осмотра не смотреть второй раз по look_in_obj
  */
-bool look_at_target(CHAR_DATA * ch, char *arg, int subcmd)
-{
-	int bits, found = FALSE, fnum, i = 0, cn = 0;
-	struct portals_list_type *port;
-	CHAR_DATA *found_char = NULL;
-	OBJ_DATA *found_obj = NULL;
-	struct char_portal_type *tmp;
-	char *desc, *what, whatp[MAX_INPUT_LENGTH], where[MAX_INPUT_LENGTH];
-	int where_bits = FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP | FIND_CHAR_ROOM | FIND_OBJ_EXDESC;
+bool look_at_target(CHAR_DATA *ch, char *arg, int subcmd) {
+  int bits, found = FALSE, fnum, i = 0, cn = 0;
+  struct portals_list_type *port;
+  CHAR_DATA *found_char = NULL;
+  OBJ_DATA *found_obj = NULL;
+  struct char_portal_type *tmp;
+  char *desc, *what, whatp[MAX_INPUT_LENGTH], where[MAX_INPUT_LENGTH];
+  int where_bits = FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP | FIND_CHAR_ROOM | FIND_OBJ_EXDESC;
 
-	if (!ch->desc)
-	{
-		return false;
-	}
+  if (!ch->desc) {
+    return false;
+  }
 
-	if (!*arg)
-	{
-		send_to_char("На что вы так мечтаете посмотреть?\r\n", ch);
-		return false;
-	}
+  if (!*arg) {
+    send_to_char("На что вы так мечтаете посмотреть?\r\n", ch);
+    return false;
+  }
 
-	half_chop(arg, whatp, where);
-	what = whatp;
+  half_chop(arg, whatp, where);
+  what = whatp;
 
-	if (isname(where, "земля комната room ground"))
-		where_bits = FIND_OBJ_ROOM | FIND_CHAR_ROOM;
-	else if (isname(where, "инвентарь inventory"))
-		where_bits = FIND_OBJ_INV;
-	else if (isname(where, "экипировка equipment"))
-		where_bits = FIND_OBJ_EQUIP;
+  if (isname(where, "земля комната room ground"))
+    where_bits = FIND_OBJ_ROOM | FIND_CHAR_ROOM;
+  else if (isname(where, "инвентарь inventory"))
+    where_bits = FIND_OBJ_INV;
+  else if (isname(where, "экипировка equipment"))
+    where_bits = FIND_OBJ_EQUIP;
 
-	// для townportal
-	if (isname(whatp, "камень") &&
-			ch->get_skill(SKILL_TOWNPORTAL) &&
-			(port = get_portal(GET_ROOM_VNUM(ch->in_room), NULL)) != NULL && IS_SET(where_bits, FIND_OBJ_ROOM))
-	{
+  // для townportal
+  if (isname(whatp, "камень") &&
+      ch->get_skill(SKILL_TOWNPORTAL) &&
+      (port = get_portal(GET_ROOM_VNUM(ch->in_room), NULL)) != NULL && IS_SET(where_bits, FIND_OBJ_ROOM)) {
 
-		if (has_char_portal(ch, GET_ROOM_VNUM(ch->in_room)))
-		{
-			send_to_char("На камне огненными буквами написано слово '&R", ch);
-			send_to_char(port->wrd, ch);
-			send_to_char("&n'.\r\n", ch);
-			return 0;
-		} else if (GET_LEVEL(ch) < MAX(1, port->level - GET_REMORT(ch) / 2))
-		{
-			send_to_char("На камне что-то написано огненными буквами.\r\n", ch);
-			send_to_char("Но вы еще недостаточно искусны, чтобы разобрать слово.\r\n", ch);
-			return false;
-		}
-		else
-		{
-			for (tmp = GET_PORTALS(ch); tmp; tmp = tmp->next)
-			{
-				cn++;
-			}
-			if (cn >= MAX_PORTALS(ch))
-			{
-				send_to_char
-				("Все доступные вам камни уже запомнены, удалите и попробуйте еще.\r\n", ch);
-				return false;
-			}
-			send_to_char("На камне огненными буквами написано слово '&R", ch);
-			send_to_char(port->wrd, ch);
-			send_to_char("&n'.\r\n", ch);
-			// теперь добавляем в память чара
-			add_portal_to_char(ch, GET_ROOM_VNUM(ch->in_room));
-			check_portals(ch);
-			return false;
-		}
-	}
+    if (has_char_portal(ch, GET_ROOM_VNUM(ch->in_room))) {
+      send_to_char("На камне огненными буквами написано слово '&R", ch);
+      send_to_char(port->wrd, ch);
+      send_to_char("&n'.\r\n", ch);
+      return 0;
+    } else if (GET_LEVEL(ch) < MAX(1, port->level - GET_REMORT(ch) / 2)) {
+      send_to_char("На камне что-то написано огненными буквами.\r\n", ch);
+      send_to_char("Но вы еще недостаточно искусны, чтобы разобрать слово.\r\n", ch);
+      return false;
+    } else {
+      for (tmp = GET_PORTALS(ch); tmp; tmp = tmp->next) {
+        cn++;
+      }
+      if (cn >= MAX_PORTALS(ch)) {
+        send_to_char
+            ("Все доступные вам камни уже запомнены, удалите и попробуйте еще.\r\n", ch);
+        return false;
+      }
+      send_to_char("На камне огненными буквами написано слово '&R", ch);
+      send_to_char(port->wrd, ch);
+      send_to_char("&n'.\r\n", ch);
+      // теперь добавляем в память чара
+      add_portal_to_char(ch, GET_ROOM_VNUM(ch->in_room));
+      check_portals(ch);
+      return false;
+    }
+  }
 
-	// заглянуть в пентаграмму
-	if (isname(whatp, "пентаграмма") && world[ch->in_room]->portal_time && IS_SET(where_bits, FIND_OBJ_ROOM))
-	{
-		const auto r = ch->in_room;
-		const auto to_room = world[r]->portal_room;
-		send_to_char("Приблизившись к пентаграмме, вы осторожно заглянули в нее.\r\n\r\n", ch);
-		act("$n0 осторожно заглянул$g в пентаграмму.\r\n", TRUE, ch, 0, 0, TO_ROOM);
-		if (world[to_room]->portal_time && (r == world[to_room]->portal_room))
-		{
-			send_to_char
-			("Яркий свет, идущий с противоположного конца прохода, застилает вам глаза.\r\n\r\n", ch);
-			return false;
-		}
-		ch->in_room = world[ch->in_room]->portal_room;
-		look_at_room(ch, 1);
-		ch->in_room = r;
-		return false;
-	}
+  // заглянуть в пентаграмму
+  if (isname(whatp, "пентаграмма") && world[ch->in_room]->portal_time && IS_SET(where_bits, FIND_OBJ_ROOM)) {
+    const auto r = ch->in_room;
+    const auto to_room = world[r]->portal_room;
+    send_to_char("Приблизившись к пентаграмме, вы осторожно заглянули в нее.\r\n\r\n", ch);
+    act("$n0 осторожно заглянул$g в пентаграмму.\r\n", TRUE, ch, 0, 0, TO_ROOM);
+    if (world[to_room]->portal_time && (r == world[to_room]->portal_room)) {
+      send_to_char
+          ("Яркий свет, идущий с противоположного конца прохода, застилает вам глаза.\r\n\r\n", ch);
+      return false;
+    }
+    ch->in_room = world[ch->in_room]->portal_room;
+    look_at_room(ch, 1);
+    ch->in_room = r;
+    return false;
+  }
 
-	bits = generic_find(what, where_bits, ch, &found_char, &found_obj);
-	// Is the target a character?
-	if (found_char != NULL)
-	{
-		if (subcmd == SCMD_LOOK_HIDE && !check_moves(ch, LOOKHIDE_MOVES))
-			return false;
-		look_at_char(found_char, ch);
-		if (ch != found_char)
-		{
-			if (subcmd == SCMD_LOOK_HIDE && ch->get_skill(SKILL_LOOK_HIDE) > 0)
-			{
-				fnum = number(1, skill_info[SKILL_LOOK_HIDE].max_percent);
-				found =
-					train_skill(ch, SKILL_LOOK_HIDE,
-								skill_info[SKILL_LOOK_HIDE].max_percent, found_char);
-				if (!WAITLESS(ch))
-					WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
-				if (found >= fnum && (fnum < 100 || IS_IMMORTAL(ch)) && !IS_IMMORTAL(found_char))
-					return false;
-			}
-			if (CAN_SEE(found_char, ch))
-				act("$n оглядел$g вас с головы до пят.", TRUE, ch, 0, found_char, TO_VICT);
-			act("$n посмотрел$g на $N3.", TRUE, ch, 0, found_char, TO_NOTVICT);
-		}
-		return false;
-	}
+  bits = generic_find(what, where_bits, ch, &found_char, &found_obj);
+  // Is the target a character?
+  if (found_char != NULL) {
+    if (subcmd == SCMD_LOOK_HIDE && !check_moves(ch, LOOKHIDE_MOVES))
+      return false;
+    look_at_char(found_char, ch);
+    if (ch != found_char) {
+      if (subcmd == SCMD_LOOK_HIDE && ch->get_skill(SKILL_LOOK_HIDE) > 0) {
+        fnum = number(1, skill_info[SKILL_LOOK_HIDE].max_percent);
+        found = calculate_skill(ch, SKILL_LOOK_HIDE, found_char);
+        train_skill(ch, SKILL_LOOK_HIDE, found < fnum, found_char);
+        if (!WAITLESS(ch))
+          WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
+        if (found >= fnum && (fnum < 100 || IS_IMMORTAL(ch)) && !IS_IMMORTAL(found_char))
+          return false;
+      }
+      if (CAN_SEE(found_char, ch))
+        act("$n оглядел$g вас с головы до пят.", TRUE, ch, 0, found_char, TO_VICT);
+      act("$n посмотрел$g на $N3.", TRUE, ch, 0, found_char, TO_NOTVICT);
+    }
+    return false;
+  }
 
-	// Strip off "number." from 2.foo and friends.
-	if (!(fnum = get_number(&what)))
-	{
-		send_to_char("Что осматриваем?\r\n", ch);
-		return false;
-	}
+  // Strip off "number." from 2.foo and friends.
+  if (!(fnum = get_number(&what))) {
+    send_to_char("Что осматриваем?\r\n", ch);
+    return false;
+  }
 
-	// Does the argument match an extra desc in the room?
-	if ((desc = find_exdesc(what, world[ch->in_room]->ex_description)) != NULL && ++i == fnum)
-	{
-		page_string(ch->desc, desc, FALSE);
-		return false;
-	}
+  // Does the argument match an extra desc in the room?
+  if ((desc = find_exdesc(what, world[ch->in_room]->ex_description)) != NULL && ++i == fnum) {
+    page_string(ch->desc, desc, FALSE);
+    return false;
+  }
 
-	// If an object was found back in generic_find
-	if (bits && (found_obj != NULL))
-	{
+  // If an object was found back in generic_find
+  if (bits && (found_obj != NULL)) {
 
-		if (Clan::ChestShow(found_obj, ch))
-		{
-			return true;
-		}
-		if (ClanSystem::show_ingr_chest(found_obj, ch))
-		{
-			return true;
-		}
-		if (Depot::is_depot(found_obj))
-		{
-			Depot::show_depot(ch);
-			return true;
-		}
+    if (Clan::ChestShow(found_obj, ch)) {
+      return true;
+    }
+    if (ClanSystem::show_ingr_chest(found_obj, ch)) {
+      return true;
+    }
+    if (Depot::is_depot(found_obj)) {
+      Depot::show_depot(ch);
+      return true;
+    }
 
-		// Собственно изменение. Вместо проверки "if (!found)" юзается проверка
-		// наличия описания у объекта, найденного функцией "generic_find"
-		if (!(desc = find_exdesc(what, found_obj->get_ex_description())))
-		{
-			show_obj_to_char(found_obj, ch, 5, TRUE, 1);	// Show no-description
-		}
-		else
-		{
-			send_to_char(desc, ch);
-			show_obj_to_char(found_obj, ch, 6, TRUE, 1);	// Find hum, glow etc
-		}
+    // Собственно изменение. Вместо проверки "if (!found)" юзается проверка
+    // наличия описания у объекта, найденного функцией "generic_find"
+    if (!(desc = find_exdesc(what, found_obj->get_ex_description()))) {
+      show_obj_to_char(found_obj, ch, 5, TRUE, 1);    // Show no-description
+    } else {
+      send_to_char(desc, ch);
+      show_obj_to_char(found_obj, ch, 6, TRUE, 1);    // Find hum, glow etc
+    }
 
-		*buf = '\0';
-		obj_info(ch, found_obj, buf);
-		send_to_char(buf, ch);
-	}
-	else
-		send_to_char("Похоже, этого здесь нет!\r\n", ch);
+    *buf = '\0';
+    obj_info(ch, found_obj, buf);
+    send_to_char(buf, ch);
+  } else
+    send_to_char("Похоже, этого здесь нет!\r\n", ch);
 
-	return false;
+  return false;
 }
 
+void skip_hide_on_look(CHAR_DATA *ch) {
 
-void skip_hide_on_look(CHAR_DATA * ch)
-{
-
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE) &&
-			((!ch->get_skill(SKILL_LOOK_HIDE) ||
-			  ((number(1, 100) -
-				calculate_skill(ch, SKILL_LOOK_HIDE, 0) - 2 * (ch->get_wis() - 9)) > 0))))
-	{
-		affect_from_char(ch, SPELL_HIDE);
-		if (!AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE))
-		{
-			send_to_char("Вы прекратили прятаться.\r\n", ch);
-			act("$n прекратил$g прятаться.", FALSE, ch, 0, 0, TO_ROOM);
-		}
-	}
-	return;
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE) &&
+      ((!ch->get_skill(SKILL_LOOK_HIDE) ||
+          ((number(1, 100) -
+              calculate_skill(ch, SKILL_LOOK_HIDE, 0) - 2 * (ch->get_wis() - 9)) > 0)))) {
+    affect_from_char(ch, SPELL_HIDE);
+    if (!AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE)) {
+      send_to_char("Вы прекратили прятаться.\r\n", ch);
+      act("$n прекратил$g прятаться.", FALSE, ch, 0, 0, TO_ROOM);
+    }
+  }
+  return;
 }
 
-void do_look(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
-{
-	char arg2[MAX_INPUT_LENGTH];
-	int look_type;
+void do_look(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  char arg2[MAX_INPUT_LENGTH];
+  int look_type;
 
-	if (!ch->desc)
-		return;
+  if (!ch->desc)
+    return;
 
-	if (GET_POS(ch) < POS_SLEEPING)
-	{
-		send_to_char("Виделся часто сон беспокойный...\r\n", ch);
-	}
-	else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-	{
-		send_to_char("Вы ослеплены!\r\n", ch);
-	}
-	else if (is_dark(ch->in_room) && !CAN_SEE_IN_DARK(ch))
-	{
-		if (GET_LEVEL(ch) > 30)
-		{
-			sprintf(buf,
-				"%sКомната=%s%d %sСвет=%s%d %sОсвещ=%s%d %sКостер=%s%d %sЛед=%s%d "
-				"%sТьма=%s%d %sСолнце=%s%d %sНебо=%s%d %sЛуна=%s%d%s.\r\n",
-				CCNRM(ch, C_NRM), CCINRM(ch, C_NRM), ch->in_room,
-				CCRED(ch, C_NRM), CCIRED(ch, C_NRM), world[ch->in_room]->light,
-				CCGRN(ch, C_NRM), CCIGRN(ch, C_NRM), world[ch->in_room]->glight,
-				CCYEL(ch, C_NRM), CCIYEL(ch, C_NRM), world[ch->in_room]->fires,
-				CCYEL(ch, C_NRM), CCIYEL(ch, C_NRM), world[ch->in_room]->ices,
-				CCBLU(ch, C_NRM), CCIBLU(ch, C_NRM), world[ch->in_room]->gdark,
-				CCMAG(ch, C_NRM), CCICYN(ch, C_NRM), weather_info.sky,
-				CCWHT(ch, C_NRM), CCIWHT(ch, C_NRM), weather_info.sunlight,
-				CCYEL(ch, C_NRM), CCIYEL(ch, C_NRM), weather_info.moon_day, CCNRM(ch, C_NRM));
-			send_to_char(buf, ch);
-		}
-		skip_hide_on_look(ch);
+  if (GET_POS(ch) < POS_SLEEPING) {
+    send_to_char("Виделся часто сон беспокойный...\r\n", ch);
+  } else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    send_to_char("Вы ослеплены!\r\n", ch);
+  } else if (is_dark(ch->in_room) && !CAN_SEE_IN_DARK(ch)) {
+    if (GET_LEVEL(ch) > 30) {
+      sprintf(buf,
+              "%sКомната=%s%d %sСвет=%s%d %sОсвещ=%s%d %sКостер=%s%d %sЛед=%s%d "
+              "%sТьма=%s%d %sСолнце=%s%d %sНебо=%s%d %sЛуна=%s%d%s.\r\n",
+              CCNRM(ch, C_NRM), CCINRM(ch, C_NRM), ch->in_room,
+              CCRED(ch, C_NRM), CCIRED(ch, C_NRM), world[ch->in_room]->light,
+              CCGRN(ch, C_NRM), CCIGRN(ch, C_NRM), world[ch->in_room]->glight,
+              CCYEL(ch, C_NRM), CCIYEL(ch, C_NRM), world[ch->in_room]->fires,
+              CCYEL(ch, C_NRM), CCIYEL(ch, C_NRM), world[ch->in_room]->ices,
+              CCBLU(ch, C_NRM), CCIBLU(ch, C_NRM), world[ch->in_room]->gdark,
+              CCMAG(ch, C_NRM), CCICYN(ch, C_NRM), weather_info.sky,
+              CCWHT(ch, C_NRM), CCIWHT(ch, C_NRM), weather_info.sunlight,
+              CCYEL(ch, C_NRM), CCIYEL(ch, C_NRM), weather_info.moon_day, CCNRM(ch, C_NRM));
+      send_to_char(buf, ch);
+    }
+    skip_hide_on_look(ch);
 
-		send_to_char("Слишком темно...\r\n", ch);
-		list_char_to_char(world[ch->in_room]->people, ch);	// glowing red eyes
-		show_glow_objs(ch);
-	}
-	else
-	{
-		half_chop(argument, arg, arg2);
+    send_to_char("Слишком темно...\r\n", ch);
+    list_char_to_char(world[ch->in_room]->people, ch);    // glowing red eyes
+    show_glow_objs(ch);
+  } else {
+    half_chop(argument, arg, arg2);
 
-		skip_hide_on_look(ch);
+    skip_hide_on_look(ch);
 
-		if (subcmd == SCMD_READ)
-		{
-			if (!*arg)
-				send_to_char("Что вы хотите прочитать?\r\n", ch);
-			else
-				look_at_target(ch, arg, subcmd);
-			return;
-		}
-		if (!*arg)	// "look" alone, without an argument at all
-		{
-			if (ch->desc)
-			{
-				ch->desc->msdp_report("ROOM");
-			}
-			look_at_room(ch, 1);
-		}
-		else if (is_abbrev(arg, "in") || is_abbrev(arg, "внутрь"))
-			look_in_obj(ch, arg2);
-		// did the char type 'look <direction>?'
-		else if (((look_type = search_block(arg, dirs, FALSE)) >= 0) ||
-				 ((look_type = search_block(arg, Dirs, FALSE)) >= 0))
-			look_in_direction(ch, look_type, EXIT_SHOW_WALL);
-		else if (is_abbrev(arg, "at") || is_abbrev(arg, "на"))
-			look_at_target(ch, arg2, subcmd);
-		else
-			look_at_target(ch, argument, subcmd);
-	}
+    if (subcmd == SCMD_READ) {
+      if (!*arg)
+        send_to_char("Что вы хотите прочитать?\r\n", ch);
+      else
+        look_at_target(ch, arg, subcmd);
+      return;
+    }
+    if (!*arg)    // "look" alone, without an argument at all
+    {
+      if (ch->desc) {
+        ch->desc->msdp_report("ROOM");
+      }
+      look_at_room(ch, 1);
+    } else if (is_abbrev(arg, "in") || is_abbrev(arg, "внутрь"))
+      look_in_obj(ch, arg2);
+      // did the char type 'look <direction>?'
+    else if (((look_type = search_block(arg, dirs, FALSE)) >= 0) ||
+        ((look_type = search_block(arg, Dirs, FALSE)) >= 0))
+      look_in_direction(ch, look_type, EXIT_SHOW_WALL);
+    else if (is_abbrev(arg, "at") || is_abbrev(arg, "на"))
+      look_at_target(ch, arg2, subcmd);
+    else
+      look_at_target(ch, argument, subcmd);
+  }
 }
 
-void do_sides(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int i;
+void do_sides(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int i;
 
-	if (!ch->desc)
-		return;
+  if (!ch->desc)
+    return;
 
-	if (GET_POS(ch) <= POS_SLEEPING)
-		send_to_char("Виделся часто сон беспокойный...\r\n", ch);
-	else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-		send_to_char("Вы ослеплены!\r\n", ch);
-	else
-	{
-		skip_hide_on_look(ch);
-		send_to_char("Вы посмотрели по сторонам.\r\n", ch);
-		for (i = 0; i < NUM_OF_DIRS; i++)
-		{
-			look_in_direction(ch, i, 0);
-		}
-	}
+  if (GET_POS(ch) <= POS_SLEEPING)
+    send_to_char("Виделся часто сон беспокойный...\r\n", ch);
+  else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
+    send_to_char("Вы ослеплены!\r\n", ch);
+  else {
+    skip_hide_on_look(ch);
+    send_to_char("Вы посмотрели по сторонам.\r\n", ch);
+    for (i = 0; i < NUM_OF_DIRS; i++) {
+      look_in_direction(ch, i, 0);
+    }
+  }
 }
 
-void do_looking(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int i;
+void do_looking(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int i;
 
-	if (!ch->desc)
-		return;
+  if (!ch->desc)
+    return;
 
-	if (GET_POS(ch) < POS_SLEEPING)
-		send_to_char("Белый Ангел возник перед вами, маняще помахивая крыльями.\r\n", ch);
-	if (GET_POS(ch) == POS_SLEEPING)
-		send_to_char("Виделся часто сон беспокойный...\r\n", ch);
-	else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-		send_to_char("Вы ослеплены!\r\n", ch);
-	else if (ch->get_skill(SKILL_LOOKING))
-	{
-		if (check_moves(ch, LOOKING_MOVES))
-		{
-			send_to_char("Вы напрягли зрение и начали присматриваться по сторонам.\r\n", ch);
-			for (i = 0; i < NUM_OF_DIRS; i++)
-				look_in_direction(ch, i, EXIT_SHOW_LOOKING);
-			if (!(IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE)))
-				WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
-		}
-	}
-	else
-		send_to_char("Вам явно не хватает этого умения.\r\n", ch);
+  if (GET_POS(ch) < POS_SLEEPING)
+    send_to_char("Белый Ангел возник перед вами, маняще помахивая крыльями.\r\n", ch);
+  if (GET_POS(ch) == POS_SLEEPING)
+    send_to_char("Виделся часто сон беспокойный...\r\n", ch);
+  else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
+    send_to_char("Вы ослеплены!\r\n", ch);
+  else if (ch->get_skill(SKILL_LOOKING)) {
+    if (check_moves(ch, LOOKING_MOVES)) {
+      send_to_char("Вы напрягли зрение и начали присматриваться по сторонам.\r\n", ch);
+      for (i = 0; i < NUM_OF_DIRS; i++)
+        look_in_direction(ch, i, EXIT_SHOW_LOOKING);
+      if (!(IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE)))
+        WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
+    }
+  } else
+    send_to_char("Вам явно не хватает этого умения.\r\n", ch);
 }
 
-void do_hearing(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int i;
+void do_hearing(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int i;
 
-	if (!ch->desc)
-		return;
+  if (!ch->desc)
+    return;
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
-	{
-		send_to_char("Вы глухи и все равно ничего не услышите.\r\n", ch);
-		return;
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS)) {
+    send_to_char("Вы глухи и все равно ничего не услышите.\r\n", ch);
+    return;
+  }
 
-	if (GET_POS(ch) < POS_SLEEPING)
-		send_to_char("Вам начали слышаться голоса предков, зовущие вас к себе.\r\n", ch);
-	if (GET_POS(ch) == POS_SLEEPING)
-		send_to_char("Морфей медленно задумчиво провел рукой по струнам и заиграл колыбельную.\r\n", ch);
-	else if (ch->get_skill(SKILL_HEARING))
-	{
-		if (check_moves(ch, HEARING_MOVES))
-		{
-			send_to_char("Вы начали сосредоточенно прислушиваться.\r\n", ch);
-			for (i = 0; i < NUM_OF_DIRS; i++)
-				hear_in_direction(ch, i, 0);
-			if (!(IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE)))
-				WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
-		}
-	}
-	else
-		send_to_char("Выучите сначала как это следует делать.\r\n", ch);
+  if (GET_POS(ch) < POS_SLEEPING)
+    send_to_char("Вам начали слышаться голоса предков, зовущие вас к себе.\r\n", ch);
+  if (GET_POS(ch) == POS_SLEEPING)
+    send_to_char("Морфей медленно задумчиво провел рукой по струнам и заиграл колыбельную.\r\n", ch);
+  else if (ch->get_skill(SKILL_HEARING)) {
+    if (check_moves(ch, HEARING_MOVES)) {
+      send_to_char("Вы начали сосредоточенно прислушиваться.\r\n", ch);
+      for (i = 0; i < NUM_OF_DIRS; i++)
+        hear_in_direction(ch, i, 0);
+      if (!(IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE)))
+        WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
+    }
+  } else
+    send_to_char("Выучите сначала как это следует делать.\r\n", ch);
 }
 
-void do_examine(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
-{
-	CHAR_DATA *tmp_char;
-	OBJ_DATA *tmp_object;
-	char where[MAX_INPUT_LENGTH];
-	int where_bits = FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP | FIND_CHAR_ROOM | FIND_OBJ_EXDESC;
+void do_examine(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  CHAR_DATA *tmp_char;
+  OBJ_DATA *tmp_object;
+  char where[MAX_INPUT_LENGTH];
+  int where_bits = FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP | FIND_CHAR_ROOM | FIND_OBJ_EXDESC;
 
+  if (GET_POS(ch) < POS_SLEEPING) {
+    send_to_char("Виделся часто сон беспокойный...\r\n", ch);
+    return;
+  } else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    send_to_char("Вы ослеплены!\r\n", ch);
+    return;
+  }
 
-	if (GET_POS(ch) < POS_SLEEPING)
-	{
-		send_to_char("Виделся часто сон беспокойный...\r\n", ch);
-		return;
-	}
-	else if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-	{
-		send_to_char("Вы ослеплены!\r\n", ch);
-		return;
-	}
+  two_arguments(argument, arg, where);
 
-	two_arguments(argument, arg, where);
+  if (!*arg) {
+    send_to_char("Что вы желаете осмотреть?\r\n", ch);
+    return;
+  }
 
-	if (!*arg)
-	{
-		send_to_char("Что вы желаете осмотреть?\r\n", ch);
-		return;
-	}
+  if (isname(where, "земля комната room ground"))
+    where_bits = FIND_OBJ_ROOM | FIND_CHAR_ROOM;
+  else if (isname(where, "инвентарь inventory"))
+    where_bits = FIND_OBJ_INV;
+  else if (isname(where, "экипировка equipment"))
+    where_bits = FIND_OBJ_EQUIP;
 
-	if (isname(where, "земля комната room ground"))
-		where_bits = FIND_OBJ_ROOM | FIND_CHAR_ROOM;
-	else if (isname(where, "инвентарь inventory"))
-		where_bits = FIND_OBJ_INV;
-	else if (isname(where, "экипировка equipment"))
-		where_bits = FIND_OBJ_EQUIP;
+  skip_hide_on_look(ch);
 
-	skip_hide_on_look(ch);
+  if (look_at_target(ch, argument, subcmd))
+    return;
 
-	if (look_at_target(ch, argument, subcmd))
-		return;
+  if (isname(arg, "пентаграмма") && world[ch->in_room]->portal_time && IS_SET(where_bits, FIND_OBJ_ROOM))
+    return;
 
-	if (isname(arg, "пентаграмма") && world[ch->in_room]->portal_time && IS_SET(where_bits, FIND_OBJ_ROOM))
-		return;
+  if (isname(arg, "камень") &&
+      ch->get_skill(SKILL_TOWNPORTAL) &&
+      (get_portal(GET_ROOM_VNUM(ch->in_room), NULL)) != NULL && IS_SET(where_bits, FIND_OBJ_ROOM))
+    return;
 
-	if (isname(arg, "камень") &&
-			ch->get_skill(SKILL_TOWNPORTAL) &&
-			(get_portal(GET_ROOM_VNUM(ch->in_room), NULL)) != NULL && IS_SET(where_bits, FIND_OBJ_ROOM))
-		return;
-
-	generic_find(arg, where_bits, ch, &tmp_char, &tmp_object);
-	if (tmp_object)
-	{
-		if (GET_OBJ_TYPE(tmp_object) == OBJ_DATA::ITEM_DRINKCON
-			|| GET_OBJ_TYPE(tmp_object) == OBJ_DATA::ITEM_FOUNTAIN
-			|| GET_OBJ_TYPE(tmp_object) == OBJ_DATA::ITEM_CONTAINER)
-		{
-			look_in_obj(ch, argument);
-		}
-	}
+  generic_find(arg, where_bits, ch, &tmp_char, &tmp_object);
+  if (tmp_object) {
+    if (GET_OBJ_TYPE(tmp_object) == OBJ_DATA::ITEM_DRINKCON
+        || GET_OBJ_TYPE(tmp_object) == OBJ_DATA::ITEM_FOUNTAIN
+        || GET_OBJ_TYPE(tmp_object) == OBJ_DATA::ITEM_CONTAINER) {
+      look_in_obj(ch, argument);
+    }
+  }
 }
 
-void do_gold(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int count = 0;
-	if (ch->get_gold() == 0)
-		send_to_char("Вы разорены!\r\n", ch);
-	else if (ch->get_gold() == 1)
-		send_to_char("У вас есть всего лишь одна куна.\r\n", ch);
-	else
-	{
-		count += sprintf(buf, "У Вас есть %ld %s.\r\n", ch->get_gold(), desc_count(ch->get_gold(), WHAT_MONEYa));
-		send_to_char(buf, ch);
-	}
+void do_gold(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int count = 0;
+  if (ch->get_gold() == 0)
+    send_to_char("Вы разорены!\r\n", ch);
+  else if (ch->get_gold() == 1)
+    send_to_char("У вас есть всего лишь одна куна.\r\n", ch);
+  else {
+    count += sprintf(buf, "У Вас есть %ld %s.\r\n", ch->get_gold(), desc_count(ch->get_gold(), WHAT_MONEYa));
+    send_to_char(buf, ch);
+  }
 }
 
 /// см pc_class_name
-const char *class_name[] = { "лекарь",
-							 "колдун",
-							 "тать",
-							 "богатырь",
-							 "наемник",
-							 "дружинник",
-							 "кудесник",
-							 "волшебник",
-							 "чернокнижник",
-							 "витязь",
-							 "охотник",
-							 "кузнец",
-							 "купец",
-							 "волхв",
-							 "жрец",
-							 "нойда",
-							 "тиуве",
-							 "берсерк",
-							 "наемник",
-							 "хирдман",
-							 "заарин",
-							 "босоркун",
-							 "равк",
-							 "кампе",
-							 "лучник",
-							 "аргун",
-							 "кепмен",
-							 "скальд",
-							 "знахарь",
-							 "бакша",
-							 "карак",
-							 "батыр",
-							 "тургауд",
-							 "нуке",
-							 "капнобатай",
-							 "акшаман",
-							 "карашаман",
-							 "чериг",
-							 "шикорхо",
-							 "дархан",
-							 "сатучы",
-							 "сеид"
-						   };
-
-
-const char *ac_text[] =
-{
-	"&WВы защищены как БОГ",	//  -30
-	"&WВы защищены как БОГ",	//  -29
-	"&WВы защищены как БОГ",	//  -28
-	"&gВы защищены почти как БОГ",	//  -27
-	"&gВы защищены почти как БОГ",	//  -26
-	"&gВы защищены почти как БОГ",	//  -25
-	"&gНаилучшая защита",	//  -24
-	"&gНаилучшая защита",	//  -23
-	"&gНаилучшая защита",	//  -22
-	"&gВеликолепная защита",	//  -21
-	"&gВеликолепная защита",	//  -20
-	"&gВеликолепная защита",	//  -19
-	"&gОтличная защита",	//  -18
-	"&gОтличная защита",	//  -17
-	"&gОтличная защита",	//  -16
-	"&GОчень хорошая защита",	//  -15
-	"&GОчень хорошая защита",	//  -14
-	"&GОчень хорошая защита",	//  -13
-	"&GВесьма хорошая защита",	//  -12
-	"&GВесьма хорошая защита",	//  -11
-	"&GВесьма хорошая защита",	//  -10
-	"&GХорошая защита",	//   -9
-	"&GХорошая защита",	//   -8
-	"&GХорошая защита",	//   -7
-	"&GНеплохая защита",	//   -6
-	"&GНеплохая защита",	//   -5
-	"&GНеплохая защита",	//   -4
-	"&YЗащита чуть выше среднего",	//   -3
-	"&YЗащита чуть выше среднего",	//   -2
-	"&YЗащита чуть выше среднего",	//   -1
-	"&YСредняя защита",	//    0
-	"&YЗащита чуть ниже среднего",
-	"&YСлабая защита",
-	"&RСлабая защита",
-	"&RОчень слабая защита",
-	"&RВы немного защищены",	// 5
-	"&RВы совсем немного защищены",
-	"&rВы чуть-чуть защищены",
-	"&rВы легко уязвимы",
-	"&rВы почти полностью уязвимы",
-	"&rВы полностью уязвимы",	// 10
+const char *class_name[] = {"лекарь",
+                            "колдун",
+                            "тать",
+                            "богатырь",
+                            "наемник",
+                            "дружинник",
+                            "кудесник",
+                            "волшебник",
+                            "чернокнижник",
+                            "витязь",
+                            "охотник",
+                            "кузнец",
+                            "купец",
+                            "волхв",
+                            "жрец",
+                            "нойда",
+                            "тиуве",
+                            "берсерк",
+                            "наемник",
+                            "хирдман",
+                            "заарин",
+                            "босоркун",
+                            "равк",
+                            "кампе",
+                            "лучник",
+                            "аргун",
+                            "кепмен",
+                            "скальд",
+                            "знахарь",
+                            "бакша",
+                            "карак",
+                            "батыр",
+                            "тургауд",
+                            "нуке",
+                            "капнобатай",
+                            "акшаман",
+                            "карашаман",
+                            "чериг",
+                            "шикорхо",
+                            "дархан",
+                            "сатучы",
+                            "сеид"
 };
 
-void print_do_score_all(CHAR_DATA *ch)
-{
-	int ac, max_dam = 0, hr = 0, modi = 0;
-	ESkill skill = SKILL_BOTHHANDS;
+const char *ac_text[] =
+    {
+        "&WВы защищены как БОГ",    //  -30
+        "&WВы защищены как БОГ",    //  -29
+        "&WВы защищены как БОГ",    //  -28
+        "&gВы защищены почти как БОГ",    //  -27
+        "&gВы защищены почти как БОГ",    //  -26
+        "&gВы защищены почти как БОГ",    //  -25
+        "&gНаилучшая защита",    //  -24
+        "&gНаилучшая защита",    //  -23
+        "&gНаилучшая защита",    //  -22
+        "&gВеликолепная защита",    //  -21
+        "&gВеликолепная защита",    //  -20
+        "&gВеликолепная защита",    //  -19
+        "&gОтличная защита",    //  -18
+        "&gОтличная защита",    //  -17
+        "&gОтличная защита",    //  -16
+        "&GОчень хорошая защита",    //  -15
+        "&GОчень хорошая защита",    //  -14
+        "&GОчень хорошая защита",    //  -13
+        "&GВесьма хорошая защита",    //  -12
+        "&GВесьма хорошая защита",    //  -11
+        "&GВесьма хорошая защита",    //  -10
+        "&GХорошая защита",    //   -9
+        "&GХорошая защита",    //   -8
+        "&GХорошая защита",    //   -7
+        "&GНеплохая защита",    //   -6
+        "&GНеплохая защита",    //   -5
+        "&GНеплохая защита",    //   -4
+        "&YЗащита чуть выше среднего",    //   -3
+        "&YЗащита чуть выше среднего",    //   -2
+        "&YЗащита чуть выше среднего",    //   -1
+        "&YСредняя защита",    //    0
+        "&YЗащита чуть ниже среднего",
+        "&YСлабая защита",
+        "&RСлабая защита",
+        "&RОчень слабая защита",
+        "&RВы немного защищены",    // 5
+        "&RВы совсем немного защищены",
+        "&rВы чуть-чуть защищены",
+        "&rВы легко уязвимы",
+        "&rВы почти полностью уязвимы",
+        "&rВы полностью уязвимы",    // 10
+    };
 
-	std::string sum = string("Вы ") + string(ch->get_name()) + string(", ")
-		+ string(class_name[static_cast<int>(GET_CLASS(ch)) + 14 * GET_KIN(ch)]) + string(".");
+void print_do_score_all(CHAR_DATA *ch) {
+  int ac, max_dam = 0, hr = 0, modi = 0;
+  ESkill skill = SKILL_BOTHHANDS;
 
-	sprintf(buf,
-			" %s-------------------------------------------------------------------------------------\r\n"
-			" || %s%-80s%s||\r\n"
-			" -------------------------------------------------------------------------------------\r\n",
-			CCCYN(ch, C_NRM),
-			CCNRM(ch, C_NRM), sum.substr(0, 80).c_str(), CCCYN(ch, C_NRM));
+  std::string sum = string("Вы ") + string(ch->get_name()) + string(", ")
+      + string(class_name[static_cast<int>(GET_CLASS(ch)) + 14 * GET_KIN(ch)]) + string(".");
 
-	sprintf(buf + strlen(buf),
-			" || %sПлемя: %-11s %s|"
-			" %sРост:        %-3d(%-3d) %s|"
-			" %sБроня:       %4d %s|"
-			" %sСопротивление: %s||\r\n",
-			CCNRM(ch, C_NRM),
-			string(PlayerRace::GetKinNameByNum(GET_KIN(ch),GET_SEX(ch))).substr(0, 14).c_str(),
-			CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), GET_HEIGHT(ch), GET_REAL_HEIGHT(ch), CCCYN(ch, C_NRM),
-			CCIGRN(ch, C_NRM), GET_ARMOUR(ch), CCCYN(ch, C_NRM),
-			CCIYEL(ch, C_NRM), CCCYN(ch, C_NRM));
+  sprintf(buf,
+          " %s-------------------------------------------------------------------------------------\r\n"
+          " || %s%-80s%s||\r\n"
+          " -------------------------------------------------------------------------------------\r\n",
+          CCCYN(ch, C_NRM),
+          CCNRM(ch, C_NRM), sum.substr(0, 80).c_str(), CCCYN(ch, C_NRM));
 
-	ac = compute_armor_class(ch) / 10;
-	if (ac < 5) {
-		const int mod = (1 - ch->get_cond_penalty(P_AC)) * 40;
-		ac = ac + mod > 5 ? 5 : ac + mod;
-	}
+  sprintf(buf + strlen(buf),
+          " || %sПлемя: %-11s %s|"
+          " %sРост:        %-3d(%-3d) %s|"
+          " %sБроня:       %4d %s|"
+          " %sСопротивление: %s||\r\n",
+          CCNRM(ch, C_NRM),
+          string(PlayerRace::GetKinNameByNum(GET_KIN(ch), GET_SEX(ch))).substr(0, 14).c_str(),
+          CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), GET_HEIGHT(ch), GET_REAL_HEIGHT(ch), CCCYN(ch, C_NRM),
+          CCIGRN(ch, C_NRM), GET_ARMOUR(ch), CCCYN(ch, C_NRM),
+          CCIYEL(ch, C_NRM), CCCYN(ch, C_NRM));
 
-	int resist = MIN(GET_RESIST(ch, FIRE_RESISTANCE), 75);
-	sprintf(buf + strlen(buf),
-			" || %sРод: %-13s %s|"
-			" %sВес:         %3d(%3d) %s|"
-			" %sЗащита:       %3d %s|"
-			" %sОгню:      %3d %s||\r\n",
-			CCNRM(ch, C_NRM),
-            string(PlayerRace::GetRaceNameByNum(GET_KIN(ch),GET_RACE(ch),GET_SEX(ch))).substr(0, 14).c_str(),
-			CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), GET_WEIGHT(ch), GET_REAL_WEIGHT(ch), CCCYN(ch, C_NRM),
-			CCIGRN(ch, C_NRM), ac, CCCYN(ch, C_NRM),
-			CCIRED(ch, C_NRM), resist, CCCYN(ch, C_NRM));
+  ac = compute_armor_class(ch) / 10;
+  if (ac < 5) {
+    const int mod = (1 - ch->get_cond_penalty(P_AC)) * 40;
+    ac = ac + mod > 5 ? 5 : ac + mod;
+  }
 
-	resist = MIN(GET_RESIST(ch, AIR_RESISTANCE), 75);
-	sprintf(buf + strlen(buf),
-			" || %sВера: %-13s%s|"
-			" %sРазмер:      %3d(%3d) %s|"
-			" %sПоглощение:   %3d %s|"
-			" %sВоздуху:   %3d %s||\r\n",
-			CCNRM(ch, C_NRM),
-			string(religion_name[GET_RELIGION(ch)][static_cast<int>(GET_SEX(ch))]).substr(0, 13).c_str(),
-			CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), GET_SIZE(ch), GET_REAL_SIZE(ch), CCCYN(ch, C_NRM),
-			CCIGRN(ch, C_NRM), GET_ABSORBE(ch), CCCYN(ch, C_NRM),
-			CCWHT(ch, C_NRM), resist, CCCYN(ch, C_NRM));
+  int resist = MIN(GET_RESIST(ch, FIRE_RESISTANCE), 75);
+  sprintf(buf + strlen(buf),
+          " || %sРод: %-13s %s|"
+          " %sВес:         %3d(%3d) %s|"
+          " %sЗащита:       %3d %s|"
+          " %sОгню:      %3d %s||\r\n",
+          CCNRM(ch, C_NRM),
+          string(PlayerRace::GetRaceNameByNum(GET_KIN(ch), GET_RACE(ch), GET_SEX(ch))).substr(0, 14).c_str(),
+          CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), GET_WEIGHT(ch), GET_REAL_WEIGHT(ch), CCCYN(ch, C_NRM),
+          CCIGRN(ch, C_NRM), ac, CCCYN(ch, C_NRM),
+          CCIRED(ch, C_NRM), resist, CCCYN(ch, C_NRM));
 
-	if (can_use_feat(ch, SHOT_FINESSE_FEAT)) //ловкий выстрел дамы от ловки
-		max_dam = get_real_dr(ch) + str_bonus(GET_REAL_DEX(ch), STR_TO_DAM);
-	else
-		max_dam = get_real_dr(ch) + str_bonus(GET_REAL_STR(ch), STR_TO_DAM);
+  resist = MIN(GET_RESIST(ch, AIR_RESISTANCE), 75);
+  sprintf(buf + strlen(buf),
+          " || %sВера: %-13s%s|"
+          " %sРазмер:      %3d(%3d) %s|"
+          " %sПоглощение:   %3d %s|"
+          " %sВоздуху:   %3d %s||\r\n",
+          CCNRM(ch, C_NRM),
+          string(religion_name[GET_RELIGION(ch)][static_cast<int>(GET_SEX(ch))]).substr(0, 13).c_str(),
+          CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), GET_SIZE(ch), GET_REAL_SIZE(ch), CCCYN(ch, C_NRM),
+          CCIGRN(ch, C_NRM), GET_ABSORBE(ch), CCCYN(ch, C_NRM),
+          CCWHT(ch, C_NRM), resist, CCCYN(ch, C_NRM));
 
-	if (can_use_feat(ch, BULLY_FEAT))
-	{
-		modi = 10 * (5 + (GET_EQ(ch, WEAR_HANDS) ? MIN(GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HANDS)), 18) : 0));
-		//modi = 10 * (5 + (GET_EQ(ch, WEAR_HANDS) ? GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HANDS)) : 0));
-		modi = MAX(100, modi);
-		max_dam += modi * max_dam / 50;
-		max_dam += MAX(0, GET_REAL_STR(ch) - 25);
-	}
-	else
-	{
-	    max_dam += 6 + 2 * GET_LEVEL(ch) / 3;
-	}
+  if (can_use_feat(ch, SHOT_FINESSE_FEAT)) //ловкий выстрел дамы от ловки
+    max_dam = get_real_dr(ch) + str_bonus(GET_REAL_DEX(ch), STR_TO_DAM);
+  else
+    max_dam = get_real_dr(ch) + str_bonus(GET_REAL_STR(ch), STR_TO_DAM);
 
-	OBJ_DATA* weapon = GET_EQ(ch, WEAR_BOTHS);
-	if (weapon)
-	{
-		if (GET_OBJ_TYPE(weapon) == OBJ_DATA::ITEM_WEAPON)
-		{
-			max_dam += GET_OBJ_VAL(weapon, 1) * (GET_OBJ_VAL(weapon, 2) + 1);
-			skill = static_cast<ESkill>(GET_OBJ_SKILL(weapon));
-			if (ch->get_skill(skill) == SKILL_INVALID)
-			{
-				hr -= (50 - MIN(50, GET_REAL_INT(ch))) / 3;
-				max_dam -= (50 - MIN(50, GET_REAL_INT(ch))) / 6;
-			}
-			else
-			{
-			    apply_weapon_bonus(GET_CLASS(ch), skill, &max_dam, &hr);
-			}
-		}
-	}
-	else
-	{
-		weapon = GET_EQ(ch, WEAR_HOLD);
-		if (weapon)
-		{
-			if (GET_OBJ_TYPE(weapon) == OBJ_DATA::ITEM_WEAPON)
-			{
-				max_dam += GET_OBJ_VAL(weapon, 1) * (GET_OBJ_VAL(weapon, 2) + 1) / 2;
-				skill = static_cast<ESkill>(GET_OBJ_SKILL(weapon));
-				if (ch->get_skill(skill) == SKILL_INVALID)
-				{
-					hr -= (50 - MIN(50, GET_REAL_INT(ch))) / 3;
-					max_dam -= (50 - MIN(50, GET_REAL_INT(ch))) / 6;
-				}
-				else
-				{
-				    apply_weapon_bonus(GET_CLASS(ch), skill, &max_dam, &hr);
-				}
-			}
-		}
-		weapon = GET_EQ(ch, WEAR_WIELD);
-		if (weapon)
-		{
-			if (GET_OBJ_TYPE(weapon) == OBJ_DATA::ITEM_WEAPON)
-			{
-				max_dam += GET_OBJ_VAL(weapon, 1) * (GET_OBJ_VAL(weapon, 2) + 1) / 2;
-				skill = static_cast<ESkill>(GET_OBJ_SKILL(weapon));
-				if (ch->get_skill(skill) == SKILL_INVALID)
-				{
-					hr -= (50 - MIN(50, GET_REAL_INT(ch))) / 3;
-					max_dam -= (50 - MIN(50, GET_REAL_INT(ch))) / 6;
-				}
-				else
-				{
-				    apply_weapon_bonus(GET_CLASS(ch), skill, &max_dam, &hr);
-				}
-			}
-		}
+  if (can_use_feat(ch, BULLY_FEAT)) {
+    modi = 10 * (5 + (GET_EQ(ch, WEAR_HANDS) ? MIN(GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HANDS)), 18) : 0));
+    //modi = 10 * (5 + (GET_EQ(ch, WEAR_HANDS) ? GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HANDS)) : 0));
+    modi = MAX(100, modi);
+    max_dam += modi * max_dam / 50;
+    max_dam += MAX(0, GET_REAL_STR(ch) - 25);
+  } else {
+    max_dam += 6 + 2 * GET_LEVEL(ch) / 3;
+  }
 
-	}
+  OBJ_DATA *weapon = GET_EQ(ch, WEAR_BOTHS);
+  if (weapon) {
+    if (GET_OBJ_TYPE(weapon) == OBJ_DATA::ITEM_WEAPON) {
+      max_dam += GET_OBJ_VAL(weapon, 1) * (GET_OBJ_VAL(weapon, 2) + 1);
+      skill = static_cast<ESkill>(GET_OBJ_SKILL(weapon));
+      if (ch->get_skill(skill) == SKILL_INVALID) {
+        hr -= (50 - MIN(50, GET_REAL_INT(ch))) / 3;
+        max_dam -= (50 - MIN(50, GET_REAL_INT(ch))) / 6;
+      } else {
+        apply_weapon_bonus(GET_CLASS(ch), skill, &max_dam, &hr);
+      }
+    }
+  } else {
+    weapon = GET_EQ(ch, WEAR_HOLD);
+    if (weapon) {
+      if (GET_OBJ_TYPE(weapon) == OBJ_DATA::ITEM_WEAPON) {
+        max_dam += GET_OBJ_VAL(weapon, 1) * (GET_OBJ_VAL(weapon, 2) + 1) / 2;
+        skill = static_cast<ESkill>(GET_OBJ_SKILL(weapon));
+        if (ch->get_skill(skill) == SKILL_INVALID) {
+          hr -= (50 - MIN(50, GET_REAL_INT(ch))) / 3;
+          max_dam -= (50 - MIN(50, GET_REAL_INT(ch))) / 6;
+        } else {
+          apply_weapon_bonus(GET_CLASS(ch), skill, &max_dam, &hr);
+        }
+      }
+    }
+    weapon = GET_EQ(ch, WEAR_WIELD);
+    if (weapon) {
+      if (GET_OBJ_TYPE(weapon) == OBJ_DATA::ITEM_WEAPON) {
+        max_dam += GET_OBJ_VAL(weapon, 1) * (GET_OBJ_VAL(weapon, 2) + 1) / 2;
+        skill = static_cast<ESkill>(GET_OBJ_SKILL(weapon));
+        if (ch->get_skill(skill) == SKILL_INVALID) {
+          hr -= (50 - MIN(50, GET_REAL_INT(ch))) / 3;
+          max_dam -= (50 - MIN(50, GET_REAL_INT(ch))) / 6;
+        } else {
+          apply_weapon_bonus(GET_CLASS(ch), skill, &max_dam, &hr);
+        }
+      }
+    }
 
-	if (weapon)
-	{
-		int tmphr = 0;
-		HitData::check_weap_feats(ch, GET_OBJ_SKILL(weapon), tmphr,  max_dam);
-		hr -= tmphr;
-	}
-	else
-	{
-		HitData::check_weap_feats(ch, SKILL_PUNCH, hr,  max_dam);
-	}
+  }
 
-	if (can_use_feat(ch, WEAPON_FINESSE_FEAT))
-	{
-		hr += str_bonus(GET_REAL_DEX(ch), STR_TO_HIT);
-	}
-	else
-	{
-		hr += str_bonus(GET_REAL_STR(ch), STR_TO_HIT);
-	}
-	hr += GET_REAL_HR(ch) - thaco(static_cast<int>(GET_CLASS(ch)), static_cast<int>(GET_LEVEL(ch)));
-	if (PRF_FLAGGED(ch, PRF_POWERATTACK)) {
-		hr -= 2;
-		max_dam += 5;
-	}
-	if (PRF_FLAGGED(ch, PRF_GREATPOWERATTACK)) {
-		hr -= 4;
-		max_dam += 10;
-	}
-	if (PRF_FLAGGED(ch, PRF_AIMINGATTACK)) {
-		hr += 2;
-		max_dam -= 5;
-	}
-	if (PRF_FLAGGED(ch, PRF_GREATAIMINGATTACK)) {
-		hr += 4;
-		max_dam -= 10;
-	}
+  if (weapon) {
+    int tmphr = 0;
+    HitData::check_weap_feats(ch, GET_OBJ_SKILL(weapon), tmphr, max_dam);
+    hr -= tmphr;
+  } else {
+    HitData::check_weap_feats(ch, SKILL_PUNCH, hr, max_dam);
+  }
 
-	max_dam += ch->obj_bonus().calc_phys_dmg(max_dam);
-	if (ch->add_abils.percent_dam_add > 0) {
-		max_dam += max_dam * ch->add_abils.percent_dam_add / 100. / 2;
-	}
-	max_dam = MAX(0, max_dam);
-	max_dam *= ch->get_cond_penalty(P_DAMROLL);
+  if (can_use_feat(ch, WEAPON_FINESSE_FEAT)) {
+    hr += str_bonus(GET_REAL_DEX(ch), STR_TO_HIT);
+  } else {
+    hr += str_bonus(GET_REAL_STR(ch), STR_TO_HIT);
+  }
+  hr += GET_REAL_HR(ch) - thaco(static_cast<int>(GET_CLASS(ch)), static_cast<int>(GET_LEVEL(ch)));
+  if (PRF_FLAGGED(ch, PRF_POWERATTACK)) {
+    hr -= 2;
+    max_dam += 5;
+  }
+  if (PRF_FLAGGED(ch, PRF_GREATPOWERATTACK)) {
+    hr -= 4;
+    max_dam += 10;
+  }
+  if (PRF_FLAGGED(ch, PRF_AIMINGATTACK)) {
+    hr += 2;
+    max_dam -= 5;
+  }
+  if (PRF_FLAGGED(ch, PRF_GREATAIMINGATTACK)) {
+    hr += 4;
+    max_dam -= 10;
+  }
 
-	hr *= ch->get_cond_penalty(P_HITROLL);
+  max_dam += ch->obj_bonus().calc_phys_dmg(max_dam);
+  if (ch->add_abils.percent_dam_add > 0) {
+    max_dam += max_dam * ch->add_abils.percent_dam_add / 100. / 2;
+  }
+  max_dam = MAX(0, max_dam);
+  max_dam *= ch->get_cond_penalty(P_DAMROLL);
 
-	resist = MIN(GET_RESIST(ch, WATER_RESISTANCE), 75);
-	sprintf(buf + strlen(buf),
-			" || %sУровень: %s%-2d        %s|"
-			" %sСила:          %2d(%2d) %s|"
-			" %sАтака:        %3d %s|"
-			" %sВоде:      %3d %s||\r\n",
-			CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), GET_LEVEL(ch), CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), ch->get_str(), GET_REAL_STR(ch), CCCYN(ch, C_NRM),
-			CCIGRN(ch, C_NRM), hr - (ch->ahorse() ? (10 - GET_SKILL(ch, SKILL_HORSE) / 20) : 0) , CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), resist, CCCYN(ch, C_NRM));
+  hr *= ch->get_cond_penalty(P_HITROLL);
 
-	resist = MIN(GET_RESIST(ch, EARTH_RESISTANCE), 75);
-	sprintf(buf + strlen(buf),
-			" || %sПеревоплощений: %s%-2d %s|"
-			" %sЛовкость:      %2d(%2d) %s|"
-			" %sУрон:        %4d %s|"
-			" %sЗемле:     %3d %s||\r\n",
-			CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), GET_REMORT(ch), CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), ch->get_dex(), GET_REAL_DEX(ch), CCCYN(ch, C_NRM),
-			CCIGRN(ch, C_NRM), int (max_dam * (ch->ahorse() ? ((GET_SKILL(ch, SKILL_HORSE) > 100) ? (1 + (GET_SKILL(ch, SKILL_HORSE) - 100) / 500.0) : 1 ) : 1)), CCCYN(ch, C_NRM),
-			CCYEL(ch, C_NRM), resist, CCCYN(ch, C_NRM));
+  resist = MIN(GET_RESIST(ch, WATER_RESISTANCE), 75);
+  sprintf(buf + strlen(buf),
+          " || %sУровень: %s%-2d        %s|"
+          " %sСила:          %2d(%2d) %s|"
+          " %sАтака:        %3d %s|"
+          " %sВоде:      %3d %s||\r\n",
+          CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), GET_LEVEL(ch), CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), ch->get_str(), GET_REAL_STR(ch), CCCYN(ch, C_NRM),
+          CCIGRN(ch, C_NRM), hr - (ch->ahorse() ? (10 - GET_SKILL(ch, SKILL_HORSE) / 20) : 0), CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), resist, CCCYN(ch, C_NRM));
 
-	resist = GET_RESIST(ch, DARK_RESISTANCE);
-	sprintf(buf + strlen(buf),
-			" || %sВозраст: %s%-3d       %s|"
-			" %sТелосложение:  %2d(%2d) %s|-------------------| &KТьме:      %3d&c ||\r\n",
-			CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), GET_AGE(ch), CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), ch->get_con(), GET_REAL_CON(ch), CCCYN(ch, C_NRM),
-			resist);
-	resist = MIN(GET_RESIST(ch, VITALITY_RESISTANCE), 75);
-	const int rcast = GET_CAST_SUCCESS(ch) * ch->get_cond_penalty(P_CAST);
-	sprintf(buf + strlen(buf),
-			" || %sОпыт: %s%-10ld   %s|"
-			" %sМудрость:      %2d(%2d) %s|"
-			" %sКолдовство:   %3d %s|"
-			"&c----------------||\r\n",
-			CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), GET_EXP(ch), CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), ch->get_wis(), GET_REAL_WIS(ch), CCCYN(ch, C_NRM),
-			CCIGRN(ch, C_NRM), rcast, CCCYN(ch, C_NRM));
+  resist = MIN(GET_RESIST(ch, EARTH_RESISTANCE), 75);
+  sprintf(buf + strlen(buf),
+          " || %sПеревоплощений: %s%-2d %s|"
+          " %sЛовкость:      %2d(%2d) %s|"
+          " %sУрон:        %4d %s|"
+          " %sЗемле:     %3d %s||\r\n",
+          CCNRM(ch, C_NRM),
+          CCWHT(ch, C_NRM),
+          GET_REMORT(ch),
+          CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM),
+          ch->get_dex(),
+          GET_REAL_DEX(ch),
+          CCCYN(ch, C_NRM),
+          CCIGRN(ch, C_NRM),
+          int(max_dam * (ch->ahorse() ? ((GET_SKILL(ch, SKILL_HORSE) > 100) ? (1
+              + (GET_SKILL(ch, SKILL_HORSE) - 100) / 500.0) : 1) : 1)),
+          CCCYN(ch, C_NRM),
+          CCYEL(ch, C_NRM),
+          resist,
+          CCCYN(ch, C_NRM));
 
-	resist = MIN(GET_RESIST(ch, VITALITY_RESISTANCE), 75);
+  resist = GET_RESIST(ch, DARK_RESISTANCE);
+  sprintf(buf + strlen(buf),
+          " || %sВозраст: %s%-3d       %s|"
+          " %sТелосложение:  %2d(%2d) %s|-------------------| &KТьме:      %3d&c ||\r\n",
+          CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), GET_AGE(ch), CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), ch->get_con(), GET_REAL_CON(ch), CCCYN(ch, C_NRM),
+          resist);
+  resist = MIN(GET_RESIST(ch, VITALITY_RESISTANCE), 75);
+  const int rcast = GET_CAST_SUCCESS(ch) * ch->get_cond_penalty(P_CAST);
+  sprintf(buf + strlen(buf),
+          " || %sОпыт: %s%-10ld   %s|"
+          " %sМудрость:      %2d(%2d) %s|"
+          " %sКолдовство:   %3d %s|"
+          "&c----------------||\r\n",
+          CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), GET_EXP(ch), CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), ch->get_wis(), GET_REAL_WIS(ch), CCCYN(ch, C_NRM),
+          CCIGRN(ch, C_NRM), rcast, CCCYN(ch, C_NRM));
 
-	if (IS_IMMORTAL(ch))
-		sprintf(buf + strlen(buf), " || %sДСУ: %s1%s             |",
-				CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), CCCYN(ch, C_NRM));
-	else
-		sprintf(buf + strlen(buf),
-				" || %sДСУ: %s%-10ld    %s|",
-				CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), level_exp(ch, GET_LEVEL(ch) + 1) - GET_EXP(ch), CCCYN(ch, C_NRM));
-	int itmp =  GET_MANAREG(ch);
-	itmp *= ch->get_cond_penalty(P_CAST);
-	sprintf(buf + strlen(buf),
-			" %sУм:            %2d(%2d) %s|"
-			" %sЗапоминание: %4d %s|"
-			" %sЖивучесть: %3d %s||\r\n",
+  resist = MIN(GET_RESIST(ch, VITALITY_RESISTANCE), 75);
 
-			CCICYN(ch, C_NRM), ch->get_int(), GET_REAL_INT(ch), CCCYN(ch, C_NRM),
-			CCIGRN(ch, C_NRM), itmp , CCCYN(ch, C_NRM),
-			CCIYEL(ch, C_NRM), resist, CCCYN(ch, C_NRM));
-	resist = MIN(GET_RESIST(ch, MIND_RESISTANCE), 75);
+  if (IS_IMMORTAL(ch))
+    sprintf(buf + strlen(buf), " || %sДСУ: %s1%s             |",
+            CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), CCCYN(ch, C_NRM));
+  else
+    sprintf(buf + strlen(buf),
+            " || %sДСУ: %s%-10ld    %s|",
+            CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), level_exp(ch, GET_LEVEL(ch) + 1) - GET_EXP(ch), CCCYN(ch, C_NRM));
+  int itmp = GET_MANAREG(ch);
+  itmp *= ch->get_cond_penalty(P_CAST);
+  sprintf(buf + strlen(buf),
+          " %sУм:            %2d(%2d) %s|"
+          " %sЗапоминание: %4d %s|"
+          " %sЖивучесть: %3d %s||\r\n",
 
-	sprintf(buf + strlen(buf),
-			" || %sДенег: %s%-8ld    %s|"
-			" %sОбаяние:       %2d(%2d) %s|-------------------|"
-			" %sРазум:     %3d %s||\r\n",
+          CCICYN(ch, C_NRM), ch->get_int(), GET_REAL_INT(ch), CCCYN(ch, C_NRM),
+          CCIGRN(ch, C_NRM), itmp, CCCYN(ch, C_NRM),
+          CCIYEL(ch, C_NRM), resist, CCCYN(ch, C_NRM));
+  resist = MIN(GET_RESIST(ch, MIND_RESISTANCE), 75);
 
-			CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), ch->get_gold(), CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), ch->get_cha(), GET_REAL_CHA(ch), CCCYN(ch, C_NRM),
-			CCIYEL(ch, C_NRM), resist, CCCYN(ch, C_NRM));
-	resist = MIN(GET_RESIST(ch, IMMUNITY_RESISTANCE), 75);
-	sprintf(buf + strlen(buf),
-			" || %sНа счету: %s%-8ld %s|"
-			" %sЖизнь:     %4d(%4d) %s|"
-			" %sВоля:         %3d%s |"
-			" %sИммунитет: %3d %s||\r\n",
+  sprintf(buf + strlen(buf),
+          " || %sДенег: %s%-8ld    %s|"
+          " %sОбаяние:       %2d(%2d) %s|-------------------|"
+          " %sРазум:     %3d %s||\r\n",
 
-			CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), ch->get_bank(), CCCYN(ch, C_NRM),
-			CCICYN(ch, C_NRM), GET_HIT(ch), GET_REAL_MAX_HIT(ch), CCCYN(ch, C_NRM),
-			CCGRN(ch, C_NRM), GET_REAL_SAVING_WILL(ch), CCCYN(ch, C_NRM),
-			CCIYEL(ch, C_NRM), resist, CCCYN(ch, C_NRM));
+          CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), ch->get_gold(), CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), ch->get_cha(), GET_REAL_CHA(ch), CCCYN(ch, C_NRM),
+          CCIYEL(ch, C_NRM), resist, CCCYN(ch, C_NRM));
+  resist = MIN(GET_RESIST(ch, IMMUNITY_RESISTANCE), 75);
+  sprintf(buf + strlen(buf),
+          " || %sНа счету: %s%-8ld %s|"
+          " %sЖизнь:     %4d(%4d) %s|"
+          " %sВоля:         %3d%s |"
+          " %sИммунитет: %3d %s||\r\n",
 
-	if (!ch->ahorse())
-		switch (GET_POS(ch))
-		{
-		case POS_DEAD:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCIRED(ch, C_NRM), string("Вы МЕРТВЫ!").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		case POS_MORTALLYW:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCIRED(ch, C_NRM), string("Вы умираете!").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		case POS_INCAP:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCRED(ch, C_NRM), string("Вы без сознания.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		case POS_STUNNED:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCIYEL(ch, C_NRM), string("Вы в обмороке!").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		case POS_SLEEPING:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCIGRN(ch, C_NRM), string("Вы спите.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		case POS_RESTING:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCGRN(ch, C_NRM), string("Вы отдыхаете.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		case POS_SITTING:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCIGRN(ch, C_NRM), string("Вы сидите.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		case POS_FIGHTING:
-			if (ch->get_fighting())
-				sprintf(buf + strlen(buf), " || %s%-19s%s|",
-						CCIRED(ch, C_NRM), string("Вы сражаетесь!").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			else
-				sprintf(buf + strlen(buf), " || %s%-19s%s|",
-						CCRED(ch, C_NRM), string("Вы машете кулаками.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		case POS_STANDING:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCNRM(ch, C_NRM), string("Вы стоите.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		default:
-			sprintf(buf + strlen(buf), " || %s%-19s%s|",
-					CCNRM(ch, C_NRM), string("You are floating..").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
-			break;
-		}
-	else
-		sprintf(buf + strlen(buf), " || %s%-19s%s|",
-				CCNRM(ch, C_NRM), string("Вы сидите верхом.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+          CCNRM(ch, C_NRM), CCWHT(ch, C_NRM), ch->get_bank(), CCCYN(ch, C_NRM),
+          CCICYN(ch, C_NRM), GET_HIT(ch), GET_REAL_MAX_HIT(ch), CCCYN(ch, C_NRM),
+          CCGRN(ch, C_NRM), GET_REAL_SAVING_WILL(ch), CCCYN(ch, C_NRM),
+          CCIYEL(ch, C_NRM), resist, CCCYN(ch, C_NRM));
 
-	sprintf(buf + strlen(buf),
-			" %sВыносл.:     %3d(%3d) %s|"
-			" %sЗдоровье:     %3d %s|"
-			"----------------||\r\n",
+  if (!ch->ahorse())
+    switch (GET_POS(ch)) {
+      case POS_DEAD:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCIRED(ch, C_NRM), string("Вы МЕРТВЫ!").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      case POS_MORTALLYW:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCIRED(ch, C_NRM), string("Вы умираете!").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      case POS_INCAP:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCRED(ch, C_NRM), string("Вы без сознания.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      case POS_STUNNED:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCIYEL(ch, C_NRM), string("Вы в обмороке!").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      case POS_SLEEPING:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCIGRN(ch, C_NRM), string("Вы спите.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      case POS_RESTING:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCGRN(ch, C_NRM), string("Вы отдыхаете.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      case POS_SITTING:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCIGRN(ch, C_NRM), string("Вы сидите.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      case POS_FIGHTING:
+        if (ch->get_fighting())
+          sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                  CCIRED(ch, C_NRM), string("Вы сражаетесь!").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        else
+          sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                  CCRED(ch, C_NRM), string("Вы машете кулаками.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      case POS_STANDING:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCNRM(ch, C_NRM), string("Вы стоите.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+      default:
+        sprintf(buf + strlen(buf), " || %s%-19s%s|",
+                CCNRM(ch, C_NRM), string("You are floating..").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
+        break;
+    }
+  else
+    sprintf(buf + strlen(buf), " || %s%-19s%s|",
+            CCNRM(ch, C_NRM), string("Вы сидите верхом.").substr(0, 19).c_str(), CCCYN(ch, C_NRM));
 
-			CCICYN(ch, C_NRM), GET_MOVE(ch), GET_REAL_MAX_MOVE(ch), CCCYN(ch, C_NRM),
-			CCGRN(ch, C_NRM), GET_REAL_SAVING_CRITICAL(ch), CCCYN(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          " %sВыносл.:     %3d(%3d) %s|"
+          " %sЗдоровье:     %3d %s|"
+          "----------------||\r\n",
 
-	if (GET_COND(ch, FULL) > NORM_COND_VALUE)
-		sprintf(buf + strlen(buf), " || %sГолоден: %sугу :(%s    |", CCNRM(ch, C_NRM), CCIRED(ch, C_NRM), CCCYN(ch, C_NRM));
-	else
-		sprintf(buf + strlen(buf), " || %sГолоден: %sнет%s       |", CCNRM(ch, C_NRM), CCGRN(ch, C_NRM), CCCYN(ch, C_NRM));
+          CCICYN(ch, C_NRM), GET_MOVE(ch), GET_REAL_MAX_MOVE(ch), CCCYN(ch, C_NRM),
+          CCGRN(ch, C_NRM), GET_REAL_SAVING_CRITICAL(ch), CCCYN(ch, C_NRM));
 
-	if (IS_MANA_CASTER(ch))
-		sprintf(buf + strlen(buf),
-				" %sМанна:   %5d(%5d) %s|",
-				CCICYN(ch, C_NRM), GET_MANA_STORED(ch), GET_MAX_MANA(ch), CCCYN(ch, C_NRM));
-	else
-		strcat(buf, "                       |");
+  if (GET_COND(ch, FULL) > NORM_COND_VALUE)
+    sprintf(buf + strlen(buf), " || %sГолоден: %sугу :(%s    |", CCNRM(ch, C_NRM), CCIRED(ch, C_NRM), CCCYN(ch, C_NRM));
+  else
+    sprintf(buf + strlen(buf), " || %sГолоден: %sнет%s       |", CCNRM(ch, C_NRM), CCGRN(ch, C_NRM), CCCYN(ch, C_NRM));
 
-	sprintf(buf + strlen(buf),
-			" %sСтойкость:    %3d %s|"
-			" &rВосст. жизни:  &c||\r\n",
-			CCGRN(ch, C_NRM), GET_REAL_SAVING_STABILITY(ch), CCCYN(ch, C_NRM));
+  if (IS_MANA_CASTER(ch))
+    sprintf(buf + strlen(buf),
+            " %sМанна:   %5d(%5d) %s|",
+            CCICYN(ch, C_NRM), GET_MANA_STORED(ch), GET_MAX_MANA(ch), CCCYN(ch, C_NRM));
+  else
+    strcat(buf, "                       |");
 
-	if (GET_COND_M(ch, THIRST))
-		sprintf(buf + strlen(buf),
-				" || %sЖажда: %sналивай!%s    |",
-				CCNRM(ch, C_NRM), CCIRED(ch, C_NRM), CCCYN(ch, C_NRM));
-	else
-		sprintf(buf + strlen(buf),
-				" || %sЖажда: %sнет%s         |",
-				CCNRM(ch, C_NRM), CCGRN(ch, C_NRM), CCCYN(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          " %sСтойкость:    %3d %s|"
+          " &rВосст. жизни:  &c||\r\n",
+          CCGRN(ch, C_NRM), GET_REAL_SAVING_STABILITY(ch), CCCYN(ch, C_NRM));
 
-	if (IS_MANA_CASTER(ch))
-		sprintf(buf + strlen(buf),
-				" %sВосстан.:    %3d сек. %s|",
-				CCICYN(ch, C_NRM), mana_gain(ch), CCCYN(ch, C_NRM));
-	else
-		strcat(buf, "                       |");
+  if (GET_COND_M(ch, THIRST))
+    sprintf(buf + strlen(buf),
+            " || %sЖажда: %sналивай!%s    |",
+            CCNRM(ch, C_NRM), CCIRED(ch, C_NRM), CCCYN(ch, C_NRM));
+  else
+    sprintf(buf + strlen(buf),
+            " || %sЖажда: %sнет%s         |",
+            CCNRM(ch, C_NRM), CCGRN(ch, C_NRM), CCCYN(ch, C_NRM));
 
-	sprintf(buf + strlen(buf),
-			" %sРеакция:      %3d %s|"
-			" %s  %+4d%% (%+4d) %s||\r\n",
-			CCGRN(ch, C_NRM), GET_REAL_SAVING_REFLEX(ch), CCCYN(ch, C_NRM),
-			CCRED(ch, C_NRM), GET_HITREG(ch), hit_gain(ch), CCCYN(ch, C_NRM));
+  if (IS_MANA_CASTER(ch))
+    sprintf(buf + strlen(buf),
+            " %sВосстан.:    %3d сек. %s|",
+            CCICYN(ch, C_NRM), mana_gain(ch), CCCYN(ch, C_NRM));
+  else
+    strcat(buf, "                       |");
 
-	if (GET_COND(ch, DRUNK) >= CHAR_DRUNKED)
-	{
-		if (affected_by_spell(ch, SPELL_ABSTINENT))
-			sprintf(buf + strlen(buf),
-					" || %sПохмелье.          %s|                       |",
-					CCIYEL(ch, C_NRM), CCCYN(ch, C_NRM));
-		else
-			sprintf(buf + strlen(buf),
-					" || %sВы пьяны.          %s|                       |",
-					CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
-	}
-	else
-	{
-		strcat(buf, " ||                    |                       |");
-	}
-	sprintf(buf + strlen(buf),
-			" %sУдача:       %4d %s|"
-			" &rВосст. сил:    &c||\r\n",
-			CCGRN(ch, C_NRM), ch->calc_morale(), CCCYN(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          " %sРеакция:      %3d %s|"
+          " %s  %+4d%% (%+4d) %s||\r\n",
+          CCGRN(ch, C_NRM), GET_REAL_SAVING_REFLEX(ch), CCCYN(ch, C_NRM),
+          CCRED(ch, C_NRM), GET_HITREG(ch), hit_gain(ch), CCCYN(ch, C_NRM));
 
-	const unsigned wdex = PlayerSystem::weight_dex_penalty(ch);
-	if (wdex == 0)
-	{
-		strcat(buf, " ||                    |                       |");
-	}
-	else
-	{
-		sprintf(buf + strlen(buf),
-			" || %sПерегруз!%s          |                       |",
-			wdex == 1 ? CCIYEL(ch, C_NRM) : CCIRED(ch, C_NRM),
-			CCCYN(ch, C_NRM));
-	}
-	sprintf(buf + strlen(buf),
-		" %sИнициатива:  %4d %s|"
-		" %s  %+4d%% (%+4d) %s||\r\n",
-		CCGRN(ch, C_NRM), calc_initiative(ch, false), CCCYN(ch, C_NRM),
-		CCRED(ch, C_NRM), GET_MOVEREG(ch), move_gain(ch), CCCYN(ch, C_NRM));
-	sprintf(buf + strlen(buf), "&c ||&n                    &c|                       &c| &gМаг. резист: %4d&c |&n                &c||\r\n", GET_MR(ch));
-	sprintf(buf + strlen(buf), "&c ||&n                    &c|                       &c| &gФиз. резист: %4d&c |&n                &c||&n\r\n", GET_PR(ch));
-	sprintf(buf + strlen(buf), " -------------------------------------------------------------------------------------\r\n");
-	if (ch->has_horse(false))
-	{
-		if (ch->ahorse())
-			sprintf(buf + strlen(buf),
-					" %s|| %sВы верхом на %-67s%s||\r\n"
-					" -------------------------------------------------------------------------------------\r\n",
-					CCCYN(ch, C_NRM), CCIGRN(ch, C_NRM),
-					(string(GET_PAD(ch->get_horse(), 5)) + string(".")).substr(0, 67).c_str(), CCCYN(ch, C_NRM));
-		else
-			sprintf(buf + strlen(buf),
-					" %s|| %sУ вас есть %-69s%s||\r\n"
-					" -------------------------------------------------------------------------------------\r\n",
-					CCCYN(ch, C_NRM), CCIGRN(ch, C_NRM),
-					(string(GET_NAME(ch->get_horse())) + string(".")).substr(0, 69).c_str(), CCCYN(ch, C_NRM));
-	}
+  if (GET_COND(ch, DRUNK) >= CHAR_DRUNKED) {
+    if (affected_by_spell(ch, SPELL_ABSTINENT))
+      sprintf(buf + strlen(buf),
+              " || %sПохмелье.          %s|                       |",
+              CCIYEL(ch, C_NRM), CCCYN(ch, C_NRM));
+    else
+      sprintf(buf + strlen(buf),
+              " || %sВы пьяны.          %s|                       |",
+              CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
+  } else {
+    strcat(buf, " ||                    |                       |");
+  }
+  sprintf(buf + strlen(buf),
+          " %sУдача:       %4d %s|"
+          " &rВосст. сил:    &c||\r\n",
+          CCGRN(ch, C_NRM), ch->calc_morale(), CCCYN(ch, C_NRM));
 
-	//Напоминаем о метке, если она есть.
-    ROOM_DATA *label_room = RoomSpells::findAffectedRoom(GET_ID(ch), SPELL_RUNE_LABEL);
-	if (label_room)
-	{
-		const int timer_room_label = RoomSpells::getUniqueAffectDuration(GET_ID(ch), SPELL_RUNE_LABEL);
-		sprintf(buf + strlen(buf),
-				" %s|| &G&qВы поставили рунную метку в комнате %s%s||\r\n",
-				CCCYN(ch, C_NRM),
-				colored_name(string(string("'")+label_room->name+string("&n&Q'.")).c_str(), 44),
-				CCCYN(ch, C_NRM));
-		if (timer_room_label > 0)
-		{
-			*buf2 = '\0';
-			(timer_room_label + 1) / SECS_PER_MUD_HOUR ? sprintf(buf2, "%d %s.", (timer_room_label + 1) / SECS_PER_MUD_HOUR + 1, desc_count((timer_room_label + 1) / SECS_PER_MUD_HOUR + 1, WHAT_HOUR)) : sprintf(buf2, "менее часа.");
-			sprintf(buf + strlen(buf),
-					" || Метка продержится еще %-58s||\r\n",buf2);
-			*buf2 = '\0';
-		}
-	}
+  const unsigned wdex = PlayerSystem::weight_dex_penalty(ch);
+  if (wdex == 0) {
+    strcat(buf, " ||                    |                       |");
+  } else {
+    sprintf(buf + strlen(buf),
+            " || %sПерегруз!%s          |                       |",
+            wdex == 1 ? CCIYEL(ch, C_NRM) : CCIRED(ch, C_NRM),
+            CCCYN(ch, C_NRM));
+  }
+  sprintf(buf + strlen(buf),
+          " %sИнициатива:  %4d %s|"
+          " %s  %+4d%% (%+4d) %s||\r\n",
+          CCGRN(ch, C_NRM), calc_initiative(ch, false), CCCYN(ch, C_NRM),
+          CCRED(ch, C_NRM), GET_MOVEREG(ch), move_gain(ch), CCCYN(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          "&c ||&n                    &c|                       &c| &gМаг. резист: %4d&c |&n                &c||\r\n",
+          GET_MR(ch));
+  sprintf(buf + strlen(buf),
+          "&c ||&n                    &c|                       &c| &gФиз. резист: %4d&c |&n                &c||&n\r\n",
+          GET_PR(ch));
+  sprintf(buf + strlen(buf),
+          " -------------------------------------------------------------------------------------\r\n");
+  if (ch->has_horse(false)) {
+    if (ch->ahorse())
+      sprintf(buf + strlen(buf),
+              " %s|| %sВы верхом на %-67s%s||\r\n"
+              " -------------------------------------------------------------------------------------\r\n",
+              CCCYN(ch, C_NRM), CCIGRN(ch, C_NRM),
+              (string(GET_PAD(ch->get_horse(), 5)) + string(".")).substr(0, 67).c_str(), CCCYN(ch, C_NRM));
+    else
+      sprintf(buf + strlen(buf),
+              " %s|| %sУ вас есть %-69s%s||\r\n"
+              " -------------------------------------------------------------------------------------\r\n",
+              CCCYN(ch, C_NRM), CCIGRN(ch, C_NRM),
+              (string(GET_NAME(ch->get_horse())) + string(".")).substr(0, 69).c_str(), CCCYN(ch, C_NRM));
+  }
 
-	int glory = Glory::get_glory(GET_UNIQUE(ch));
+  //Напоминаем о метке, если она есть.
+  ROOM_DATA *label_room = RoomSpells::findAffectedRoom(GET_ID(ch), SPELL_RUNE_LABEL);
+  if (label_room) {
+    const int timer_room_label = RoomSpells::getUniqueAffectDuration(GET_ID(ch), SPELL_RUNE_LABEL);
+    sprintf(buf + strlen(buf),
+            " %s|| &G&qВы поставили рунную метку в комнате %s%s||\r\n",
+            CCCYN(ch, C_NRM),
+            colored_name(string(string("'") + label_room->name + string("&n&Q'.")).c_str(), 44),
+            CCCYN(ch, C_NRM));
+    if (timer_room_label > 0) {
+      *buf2 = '\0';
+      (timer_room_label + 1) / SECS_PER_MUD_HOUR ? sprintf(buf2,
+                                                           "%d %s.",
+                                                           (timer_room_label + 1) / SECS_PER_MUD_HOUR + 1,
+                                                           desc_count((timer_room_label + 1) / SECS_PER_MUD_HOUR + 1,
+                                                                      WHAT_HOUR)) : sprintf(buf2, "менее часа.");
+      sprintf(buf + strlen(buf),
+              " || Метка продержится еще %-58s||\r\n", buf2);
+      *buf2 = '\0';
+    }
+  }
+
+  int glory = Glory::get_glory(GET_UNIQUE(ch));
 /*	if (glory)
 		sprintf(buf + strlen(buf),
 				" %s|| %sВы заслужили %5d %-61s%s||\r\n",
@@ -3775,2597 +3228,2283 @@ void print_do_score_all(CHAR_DATA *ch)
 				(string(desc_count(glory, WHAT_POINT)) + string(" славы для временного улучшения характеристик.")).substr(0, 61).c_str(),
 				CCCYN(ch, C_NRM));
 */
-	glory = GloryConst::get_glory(GET_UNIQUE(ch));
-	if (glory)
-		sprintf(buf + strlen(buf),
-				" %s|| %sВы заслужили %5d %-61s%s||\r\n",
-				CCCYN(ch, C_NRM), CCWHT(ch, C_NRM), glory,
-				(string(desc_count(glory, WHAT_POINT)) + string(" постоянной славы.")).substr(0, 61).c_str(),
-				CCCYN(ch, C_NRM));
+  glory = GloryConst::get_glory(GET_UNIQUE(ch));
+  if (glory)
+    sprintf(buf + strlen(buf),
+            " %s|| %sВы заслужили %5d %-61s%s||\r\n",
+            CCCYN(ch, C_NRM), CCWHT(ch, C_NRM), glory,
+            (string(desc_count(glory, WHAT_POINT)) + string(" постоянной славы.")).substr(0, 61).c_str(),
+            CCCYN(ch, C_NRM));
 
-	if (GET_GOD_FLAG(ch, GF_REMORT) && CLAN(ch))
-	{
-		sprintf(buf + strlen(buf),
-			" || Вы самоотверженно отдаете весь получаемый опыт своей дружине.                   ||\r\n");
-	}
+  if (GET_GOD_FLAG(ch, GF_REMORT) && CLAN(ch)) {
+    sprintf(buf + strlen(buf),
+            " || Вы самоотверженно отдаете весь получаемый опыт своей дружине.                   ||\r\n");
+  }
 
-	if (PRF_FLAGGED(ch, PRF_SUMMONABLE))
-		sprintf(buf + strlen(buf),
-				" || Вы можете быть призваны.                                                        ||\r\n");
-	else
-		sprintf(buf + strlen(buf),
-				" || Вы защищены от призыва.                                                         ||\r\n");
-	if (PRF_FLAGGED(ch, PRF_BLIND))
-		sprintf(buf + strlen(buf),
-				" || Режим слепого игрока включен.                                                   ||\r\n");
-	if (Bonus::is_bonus(0))
-		sprintf(buf + strlen(buf),
-			" || %-79s ||\r\n || %-79s ||\r\n", Bonus::str_type_bonus().c_str(), Bonus::bonus_end().c_str());
-	if (!NAME_GOD(ch) && GET_LEVEL(ch) <= NAME_LEVEL)
-	{
-		sprintf(buf + strlen(buf),
-				" &c|| &RВНИМАНИЕ!&n ваше имя не одобрил никто из богов!&c                                   ||\r\n");
-		sprintf(buf + strlen(buf),
-				" || &nCкоро вы прекратите получать опыт, обратитесь к богам для одобрения имени.      &c||\r\n");
-	}
-	else if (NAME_BAD(ch))
-	{
-		sprintf(buf + strlen(buf),
-				" || &RВНИМАНИЕ!&n ваше имя запрещено богами. Очень скоро вы прекратите получать опыт.   &c||\r\n");
-	}
-	if (GET_LEVEL(ch) < LVL_IMMORT)
-		sprintf(buf + strlen(buf),
-				" || %sВы можете вступить в группу с максимальной разницей                             %s||\r\n"
-				" || %sв %2d %-75s%s||\r\n",
-				CCNRM(ch, C_NRM), CCCYN(ch, C_NRM), CCNRM(ch, C_NRM),
-				grouping[static_cast<int>(GET_CLASS(ch))][static_cast<int>(GET_REMORT(ch))],
-				(string(desc_count(grouping[static_cast<int>(GET_CLASS(ch))][static_cast<int>(GET_REMORT(ch))], WHAT_LEVEL))
-				 + string(" без потерь для опыта.")).substr(0, 76).c_str(), CCCYN(ch, C_NRM));
+  if (PRF_FLAGGED(ch, PRF_SUMMONABLE))
+    sprintf(buf + strlen(buf),
+            " || Вы можете быть призваны.                                                        ||\r\n");
+  else
+    sprintf(buf + strlen(buf),
+            " || Вы защищены от призыва.                                                         ||\r\n");
+  if (PRF_FLAGGED(ch, PRF_BLIND))
+    sprintf(buf + strlen(buf),
+            " || Режим слепого игрока включен.                                                   ||\r\n");
+  if (Bonus::is_bonus(0))
+    sprintf(buf + strlen(buf),
+            " || %-79s ||\r\n || %-79s ||\r\n", Bonus::str_type_bonus().c_str(), Bonus::bonus_end().c_str());
+  if (!NAME_GOD(ch) && GET_LEVEL(ch) <= NAME_LEVEL) {
+    sprintf(buf + strlen(buf),
+            " &c|| &RВНИМАНИЕ!&n ваше имя не одобрил никто из богов!&c                                   ||\r\n");
+    sprintf(buf + strlen(buf),
+            " || &nCкоро вы прекратите получать опыт, обратитесь к богам для одобрения имени.      &c||\r\n");
+  } else if (NAME_BAD(ch)) {
+    sprintf(buf + strlen(buf),
+            " || &RВНИМАНИЕ!&n ваше имя запрещено богами. Очень скоро вы прекратите получать опыт.   &c||\r\n");
+  }
+  if (GET_LEVEL(ch) < LVL_IMMORT)
+    sprintf(buf + strlen(buf),
+            " || %sВы можете вступить в группу с максимальной разницей                             %s||\r\n"
+            " || %sв %2d %-75s%s||\r\n",
+            CCNRM(ch, C_NRM), CCCYN(ch, C_NRM), CCNRM(ch, C_NRM),
+            grouping[static_cast<int>(GET_CLASS(ch))][static_cast<int>(GET_REMORT(ch))],
+            (string(desc_count(grouping[static_cast<int>(GET_CLASS(ch))][static_cast<int>(GET_REMORT(ch))], WHAT_LEVEL))
+                + string(" без потерь для опыта.")).substr(0, 76).c_str(), CCCYN(ch, C_NRM));
 
-	if (RENTABLE(ch))
-	{
-		const time_t rent_time = RENTABLE(ch) - time(0);
-		const int minutes = rent_time > 60 ? rent_time / 60 : 0;
-		sprintf(buf + strlen(buf),
-				" || %sВ связи с боевыми действиями вы не можете уйти на постой еще %-18s%s ||\r\n",
-				CCIRED(ch, C_NRM),
-				minutes ? (boost::lexical_cast<std::string>(minutes) + string(" ") + string(desc_count(minutes, WHAT_MINu)) + string(".")).substr(0, 18).c_str()
-						: (boost::lexical_cast<std::string>(rent_time) + string(" ") + string(desc_count(rent_time, WHAT_SEC)) + string(".")).substr(0, 18).c_str(),
-				CCCYN(ch, C_NRM));
-	}
-	else if ((ch->in_room != NOWHERE) && ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL) && !PLR_FLAGGED(ch, PLR_KILLER))
-		sprintf(buf + strlen(buf),
-				" || %sТут вы чувствуете себя в безопасности.                                          %s||\r\n",
-				CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
+  if (RENTABLE(ch)) {
+    const time_t rent_time = RENTABLE(ch) - time(0);
+    const int minutes = rent_time > 60 ? rent_time / 60 : 0;
+    sprintf(buf + strlen(buf),
+            " || %sВ связи с боевыми действиями вы не можете уйти на постой еще %-18s%s ||\r\n",
+            CCIRED(ch, C_NRM),
+            minutes ? (boost::lexical_cast<std::string>(minutes) + string(" ") + string(desc_count(minutes, WHAT_MINu))
+                + string(".")).substr(0, 18).c_str()
+                    : (boost::lexical_cast<std::string>(rent_time) + string(" ")
+                + string(desc_count(rent_time, WHAT_SEC)) + string(".")).substr(0, 18).c_str(),
+            CCCYN(ch, C_NRM));
+  } else if ((ch->in_room != NOWHERE) && ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL) && !PLR_FLAGGED(ch, PLR_KILLER))
+    sprintf(buf + strlen(buf),
+            " || %sТут вы чувствуете себя в безопасности.                                          %s||\r\n",
+            CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
 
-	if (ROOM_FLAGGED(ch->in_room, ROOM_SMITH) && (ch->get_skill(SKILL_INSERTGEM) || ch->get_skill(SKILL_REPAIR) || ch->get_skill(SKILL_TRANSFORMWEAPON)))
-		sprintf(buf + strlen(buf),
-				" || %sЭто место отлично подходит для занятий кузнечным делом.                         %s||\r\n",
-				CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
+  if (ROOM_FLAGGED(ch->in_room, ROOM_SMITH)
+      && (ch->get_skill(SKILL_INSERTGEM) || ch->get_skill(SKILL_REPAIR) || ch->get_skill(SKILL_TRANSFORMWEAPON)))
+    sprintf(buf + strlen(buf),
+            " || %sЭто место отлично подходит для занятий кузнечным делом.                         %s||\r\n",
+            CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
 
-	if (mail::has_mail(ch->get_uid()))
-		sprintf(buf + strlen(buf),
-				" || %sВас ожидает новое письмо, зайдите на почту.                                     %s||\r\n",
-				CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
+  if (mail::has_mail(ch->get_uid()))
+    sprintf(buf + strlen(buf),
+            " || %sВас ожидает новое письмо, зайдите на почту.                                     %s||\r\n",
+            CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
 
-	if (Parcel::has_parcel(ch))
-		sprintf(buf + strlen(buf),
-				" || %sВас ожидает посылка, зайдите на почту.                                          %s||\r\n",
-				CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
+  if (Parcel::has_parcel(ch))
+    sprintf(buf + strlen(buf),
+            " || %sВас ожидает посылка, зайдите на почту.                                          %s||\r\n",
+            CCIGRN(ch, C_NRM), CCCYN(ch, C_NRM));
 
-	if (ch->get_protecting())
-		sprintf(buf + strlen(buf),
-				" || %sВы прикрываете %-65s%s||\r\n",
-				CCIGRN(ch, C_NRM), string(GET_PAD(ch->get_protecting(),3)+string(" от нападения.")).substr(0,65).c_str(),
-				CCCYN(ch, C_NRM));
+  if (ch->get_protecting())
+    sprintf(buf + strlen(buf),
+            " || %sВы прикрываете %-65s%s||\r\n",
+            CCIGRN(ch, C_NRM),
+            string(GET_PAD(ch->get_protecting(), 3) + string(" от нападения.")).substr(0, 65).c_str(),
+            CCCYN(ch, C_NRM));
 
-	if (GET_GOD_FLAG(ch, GF_GODSCURSE) && GCURSE_DURATION(ch))
-	{
-		const int hrs = (GCURSE_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((GCURSE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf + strlen(buf),
-				" || %sВы прокляты Богами на %3d %-5s %2d %-45s%s||\r\n",
-				CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
-				mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 45).c_str(), CCCYN(ch, C_NRM));
-	}
+  if (GET_GOD_FLAG(ch, GF_GODSCURSE) && GCURSE_DURATION(ch)) {
+    const int hrs = (GCURSE_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((GCURSE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf + strlen(buf),
+            " || %sВы прокляты Богами на %3d %-5s %2d %-45s%s||\r\n",
+            CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
+            mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 45).c_str(), CCCYN(ch, C_NRM));
+  }
 
-	if (PLR_FLAGGED(ch, PLR_HELLED) && HELL_DURATION(ch) && HELL_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (HELL_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((HELL_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf + strlen(buf),
-				" || %sВам предстоит провести в темнице еще %6d %-5s %2d %-27s%s||\r\n"
-				" || %s[%-79s%s||\r\n",
-				CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
-				mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 27).c_str(),
-				CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
-				(string(HELL_REASON(ch) ? HELL_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
-				CCCYN(ch, C_NRM));
-	}
+  if (PLR_FLAGGED(ch, PLR_HELLED) && HELL_DURATION(ch) && HELL_DURATION(ch) > time(NULL)) {
+    const int hrs = (HELL_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((HELL_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf + strlen(buf),
+            " || %sВам предстоит провести в темнице еще %6d %-5s %2d %-27s%s||\r\n"
+            " || %s[%-79s%s||\r\n",
+            CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
+            mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 27).c_str(),
+            CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
+            (string(HELL_REASON(ch) ? HELL_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
+            CCCYN(ch, C_NRM));
+  }
 
-	if (PLR_FLAGGED(ch, PLR_MUTE) && MUTE_DURATION(ch) != 0 && MUTE_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (MUTE_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((MUTE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf + strlen(buf),
-				" || %sВы не сможете кричать еще %6d %-5s %2d %-38s%s||\r\n"
-				" || %s[%-79s%s||\r\n",
-				CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
-				mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 38).c_str(),
-				CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
-				(string(MUTE_REASON(ch) ? MUTE_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
-				CCCYN(ch, C_NRM));
-	}
+  if (PLR_FLAGGED(ch, PLR_MUTE) && MUTE_DURATION(ch) != 0 && MUTE_DURATION(ch) > time(NULL)) {
+    const int hrs = (MUTE_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((MUTE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf + strlen(buf),
+            " || %sВы не сможете кричать еще %6d %-5s %2d %-38s%s||\r\n"
+            " || %s[%-79s%s||\r\n",
+            CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
+            mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 38).c_str(),
+            CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
+            (string(MUTE_REASON(ch) ? MUTE_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
+            CCCYN(ch, C_NRM));
+  }
 
-	if (!PLR_FLAGGED(ch, PLR_REGISTERED) && UNREG_DURATION(ch) != 0 && UNREG_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (UNREG_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((UNREG_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf + strlen(buf),
-				" || %sВы не сможете входить с одного IP еще %6d %-5s %2d %-26s%s||\r\n"
-				" || %s[%-79s%s||\r\n",
-				CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
-				mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 38).c_str(),
-				CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
-				(string(UNREG_REASON(ch) ? UNREG_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
-				CCCYN(ch, C_NRM));
-	}
+  if (!PLR_FLAGGED(ch, PLR_REGISTERED) && UNREG_DURATION(ch) != 0 && UNREG_DURATION(ch) > time(NULL)) {
+    const int hrs = (UNREG_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((UNREG_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf + strlen(buf),
+            " || %sВы не сможете входить с одного IP еще %6d %-5s %2d %-26s%s||\r\n"
+            " || %s[%-79s%s||\r\n",
+            CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
+            mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 38).c_str(),
+            CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
+            (string(UNREG_REASON(ch) ? UNREG_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
+            CCCYN(ch, C_NRM));
+  }
 
-	if (PLR_FLAGGED(ch, PLR_DUMB) && DUMB_DURATION(ch) != 0 && DUMB_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (DUMB_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((DUMB_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf + strlen(buf),
-				" || %sВы будете молчать еще %6d %-5s %2d %-42s%s||\r\n"
-				" || %s[%-79s%s||\r\n",
-				CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
-				mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 42).c_str(),
-				CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
-				(string(DUMB_REASON(ch) ? DUMB_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
-				CCCYN(ch, C_NRM));
-	}
+  if (PLR_FLAGGED(ch, PLR_DUMB) && DUMB_DURATION(ch) != 0 && DUMB_DURATION(ch) > time(NULL)) {
+    const int hrs = (DUMB_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((DUMB_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf + strlen(buf),
+            " || %sВы будете молчать еще %6d %-5s %2d %-42s%s||\r\n"
+            " || %s[%-79s%s||\r\n",
+            CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
+            mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 42).c_str(),
+            CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
+            (string(DUMB_REASON(ch) ? DUMB_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
+            CCCYN(ch, C_NRM));
+  }
 
-	if (PLR_FLAGGED(ch, PLR_FROZEN) && FREEZE_DURATION(ch) != 0 && FREEZE_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (FREEZE_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((FREEZE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf + strlen(buf),
-				" || %sВы будете заморожены еще %6d %-5s %2d %-39s%s||\r\n"
-				" || %s[%-79s%s||\r\n",
-				CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
-				mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 42).c_str(),
-				CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
-				(string(FREEZE_REASON(ch) ? FREEZE_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
-				CCCYN(ch, C_NRM));
-	}
+  if (PLR_FLAGGED(ch, PLR_FROZEN) && FREEZE_DURATION(ch) != 0 && FREEZE_DURATION(ch) > time(NULL)) {
+    const int hrs = (FREEZE_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((FREEZE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf + strlen(buf),
+            " || %sВы будете заморожены еще %6d %-5s %2d %-39s%s||\r\n"
+            " || %s[%-79s%s||\r\n",
+            CCRED(ch, C_NRM), hrs, string(desc_count(hrs, WHAT_HOUR)).substr(0, 5).c_str(),
+            mins, (string(desc_count(mins, WHAT_MINu)) + string(".")).substr(0, 42).c_str(),
+            CCCYN(ch, C_NRM), CCRED(ch, C_NRM),
+            (string(FREEZE_REASON(ch) ? FREEZE_REASON(ch) : "-") + string("].")).substr(0, 79).c_str(),
+            CCCYN(ch, C_NRM));
+  }
 
-	if (ch->is_morphed())
-	{
-		sprintf(buf + strlen(buf),
-			" || %sВы находитесь в звериной форме - %-47s%s||\r\n",
-			CCYEL(ch, C_NRM),
-			ch->get_morph_desc().substr(0, 47).c_str(),
-			CCCYN(ch, C_NRM));
-	}
-	strcat(buf, " ||                                                                                 ||\r\n");
-	strcat(buf, " -------------------------------------------------------------------------------------\r\n");
-	strcat(buf, CCNRM(ch, C_NRM));
-	send_to_char(buf, ch);
-	if (PRF_FLAGGED(ch, PRF_TESTER))
-		test_self_hitroll(ch);
+  if (ch->is_morphed()) {
+    sprintf(buf + strlen(buf),
+            " || %sВы находитесь в звериной форме - %-47s%s||\r\n",
+            CCYEL(ch, C_NRM),
+            ch->get_morph_desc().substr(0, 47).c_str(),
+            CCCYN(ch, C_NRM));
+  }
+  strcat(buf, " ||                                                                                 ||\r\n");
+  strcat(buf, " -------------------------------------------------------------------------------------\r\n");
+  strcat(buf, CCNRM(ch, C_NRM));
+  send_to_char(buf, ch);
+  if (PRF_FLAGGED(ch, PRF_TESTER))
+    test_self_hitroll(ch);
 }
 
-void do_score(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	TIME_INFO_DATA playing_time;
-	int ac, ac_t;
+void do_score(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  TIME_INFO_DATA playing_time;
+  int ac, ac_t;
 
-	skip_spaces(&argument);
+  skip_spaces(&argument);
 
-	if (IS_NPC(ch))
-		return;
+  if (IS_NPC(ch))
+    return;
 
-	//Обработка команды "счет все", добавил Adept. Ширина таблицы - 85 символов + пробел.
-	if (is_abbrev(argument, "все") || is_abbrev(argument, "all"))
-	{
-		print_do_score_all(ch);
-		return;
-	}
+  //Обработка команды "счет все", добавил Adept. Ширина таблицы - 85 символов + пробел.
+  if (is_abbrev(argument, "все") || is_abbrev(argument, "all")) {
+    print_do_score_all(ch);
+    return;
+  }
 
-	sprintf(buf, "Вы %s (%s, %s, %s, %s %d уровня).\r\n",
-		ch->only_title().c_str(),
-		string(PlayerRace::GetKinNameByNum(GET_KIN(ch), GET_SEX(ch))).c_str(),
-		string(PlayerRace::GetRaceNameByNum(GET_KIN(ch), GET_RACE(ch), GET_SEX(ch))).c_str(),
-		religion_name[GET_RELIGION(ch)][static_cast<int>(GET_SEX(ch))],
-		class_name[static_cast<int>(GET_CLASS(ch)) + 14 * GET_KIN(ch)], GET_LEVEL(ch));
+  sprintf(buf, "Вы %s (%s, %s, %s, %s %d уровня).\r\n",
+          ch->only_title().c_str(),
+          string(PlayerRace::GetKinNameByNum(GET_KIN(ch), GET_SEX(ch))).c_str(),
+          string(PlayerRace::GetRaceNameByNum(GET_KIN(ch), GET_RACE(ch), GET_SEX(ch))).c_str(),
+          religion_name[GET_RELIGION(ch)][static_cast<int>(GET_SEX(ch))],
+          class_name[static_cast<int>(GET_CLASS(ch)) + 14 * GET_KIN(ch)], GET_LEVEL(ch));
 
-	if (!NAME_GOD(ch) && GET_LEVEL(ch) <= NAME_LEVEL)
-	{
-		sprintf(buf + strlen(buf), "\r\n&RВНИМАНИЕ!&n Ваше имя не одобрил никто из богов!\r\n");
-		sprintf(buf + strlen(buf), "Очень скоро вы прекратите получать опыт,\r\n");
-		sprintf(buf + strlen(buf), "обратитесь к богам для одобрения имени.\r\n\r\n");
-	}
-	else if (NAME_BAD(ch))
-	{
-		sprintf(buf + strlen(buf), "\r\n&RВНИМАНИЕ!&n Ваше имя запрещено богами.\r\n");
-		sprintf(buf + strlen(buf), "Очень скоро вы прекратите получать опыт.\r\n\r\n");
-	}
+  if (!NAME_GOD(ch) && GET_LEVEL(ch) <= NAME_LEVEL) {
+    sprintf(buf + strlen(buf), "\r\n&RВНИМАНИЕ!&n Ваше имя не одобрил никто из богов!\r\n");
+    sprintf(buf + strlen(buf), "Очень скоро вы прекратите получать опыт,\r\n");
+    sprintf(buf + strlen(buf), "обратитесь к богам для одобрения имени.\r\n\r\n");
+  } else if (NAME_BAD(ch)) {
+    sprintf(buf + strlen(buf), "\r\n&RВНИМАНИЕ!&n Ваше имя запрещено богами.\r\n");
+    sprintf(buf + strlen(buf), "Очень скоро вы прекратите получать опыт.\r\n\r\n");
+  }
 
-	sprintf(buf + strlen(buf), "Сейчас вам %d %s. ", GET_REAL_AGE(ch), desc_count(GET_REAL_AGE(ch), WHAT_YEAR));
+  sprintf(buf + strlen(buf), "Сейчас вам %d %s. ", GET_REAL_AGE(ch), desc_count(GET_REAL_AGE(ch), WHAT_YEAR));
 
-	if (age(ch)->month == 0 && age(ch)->day == 0)
-	{
-		sprintf(buf2, "%sУ вас сегодня День Варенья!%s\r\n", CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-		strcat(buf, buf2);
-	}
-	else
-		strcat(buf, "\r\n");
+  if (age(ch)->month == 0 && age(ch)->day == 0) {
+    sprintf(buf2, "%sУ вас сегодня День Варенья!%s\r\n", CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+    strcat(buf, buf2);
+  } else
+    strcat(buf, "\r\n");
 
-	sprintf(buf + strlen(buf),
-			"Вы можете выдержать %d(%d) %s повреждения, и пройти %d(%d) %s по ровной местности.\r\n",
-			GET_HIT(ch), GET_REAL_MAX_HIT(ch), desc_count(GET_HIT(ch),
-					WHAT_ONEu),
-			GET_MOVE(ch), GET_REAL_MAX_MOVE(ch), desc_count(GET_MOVE(ch), WHAT_MOVEu));
+  sprintf(buf + strlen(buf),
+          "Вы можете выдержать %d(%d) %s повреждения, и пройти %d(%d) %s по ровной местности.\r\n",
+          GET_HIT(ch), GET_REAL_MAX_HIT(ch), desc_count(GET_HIT(ch),
+                                                        WHAT_ONEu),
+          GET_MOVE(ch), GET_REAL_MAX_MOVE(ch), desc_count(GET_MOVE(ch), WHAT_MOVEu));
 
-	if (IS_MANA_CASTER(ch))
-	{
-		sprintf(buf + strlen(buf),
-				"Ваша магическая энергия %d(%d) и вы восстанавливаете %d в сек.\r\n",
-				GET_MANA_STORED(ch), GET_MAX_MANA(ch), mana_gain(ch));
-	}
+  if (IS_MANA_CASTER(ch)) {
+    sprintf(buf + strlen(buf),
+            "Ваша магическая энергия %d(%d) и вы восстанавливаете %d в сек.\r\n",
+            GET_MANA_STORED(ch), GET_MAX_MANA(ch), mana_gain(ch));
+  }
 
-	sprintf(buf + strlen(buf),
-			"%sВаши характеристики :\r\n"
-			"  Сила : %2d(%2d)"
-			"  Подв : %2d(%2d)"
-			"  Тело : %2d(%2d)"
-			"  Мудр : %2d(%2d)"
-			"  Ум   : %2d(%2d)"
-			"  Обаян: %2d(%2d)\r\n"
-			"  Размер %3d(%3d)"
-			"  Рост   %3d(%3d)"
-			"  Вес    %3d(%3d)%s\r\n",
-			CCICYN(ch, C_NRM), ch->get_str(), GET_REAL_STR(ch),
-			ch->get_dex(), GET_REAL_DEX(ch),
-			ch->get_con(), GET_REAL_CON(ch),
-			ch->get_wis(), GET_REAL_WIS(ch),
-			ch->get_int(), GET_REAL_INT(ch),
-			ch->get_cha(), GET_REAL_CHA(ch),
-			GET_SIZE(ch), GET_REAL_SIZE(ch),
-			GET_HEIGHT(ch), GET_REAL_HEIGHT(ch), GET_WEIGHT(ch), GET_REAL_WEIGHT(ch), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          "%sВаши характеристики :\r\n"
+          "  Сила : %2d(%2d)"
+          "  Подв : %2d(%2d)"
+          "  Тело : %2d(%2d)"
+          "  Мудр : %2d(%2d)"
+          "  Ум   : %2d(%2d)"
+          "  Обаян: %2d(%2d)\r\n"
+          "  Размер %3d(%3d)"
+          "  Рост   %3d(%3d)"
+          "  Вес    %3d(%3d)%s\r\n",
+          CCICYN(ch, C_NRM), ch->get_str(), GET_REAL_STR(ch),
+          ch->get_dex(), GET_REAL_DEX(ch),
+          ch->get_con(), GET_REAL_CON(ch),
+          ch->get_wis(), GET_REAL_WIS(ch),
+          ch->get_int(), GET_REAL_INT(ch),
+          ch->get_cha(), GET_REAL_CHA(ch),
+          GET_SIZE(ch), GET_REAL_SIZE(ch),
+          GET_HEIGHT(ch), GET_REAL_HEIGHT(ch), GET_WEIGHT(ch), GET_REAL_WEIGHT(ch), CCNRM(ch, C_NRM));
 
-	if (IS_IMMORTAL(ch))
-	{
-		sprintf(buf + strlen(buf),
-				"%sВаши боевые качества :\r\n"
-				"  AC   : %4d(%4d)"
-				"  DR   : %4d(%4d)%s\r\n",
-				CCIGRN(ch, C_NRM), GET_AC(ch), compute_armor_class(ch),
-				GET_DR(ch), GET_REAL_DR(ch), CCNRM(ch, C_NRM));
-	}
-	else
-	{
-		ac = compute_armor_class(ch) / 10;
+  if (IS_IMMORTAL(ch)) {
+    sprintf(buf + strlen(buf),
+            "%sВаши боевые качества :\r\n"
+            "  AC   : %4d(%4d)"
+            "  DR   : %4d(%4d)%s\r\n",
+            CCIGRN(ch, C_NRM), GET_AC(ch), compute_armor_class(ch),
+            GET_DR(ch), GET_REAL_DR(ch), CCNRM(ch, C_NRM));
+  } else {
+    ac = compute_armor_class(ch) / 10;
 
-		if (ac < 5)
-		{
-			const int mod = (1 - ch->get_cond_penalty(P_AC)) * 40;
-			ac = ac + mod > 5 ? 5 : ac + mod;
-		}
+    if (ac < 5) {
+      const int mod = (1 - ch->get_cond_penalty(P_AC)) * 40;
+      ac = ac + mod > 5 ? 5 : ac + mod;
+    }
 
-		ac_t = MAX(MIN(ac + 30, 40), 0);
-		sprintf(buf + strlen(buf), "&GВаши боевые качества :\r\n"
-				"  Защита  (AC)     : %4d - %s&G\r\n"
-				"  Броня/Поглощение : %4d/%d&n\r\n",
-				ac, ac_text[ac_t], GET_ARMOUR(ch), GET_ABSORBE(ch));
-	}
-	sprintf(buf + strlen(buf), "Ваш опыт - %ld %s. ", GET_EXP(ch), desc_count(GET_EXP(ch), WHAT_POINT));
-	if (GET_LEVEL(ch) < LVL_IMMORT)
-	{
-		if (PRF_FLAGGED(ch, PRF_BLIND))
-		{
-			sprintf(buf + strlen(buf), "\r\n");
-		}
-		sprintf(buf + strlen(buf),
-			"Вам осталось набрать %ld %s до следующего уровня.\r\n",
-			level_exp(ch, GET_LEVEL(ch) + 1) - GET_EXP(ch),
-			desc_count(level_exp(ch, GET_LEVEL(ch) + 1) - GET_EXP(ch), WHAT_POINT));
-	}
-	else
-		sprintf(buf + strlen(buf), "\r\n");
+    ac_t = MAX(MIN(ac + 30, 40), 0);
+    sprintf(buf + strlen(buf), "&GВаши боевые качества :\r\n"
+                               "  Защита  (AC)     : %4d - %s&G\r\n"
+                               "  Броня/Поглощение : %4d/%d&n\r\n",
+            ac, ac_text[ac_t], GET_ARMOUR(ch), GET_ABSORBE(ch));
+  }
+  sprintf(buf + strlen(buf), "Ваш опыт - %ld %s. ", GET_EXP(ch), desc_count(GET_EXP(ch), WHAT_POINT));
+  if (GET_LEVEL(ch) < LVL_IMMORT) {
+    if (PRF_FLAGGED(ch, PRF_BLIND)) {
+      sprintf(buf + strlen(buf), "\r\n");
+    }
+    sprintf(buf + strlen(buf),
+            "Вам осталось набрать %ld %s до следующего уровня.\r\n",
+            level_exp(ch, GET_LEVEL(ch) + 1) - GET_EXP(ch),
+            desc_count(level_exp(ch, GET_LEVEL(ch) + 1) - GET_EXP(ch), WHAT_POINT));
+  } else
+    sprintf(buf + strlen(buf), "\r\n");
 
-	sprintf(buf + strlen(buf), "У вас на руках %ld %s и %d %s",
-		ch->get_gold(), desc_count(ch->get_gold(), WHAT_MONEYa), ch->get_hryvn(), desc_count(ch->get_hryvn(), WHAT_TORC));
-	if (ch->get_bank() > 0)
-		sprintf(buf + strlen(buf), " (и еще %ld %s припрятано в лежне).\r\n",
-			ch->get_bank(), desc_count(ch->get_bank(), WHAT_MONEYa));
-	else
-		strcat(buf, ".\r\n");
+  sprintf(buf + strlen(buf),
+          "У вас на руках %ld %s и %d %s",
+          ch->get_gold(),
+          desc_count(ch->get_gold(), WHAT_MONEYa),
+          ch->get_hryvn(),
+          desc_count(ch->get_hryvn(), WHAT_TORC));
+  if (ch->get_bank() > 0)
+    sprintf(buf + strlen(buf), " (и еще %ld %s припрятано в лежне).\r\n",
+            ch->get_bank(), desc_count(ch->get_bank(), WHAT_MONEYa));
+  else
+    strcat(buf, ".\r\n");
 
+  if (GET_LEVEL(ch) < LVL_IMMORT) {
+    sprintf(buf + strlen(buf),
+            "Вы можете вступить в группу с максимальной разницей в %d %s без потерь для опыта.\r\n",
+            grouping[static_cast<int>(GET_CLASS(ch))][static_cast<int>(GET_REMORT(ch))],
+            desc_count(grouping[static_cast<int>(GET_CLASS(ch))][static_cast<int>(GET_REMORT(ch))], WHAT_LEVEL));
+  }
 
-	if (GET_LEVEL(ch) < LVL_IMMORT)
-	{
-		sprintf(buf + strlen(buf),
-				"Вы можете вступить в группу с максимальной разницей в %d %s без потерь для опыта.\r\n",
-				grouping[static_cast<int>(GET_CLASS(ch))][static_cast<int>(GET_REMORT(ch))],
-				desc_count(grouping[static_cast<int>(GET_CLASS(ch))][static_cast<int>(GET_REMORT(ch))], WHAT_LEVEL));
-	}
+  //Напоминаем о метке, если она есть.
+  ROOM_DATA *label_room = RoomSpells::findAffectedRoom(GET_ID(ch), SPELL_RUNE_LABEL);
+  if (label_room) {
+    sprintf(buf + strlen(buf),
+            "&G&qВы поставили рунную метку в комнате '%s'.&Q&n\r\n",
+            string(label_room->name).c_str());
+  }
 
-	//Напоминаем о метке, если она есть.
-    ROOM_DATA *label_room = RoomSpells::findAffectedRoom(GET_ID(ch), SPELL_RUNE_LABEL);
-    if (label_room)
-	{
-        sprintf(buf + strlen(buf),
-                "&G&qВы поставили рунную метку в комнате '%s'.&Q&n\r\n",
-                string(label_room->name).c_str());
-	}
+  int glory = Glory::get_glory(GET_UNIQUE(ch));
+  if (glory) {
+    sprintf(buf + strlen(buf), "Вы заслужили %d %s славы.\r\n",
+            glory, desc_count(glory, WHAT_POINT));
+  }
+  glory = GloryConst::get_glory(GET_UNIQUE(ch));
+  if (glory) {
+    sprintf(buf + strlen(buf), "Вы заслужили %d %s постоянной славы.\r\n",
+            glory, desc_count(glory, WHAT_POINT));
+  }
 
-	int glory = Glory::get_glory(GET_UNIQUE(ch));
-	if (glory)
-	{
-		sprintf(buf + strlen(buf), "Вы заслужили %d %s славы.\r\n",
-				glory, desc_count(glory, WHAT_POINT));
-	}
-	glory = GloryConst::get_glory(GET_UNIQUE(ch));
-	if (glory)
-	{
-		sprintf(buf + strlen(buf), "Вы заслужили %d %s постоянной славы.\r\n",
-				glory, desc_count(glory, WHAT_POINT));
-	}
+  playing_time = *real_time_passed((time(0) - ch->player_data.time.logon) + ch->player_data.time.played, 0);
+  sprintf(buf + strlen(buf), "Вы играете %d %s %d %s реального времени.\r\n",
+          playing_time.day, desc_count(playing_time.day, WHAT_DAY),
+          playing_time.hours, desc_count(playing_time.hours, WHAT_HOUR));
 
-	playing_time = *real_time_passed((time(0) - ch->player_data.time.logon) + ch->player_data.time.played, 0);
-	sprintf(buf + strlen(buf), "Вы играете %d %s %d %s реального времени.\r\n",
-			playing_time.day, desc_count(playing_time.day, WHAT_DAY),
-			playing_time.hours, desc_count(playing_time.hours, WHAT_HOUR));
+  if (!ch->ahorse())
+    switch (GET_POS(ch)) {
+      case POS_DEAD: strcat(buf, "Вы МЕРТВЫ!\r\n");
+        break;
+      case POS_MORTALLYW: strcat(buf, "Вы смертельно ранены и нуждаетесь в помощи!\r\n");
+        break;
+      case POS_INCAP: strcat(buf, "Вы без сознания и медленно умираете...\r\n");
+        break;
+      case POS_STUNNED: strcat(buf, "Вы в обмороке!\r\n");
+        break;
+      case POS_SLEEPING: strcat(buf, "Вы спите.\r\n");
+        break;
+      case POS_RESTING: strcat(buf, "Вы отдыхаете.\r\n");
+        break;
+      case POS_SITTING: strcat(buf, "Вы сидите.\r\n");
+        break;
+      case POS_FIGHTING:
+        if (ch->get_fighting())
+          sprintf(buf + strlen(buf), "Вы сражаетесь с %s.\r\n", GET_PAD(ch->get_fighting(), 4));
+        else
+          strcat(buf, "Вы машете кулаками по воздуху.\r\n");
+        break;
+      case POS_STANDING: strcat(buf, "Вы стоите.\r\n");
+        break;
+      default: strcat(buf, "You are floating.\r\n");
+        break;
+    }
+  send_to_char(buf, ch);
 
-	if (!ch->ahorse())
-		switch (GET_POS(ch))
-		{
-		case POS_DEAD:
-			strcat(buf, "Вы МЕРТВЫ!\r\n");
-			break;
-		case POS_MORTALLYW:
-			strcat(buf, "Вы смертельно ранены и нуждаетесь в помощи!\r\n");
-			break;
-		case POS_INCAP:
-			strcat(buf, "Вы без сознания и медленно умираете...\r\n");
-			break;
-		case POS_STUNNED:
-			strcat(buf, "Вы в обмороке!\r\n");
-			break;
-		case POS_SLEEPING:
-			strcat(buf, "Вы спите.\r\n");
-			break;
-		case POS_RESTING:
-			strcat(buf, "Вы отдыхаете.\r\n");
-			break;
-		case POS_SITTING:
-			strcat(buf, "Вы сидите.\r\n");
-			break;
-		case POS_FIGHTING:
-			if (ch->get_fighting())
-				sprintf(buf + strlen(buf), "Вы сражаетесь с %s.\r\n", GET_PAD(ch->get_fighting(), 4));
-			else
-				strcat(buf, "Вы машете кулаками по воздуху.\r\n");
-			break;
-		case POS_STANDING:
-			strcat(buf, "Вы стоите.\r\n");
-			break;
-		default:
-			strcat(buf, "You are floating.\r\n");
-			break;
-		}
-	send_to_char(buf, ch);
+  strcpy(buf, CCIGRN(ch, C_NRM));
+  const auto value_drunked = GET_COND(ch, DRUNK);
+  if (value_drunked >= CHAR_DRUNKED) {
+    if (affected_by_spell(ch, SPELL_ABSTINENT))
+      strcat(buf, "Привет с большого бодуна!\r\n");
+    else {
+      if (value_drunked >= CHAR_MORTALLY_DRUNKED)
+        strcat(buf, "Вы так пьяны, что ваши ноги не хотят слушаться вас...\r\n");
+      else if (value_drunked >= 10)
+        strcat(buf, "Вы так пьяны, что вам хочется петь песни.\r\n");
+      else if (value_drunked >= 5)
+        strcat(buf, "Вы пьяны.\r\n");
+      else
+        strcat(buf, "Вы немного пьяны.\r\n");
+    }
 
-	strcpy(buf, CCIGRN(ch, C_NRM));
-	const auto value_drunked = GET_COND(ch, DRUNK);
-	if (value_drunked >= CHAR_DRUNKED)
-	{
-		if (affected_by_spell(ch, SPELL_ABSTINENT))
-			strcat(buf, "Привет с большого бодуна!\r\n");
-		else
-		{
-			if (value_drunked >= CHAR_MORTALLY_DRUNKED)
-				strcat(buf, "Вы так пьяны, что ваши ноги не хотят слушаться вас...\r\n");
-			else if (value_drunked >= 10)
-				strcat(buf, "Вы так пьяны, что вам хочется петь песни.\r\n");
-			else if (value_drunked >= 5)
-				strcat(buf, "Вы пьяны.\r\n");
-			else
-				strcat(buf, "Вы немного пьяны.\r\n");
-		}
-
-	}
-	if (GET_COND_M(ch, FULL))
-		strcat(buf, "Вы голодны.\r\n");
-	if (GET_COND_M(ch, THIRST))
-		strcat(buf, "Вас мучает жажда.\r\n");
-	/*
+  }
+  if (GET_COND_M(ch, FULL))
+    strcat(buf, "Вы голодны.\r\n");
+  if (GET_COND_M(ch, THIRST))
+    strcat(buf, "Вас мучает жажда.\r\n");
+  /*
 	   strcat(buf, CCICYN(ch, C_NRM));
 	   strcat(buf,"Аффекты :\r\n");
 	   (ch)->char_specials.saved.affected_by.sprintbits(affected_bits, buf2, "\r\n");
 	   strcat(buf,buf2);
 	 */
-	if (PRF_FLAGGED(ch, PRF_SUMMONABLE))
-		strcat(buf, "Вы можете быть призваны.\r\n");
+  if (PRF_FLAGGED(ch, PRF_SUMMONABLE))
+    strcat(buf, "Вы можете быть призваны.\r\n");
 
-	if (ch->has_horse(false))
-	{
-		if (ch->ahorse())
-			sprintf(buf + strlen(buf), "Вы верхом на %s.\r\n", GET_PAD(ch->get_horse(), 5));
-		else
-			sprintf(buf + strlen(buf), "У вас есть %s.\r\n", GET_NAME(ch->get_horse()));
-	}
-	strcat(buf, CCNRM(ch, C_NRM));
-	send_to_char(buf, ch);
-	if (RENTABLE(ch))
-	{
-		sprintf(buf,
-				"%sВ связи с боевыми действиями вы не можете уйти на постой.%s\r\n",
-				CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-		send_to_char(buf, ch);
-	}
-	else if ((ch->in_room != NOWHERE) && ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL) && !PLR_FLAGGED(ch, PLR_KILLER))
-	{
-		sprintf(buf, "%sТут вы чувствуете себя в безопасности.%s\r\n", CCIGRN(ch, C_NRM), CCNRM(ch, C_NRM));
-		send_to_char(buf, ch);
-	}
+  if (ch->has_horse(false)) {
+    if (ch->ahorse())
+      sprintf(buf + strlen(buf), "Вы верхом на %s.\r\n", GET_PAD(ch->get_horse(), 5));
+    else
+      sprintf(buf + strlen(buf), "У вас есть %s.\r\n", GET_NAME(ch->get_horse()));
+  }
+  strcat(buf, CCNRM(ch, C_NRM));
+  send_to_char(buf, ch);
+  if (RENTABLE(ch)) {
+    sprintf(buf,
+            "%sВ связи с боевыми действиями вы не можете уйти на постой.%s\r\n",
+            CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+    send_to_char(buf, ch);
+  } else if ((ch->in_room != NOWHERE) && ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL) && !PLR_FLAGGED(ch, PLR_KILLER)) {
+    sprintf(buf, "%sТут вы чувствуете себя в безопасности.%s\r\n", CCIGRN(ch, C_NRM), CCNRM(ch, C_NRM));
+    send_to_char(buf, ch);
+  }
 
-	if (ROOM_FLAGGED(ch->in_room, ROOM_SMITH) && (ch->get_skill(SKILL_INSERTGEM) || ch->get_skill(SKILL_REPAIR) || ch->get_skill(SKILL_TRANSFORMWEAPON)))
-	{
-		sprintf(buf, "%sЭто место отлично подходит для занятий кузнечным делом.%s\r\n", CCIGRN(ch, C_NRM), CCNRM(ch, C_NRM));
-		send_to_char(buf, ch);
-	}
+  if (ROOM_FLAGGED(ch->in_room, ROOM_SMITH)
+      && (ch->get_skill(SKILL_INSERTGEM) || ch->get_skill(SKILL_REPAIR) || ch->get_skill(SKILL_TRANSFORMWEAPON))) {
+    sprintf(buf,
+            "%sЭто место отлично подходит для занятий кузнечным делом.%s\r\n",
+            CCIGRN(ch, C_NRM),
+            CCNRM(ch, C_NRM));
+    send_to_char(buf, ch);
+  }
 
-	if (mail::has_mail(ch->get_uid()))
-	{
-		sprintf(buf, "%sВас ожидает новое письмо, зайдите на почту!%s\r\n", CCIGRN(ch, C_NRM), CCNRM(ch, C_NRM));
-		send_to_char(buf, ch);
-	}
+  if (mail::has_mail(ch->get_uid())) {
+    sprintf(buf, "%sВас ожидает новое письмо, зайдите на почту!%s\r\n", CCIGRN(ch, C_NRM), CCNRM(ch, C_NRM));
+    send_to_char(buf, ch);
+  }
 
-	if (Parcel::has_parcel(ch))
-	{
-		sprintf(buf, "%sВас ожидает посылка, зайдите на почту!%s\r\n", CCIGRN(ch, C_NRM), CCNRM(ch, C_NRM));
-		send_to_char(buf, ch);
-	}
+  if (Parcel::has_parcel(ch)) {
+    sprintf(buf, "%sВас ожидает посылка, зайдите на почту!%s\r\n", CCIGRN(ch, C_NRM), CCNRM(ch, C_NRM));
+    send_to_char(buf, ch);
+  }
 
-	if (PLR_FLAGGED(ch, PLR_HELLED) && HELL_DURATION(ch) && HELL_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (HELL_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((HELL_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf,
-				"Вам предстоит провести в темнице еще %d %s %d %s [%s].\r\n",
-				hrs, desc_count(hrs, WHAT_HOUR), mins, desc_count(mins,
-						WHAT_MINu),
-				HELL_REASON(ch) ? HELL_REASON(ch) : "-");
-		send_to_char(buf, ch);
-	}
-	if (PLR_FLAGGED(ch, PLR_MUTE) && MUTE_DURATION(ch) != 0 && MUTE_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (MUTE_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((MUTE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf, "Вы не сможете кричать еще %d %s %d %s [%s].\r\n",
-				hrs, desc_count(hrs, WHAT_HOUR),
-				mins, desc_count(mins, WHAT_MINu), MUTE_REASON(ch) ? MUTE_REASON(ch) : "-");
-		send_to_char(buf, ch);
-	}
-	if (PLR_FLAGGED(ch, PLR_DUMB) && DUMB_DURATION(ch) != 0 && DUMB_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (DUMB_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((DUMB_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf, "Вы будете молчать еще %d %s %d %s [%s].\r\n",
-				hrs, desc_count(hrs, WHAT_HOUR),
-				mins, desc_count(mins, WHAT_MINu), DUMB_REASON(ch) ? DUMB_REASON(ch) : "-");
-		send_to_char(buf, ch);
-	}
-	if (PLR_FLAGGED(ch, PLR_FROZEN) && FREEZE_DURATION(ch) != 0 && FREEZE_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (FREEZE_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((FREEZE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf, "Вы будете заморожены еще %d %s %d %s [%s].\r\n",
-				hrs, desc_count(hrs, WHAT_HOUR),
-				mins, desc_count(mins, WHAT_MINu), FREEZE_REASON(ch) ? FREEZE_REASON(ch) : "-");
-		send_to_char(buf, ch);
-	}
+  if (PLR_FLAGGED(ch, PLR_HELLED) && HELL_DURATION(ch) && HELL_DURATION(ch) > time(NULL)) {
+    const int hrs = (HELL_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((HELL_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf,
+            "Вам предстоит провести в темнице еще %d %s %d %s [%s].\r\n",
+            hrs, desc_count(hrs, WHAT_HOUR), mins, desc_count(mins,
+                                                              WHAT_MINu),
+            HELL_REASON(ch) ? HELL_REASON(ch) : "-");
+    send_to_char(buf, ch);
+  }
+  if (PLR_FLAGGED(ch, PLR_MUTE) && MUTE_DURATION(ch) != 0 && MUTE_DURATION(ch) > time(NULL)) {
+    const int hrs = (MUTE_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((MUTE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf, "Вы не сможете кричать еще %d %s %d %s [%s].\r\n",
+            hrs, desc_count(hrs, WHAT_HOUR),
+            mins, desc_count(mins, WHAT_MINu), MUTE_REASON(ch) ? MUTE_REASON(ch) : "-");
+    send_to_char(buf, ch);
+  }
+  if (PLR_FLAGGED(ch, PLR_DUMB) && DUMB_DURATION(ch) != 0 && DUMB_DURATION(ch) > time(NULL)) {
+    const int hrs = (DUMB_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((DUMB_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf, "Вы будете молчать еще %d %s %d %s [%s].\r\n",
+            hrs, desc_count(hrs, WHAT_HOUR),
+            mins, desc_count(mins, WHAT_MINu), DUMB_REASON(ch) ? DUMB_REASON(ch) : "-");
+    send_to_char(buf, ch);
+  }
+  if (PLR_FLAGGED(ch, PLR_FROZEN) && FREEZE_DURATION(ch) != 0 && FREEZE_DURATION(ch) > time(NULL)) {
+    const int hrs = (FREEZE_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((FREEZE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf, "Вы будете заморожены еще %d %s %d %s [%s].\r\n",
+            hrs, desc_count(hrs, WHAT_HOUR),
+            mins, desc_count(mins, WHAT_MINu), FREEZE_REASON(ch) ? FREEZE_REASON(ch) : "-");
+    send_to_char(buf, ch);
+  }
 
-	if (!PLR_FLAGGED(ch, PLR_REGISTERED) && UNREG_DURATION(ch) != 0 && UNREG_DURATION(ch) > time(NULL))
-	{
-		const int hrs = (UNREG_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((UNREG_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf, "Вы не сможете заходить с одного IP еще %d %s %d %s [%s].\r\n",
-				hrs, desc_count(hrs, WHAT_HOUR),
-				mins, desc_count(mins, WHAT_MINu), UNREG_REASON(ch) ? UNREG_REASON(ch) : "-");
-		send_to_char(buf, ch);
-	}
+  if (!PLR_FLAGGED(ch, PLR_REGISTERED) && UNREG_DURATION(ch) != 0 && UNREG_DURATION(ch) > time(NULL)) {
+    const int hrs = (UNREG_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((UNREG_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf, "Вы не сможете заходить с одного IP еще %d %s %d %s [%s].\r\n",
+            hrs, desc_count(hrs, WHAT_HOUR),
+            mins, desc_count(mins, WHAT_MINu), UNREG_REASON(ch) ? UNREG_REASON(ch) : "-");
+    send_to_char(buf, ch);
+  }
 
-	if (GET_GOD_FLAG(ch, GF_GODSCURSE) && GCURSE_DURATION(ch))
-	{
-		const int hrs = (GCURSE_DURATION(ch) - time(NULL)) / 3600;
-		const int mins = ((GCURSE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
-		sprintf(buf, "Вы прокляты Богами на %d %s %d %s.\r\n",
-				hrs, desc_count(hrs, WHAT_HOUR), mins, desc_count(mins, WHAT_MINu));
-		send_to_char(buf, ch);
-	}
+  if (GET_GOD_FLAG(ch, GF_GODSCURSE) && GCURSE_DURATION(ch)) {
+    const int hrs = (GCURSE_DURATION(ch) - time(NULL)) / 3600;
+    const int mins = ((GCURSE_DURATION(ch) - time(NULL)) % 3600 + 59) / 60;
+    sprintf(buf, "Вы прокляты Богами на %d %s %d %s.\r\n",
+            hrs, desc_count(hrs, WHAT_HOUR), mins, desc_count(mins, WHAT_MINu));
+    send_to_char(buf, ch);
+  }
 
-	if (ch->is_morphed())
-	{
-		sprintf(buf, "Вы находитесь в звериной форме - %s.\r\n", ch->get_morph_desc().c_str());
-		send_to_char(buf, ch);
-	}
-	if (can_use_feat(ch, COLLECTORSOULS_FEAT))
-	{
-		const int souls = ch->get_souls();
-		if (souls == 0)
-		{
-			sprintf(buf, "Вы не имеете чужих душ.\r\n");
-			send_to_char(buf, ch);
-		}
-		else
-		{
-			if (souls == 1)
-			{
-				sprintf(buf, "Вы имеете всего одну душу в запасе.\r\n");
-				send_to_char(buf, ch);
-			}
-			if (souls > 1 && souls < 5)
-			{
-				sprintf(buf, "Вы имеете %d души в запасе.\r\n", souls);
-				send_to_char(buf, ch);
-			}
-			if (souls >= 5)
-			{
-				sprintf(buf, "Вы имеете %d чужих душ в запасе.\r\n", souls);
-				send_to_char(buf, ch);
-			}
-		}
-	}
-	if (ch->get_ice_currency() > 0)
-	{
-		if (ch->get_ice_currency() == 1)
-		{
-			sprintf(buf, "У вас в наличии есть одна жалкая искристая снежинка.\r\n");
-			send_to_char(buf, ch);
-		}
-		else if (ch->get_ice_currency() < 5)
-		{
-			sprintf(buf, "У вас в наличии есть жалкие %d искристые снежинки.\r\n", ch->get_ice_currency());
-			send_to_char(buf, ch);
-		}
-		else
-		{
-			sprintf(buf, "У вас в наличии есть %d искристых снежинок.\r\n", ch->get_ice_currency());
-			send_to_char(buf, ch);
-		}
-	}
+  if (ch->is_morphed()) {
+    sprintf(buf, "Вы находитесь в звериной форме - %s.\r\n", ch->get_morph_desc().c_str());
+    send_to_char(buf, ch);
+  }
+  if (can_use_feat(ch, COLLECTORSOULS_FEAT)) {
+    const int souls = ch->get_souls();
+    if (souls == 0) {
+      sprintf(buf, "Вы не имеете чужих душ.\r\n");
+      send_to_char(buf, ch);
+    } else {
+      if (souls == 1) {
+        sprintf(buf, "Вы имеете всего одну душу в запасе.\r\n");
+        send_to_char(buf, ch);
+      }
+      if (souls > 1 && souls < 5) {
+        sprintf(buf, "Вы имеете %d души в запасе.\r\n", souls);
+        send_to_char(buf, ch);
+      }
+      if (souls >= 5) {
+        sprintf(buf, "Вы имеете %d чужих душ в запасе.\r\n", souls);
+        send_to_char(buf, ch);
+      }
+    }
+  }
+  if (ch->get_ice_currency() > 0) {
+    if (ch->get_ice_currency() == 1) {
+      sprintf(buf, "У вас в наличии есть одна жалкая искристая снежинка.\r\n");
+      send_to_char(buf, ch);
+    } else if (ch->get_ice_currency() < 5) {
+      sprintf(buf, "У вас в наличии есть жалкие %d искристые снежинки.\r\n", ch->get_ice_currency());
+      send_to_char(buf, ch);
+    } else {
+      sprintf(buf, "У вас в наличии есть %d искристых снежинок.\r\n", ch->get_ice_currency());
+      send_to_char(buf, ch);
+    }
+  }
 }
 
 //29.11.09 Отображение количества рипов (с) Василиса
 // edited by WorM 2011.05.21
-void do_mystat(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	skip_spaces(&argument);
-	if (is_abbrev(argument, "очистить") || is_abbrev(argument, "clear"))
-	{
-		GET_RIP_MOBTHIS(ch) = GET_EXP_MOBTHIS(ch) = GET_RIP_MOB(ch) = GET_EXP_MOB(ch) =
-		GET_RIP_PKTHIS(ch) = GET_EXP_PKTHIS(ch) = GET_RIP_PK(ch) = GET_EXP_PK(ch) =
-		GET_RIP_DTTHIS(ch) = GET_EXP_DTTHIS (ch) = GET_RIP_DT(ch) = GET_EXP_DT(ch) =
-		GET_RIP_OTHERTHIS(ch) = GET_EXP_OTHERTHIS(ch) = GET_RIP_OTHER(ch) = GET_EXP_OTHER(ch) =
-		GET_WIN_ARENA(ch) = GET_RIP_ARENA(ch) = GET_EXP_ARENA(ch) = 0;
-		send_to_char("Статистика очищена.\r\n", ch);
-	}
-	else
-	{
-		sprintf(buf,    " &C--------------------------------------------------------------------------------------&n\r\n"
-				" &C||&n   Статистика ваших смертей   &C|&n         &WТекущее&n         &C|&n                         &C||&n\r\n"
-				" &C||&n (количество, потеряно опыта) &C|&n      &Wперевоплощение&n     &C|&n           &KВсего&n         &C||&n\r\n"
-				" &C--------------------------------------------------------------------------------------&n\r\n"
-				" &C||&n    В неравном бою с тварями: &C|&n &W%4d (%16llu)&n &C|&n &K%4d (%16llu)&n &C||&n\r\n"
-				" &C||&n    В неравном бою с врагами: &C|&n &W%4d (%16llu)&n &C|&n &K%4d (%16llu)&n &C||&n\r\n"
-				" &C||&n             В гиблых местах: &C|&n &W%4d (%16llu)&n &C|&n &K%4d (%16llu)&n &C||&n\r\n"
-				" &C||&n   По стечению обстоятельств: &C|&n &W%4d (%16llu)&n &C|&n &K%4d (%16llu)&n &C||&n\r\n"
-				" &C--------------------------------------------------------------------------------------&n\r\n"
-				" &C||&n                       &yИТОГО:&n &C|&n &W%4d (%16llu)&n &C| &K%4d (%16llu)&n &n&C||&n\r\n"
-				" &C--------------------------------------------------------------------------------------&n\r\n"
-				" &C||&n &WНа арене (всего):                                                                &n&C||&n\r\n"
-				" &C||&n   &wУбито игроков:&n&r%4d&n     &wСмертей:&n&r%4d&n           &wПотеряно опыта:&n &r%16llu&n &C||&n\r\n"
-				" &C--------------------------------------------------------------------------------------&n\r\n"
-				,
-				GET_RIP_MOBTHIS(ch),GET_EXP_MOBTHIS(ch), GET_RIP_MOB(ch), GET_EXP_MOB(ch),
-				GET_RIP_PKTHIS(ch),GET_EXP_PKTHIS(ch), GET_RIP_PK(ch), GET_EXP_PK(ch),
-				GET_RIP_DTTHIS(ch),GET_EXP_DTTHIS (ch), GET_RIP_DT(ch), GET_EXP_DT(ch),
-				GET_RIP_OTHERTHIS(ch),GET_EXP_OTHERTHIS(ch), GET_RIP_OTHER(ch), GET_EXP_OTHER(ch),
-				GET_RIP_MOBTHIS(ch)+GET_RIP_PKTHIS(ch)+GET_RIP_DTTHIS(ch)+GET_RIP_OTHERTHIS(ch),
-				GET_EXP_MOBTHIS(ch)+GET_EXP_PKTHIS(ch)+GET_EXP_DTTHIS(ch)+GET_EXP_OTHERTHIS(ch)+GET_EXP_ARENA(ch),
-				GET_RIP_MOB(ch)+GET_RIP_PK(ch)+GET_RIP_DT(ch)+GET_RIP_OTHER(ch),
-				GET_EXP_MOB(ch)+GET_EXP_PK(ch)+GET_EXP_DT(ch)+GET_EXP_OTHER(ch)+GET_EXP_ARENA(ch),
-				GET_WIN_ARENA(ch),GET_RIP_ARENA(ch), GET_EXP_ARENA(ch));
-		send_to_char(buf, ch);
-	}
+void do_mystat(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  skip_spaces(&argument);
+  if (is_abbrev(argument, "очистить") || is_abbrev(argument, "clear")) {
+    GET_RIP_MOBTHIS(ch) = GET_EXP_MOBTHIS(ch) = GET_RIP_MOB(ch) = GET_EXP_MOB(ch) =
+    GET_RIP_PKTHIS(ch) = GET_EXP_PKTHIS(ch) = GET_RIP_PK(ch) = GET_EXP_PK(ch) =
+    GET_RIP_DTTHIS(ch) = GET_EXP_DTTHIS (ch) = GET_RIP_DT(ch) = GET_EXP_DT(ch) =
+    GET_RIP_OTHERTHIS(ch) = GET_EXP_OTHERTHIS(ch) = GET_RIP_OTHER(ch) = GET_EXP_OTHER(ch) =
+    GET_WIN_ARENA(ch) = GET_RIP_ARENA(ch) = GET_EXP_ARENA(ch) = 0;
+    send_to_char("Статистика очищена.\r\n", ch);
+  } else {
+    sprintf(buf, " &C--------------------------------------------------------------------------------------&n\r\n"
+                 " &C||&n   Статистика ваших смертей   &C|&n         &WТекущее&n         &C|&n                         &C||&n\r\n"
+                 " &C||&n (количество, потеряно опыта) &C|&n      &Wперевоплощение&n     &C|&n           &KВсего&n         &C||&n\r\n"
+                 " &C--------------------------------------------------------------------------------------&n\r\n"
+                 " &C||&n    В неравном бою с тварями: &C|&n &W%4d (%16llu)&n &C|&n &K%4d (%16llu)&n &C||&n\r\n"
+                 " &C||&n    В неравном бою с врагами: &C|&n &W%4d (%16llu)&n &C|&n &K%4d (%16llu)&n &C||&n\r\n"
+                 " &C||&n             В гиблых местах: &C|&n &W%4d (%16llu)&n &C|&n &K%4d (%16llu)&n &C||&n\r\n"
+                 " &C||&n   По стечению обстоятельств: &C|&n &W%4d (%16llu)&n &C|&n &K%4d (%16llu)&n &C||&n\r\n"
+                 " &C--------------------------------------------------------------------------------------&n\r\n"
+                 " &C||&n                       &yИТОГО:&n &C|&n &W%4d (%16llu)&n &C| &K%4d (%16llu)&n &n&C||&n\r\n"
+                 " &C--------------------------------------------------------------------------------------&n\r\n"
+                 " &C||&n &WНа арене (всего):                                                                &n&C||&n\r\n"
+                 " &C||&n   &wУбито игроков:&n&r%4d&n     &wСмертей:&n&r%4d&n           &wПотеряно опыта:&n &r%16llu&n &C||&n\r\n"
+                 " &C--------------------------------------------------------------------------------------&n\r\n",
+            GET_RIP_MOBTHIS(ch), GET_EXP_MOBTHIS(ch), GET_RIP_MOB(ch), GET_EXP_MOB(ch),
+            GET_RIP_PKTHIS(ch), GET_EXP_PKTHIS(ch), GET_RIP_PK(ch), GET_EXP_PK(ch),
+            GET_RIP_DTTHIS(ch), GET_EXP_DTTHIS (ch), GET_RIP_DT(ch), GET_EXP_DT(ch),
+            GET_RIP_OTHERTHIS(ch), GET_EXP_OTHERTHIS(ch), GET_RIP_OTHER(ch), GET_EXP_OTHER(ch),
+            GET_RIP_MOBTHIS(ch) + GET_RIP_PKTHIS(ch) + GET_RIP_DTTHIS(ch) + GET_RIP_OTHERTHIS(ch),
+            GET_EXP_MOBTHIS(ch) + GET_EXP_PKTHIS(ch) + GET_EXP_DTTHIS(ch) + GET_EXP_OTHERTHIS(ch) + GET_EXP_ARENA(ch),
+            GET_RIP_MOB(ch) + GET_RIP_PK(ch) + GET_RIP_DT(ch) + GET_RIP_OTHER(ch),
+            GET_EXP_MOB(ch) + GET_EXP_PK(ch) + GET_EXP_DT(ch) + GET_EXP_OTHER(ch) + GET_EXP_ARENA(ch),
+            GET_WIN_ARENA(ch), GET_RIP_ARENA(ch), GET_EXP_ARENA(ch));
+    send_to_char(buf, ch);
+  }
 }
 // end by WorM
 // конец правки (с) Василиса
 
-void do_inventory(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	send_to_char("Вы несете:\r\n", ch);
-	list_obj_to_char(ch->carrying, ch, 1, 2);
+void do_inventory(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  send_to_char("Вы несете:\r\n", ch);
+  list_obj_to_char(ch->carrying, ch, 1, 2);
 }
 
-void do_equipment(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	int i, found = 0;
-	skip_spaces(&argument);
+void do_equipment(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  int i, found = 0;
+  skip_spaces(&argument);
 
-	send_to_char("На вас надето:\r\n", ch);
-	for (i = 0; i < NUM_WEARS; i++)
-	{
-		if (GET_EQ(ch, i))
-		{
-			if (CAN_SEE_OBJ(ch, GET_EQ(ch, i)))
-			{
-				send_to_char(where[i], ch);
-				show_obj_to_char(GET_EQ(ch, i), ch, 1, TRUE, 1);
-				found = TRUE;
-			}
-			else
-			{
-				send_to_char(where[i], ch);
-				send_to_char("что-то.\r\n", ch);
-				found = TRUE;
-			}
-		}
-		else		// added by Pereplut
-		{
-			if (is_abbrev(argument, "все") || is_abbrev(argument, "all"))
-			{
-			    if (GET_EQ(ch, 18))
-				if ((i==16) || (i==17))
-				    continue;
-                            if ((i==19)&&(GET_EQ(ch, WEAR_BOTHS)))
-                            {
-                                if (!(((GET_OBJ_TYPE(GET_EQ(ch, WEAR_BOTHS))) == OBJ_DATA::ITEM_WEAPON) && (GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS)) == SKILL_BOWS )))
-                                    continue;
-                            }
-                            else if (i==19)
-				continue;
- 			    if (GET_EQ(ch, 16) || GET_EQ(ch, 17))
-				if (i==18)
-				    continue;
-			    if (GET_EQ(ch, 11))
-				{
-					if ((i==17) || (i==18))
-						continue;
-				}
-				send_to_char(where[i], ch);
-				sprintf(buf, "%s[ Ничего ]%s\r\n", CCINRM(ch, C_NRM), CCNRM(ch, C_NRM));
-				send_to_char(buf, ch);
-				found = TRUE;
-			}
-		}
-	}
-	if (!found)
-	{
-		if (IS_FEMALE(ch))
-			send_to_char("Костюм Евы вам очень идет :)\r\n", ch);
-		else
-			send_to_char(" Вы голы, аки сокол.\r\n", ch);
-	}
+  send_to_char("На вас надето:\r\n", ch);
+  for (i = 0; i < NUM_WEARS; i++) {
+    if (GET_EQ(ch, i)) {
+      if (CAN_SEE_OBJ(ch, GET_EQ(ch, i))) {
+        send_to_char(where[i], ch);
+        show_obj_to_char(GET_EQ(ch, i), ch, 1, TRUE, 1);
+        found = TRUE;
+      } else {
+        send_to_char(where[i], ch);
+        send_to_char("что-то.\r\n", ch);
+        found = TRUE;
+      }
+    } else        // added by Pereplut
+    {
+      if (is_abbrev(argument, "все") || is_abbrev(argument, "all")) {
+        if (GET_EQ(ch, 18))
+          if ((i == 16) || (i == 17))
+            continue;
+        if ((i == 19) && (GET_EQ(ch, WEAR_BOTHS))) {
+          if (!(((GET_OBJ_TYPE(GET_EQ(ch, WEAR_BOTHS))) == OBJ_DATA::ITEM_WEAPON)
+              && (GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS)) == SKILL_BOWS)))
+            continue;
+        } else if (i == 19)
+          continue;
+        if (GET_EQ(ch, 16) || GET_EQ(ch, 17))
+          if (i == 18)
+            continue;
+        if (GET_EQ(ch, 11)) {
+          if ((i == 17) || (i == 18))
+            continue;
+        }
+        send_to_char(where[i], ch);
+        sprintf(buf, "%s[ Ничего ]%s\r\n", CCINRM(ch, C_NRM), CCNRM(ch, C_NRM));
+        send_to_char(buf, ch);
+        found = TRUE;
+      }
+    }
+  }
+  if (!found) {
+    if (IS_FEMALE(ch))
+      send_to_char("Костюм Евы вам очень идет :)\r\n", ch);
+    else
+      send_to_char(" Вы голы, аки сокол.\r\n", ch);
+  }
 }
 
-void do_time(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int day, month, days_go;
-	if (IS_NPC(ch))
-		return;
-	sprintf(buf, "Сейчас ");
-	switch (time_info.hours % 24)
-	{
-	case 0:
-		sprintf(buf + strlen(buf), "полночь, ");
-		break;
-	case 1:
-		sprintf(buf + strlen(buf), "1 час ночи, ");
-		break;
-	case 2:
-	case 3:
-	case 4:
-		sprintf(buf + strlen(buf), "%d часа ночи, ", time_info.hours);
-		break;
-	case 5:
-	case 6:
-	case 7:
-	case 8:
-	case 9:
-	case 10:
-	case 11:
-		sprintf(buf + strlen(buf), "%d часов утра, ", time_info.hours);
-		break;
-	case 12:
-		sprintf(buf + strlen(buf), "полдень, ");
-		break;
-	case 13:
-		sprintf(buf + strlen(buf), "1 час пополудни, ");
-		break;
-	case 14:
-	case 15:
-	case 16:
-		sprintf(buf + strlen(buf), "%d часа пополудни, ", time_info.hours - 12);
-		break;
-	case 17:
-	case 18:
-	case 19:
-	case 20:
-	case 21:
-	case 22:
-	case 23:
-		sprintf(buf + strlen(buf), "%d часов вечера, ", time_info.hours - 12);
-		break;
-	}
+void do_time(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int day, month, days_go;
+  if (IS_NPC(ch))
+    return;
+  sprintf(buf, "Сейчас ");
+  switch (time_info.hours % 24) {
+    case 0: sprintf(buf + strlen(buf), "полночь, ");
+      break;
+    case 1: sprintf(buf + strlen(buf), "1 час ночи, ");
+      break;
+    case 2:
+    case 3:
+    case 4: sprintf(buf + strlen(buf), "%d часа ночи, ", time_info.hours);
+      break;
+    case 5:
+    case 6:
+    case 7:
+    case 8:
+    case 9:
+    case 10:
+    case 11: sprintf(buf + strlen(buf), "%d часов утра, ", time_info.hours);
+      break;
+    case 12: sprintf(buf + strlen(buf), "полдень, ");
+      break;
+    case 13: sprintf(buf + strlen(buf), "1 час пополудни, ");
+      break;
+    case 14:
+    case 15:
+    case 16: sprintf(buf + strlen(buf), "%d часа пополудни, ", time_info.hours - 12);
+      break;
+    case 17:
+    case 18:
+    case 19:
+    case 20:
+    case 21:
+    case 22:
+    case 23: sprintf(buf + strlen(buf), "%d часов вечера, ", time_info.hours - 12);
+      break;
+  }
 
-	if (GET_RELIGION(ch) == RELIGION_POLY)
-		strcat(buf, weekdays_poly[weather_info.week_day_poly]);
-	else
-		strcat(buf, weekdays[weather_info.week_day_mono]);
-	switch (weather_info.sunlight)
-	{
-	case SUN_DARK:
-		strcat(buf, ", ночь");
-		break;
-	case SUN_SET:
-		strcat(buf, ", закат");
-		break;
-	case SUN_LIGHT:
-		strcat(buf, ", день");
-		break;
-	case SUN_RISE:
-		strcat(buf, ", рассвет");
-		break;
-	}
-	strcat(buf, ".\r\n");
-	send_to_char(buf, ch);
+  if (GET_RELIGION(ch) == RELIGION_POLY)
+    strcat(buf, weekdays_poly[weather_info.week_day_poly]);
+  else
+    strcat(buf, weekdays[weather_info.week_day_mono]);
+  switch (weather_info.sunlight) {
+    case SUN_DARK: strcat(buf, ", ночь");
+      break;
+    case SUN_SET: strcat(buf, ", закат");
+      break;
+    case SUN_LIGHT: strcat(buf, ", день");
+      break;
+    case SUN_RISE: strcat(buf, ", рассвет");
+      break;
+  }
+  strcat(buf, ".\r\n");
+  send_to_char(buf, ch);
 
-	day = time_info.day + 1;	// day in [1..30]
-	*buf = '\0';
-	if (GET_RELIGION(ch) == RELIGION_POLY || IS_IMMORTAL(ch))
-	{
-		days_go = time_info.month * DAYS_PER_MONTH + time_info.day;
-		month = days_go / 40;
-		days_go = (days_go % 40) + 1;
-		sprintf(buf + strlen(buf), "%s, %dй День, Год %d%s",
-				month_name_poly[month], days_go, time_info.year, IS_IMMORTAL(ch) ? ".\r\n" : "");
-	}
-	if (GET_RELIGION(ch) == RELIGION_MONO || IS_IMMORTAL(ch))
-		sprintf(buf + strlen(buf), "%s, %dй День, Год %d",
-				month_name[static_cast<int>(time_info.month)], day, time_info.year);
-	if (IS_IMMORTAL(ch))
-		sprintf(buf + strlen(buf), "\r\n%d.%d.%d, дней с начала года: %d", day, time_info.month+1, time_info.year, (time_info.month *DAYS_PER_MONTH) + day);
-	switch (weather_info.season)
-	{
-	case SEASON_WINTER:
-		strcat(buf, ", зима");
-		break;
-	case SEASON_SPRING:
-		strcat(buf, ", весна");
-		break;
-	case SEASON_SUMMER:
-		strcat(buf, ", лето");
-		break;
-	case SEASON_AUTUMN:
-		strcat(buf, ", осень");
-		break;
-	}
-	strcat(buf, ".\r\n");
-	send_to_char(buf, ch);
-	gods_day_now(ch);
+  day = time_info.day + 1;    // day in [1..30]
+  *buf = '\0';
+  if (GET_RELIGION(ch) == RELIGION_POLY || IS_IMMORTAL(ch)) {
+    days_go = time_info.month * DAYS_PER_MONTH + time_info.day;
+    month = days_go / 40;
+    days_go = (days_go % 40) + 1;
+    sprintf(buf + strlen(buf), "%s, %dй День, Год %d%s",
+            month_name_poly[month], days_go, time_info.year, IS_IMMORTAL(ch) ? ".\r\n" : "");
+  }
+  if (GET_RELIGION(ch) == RELIGION_MONO || IS_IMMORTAL(ch))
+    sprintf(buf + strlen(buf), "%s, %dй День, Год %d",
+            month_name[static_cast<int>(time_info.month)], day, time_info.year);
+  if (IS_IMMORTAL(ch))
+    sprintf(buf + strlen(buf),
+            "\r\n%d.%d.%d, дней с начала года: %d",
+            day,
+            time_info.month + 1,
+            time_info.year,
+            (time_info.month * DAYS_PER_MONTH) + day);
+  switch (weather_info.season) {
+    case SEASON_WINTER: strcat(buf, ", зима");
+      break;
+    case SEASON_SPRING: strcat(buf, ", весна");
+      break;
+    case SEASON_SUMMER: strcat(buf, ", лето");
+      break;
+    case SEASON_AUTUMN: strcat(buf, ", осень");
+      break;
+  }
+  strcat(buf, ".\r\n");
+  send_to_char(buf, ch);
+  gods_day_now(ch);
 }
 
-int get_moon(int sky)
-{
-	if (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT || sky == SKY_RAINING)
-		return (0);
-	else if (weather_info.moon_day <= NEWMOONSTOP || weather_info.moon_day >= NEWMOONSTART)
-		return (1);
-	else if (weather_info.moon_day < HALFMOONSTART)
-		return (2);
-	else if (weather_info.moon_day < FULLMOONSTART)
-		return (3);
-	else if (weather_info.moon_day <= FULLMOONSTOP)
-		return (4);
-	else if (weather_info.moon_day < LASTHALFMOONSTART)
-		return (5);
-	else
-		return (6);
-	return (0);
+int get_moon(int sky) {
+  if (weather_info.sunlight == SUN_RISE || weather_info.sunlight == SUN_LIGHT || sky == SKY_RAINING)
+    return (0);
+  else if (weather_info.moon_day <= NEWMOONSTOP || weather_info.moon_day >= NEWMOONSTART)
+    return (1);
+  else if (weather_info.moon_day < HALFMOONSTART)
+    return (2);
+  else if (weather_info.moon_day < FULLMOONSTART)
+    return (3);
+  else if (weather_info.moon_day <= FULLMOONSTOP)
+    return (4);
+  else if (weather_info.moon_day < LASTHALFMOONSTART)
+    return (5);
+  else
+    return (6);
+  return (0);
 }
 
-void do_weather(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int sky = weather_info.sky, weather_type = weather_info.weather_type;
-	const char *sky_look[] = { "облачное",
-							   "пасмурное",
-							   "покрыто тяжелыми тучами",
-							   "ясное"
-							 };
-	const char *moon_look[] = { "Новолуние.",
-								"Растущий серп луны.",
-								"Растущая луна.",
-								"Полнолуние.",
-								"Убывающая луна.",
-								"Убывающий серп луны."
-							  };
+void do_weather(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int sky = weather_info.sky, weather_type = weather_info.weather_type;
+  const char *sky_look[] = {"облачное",
+                            "пасмурное",
+                            "покрыто тяжелыми тучами",
+                            "ясное"
+  };
+  const char *moon_look[] = {"Новолуние.",
+                             "Растущий серп луны.",
+                             "Растущая луна.",
+                             "Полнолуние.",
+                             "Убывающая луна.",
+                             "Убывающий серп луны."
+  };
 
-	if (OUTSIDE(ch))
-	{
-		*buf = '\0';
-		if (world[ch->in_room]->weather.duration > 0)
-		{
-			sky = world[ch->in_room]->weather.sky;
-			weather_type = world[ch->in_room]->weather.weather_type;
-		}
-		sprintf(buf + strlen(buf),
-				"Небо %s. %s\r\n%s\r\n", sky_look[sky],
-				get_moon(sky) ? moon_look[get_moon(sky) - 1] : "",
-				(weather_info.change >=
-				 0 ? "Атмосферное давление повышается." : "Атмосферное давление понижается."));
-		sprintf(buf + strlen(buf), "На дворе %d %s.\r\n",
-				weather_info.temperature, desc_count(weather_info.temperature, WHAT_DEGREE));
+  if (OUTSIDE(ch)) {
+    *buf = '\0';
+    if (world[ch->in_room]->weather.duration > 0) {
+      sky = world[ch->in_room]->weather.sky;
+      weather_type = world[ch->in_room]->weather.weather_type;
+    }
+    sprintf(buf + strlen(buf),
+            "Небо %s. %s\r\n%s\r\n", sky_look[sky],
+            get_moon(sky) ? moon_look[get_moon(sky) - 1] : "",
+            (weather_info.change >=
+                0 ? "Атмосферное давление повышается." : "Атмосферное давление понижается."));
+    sprintf(buf + strlen(buf), "На дворе %d %s.\r\n",
+            weather_info.temperature, desc_count(weather_info.temperature, WHAT_DEGREE));
 
-		if (IS_SET(weather_info.weather_type, WEATHER_BIGWIND))
-			strcat(buf, "Сильный ветер.\r\n");
-		else if (IS_SET(weather_info.weather_type, WEATHER_MEDIUMWIND))
-			strcat(buf, "Умеренный ветер.\r\n");
-		else if (IS_SET(weather_info.weather_type, WEATHER_LIGHTWIND))
-			strcat(buf, "Легкий ветерок.\r\n");
+    if (IS_SET(weather_info.weather_type, WEATHER_BIGWIND))
+      strcat(buf, "Сильный ветер.\r\n");
+    else if (IS_SET(weather_info.weather_type, WEATHER_MEDIUMWIND))
+      strcat(buf, "Умеренный ветер.\r\n");
+    else if (IS_SET(weather_info.weather_type, WEATHER_LIGHTWIND))
+      strcat(buf, "Легкий ветерок.\r\n");
 
-		if (IS_SET(weather_type, WEATHER_BIGSNOW))
-			strcat(buf, "Валит снег.\r\n");
-		else if (IS_SET(weather_type, WEATHER_MEDIUMSNOW))
-			strcat(buf, "Снегопад.\r\n");
-		else if (IS_SET(weather_type, WEATHER_LIGHTSNOW))
-			strcat(buf, "Легкий снежок.\r\n");
+    if (IS_SET(weather_type, WEATHER_BIGSNOW))
+      strcat(buf, "Валит снег.\r\n");
+    else if (IS_SET(weather_type, WEATHER_MEDIUMSNOW))
+      strcat(buf, "Снегопад.\r\n");
+    else if (IS_SET(weather_type, WEATHER_LIGHTSNOW))
+      strcat(buf, "Легкий снежок.\r\n");
 
-		if (IS_SET(weather_type, WEATHER_GRAD))
-			strcat(buf, "Дождь с градом.\r\n");
-		else if (IS_SET(weather_type, WEATHER_BIGRAIN))
-			strcat(buf, "Льет, как из ведра.\r\n");
-		else if (IS_SET(weather_type, WEATHER_MEDIUMRAIN))
-			strcat(buf, "Идет дождь.\r\n");
-		else if (IS_SET(weather_type, WEATHER_LIGHTRAIN))
-			strcat(buf, "Моросит дождик.\r\n");
+    if (IS_SET(weather_type, WEATHER_GRAD))
+      strcat(buf, "Дождь с градом.\r\n");
+    else if (IS_SET(weather_type, WEATHER_BIGRAIN))
+      strcat(buf, "Льет, как из ведра.\r\n");
+    else if (IS_SET(weather_type, WEATHER_MEDIUMRAIN))
+      strcat(buf, "Идет дождь.\r\n");
+    else if (IS_SET(weather_type, WEATHER_LIGHTRAIN))
+      strcat(buf, "Моросит дождик.\r\n");
 
-		send_to_char(buf, ch);
-	}
-	else
-		send_to_char("Вы ничего не можете сказать о погоде сегодня.\r\n", ch);
-	if (IS_GOD(ch))
-	{
-		sprintf(buf, "День: %d Месяц: %s Час: %d Такт = %d\r\n"
-				"Температура =%-5d, за день = %-8d, за неделю = %-8d\r\n"
-				"Давление    =%-5d, за день = %-8d, за неделю = %-8d\r\n"
-				"Выпало дождя = %d(%d), снега = %d(%d). Лед = %d(%d). Погода = %08x(%08x).\r\n",
-				time_info.day, month_name[time_info.month], time_info.hours,
-				weather_info.hours_go, weather_info.temperature,
-				weather_info.temp_last_day, weather_info.temp_last_week,
-				weather_info.pressure, weather_info.press_last_day,
-				weather_info.press_last_week, weather_info.rainlevel,
-				world[ch->in_room]->weather.rainlevel, weather_info.snowlevel,
-				world[ch->in_room]->weather.snowlevel, weather_info.icelevel,
-				world[ch->in_room]->weather.icelevel,
-				weather_info.weather_type, world[ch->in_room]->weather.weather_type);
-		send_to_char(buf, ch);
-	}
+    send_to_char(buf, ch);
+  } else
+    send_to_char("Вы ничего не можете сказать о погоде сегодня.\r\n", ch);
+  if (IS_GOD(ch)) {
+    sprintf(buf, "День: %d Месяц: %s Час: %d Такт = %d\r\n"
+                 "Температура =%-5d, за день = %-8d, за неделю = %-8d\r\n"
+                 "Давление    =%-5d, за день = %-8d, за неделю = %-8d\r\n"
+                 "Выпало дождя = %d(%d), снега = %d(%d). Лед = %d(%d). Погода = %08x(%08x).\r\n",
+            time_info.day, month_name[time_info.month], time_info.hours,
+            weather_info.hours_go, weather_info.temperature,
+            weather_info.temp_last_day, weather_info.temp_last_week,
+            weather_info.pressure, weather_info.press_last_day,
+            weather_info.press_last_week, weather_info.rainlevel,
+            world[ch->in_room]->weather.rainlevel, weather_info.snowlevel,
+            world[ch->in_room]->weather.snowlevel, weather_info.icelevel,
+            world[ch->in_room]->weather.icelevel,
+            weather_info.weather_type, world[ch->in_room]->weather.weather_type);
+    send_to_char(buf, ch);
+  }
 }
 
-namespace
-{
+namespace {
 
-const char* IMM_WHO_FORMAT =
-"Формат: кто [минуров[-максуров]] [-n имя] [-c профлист] [-s] [-r] [-z] [-h] [-b|-и]\r\n";
+const char *IMM_WHO_FORMAT =
+    "Формат: кто [минуров[-максуров]] [-n имя] [-c профлист] [-s] [-r] [-z] [-h] [-b|-и]\r\n";
 
-const char* MORT_WHO_FORMAT = "Формат: кто [имя] [-?]\r\n";
+const char *MORT_WHO_FORMAT = "Формат: кто [имя] [-?]\r\n";
 
 } // namespace
 
-void do_who(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	char name_search[MAX_INPUT_LENGTH];
-	name_search[0] = '\0';
+void do_who(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  char name_search[MAX_INPUT_LENGTH];
+  name_search[0] = '\0';
 
-	// Флаги для опций
-	int low = 0, high = LVL_IMPL;
-	int showclass = 0, num_can_see = 0;
-	int imms_num = 0, morts_num = 0, demigods_num = 0;
-	bool localwho = false, short_list = false;
-	bool who_room = false, showname = false;
+  // Флаги для опций
+  int low = 0, high = LVL_IMPL;
+  int showclass = 0, num_can_see = 0;
+  int imms_num = 0, morts_num = 0, demigods_num = 0;
+  bool localwho = false, short_list = false;
+  bool who_room = false, showname = false;
 
-	skip_spaces(&argument);
-	strcpy(buf, argument);
+  skip_spaces(&argument);
+  strcpy(buf, argument);
 
-	// Проверка аргументов команды "кто"
-	while (*buf)
-	{
-		half_chop(buf, arg, buf1);
-		if (!str_cmp(arg, "боги") && strlen(arg) == 4)
-		{
-			low = LVL_IMMORT;
-			high = LVL_IMPL;
-			strcpy(buf, buf1);
-		}
-		else if (a_isdigit(*arg))
-		{
-			if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-				sscanf(arg, "%d-%d", &low, &high);
-			strcpy(buf, buf1);
-		}
-		else if (*arg == '-')
-		{
-			const char mode = *(arg + 1);	// just in case; we destroy arg in the switch
-			switch (mode)
-			{
-			case 'b':
-			case 'и':
-				if (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_DEMIGOD) || PRF_FLAGGED(ch, PRF_CODERINFO))
-					showname = true;
-				strcpy(buf, buf1);
-				break;
-			case 'z':
-				if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-					localwho = true;
-				strcpy(buf, buf1);
-				break;
-			case 's':
-				if (IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-					short_list = true;
-				strcpy(buf, buf1);
-				break;
-			case 'l':
-				half_chop(buf1, arg, buf);
-				if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-					sscanf(arg, "%d-%d", &low, &high);
-				break;
-			case 'n':
-				half_chop(buf1, name_search, buf);
-				break;
-			case 'r':
-				if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-					who_room = true;
-				strcpy(buf, buf1);
-				break;
-			case 'c':
-				half_chop(buf1, arg, buf);
-				if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-				{
-					const size_t len = strlen(arg);
-					for (size_t i = 0; i < len; i++)
-					{
-						showclass |= find_class_bitvector(arg[i]);
-					}
-				}
-				break;
-			case 'h':
-			case '?':
-			default:
-				if (IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-					send_to_char(IMM_WHO_FORMAT, ch);
-				else
-					send_to_char(MORT_WHO_FORMAT, ch);
-				return;
-			}	// end of switch
-		}
-		else  	// endif
-		{
-			strcpy(name_search, arg);
-			strcpy(buf, buf1);
+  // Проверка аргументов команды "кто"
+  while (*buf) {
+    half_chop(buf, arg, buf1);
+    if (!str_cmp(arg, "боги") && strlen(arg) == 4) {
+      low = LVL_IMMORT;
+      high = LVL_IMPL;
+      strcpy(buf, buf1);
+    } else if (a_isdigit(*arg)) {
+      if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
+        sscanf(arg, "%d-%d", &low, &high);
+      strcpy(buf, buf1);
+    } else if (*arg == '-') {
+      const char mode = *(arg + 1);    // just in case; we destroy arg in the switch
+      switch (mode) {
+        case 'b':
+        case 'и':
+          if (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_DEMIGOD) || PRF_FLAGGED(ch, PRF_CODERINFO))
+            showname = true;
+          strcpy(buf, buf1);
+          break;
+        case 'z':
+          if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
+            localwho = true;
+          strcpy(buf, buf1);
+          break;
+        case 's':
+          if (IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
+            short_list = true;
+          strcpy(buf, buf1);
+          break;
+        case 'l': half_chop(buf1, arg, buf);
+          if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
+            sscanf(arg, "%d-%d", &low, &high);
+          break;
+        case 'n': half_chop(buf1, name_search, buf);
+          break;
+        case 'r':
+          if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
+            who_room = true;
+          strcpy(buf, buf1);
+          break;
+        case 'c': half_chop(buf1, arg, buf);
+          if (IS_GOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO)) {
+            const size_t len = strlen(arg);
+            for (size_t i = 0; i < len; i++) {
+              showclass |= find_class_bitvector(arg[i]);
+            }
+          }
+          break;
+        case 'h':
+        case '?':
+        default:
+          if (IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
+            send_to_char(IMM_WHO_FORMAT, ch);
+          else
+            send_to_char(MORT_WHO_FORMAT, ch);
+          return;
+      }    // end of switch
+    } else    // endif
+    {
+      strcpy(name_search, arg);
+      strcpy(buf, buf1);
 
-		}
-	}			// end while (parser)
+    }
+  }            // end while (parser)
 
-	if (who_spamcontrol(ch, strlen(name_search) ? WHO_LISTNAME : WHO_LISTALL))
-		return;
+  if (who_spamcontrol(ch, strlen(name_search) ? WHO_LISTNAME : WHO_LISTALL))
+    return;
 
-	// Строки содержащие имена
-	sprintf(buf, "%sБОГИ%s\r\n", CCICYN(ch, C_NRM), CCNRM(ch, C_NRM));
-	std::string imms(buf);
+  // Строки содержащие имена
+  sprintf(buf, "%sБОГИ%s\r\n", CCICYN(ch, C_NRM), CCNRM(ch, C_NRM));
+  std::string imms(buf);
 
-	sprintf(buf, "%sПривилегированные%s\r\n", CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
-	std::string demigods(buf);
+  sprintf(buf, "%sПривилегированные%s\r\n", CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
+  std::string demigods(buf);
 
-	sprintf(buf, "%sИгроки%s\r\n", CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
-	std::string morts(buf);
+  sprintf(buf, "%sИгроки%s\r\n", CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
+  std::string morts(buf);
 
-	int all = 0;
+  int all = 0;
 
-	for (const auto tch: character_list)
-	{
-		if (IS_NPC(tch))
-			continue;
+  for (const auto tch: character_list) {
+    if (IS_NPC(tch))
+      continue;
 
-		if (!HERE(tch))
-			continue;
+    if (!HERE(tch))
+      continue;
 
-		if (!*argument && GET_LEVEL(tch) < LVL_IMMORT)
-			++all;
+    if (!*argument && GET_LEVEL(tch) < LVL_IMMORT)
+      ++all;
 
-		if (*name_search && !(isname(name_search, GET_NAME(tch))))
-			continue;
+    if (*name_search && !(isname(name_search, GET_NAME(tch))))
+      continue;
 
-		if (!CAN_SEE_CHAR(ch, tch) || GET_LEVEL(tch) < low || GET_LEVEL(tch) > high)
-			continue;
-		if (localwho && world[ch->in_room]->zone != world[tch->in_room]->zone)
-			continue;
-		if (who_room && (tch->in_room != ch->in_room))
-			continue;
-		if (showclass && !(showclass & (1 << GET_CLASS(tch))))
-			continue;
-		if (showname && !(!NAME_GOD(tch) && GET_LEVEL(tch) <= NAME_LEVEL))
-			continue;
-		if (PLR_FLAGGED(tch, PLR_NAMED) && NAME_DURATION(tch) && !IS_IMMORTAL(ch) && !PRF_FLAGGED(ch, PRF_CODERINFO) && ch != tch.get())
-			continue;
+    if (!CAN_SEE_CHAR(ch, tch) || GET_LEVEL(tch) < low || GET_LEVEL(tch) > high)
+      continue;
+    if (localwho && world[ch->in_room]->zone != world[tch->in_room]->zone)
+      continue;
+    if (who_room && (tch->in_room != ch->in_room))
+      continue;
+    if (showclass && !(showclass & (1 << GET_CLASS(tch))))
+      continue;
+    if (showname && !(!NAME_GOD(tch) && GET_LEVEL(tch) <= NAME_LEVEL))
+      continue;
+    if (PLR_FLAGGED(tch, PLR_NAMED) && NAME_DURATION(tch) && !IS_IMMORTAL(ch) && !PRF_FLAGGED(ch, PRF_CODERINFO)
+        && ch != tch.get())
+      continue;
 
-		*buf = '\0';
-		num_can_see++;
+    *buf = '\0';
+    num_can_see++;
 
-		if (short_list)
-		{
-			char tmp[MAX_INPUT_LENGTH];
-			snprintf(tmp, sizeof(tmp), "%s%s%s", CCPK(ch, C_NRM, tch), GET_NAME(tch), CCNRM(ch, C_NRM));
-			if (IS_IMPL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-			{
-				sprintf(buf, "%s[%2d %s %s] %-30s%s",
-					IS_GOD(tch) ? CCWHT(ch, C_SPR) : "",
-					GET_LEVEL(tch), KIN_ABBR(tch), CLASS_ABBR(tch),
-					tmp, IS_GOD(tch) ? CCNRM(ch, C_SPR) : "");
-			}
-			else
-			{
-				sprintf(buf, "%s%-30s%s",
-					IS_IMMORTAL(tch) ? CCWHT(ch, C_SPR) : "",
-					tmp, IS_IMMORTAL(tch) ? CCNRM(ch, C_SPR) : "");
-			}
-		}
-		else
-		{
-			if (IS_IMPL(ch)
-				|| PRF_FLAGGED(ch, PRF_CODERINFO))
-			{
-				sprintf(buf, "%s[%2d %2d %s(%5d)] %s%s%s%s",
-					IS_IMMORTAL(tch) ? CCWHT(ch, C_SPR) : "",
-					GET_LEVEL(tch),
-					GET_REMORT(tch),
-					CLASS_ABBR(tch),
-					tch->get_pfilepos(),
-					CCPK(ch, C_NRM, tch),
-					IS_IMMORTAL(tch) ? CCWHT(ch, C_SPR) : "", tch->race_or_title().c_str(), CCNRM(ch, C_NRM));
-			}
-			else
-			{
-				sprintf(buf, "%s %s%s%s",
-					CCPK(ch, C_NRM, tch),
-					IS_IMMORTAL(tch) ? CCWHT(ch, C_SPR) : "", tch->race_or_title().c_str(), CCNRM(ch, C_NRM));
-			}
+    if (short_list) {
+      char tmp[MAX_INPUT_LENGTH];
+      snprintf(tmp, sizeof(tmp), "%s%s%s", CCPK(ch, C_NRM, tch), GET_NAME(tch), CCNRM(ch, C_NRM));
+      if (IS_IMPL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO)) {
+        sprintf(buf, "%s[%2d %s %s] %-30s%s",
+                IS_GOD(tch) ? CCWHT(ch, C_SPR) : "",
+                GET_LEVEL(tch), KIN_ABBR(tch), CLASS_ABBR(tch),
+                tmp, IS_GOD(tch) ? CCNRM(ch, C_SPR) : "");
+      } else {
+        sprintf(buf, "%s%-30s%s",
+                IS_IMMORTAL(tch) ? CCWHT(ch, C_SPR) : "",
+                tmp, IS_IMMORTAL(tch) ? CCNRM(ch, C_SPR) : "");
+      }
+    } else {
+      if (IS_IMPL(ch)
+          || PRF_FLAGGED(ch, PRF_CODERINFO)) {
+        sprintf(buf, "%s[%2d %2d %s(%5d)] %s%s%s%s",
+                IS_IMMORTAL(tch) ? CCWHT(ch, C_SPR) : "",
+                GET_LEVEL(tch),
+                GET_REMORT(tch),
+                CLASS_ABBR(tch),
+                tch->get_pfilepos(),
+                CCPK(ch, C_NRM, tch),
+                IS_IMMORTAL(tch) ? CCWHT(ch, C_SPR) : "", tch->race_or_title().c_str(), CCNRM(ch, C_NRM));
+      } else {
+        sprintf(buf, "%s %s%s%s",
+                CCPK(ch, C_NRM, tch),
+                IS_IMMORTAL(tch) ? CCWHT(ch, C_SPR) : "", tch->race_or_title().c_str(), CCNRM(ch, C_NRM));
+      }
 
-			if (GET_INVIS_LEV(tch))
-				sprintf(buf + strlen(buf), " (i%d)", GET_INVIS_LEV(tch));
-			else if (AFF_FLAGGED(tch, EAffectFlag::AFF_INVISIBLE))
-				sprintf(buf + strlen(buf), " (невидим%s)", GET_CH_SUF_6(tch));
-			if (AFF_FLAGGED(tch, EAffectFlag::AFF_HIDE))
-				strcat(buf, " (прячется)");
-			if (AFF_FLAGGED(tch, EAffectFlag::AFF_CAMOUFLAGE))
-				strcat(buf, " (маскируется)");
+      if (GET_INVIS_LEV(tch))
+        sprintf(buf + strlen(buf), " (i%d)", GET_INVIS_LEV(tch));
+      else if (AFF_FLAGGED(tch, EAffectFlag::AFF_INVISIBLE))
+        sprintf(buf + strlen(buf), " (невидим%s)", GET_CH_SUF_6(tch));
+      if (AFF_FLAGGED(tch, EAffectFlag::AFF_HIDE))
+        strcat(buf, " (прячется)");
+      if (AFF_FLAGGED(tch, EAffectFlag::AFF_CAMOUFLAGE))
+        strcat(buf, " (маскируется)");
 
-			if (PLR_FLAGGED(tch, PLR_MAILING))
-				strcat(buf, " (отправляет письмо)");
-			else if (PLR_FLAGGED(tch, PLR_WRITING))
-				strcat(buf, " (пишет)");
+      if (PLR_FLAGGED(tch, PLR_MAILING))
+        strcat(buf, " (отправляет письмо)");
+      else if (PLR_FLAGGED(tch, PLR_WRITING))
+        strcat(buf, " (пишет)");
 
-			if (PRF_FLAGGED(tch, PRF_NOHOLLER))
-				sprintf(buf + strlen(buf), " (глух%s)", GET_CH_SUF_1(tch));
-			if (PRF_FLAGGED(tch, PRF_NOTELL))
-				sprintf(buf + strlen(buf), " (занят%s)", GET_CH_SUF_6(tch));
-			if (PLR_FLAGGED(tch, PLR_MUTE))
-				sprintf(buf + strlen(buf), " (молчит)");
-			if (PLR_FLAGGED(tch, PLR_DUMB))
-				sprintf(buf + strlen(buf), " (нем%s)", GET_CH_SUF_6(tch));
-			if (PLR_FLAGGED(tch, PLR_KILLER) == PLR_KILLER)
-				sprintf(buf + strlen(buf), "&R (ДУШЕГУБ)&n");
-			if ( (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_DEMIGOD)) &&  !NAME_GOD(tch)
-					&& GET_LEVEL(tch) <= NAME_LEVEL)
-			{
-				sprintf(buf + strlen(buf), " &W!НЕ ОДОБРЕНО!&n");
-				if (showname)
-				{
-					sprintf(buf + strlen(buf),
-							"\r\nПадежи: %s/%s/%s/%s/%s/%s Email: &S%s&s Пол: %s",
-							GET_PAD(tch, 0), GET_PAD(tch, 1), GET_PAD(tch, 2),
-							GET_PAD(tch, 3), GET_PAD(tch, 4), GET_PAD(tch, 5),
-							GET_GOD_FLAG(ch, GF_DEMIGOD) ? "скрыто" : GET_EMAIL(tch),
-							genders[static_cast<int>(GET_SEX(tch))]);
-				}
-			}
-			if ((GET_LEVEL(ch) == LVL_IMPL) && (RENTABLE(tch)))
-			    sprintf(buf + strlen(buf), " &R(В КРОВИ)&n");
-			else if ((IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO)) && NAME_BAD(tch))
-			{
-				sprintf(buf + strlen(buf), " &Wзапрет %s!&n", get_name_by_id(NAME_ID_GOD(tch)));
-			}
-			if (IS_GOD(ch) && (GET_GOD_FLAG(tch, GF_TESTER) || PRF_FLAGGED(tch, PRF_TESTER)))
-				sprintf(buf + strlen(buf), " &G(ТЕСТЕР!)&n");
-			if (IS_GOD(ch) && (PLR_FLAGGED(tch, PLR_AUTOBOT)))
-				sprintf(buf + strlen(buf), " &G(БОТ!)&n");
-			if (IS_IMMORTAL(tch))
-				strcat(buf, CCNRM(ch, C_SPR));
-		}		// endif shortlist
+      if (PRF_FLAGGED(tch, PRF_NOHOLLER))
+        sprintf(buf + strlen(buf), " (глух%s)", GET_CH_SUF_1(tch));
+      if (PRF_FLAGGED(tch, PRF_NOTELL))
+        sprintf(buf + strlen(buf), " (занят%s)", GET_CH_SUF_6(tch));
+      if (PLR_FLAGGED(tch, PLR_MUTE))
+        sprintf(buf + strlen(buf), " (молчит)");
+      if (PLR_FLAGGED(tch, PLR_DUMB))
+        sprintf(buf + strlen(buf), " (нем%s)", GET_CH_SUF_6(tch));
+      if (PLR_FLAGGED(tch, PLR_KILLER) == PLR_KILLER)
+        sprintf(buf + strlen(buf), "&R (ДУШЕГУБ)&n");
+      if ((IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_DEMIGOD)) && !NAME_GOD(tch)
+          && GET_LEVEL(tch) <= NAME_LEVEL) {
+        sprintf(buf + strlen(buf), " &W!НЕ ОДОБРЕНО!&n");
+        if (showname) {
+          sprintf(buf + strlen(buf),
+                  "\r\nПадежи: %s/%s/%s/%s/%s/%s Email: &S%s&s Пол: %s",
+                  GET_PAD(tch, 0), GET_PAD(tch, 1), GET_PAD(tch, 2),
+                  GET_PAD(tch, 3), GET_PAD(tch, 4), GET_PAD(tch, 5),
+                  GET_GOD_FLAG(ch, GF_DEMIGOD) ? "скрыто" : GET_EMAIL(tch),
+                  genders[static_cast<int>(GET_SEX(tch))]);
+        }
+      }
+      if ((GET_LEVEL(ch) == LVL_IMPL) && (RENTABLE(tch)))
+        sprintf(buf + strlen(buf), " &R(В КРОВИ)&n");
+      else if ((IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO)) && NAME_BAD(tch)) {
+        sprintf(buf + strlen(buf), " &Wзапрет %s!&n", get_name_by_id(NAME_ID_GOD(tch)));
+      }
+      if (IS_GOD(ch) && (GET_GOD_FLAG(tch, GF_TESTER) || PRF_FLAGGED(tch, PRF_TESTER)))
+        sprintf(buf + strlen(buf), " &G(ТЕСТЕР!)&n");
+      if (IS_GOD(ch) && (PLR_FLAGGED(tch, PLR_AUTOBOT)))
+        sprintf(buf + strlen(buf), " &G(БОТ!)&n");
+      if (IS_IMMORTAL(tch))
+        strcat(buf, CCNRM(ch, C_SPR));
+    }        // endif shortlist
 
-		if (IS_IMMORTAL(tch))
-		{
-			imms_num++;
-			imms += buf;
-			if (!short_list || !(imms_num % 4))
-			{
-				imms += "\r\n";
-			}
-		}
-		else if (GET_GOD_FLAG(tch, GF_DEMIGOD)
-			&& (IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO) || GET_GOD_FLAG(tch, GF_DEMIGOD)))
-		{
-			demigods_num++;
-			demigods += buf;
-			if (!short_list || !(demigods_num % 4))
-			{
-				demigods += "\r\n";
-			}
-		}
-		else
-		{
-			morts_num++;
-			morts += buf;
-			if (!short_list || !(morts_num % 4))
-				morts += "\r\n";
-		}
-	}			// end of for
+    if (IS_IMMORTAL(tch)) {
+      imms_num++;
+      imms += buf;
+      if (!short_list || !(imms_num % 4)) {
+        imms += "\r\n";
+      }
+    } else if (GET_GOD_FLAG(tch, GF_DEMIGOD)
+        && (IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO) || GET_GOD_FLAG(tch, GF_DEMIGOD))) {
+      demigods_num++;
+      demigods += buf;
+      if (!short_list || !(demigods_num % 4)) {
+        demigods += "\r\n";
+      }
+    } else {
+      morts_num++;
+      morts += buf;
+      if (!short_list || !(morts_num % 4))
+        morts += "\r\n";
+    }
+  }            // end of for
 
-	if (morts_num + imms_num + demigods_num == 0)
-	{
-		send_to_char("\r\nВы никого не видите.\r\n", ch);
-		// !!!
-		return;
-	}
+  if (morts_num + imms_num + demigods_num == 0) {
+    send_to_char("\r\nВы никого не видите.\r\n", ch);
+    // !!!
+    return;
+  }
 
-	std::string out;
+  std::string out;
 
-	if (imms_num > 0)
-	{
-		out += imms;
-	}
-	if (demigods_num > 0)
-	{
-		if (short_list)
-		{
-			out += "\r\n";
-		}
-		out += demigods;
-	}
-	if (morts_num > 0)
-	{
-		if (short_list)
-		{
-			out += "\r\n";
-		}
-		out += morts;
-	}
+  if (imms_num > 0) {
+    out += imms;
+  }
+  if (demigods_num > 0) {
+    if (short_list) {
+      out += "\r\n";
+    }
+    out += demigods;
+  }
+  if (morts_num > 0) {
+    if (short_list) {
+      out += "\r\n";
+    }
+    out += morts;
+  }
 
-	out += "\r\nВсего:";
-	if (imms_num)
-	{
-		sprintf(buf, " бессмертных %d", imms_num);
-		out += buf;
-	}
-	if (demigods_num)
-	{
-		sprintf(buf, " привилегированных %d", demigods_num);
-		out += buf;
-	}
-	if (all && morts_num)
-	{
-		sprintf(buf, " смертных %d (видимых %d)", all, morts_num);
-		out += buf;
-	}
-	else if (morts_num)
-	{
-		sprintf(buf, " смертных %d", morts_num);
-		out += buf;
-	}
+  out += "\r\nВсего:";
+  if (imms_num) {
+    sprintf(buf, " бессмертных %d", imms_num);
+    out += buf;
+  }
+  if (demigods_num) {
+    sprintf(buf, " привилегированных %d", demigods_num);
+    out += buf;
+  }
+  if (all && morts_num) {
+    sprintf(buf, " смертных %d (видимых %d)", all, morts_num);
+    out += buf;
+  } else if (morts_num) {
+    sprintf(buf, " смертных %d", morts_num);
+    out += buf;
+  }
 
-	out += ".\r\n";
-	page_string(ch->desc, out);
+  out += ".\r\n";
+  page_string(ch->desc, out);
 }
 
-std::string print_server_uptime()
-{
-	const auto boot_time = shutdown_parameters.get_boot_time();
-	const time_t diff = time(0) - boot_time;
-	const int d = diff / 86400;
-	const int h = (diff / 3600) % 24;
-	const int m = (diff / 60) % 60;
-	const int s = diff % 60;
-	return boost::str(boost::format("Времени с перезагрузки: %dд %02d:%02d:%02d\r\n") % d % h % m % s);
+std::string print_server_uptime() {
+  const auto boot_time = shutdown_parameters.get_boot_time();
+  const time_t diff = time(0) - boot_time;
+  const int d = diff / 86400;
+  const int h = (diff / 3600) % 24;
+  const int m = (diff / 60) % 60;
+  const int s = diff % 60;
+  return boost::str(boost::format("Времени с перезагрузки: %dд %02d:%02d:%02d\r\n") % d % h % m % s);
 }
 
-void do_statistic(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int proff[NUM_PLAYER_CLASSES][2];
-	int ptot[NUM_PLAYER_CLASSES];
-	int i, clan = 0, noclan = 0, hilvl = 0, lowlvl = 0, all = 0, rem = 0, norem = 0, pk = 0, nopk = 0;
+void do_statistic(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int proff[NUM_PLAYER_CLASSES][2];
+  int ptot[NUM_PLAYER_CLASSES];
+  int i, clan = 0, noclan = 0, hilvl = 0, lowlvl = 0, all = 0, rem = 0, norem = 0, pk = 0, nopk = 0;
 
-	for (i = 0; i < NUM_PLAYER_CLASSES; i++)
-	{
-		proff[i][0] = 0;
-		proff[i][1] = 0;
-		ptot[i] = 0;
-	}
+  for (i = 0; i < NUM_PLAYER_CLASSES; i++) {
+    proff[i][0] = 0;
+    proff[i][1] = 0;
+    ptot[i] = 0;
+  }
 
-	for (const auto tch : character_list)
-	{
-		if (IS_NPC(tch) || GET_LEVEL(tch) >= LVL_IMMORT || !HERE(tch))
-			continue;
+  for (const auto tch : character_list) {
+    if (IS_NPC(tch) || GET_LEVEL(tch) >= LVL_IMMORT || !HERE(tch))
+      continue;
 
-		if (CLAN(tch))
-			clan++;
-		else
-			noclan++;
-		if (GET_LEVEL(tch) >= 25)
-			hilvl++;
-		else
-			lowlvl++;
-		if (GET_REMORT(tch) >= 1)
-			rem++;
-		else
-			norem++;
-		all++;
-		if (pk_count(tch.get()) >= 1)
-		{
-			pk++;
-		}
-		else
-		{
-			nopk++;
-		}
+    if (CLAN(tch))
+      clan++;
+    else
+      noclan++;
+    if (GET_LEVEL(tch) >= 25)
+      hilvl++;
+    else
+      lowlvl++;
+    if (GET_REMORT(tch) >= 1)
+      rem++;
+    else
+      norem++;
+    all++;
+    if (pk_count(tch.get()) >= 1) {
+      pk++;
+    } else {
+      nopk++;
+    }
 
-		if (GET_LEVEL(tch) >= 25)
-			proff[static_cast<int>(GET_CLASS(tch))][0]++;
-		else
-			proff[static_cast<int>(GET_CLASS(tch))][1]++;
-		ptot[static_cast<int>(GET_CLASS(tch))]++;
-	}
-	sprintf(buf, "%sСтатистика по игрокам, находящимся в игре (всего / 25 и выше / ниже 25):%s\r\n", CCICYN(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Лекари        %s[%s%2d/%2d/%2d%s]%s       ",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_CLERIC], proff[CLASS_CLERIC][0], proff[CLASS_CLERIC][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Колдуны     %s[%s%2d/%2d/%2d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_BATTLEMAGE], proff[CLASS_BATTLEMAGE][0],
-			proff[CLASS_BATTLEMAGE][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Тати          %s[%s%2d/%2d/%2d%s]%s       ",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_THIEF], proff[CLASS_THIEF][0], proff[CLASS_THIEF][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Богатыри    %s[%s%2d/%2d/%2d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_WARRIOR], proff[CLASS_WARRIOR][0], proff[CLASS_WARRIOR][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Наемники      %s[%s%2d/%2d/%2d%s]%s       ",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_ASSASINE], proff[CLASS_ASSASINE][0],
-			proff[CLASS_ASSASINE][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Дружинники  %s[%s%2d/%2d/%2d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_GUARD], proff[CLASS_GUARD][0], proff[CLASS_GUARD][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Кудесники     %s[%s%2d/%2d/%2d%s]%s       ",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_CHARMMAGE], proff[CLASS_CHARMMAGE][0],
-			proff[CLASS_CHARMMAGE][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Волшебники  %s[%s%2d/%2d/%2d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM),
-			ptot[CLASS_DEFENDERMAGE], proff[CLASS_DEFENDERMAGE][0], proff[CLASS_DEFENDERMAGE][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Чернокнижники %s[%s%2d/%2d/%2d%s]%s       ",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_NECROMANCER], proff[CLASS_NECROMANCER][0],
-			proff[CLASS_NECROMANCER][1], CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Витязи      %s[%s%2d/%2d/%2d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_PALADINE], proff[CLASS_PALADINE][0],
-			proff[CLASS_PALADINE][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Охотники      %s[%s%2d/%2d/%2d%s]%s       ",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_RANGER], proff[CLASS_RANGER][0], proff[CLASS_RANGER][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Кузнецы     %s[%s%2d/%2d/%2d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_SMITH], proff[CLASS_SMITH][0], proff[CLASS_SMITH][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Купцы         %s[%s%2d/%2d/%2d%s]%s       ",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_MERCHANT], proff[CLASS_MERCHANT][0],
-			proff[CLASS_MERCHANT][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Волхвы      %s[%s%2d/%2d/%2d%s]%s\r\n\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_DRUID], proff[CLASS_DRUID][0], proff[CLASS_DRUID][1],
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf),
-			"Игроков выше|ниже 25 уровня     %s[%s%*d%s|%s%*d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, hilvl, CCIRED(ch,
-					C_NRM),
-			CCICYN(ch, C_NRM), 3, lowlvl, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf),
-			"Игроков с перевоплощениями|без  %s[%s%*d%s|%s%*d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, rem, CCIRED(ch, C_NRM),
-			CCICYN(ch, C_NRM), 3, norem, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf),
-			"Клановых|внеклановых игроков    %s[%s%*d%s|%s%*d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, clan, CCIRED(ch,
-					C_NRM),
-			CCICYN(ch, C_NRM), 3, noclan, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf),
-			"Игроков с флагами ПК|без ПК     %s[%s%*d%s|%s%*d%s]%s\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, pk, CCIRED(ch,
-					C_NRM),
-			CCICYN(ch, C_NRM), 3, nopk, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(buf + strlen(buf), "Всего игроков %s[%s%*d%s]%s\r\n\r\n",
-			CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, all, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	send_to_char(buf, ch);
+    if (GET_LEVEL(tch) >= 25)
+      proff[static_cast<int>(GET_CLASS(tch))][0]++;
+    else
+      proff[static_cast<int>(GET_CLASS(tch))][1]++;
+    ptot[static_cast<int>(GET_CLASS(tch))]++;
+  }
+  sprintf(buf,
+          "%sСтатистика по игрокам, находящимся в игре (всего / 25 и выше / ниже 25):%s\r\n",
+          CCICYN(ch, C_NRM),
+          CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Лекари        %s[%s%2d/%2d/%2d%s]%s       ",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_CLERIC], proff[CLASS_CLERIC][0], proff[CLASS_CLERIC][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Колдуны     %s[%s%2d/%2d/%2d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_BATTLEMAGE], proff[CLASS_BATTLEMAGE][0],
+          proff[CLASS_BATTLEMAGE][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Тати          %s[%s%2d/%2d/%2d%s]%s       ",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_THIEF], proff[CLASS_THIEF][0], proff[CLASS_THIEF][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Богатыри    %s[%s%2d/%2d/%2d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_WARRIOR], proff[CLASS_WARRIOR][0], proff[CLASS_WARRIOR][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Наемники      %s[%s%2d/%2d/%2d%s]%s       ",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_ASSASINE], proff[CLASS_ASSASINE][0],
+          proff[CLASS_ASSASINE][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Дружинники  %s[%s%2d/%2d/%2d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_GUARD], proff[CLASS_GUARD][0], proff[CLASS_GUARD][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Кудесники     %s[%s%2d/%2d/%2d%s]%s       ",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_CHARMMAGE], proff[CLASS_CHARMMAGE][0],
+          proff[CLASS_CHARMMAGE][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Волшебники  %s[%s%2d/%2d/%2d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM),
+          ptot[CLASS_DEFENDERMAGE], proff[CLASS_DEFENDERMAGE][0], proff[CLASS_DEFENDERMAGE][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Чернокнижники %s[%s%2d/%2d/%2d%s]%s       ",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_NECROMANCER], proff[CLASS_NECROMANCER][0],
+          proff[CLASS_NECROMANCER][1], CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Витязи      %s[%s%2d/%2d/%2d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_PALADINE], proff[CLASS_PALADINE][0],
+          proff[CLASS_PALADINE][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Охотники      %s[%s%2d/%2d/%2d%s]%s       ",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_RANGER], proff[CLASS_RANGER][0], proff[CLASS_RANGER][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Кузнецы     %s[%s%2d/%2d/%2d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_SMITH], proff[CLASS_SMITH][0], proff[CLASS_SMITH][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Купцы         %s[%s%2d/%2d/%2d%s]%s       ",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_MERCHANT], proff[CLASS_MERCHANT][0],
+          proff[CLASS_MERCHANT][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Волхвы      %s[%s%2d/%2d/%2d%s]%s\r\n\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), ptot[CLASS_DRUID], proff[CLASS_DRUID][0], proff[CLASS_DRUID][1],
+          CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          "Игроков выше|ниже 25 уровня     %s[%s%*d%s|%s%*d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, hilvl, CCIRED(ch,
+                                                                 C_NRM),
+          CCICYN(ch, C_NRM), 3, lowlvl, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          "Игроков с перевоплощениями|без  %s[%s%*d%s|%s%*d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, rem, CCIRED(ch, C_NRM),
+          CCICYN(ch, C_NRM), 3, norem, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          "Клановых|внеклановых игроков    %s[%s%*d%s|%s%*d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, clan, CCIRED(ch,
+                                                                C_NRM),
+          CCICYN(ch, C_NRM), 3, noclan, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf),
+          "Игроков с флагами ПК|без ПК     %s[%s%*d%s|%s%*d%s]%s\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, pk, CCIRED(ch,
+                                                              C_NRM),
+          CCICYN(ch, C_NRM), 3, nopk, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  sprintf(buf + strlen(buf), "Всего игроков %s[%s%*d%s]%s\r\n\r\n",
+          CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), 3, all, CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  send_to_char(buf, ch);
 
-	char buf_[MAX_INPUT_LENGTH];
-	std::string out;
+  char buf_[MAX_INPUT_LENGTH];
+  std::string out;
 
-	out += print_server_uptime();
-	snprintf(buf_, sizeof(buf_),
-		"Героев (без ПК) | Тварей убито  %s[%s%3d%s|%s %2d%s]%s\r\n",
-		CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), char_stat::pkilled,
-		CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), char_stat::mkilled,
-		CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	out += buf_;
-	out += char_stat::print_class_exp(ch);
+  out += print_server_uptime();
+  snprintf(buf_, sizeof(buf_),
+           "Героев (без ПК) | Тварей убито  %s[%s%3d%s|%s %2d%s]%s\r\n",
+           CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), char_stat::pkilled,
+           CCIRED(ch, C_NRM), CCICYN(ch, C_NRM), char_stat::mkilled,
+           CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+  out += buf_;
+  out += char_stat::print_class_exp(ch);
 
-	send_to_char(out, ch);
+  send_to_char(out, ch);
 }
-
 
 #define USERS_FORMAT \
 "Формат: users [-l minlevel[-maxlevel]] [-n name] [-h host] [-c classlist] [-o] [-p]\r\n"
 #define MAX_LIST_LEN 200
-void do_users(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	const char *format = "%3d %-7s %-12s %-14s %-3s %-8s ";
-	char line[200], line2[220], idletime[10], classname[20];
-	char state[30] = "\0", *timeptr, mode;
-	char name_search[MAX_INPUT_LENGTH] = "\0", host_search[MAX_INPUT_LENGTH];
+void do_users(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  const char *format = "%3d %-7s %-12s %-14s %-3s %-8s ";
+  char line[200], line2[220], idletime[10], classname[20];
+  char state[30] = "\0", *timeptr, mode;
+  char name_search[MAX_INPUT_LENGTH] = "\0", host_search[MAX_INPUT_LENGTH];
 // Хорс
-	char host_by_name[MAX_INPUT_LENGTH] = "\0";
-	DESCRIPTOR_DATA *list_players[MAX_LIST_LEN];
-	DESCRIPTOR_DATA *d_tmp;
-	int count_pl;
-	int cycle_i, is, flag_change;
-	unsigned long a1, a2;
-	int showremorts = 0, showemail = 0, locating = 0;
-	char sorting = '!';
-	DESCRIPTOR_DATA *d;
-	int low = 0, high = LVL_IMPL, num_can_see = 0;
-	int showclass = 0, outlaws = 0, playing = 0, deadweight = 0;
+  char host_by_name[MAX_INPUT_LENGTH] = "\0";
+  DESCRIPTOR_DATA *list_players[MAX_LIST_LEN];
+  DESCRIPTOR_DATA *d_tmp;
+  int count_pl;
+  int cycle_i, is, flag_change;
+  unsigned long a1, a2;
+  int showremorts = 0, showemail = 0, locating = 0;
+  char sorting = '!';
+  DESCRIPTOR_DATA *d;
+  int low = 0, high = LVL_IMPL, num_can_see = 0;
+  int showclass = 0, outlaws = 0, playing = 0, deadweight = 0;
 
-	host_search[0] = name_search[0] = '\0';
+  host_search[0] = name_search[0] = '\0';
 
-	strcpy(buf, argument);
-	while (*buf)
-	{
-		half_chop(buf, arg, buf1);
-		if (*arg == '-')
-		{
-			mode = *(arg + 1);	// just in case; we destroy arg in the switch
-			switch (mode)
-			{
-			case 'o':
-			case 'k':
-				outlaws = 1;
-				playing = 1;
-				strcpy(buf, buf1);
-				break;
-			case 'p':
-				playing = 1;
-				strcpy(buf, buf1);
-				break;
-			case 'd':
-				deadweight = 1;
-				strcpy(buf, buf1);
-				break;
-			case 'l':
-				if (!IS_GOD(ch))
-					return;
-				playing = 1;
-				half_chop(buf1, arg, buf);
-				sscanf(arg, "%d-%d", &low, &high);
-				break;
-			case 'n':
-				playing = 1;
-				half_chop(buf1, name_search, buf);
-				break;
-			case 'h':
-				playing = 1;
-				half_chop(buf1, host_search, buf);
-				break;
-			case 'u':
-				playing = 1;
-				half_chop(buf1, host_by_name, buf);
-				break;
-			case 'w':
-				if (!IS_GRGOD(ch))
-					return;
-				playing = 1;
-				locating = 1;
-				strcpy(buf, buf1);
-				break;
-			case 'c':
-			{
-				playing = 1;
-				half_chop(buf1, arg, buf);
-				const size_t len = strlen(arg);
-				for (size_t i = 0; i < len; i++)
-				{
-					showclass |= find_class_bitvector(arg[i]);
-				}
-				break;
-			}
-			case 'e':
-				showemail = 1;
-				strcpy(buf, buf1);
-				break;
-			case 'r':
-				showremorts = 1;
-				strcpy(buf, buf1);
-				break;
+  strcpy(buf, argument);
+  while (*buf) {
+    half_chop(buf, arg, buf1);
+    if (*arg == '-') {
+      mode = *(arg + 1);    // just in case; we destroy arg in the switch
+      switch (mode) {
+        case 'o':
+        case 'k': outlaws = 1;
+          playing = 1;
+          strcpy(buf, buf1);
+          break;
+        case 'p': playing = 1;
+          strcpy(buf, buf1);
+          break;
+        case 'd': deadweight = 1;
+          strcpy(buf, buf1);
+          break;
+        case 'l':
+          if (!IS_GOD(ch))
+            return;
+          playing = 1;
+          half_chop(buf1, arg, buf);
+          sscanf(arg, "%d-%d", &low, &high);
+          break;
+        case 'n': playing = 1;
+          half_chop(buf1, name_search, buf);
+          break;
+        case 'h': playing = 1;
+          half_chop(buf1, host_search, buf);
+          break;
+        case 'u': playing = 1;
+          half_chop(buf1, host_by_name, buf);
+          break;
+        case 'w':
+          if (!IS_GRGOD(ch))
+            return;
+          playing = 1;
+          locating = 1;
+          strcpy(buf, buf1);
+          break;
+        case 'c': {
+          playing = 1;
+          half_chop(buf1, arg, buf);
+          const size_t len = strlen(arg);
+          for (size_t i = 0; i < len; i++) {
+            showclass |= find_class_bitvector(arg[i]);
+          }
+          break;
+        }
+        case 'e': showemail = 1;
+          strcpy(buf, buf1);
+          break;
+        case 'r': showremorts = 1;
+          strcpy(buf, buf1);
+          break;
 
-			case 's':
-				//sorting = 'i';
-				sorting = *(arg + 2);
-				strcpy(buf, buf1);
-				break;
-			default:
-				send_to_char(USERS_FORMAT, ch);
-				return;
-			}	// end of switch
+        case 's':
+          //sorting = 'i';
+          sorting = *(arg + 2);
+          strcpy(buf, buf1);
+          break;
+        default: send_to_char(USERS_FORMAT, ch);
+          return;
+      }    // end of switch
 
-		}
-		else  	// endif
-		{
-			strcpy(name_search, arg);
-			strcpy(buf, buf1);
-		}
-	}			// end while (parser)
-	if (showemail)
-	{
-		strcpy(line, "Ном Професс       Имя         Состояние       Idl Логин    Сайт       E-mail\r\n");
-	}
-	else
-	{
-		strcpy(line, "Ном Професс       Имя         Состояние       Idl Логин    Сайт\r\n");
-	}
-	strcat(line, "--- ---------- ------------ ----------------- --- -------- ----------------------------\r\n");
-	send_to_char(line, ch);
+    } else    // endif
+    {
+      strcpy(name_search, arg);
+      strcpy(buf, buf1);
+    }
+  }            // end while (parser)
+  if (showemail) {
+    strcpy(line, "Ном Професс       Имя         Состояние       Idl Логин    Сайт       E-mail\r\n");
+  } else {
+    strcpy(line, "Ном Професс       Имя         Состояние       Idl Логин    Сайт\r\n");
+  }
+  strcat(line, "--- ---------- ------------ ----------------- --- -------- ----------------------------\r\n");
+  send_to_char(line, ch);
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
 // Хорс
-	if (strlen(host_by_name) != 0)
-	{
-		strcpy(host_search, "!");
-	}
+  if (strlen(host_by_name) != 0) {
+    strcpy(host_search, "!");
+  }
 
-	for (d = descriptor_list, count_pl = 0; d && count_pl < MAX_LIST_LEN; d = d->next, count_pl++)
-	{
-		list_players[count_pl] = d;
+  for (d = descriptor_list, count_pl = 0; d && count_pl < MAX_LIST_LEN; d = d->next, count_pl++) {
+    list_players[count_pl] = d;
 
-		const auto character = d->get_character();
-		if (!character)
-		{
-			continue;
-		}
+    const auto character = d->get_character();
+    if (!character) {
+      continue;
+    }
 
-		if (isname(host_by_name, GET_NAME(character)))
-		{
-			strcpy(host_search, d->host);
-		}
-	}
+    if (isname(host_by_name, GET_NAME(character))) {
+      strcpy(host_search, d->host);
+    }
+  }
 
-	if (sorting != '!')
-	{
-		is = 1;
-		while (is)
-		{
-			is = 0;
-			for (cycle_i = 1; cycle_i < count_pl; cycle_i++)
-			{
-				flag_change = 0;
-				d = list_players[cycle_i - 1];
+  if (sorting != '!') {
+    is = 1;
+    while (is) {
+      is = 0;
+      for (cycle_i = 1; cycle_i < count_pl; cycle_i++) {
+        flag_change = 0;
+        d = list_players[cycle_i - 1];
 
-				const auto t = d->get_character();
+        const auto t = d->get_character();
 
-				d_tmp = list_players[cycle_i];
+        d_tmp = list_players[cycle_i];
 
-				const auto t_tmp = d_tmp->get_character();
+        const auto t_tmp = d_tmp->get_character();
 
-				switch (sorting)
-				{
-				case 'n':
-					if (0 < strcoll(t ? t->get_pc_name().c_str() : "", t_tmp ? t_tmp->get_pc_name().c_str() : ""))
-					{
-						flag_change = 1;
-					}
-					break;
+        switch (sorting) {
+          case 'n':
+            if (0 < strcoll(t ? t->get_pc_name().c_str() : "", t_tmp ? t_tmp->get_pc_name().c_str() : "")) {
+              flag_change = 1;
+            }
+            break;
 
-				case 'e':
-					if (strcoll(t ? GET_EMAIL(t) : "", t_tmp ? GET_EMAIL(t_tmp) : "") > 0)
-						flag_change = 1;
-					break;
+          case 'e':
+            if (strcoll(t ? GET_EMAIL(t) : "", t_tmp ? GET_EMAIL(t_tmp) : "") > 0)
+              flag_change = 1;
+            break;
 
-				default:
-					a1 = get_ip(const_cast<char*>(d->host));
-					a2 = get_ip(const_cast<char*>(d_tmp->host));
-					if (a1 > a2)
-						flag_change = 1;
-				}
-				if (flag_change)
-				{
-					list_players[cycle_i - 1] = d_tmp;
-					list_players[cycle_i] = d;
-					is = 1;
-				}
-			}
-		}
-	}
+          default: a1 = get_ip(const_cast<char *>(d->host));
+            a2 = get_ip(const_cast<char *>(d_tmp->host));
+            if (a1 > a2)
+              flag_change = 1;
+        }
+        if (flag_change) {
+          list_players[cycle_i - 1] = d_tmp;
+          list_players[cycle_i] = d;
+          is = 1;
+        }
+      }
+    }
+  }
 
-	for (cycle_i = 0; cycle_i < count_pl; cycle_i++)
-	{
-		d = list_players[cycle_i];
+  for (cycle_i = 0; cycle_i < count_pl; cycle_i++) {
+    d = list_players[cycle_i];
 // ---
-		if (STATE(d) != CON_PLAYING && playing)
-			continue;
-		if (STATE(d) == CON_PLAYING && deadweight)
-			continue;
-		if (STATE(d) == CON_PLAYING)
-		{
-			const auto character = d->get_character();
-			if (!character)
-			{
-				continue;
-			}
+    if (STATE(d) != CON_PLAYING && playing)
+      continue;
+    if (STATE(d) == CON_PLAYING && deadweight)
+      continue;
+    if (STATE(d) == CON_PLAYING) {
+      const auto character = d->get_character();
+      if (!character) {
+        continue;
+      }
 
-			if (*host_search && !strstr(d->host, host_search))
-				continue;
-			if (*name_search && !isname(name_search, GET_NAME(character)))
-				continue;
-			if (!CAN_SEE(ch, character) || GET_LEVEL(character) < low || GET_LEVEL(character) > high)
-				continue;
-			if (outlaws && !PLR_FLAGGED((ch), PLR_KILLER))
-				continue;
-			if (showclass && !(showclass & (1 << GET_CLASS(character))))
-				continue;
-			if (GET_INVIS_LEV(character) > GET_LEVEL(ch))
-				continue;
+      if (*host_search && !strstr(d->host, host_search))
+        continue;
+      if (*name_search && !isname(name_search, GET_NAME(character)))
+        continue;
+      if (!CAN_SEE(ch, character) || GET_LEVEL(character) < low || GET_LEVEL(character) > high)
+        continue;
+      if (outlaws && !PLR_FLAGGED((ch), PLR_KILLER))
+        continue;
+      if (showclass && !(showclass & (1 << GET_CLASS(character))))
+        continue;
+      if (GET_INVIS_LEV(character) > GET_LEVEL(ch))
+        continue;
 
-			if (d->original)
-				if (showremorts)
-					sprintf(classname, "[%2d %2d %s %s]", GET_LEVEL(d->original), GET_REMORT(d->original), KIN_ABBR(d->original), CLASS_ABBR(d->original));
-				else
-					sprintf(classname, "[%2d %s %s]   ", GET_LEVEL(d->original), KIN_ABBR(d->original), CLASS_ABBR(d->original));
-			else
-				if (showremorts)
-					sprintf(classname, "[%2d %2d %s %s]", GET_LEVEL(d->character), GET_REMORT(d->character), KIN_ABBR(d->character), CLASS_ABBR(d->character));
-				else
-					sprintf(classname, "[%2d %s %s]   ", GET_LEVEL(d->character), KIN_ABBR(d->character), CLASS_ABBR(d->character));
-		}
-		else
-		{
-			strcpy(classname, "      -      ");
-		}
+      if (d->original)
+        if (showremorts)
+          sprintf(classname,
+                  "[%2d %2d %s %s]",
+                  GET_LEVEL(d->original),
+                  GET_REMORT(d->original),
+                  KIN_ABBR(d->original),
+                  CLASS_ABBR(d->original));
+        else
+          sprintf(classname, "[%2d %s %s]   ", GET_LEVEL(d->original), KIN_ABBR(d->original), CLASS_ABBR(d->original));
+      else if (showremorts)
+        sprintf(classname,
+                "[%2d %2d %s %s]",
+                GET_LEVEL(d->character),
+                GET_REMORT(d->character),
+                KIN_ABBR(d->character),
+                CLASS_ABBR(d->character));
+      else
+        sprintf(classname, "[%2d %s %s]   ", GET_LEVEL(d->character), KIN_ABBR(d->character), CLASS_ABBR(d->character));
+    } else {
+      strcpy(classname, "      -      ");
+    }
 
-		if (GET_LEVEL(ch) < LVL_IMPL && !PRF_FLAGGED(ch, PRF_CODERINFO))
-		{
-			strcpy(classname, "      -      ");
-		}
+    if (GET_LEVEL(ch) < LVL_IMPL && !PRF_FLAGGED(ch, PRF_CODERINFO)) {
+      strcpy(classname, "      -      ");
+    }
 
-		timeptr = asctime(localtime(&d->login_time));
-		timeptr += 11;
-		*(timeptr + 8) = '\0';
+    timeptr = asctime(localtime(&d->login_time));
+    timeptr += 11;
+    *(timeptr + 8) = '\0';
 
-		if (STATE(d) == CON_PLAYING && d->original)
-			strcpy(state, "Switched");
-		else
-			sprinttype(STATE(d), connected_types, state);
+    if (STATE(d) == CON_PLAYING && d->original)
+      strcpy(state, "Switched");
+    else
+      sprinttype(STATE(d), connected_types, state);
 
-		if (d->character
-			&& STATE(d) == CON_PLAYING
-			&& !IS_GOD(d->character))
-		{
-			sprintf(idletime, "%3d", d->character->char_specials.timer *
-				SECS_PER_MUD_HOUR / SECS_PER_REAL_MIN);
-		}
-		else
-		{
-			strcpy(idletime, "");
-		}
+    if (d->character
+        && STATE(d) == CON_PLAYING
+        && !IS_GOD(d->character)) {
+      sprintf(idletime, "%3d", d->character->char_specials.timer *
+          SECS_PER_MUD_HOUR / SECS_PER_REAL_MIN);
+    } else {
+      strcpy(idletime, "");
+    }
 
-		if (d->character
-			&& d->character->get_pc_name().c_str())
-		{
-			if (d->original)
-			{
-				sprintf(line, format, d->desc_num, classname, d->original->get_pc_name().c_str(), state, idletime, timeptr);
-			}
-			else
-			{
-				sprintf(line, format, d->desc_num, classname, d->character->get_pc_name().c_str(), state, idletime, timeptr);
-			}
-		}
-		else
-		{
-			sprintf(line, format, d->desc_num, "   -   ", "UNDEFINED", state, idletime, timeptr);
-		}
+    if (d->character
+        && d->character->get_pc_name().c_str()) {
+      if (d->original) {
+        sprintf(line, format, d->desc_num, classname, d->original->get_pc_name().c_str(), state, idletime, timeptr);
+      } else {
+        sprintf(line, format, d->desc_num, classname, d->character->get_pc_name().c_str(), state, idletime, timeptr);
+      }
+    } else {
+      sprintf(line, format, d->desc_num, "   -   ", "UNDEFINED", state, idletime, timeptr);
+    }
 
 // Хорс
-		if (d && *d->host)
-		{
-			sprintf(line2, "[%s]", d->host);
-			strcat(line, line2);
-		}
-		else
-		{
-			strcat(line, "[Неизвестный хост]");
-		}
+    if (d && *d->host) {
+      sprintf(line2, "[%s]", d->host);
+      strcat(line, line2);
+    } else {
+      strcat(line, "[Неизвестный хост]");
+    }
 
-		if (showemail)
-		{
-			sprintf(line2, "[&S%s&s]",
-					d->original ? GET_EMAIL(d->original) : d->character ? GET_EMAIL(d->character) : "");
-			strcat(line, line2);
-		}
+    if (showemail) {
+      sprintf(line2, "[&S%s&s]",
+              d->original ? GET_EMAIL(d->original) : d->character ? GET_EMAIL(d->character) : "");
+      strcat(line, line2);
+    }
 
-		if (locating && (*name_search || *host_by_name))
-		{
-			if (STATE(d) == CON_PLAYING)
-			{
-				const auto ci = d->get_character();
-				if (ci
-					&& CAN_SEE(ch, ci)
-					&& ci->in_room != NOWHERE)
-				{
-					if (d->original && d->character)
-					{
-						sprintf(line2, " [%5d] %s (in %s)",
-							GET_ROOM_VNUM(IN_ROOM(d->character)),
-							world[d->character->in_room]->name, GET_NAME(d->character));
-					}
-					else
-					{
-						sprintf(line2, " [%5d] %s",
-							GET_ROOM_VNUM(IN_ROOM(ci)), world[ci->in_room]->name);
-					}
-				}
+    if (locating && (*name_search || *host_by_name)) {
+      if (STATE(d) == CON_PLAYING) {
+        const auto ci = d->get_character();
+        if (ci
+            && CAN_SEE(ch, ci)
+            && ci->in_room != NOWHERE) {
+          if (d->original && d->character) {
+            sprintf(line2, " [%5d] %s (in %s)",
+                    GET_ROOM_VNUM(IN_ROOM(d->character)),
+                    world[d->character->in_room]->name, GET_NAME(d->character));
+          } else {
+            sprintf(line2, " [%5d] %s",
+                    GET_ROOM_VNUM(IN_ROOM(ci)), world[ci->in_room]->name);
+          }
+        }
 
-				strcat(line, line2);
-			}
-		}
+        strcat(line, line2);
+      }
+    }
 
 //--
-		strcat(line, "\r\n");
-		if (STATE(d) != CON_PLAYING)
-		{
-			sprintf(line2, "%s%s%s", CCGRN(ch, C_SPR), line, CCNRM(ch, C_SPR));
-			strcpy(line, line2);
-		}
+    strcat(line, "\r\n");
+    if (STATE(d) != CON_PLAYING) {
+      sprintf(line2, "%s%s%s", CCGRN(ch, C_SPR), line, CCNRM(ch, C_SPR));
+      strcpy(line, line2);
+    }
 
-		if (STATE(d) != CON_PLAYING || (STATE(d) == CON_PLAYING && d->character && CAN_SEE(ch, d->character)))
-		{
-			send_to_char(line, ch);
-			num_can_see++;
-		}
-	}
+    if (STATE(d) != CON_PLAYING || (STATE(d) == CON_PLAYING && d->character && CAN_SEE(ch, d->character))) {
+      send_to_char(line, ch);
+      num_can_see++;
+    }
+  }
 
-	sprintf(line, "\r\n%d видимых соединений.\r\n", num_can_see);
-	page_string(ch->desc, line, TRUE);
+  sprintf(line, "\r\n%d видимых соединений.\r\n", num_can_see);
+  page_string(ch->desc, line, TRUE);
 }
 
 void sendWhoami(CHAR_DATA *ch) {
-    sprintf(buf, "Персонаж : %s\r\n", GET_NAME(ch));
-    sprintf(buf + strlen(buf),
-            "Падежи : &W%s&n/&W%s&n/&W%s&n/&W%s&n/&W%s&n/&W%s&n\r\n",
-            ch->get_name().c_str(), GET_PAD(ch, 1), GET_PAD(ch, 2),
-            GET_PAD(ch, 3), GET_PAD(ch, 4), GET_PAD(ch, 5));
+  sprintf(buf, "Персонаж : %s\r\n", GET_NAME(ch));
+  sprintf(buf + strlen(buf),
+          "Падежи : &W%s&n/&W%s&n/&W%s&n/&W%s&n/&W%s&n/&W%s&n\r\n",
+          ch->get_name().c_str(), GET_PAD(ch, 1), GET_PAD(ch, 2),
+          GET_PAD(ch, 3), GET_PAD(ch, 4), GET_PAD(ch, 5));
 
-    sprintf(buf + strlen(buf), "Ваш e-mail : &S%s&s\r\n", GET_EMAIL(ch));
-    time_t birt = ch->player_data.time.birth;
-    sprintf(buf + strlen(buf), "Дата вашего рождения : %s\r\n", rustime(localtime(&birt)));
-    sprintf(buf + strlen(buf), "Ваш IP-адрес : %s\r\n", ch->desc ? ch->desc->host : "Unknown");
+  sprintf(buf + strlen(buf), "Ваш e-mail : &S%s&s\r\n", GET_EMAIL(ch));
+  time_t birt = ch->player_data.time.birth;
+  sprintf(buf + strlen(buf), "Дата вашего рождения : %s\r\n", rustime(localtime(&birt)));
+  sprintf(buf + strlen(buf), "Ваш IP-адрес : %s\r\n", ch->desc ? ch->desc->host : "Unknown");
+  send_to_char(buf, ch);
+  if (!NAME_GOD(ch)) {
+    sprintf(buf, "Имя никем не одобрено!\r\n");
     send_to_char(buf, ch);
-    if (!NAME_GOD(ch))
-    {
-        sprintf(buf, "Имя никем не одобрено!\r\n");
-        send_to_char(buf, ch);
-    }
+  } else {
+    const int god_level = NAME_GOD(ch) > 1000 ? NAME_GOD(ch) - 1000 : NAME_GOD(ch);
+    sprintf(buf1, "%s", get_name_by_id(NAME_ID_GOD(ch)));
+    *buf1 = UPPER(*buf1);
+
+    static const char *by_rank_god = "Богом";
+    static const char *by_rank_privileged = "привилегированным игроком";
+    const char *by_rank = god_level < LVL_IMMORT ? by_rank_privileged : by_rank_god;
+
+    if (NAME_GOD(ch) < 1000)
+      snprintf(buf, MAX_STRING_LENGTH, "&RИмя запрещено %s %s&n\r\n", by_rank, buf1);
     else
-    {
-        const int god_level = NAME_GOD(ch) > 1000 ? NAME_GOD(ch) - 1000 : NAME_GOD(ch);
-        sprintf(buf1, "%s", get_name_by_id(NAME_ID_GOD(ch)));
-        *buf1 = UPPER(*buf1);
-
-        static const char *by_rank_god = "Богом";
-        static const char *by_rank_privileged = "привилегированным игроком";
-        const char * by_rank = god_level < LVL_IMMORT ?  by_rank_privileged : by_rank_god;
-
-        if (NAME_GOD(ch) < 1000)
-            snprintf(buf, MAX_STRING_LENGTH, "&RИмя запрещено %s %s&n\r\n", by_rank, buf1);
-        else
-            snprintf(buf, MAX_STRING_LENGTH, "&WИмя одобрено %s %s&n\r\n", by_rank, buf1);
-        send_to_char(buf, ch);
-    }
-    sprintf(buf, "Перевоплощений: %d\r\n", GET_REMORT(ch));
+      snprintf(buf, MAX_STRING_LENGTH, "&WИмя одобрено %s %s&n\r\n", by_rank, buf1);
     send_to_char(buf, ch);
-    Clan::CheckPkList(ch);
-    if (ch->player_specials->saved.telegram_id != 0) { //тут прямое обращение, ибо базовый класс, а не наследник
-        send_to_char(ch, "Подключен Телеграм, chat_id: %lu\r\n", ch->player_specials->saved.telegram_id);
-    }
+  }
+  sprintf(buf, "Перевоплощений: %d\r\n", GET_REMORT(ch));
+  send_to_char(buf, ch);
+  Clan::CheckPkList(ch);
+  if (ch->player_specials->saved.telegram_id != 0) { //тут прямое обращение, ибо базовый класс, а не наследник
+    send_to_char(ch, "Подключен Телеграм, chat_id: %lu\r\n", ch->player_specials->saved.telegram_id);
+  }
 
 }
 
 // Generic page_string function for displaying text
-void do_gen_ps(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int subcmd)
-{
-	//DESCRIPTOR_DATA *d;
-	switch (subcmd)
-	{
-	case SCMD_CREDITS:
-		page_string(ch->desc, credits, 0);
-		break;
-	case SCMD_INFO:
-		page_string(ch->desc, info, 0);
-		break;
-	case SCMD_IMMLIST:
-		page_string(ch->desc, immlist, 0);
-		break;
-	case SCMD_HANDBOOK:
-		page_string(ch->desc, handbook, 0);
-		break;
-	case SCMD_POLICIES:
-		page_string(ch->desc, policies, 0);
-		break;
-	case SCMD_MOTD:
-		page_string(ch->desc, motd, 0);
-		break;
-	case SCMD_RULES:
-		page_string(ch->desc, rules, 0);
-		break;
-	case SCMD_CLEAR:
-		send_to_char("\033[H\033[J", ch);
-		break;
-	case SCMD_VERSION:
-		show_code_date(ch);
-		break;
-	case SCMD_WHOAMI:
-	{
-        sendWhoami(ch);
-		break;
-	}
-	default:
-		log("SYSERR: Unhandled case in do_gen_ps. (%d)", subcmd);
-		return;
-	}
+void do_gen_ps(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int subcmd) {
+  //DESCRIPTOR_DATA *d;
+  switch (subcmd) {
+    case SCMD_CREDITS: page_string(ch->desc, credits, 0);
+      break;
+    case SCMD_INFO: page_string(ch->desc, info, 0);
+      break;
+    case SCMD_IMMLIST: page_string(ch->desc, immlist, 0);
+      break;
+    case SCMD_HANDBOOK: page_string(ch->desc, handbook, 0);
+      break;
+    case SCMD_POLICIES: page_string(ch->desc, policies, 0);
+      break;
+    case SCMD_MOTD: page_string(ch->desc, motd, 0);
+      break;
+    case SCMD_RULES: page_string(ch->desc, rules, 0);
+      break;
+    case SCMD_CLEAR: send_to_char("\033[H\033[J", ch);
+      break;
+    case SCMD_VERSION: show_code_date(ch);
+      break;
+    case SCMD_WHOAMI: {
+      sendWhoami(ch);
+      break;
+    }
+    default: log("SYSERR: Unhandled case in do_gen_ps. (%d)", subcmd);
+      return;
+  }
 }
 
-void perform_mortal_where(CHAR_DATA * ch, char *arg)
-{
-	DESCRIPTOR_DATA *d;
+void perform_mortal_where(CHAR_DATA *ch, char *arg) {
+  DESCRIPTOR_DATA *d;
 
-	send_to_char("Кто много знает, тот плохо спит.\r\n", ch);
-	return;
+  send_to_char("Кто много знает, тот плохо спит.\r\n", ch);
+  return;
 
-	if (!*arg)
-	{
-		send_to_char("Игроки, находящиеся в зоне\r\n--------------------\r\n", ch);
-		for (d = descriptor_list; d; d = d->next)
-		{
-			if (STATE(d) != CON_PLAYING
-				|| d->character.get() == ch)
-			{
-				continue;
-			}
+  if (!*arg) {
+    send_to_char("Игроки, находящиеся в зоне\r\n--------------------\r\n", ch);
+    for (d = descriptor_list; d; d = d->next) {
+      if (STATE(d) != CON_PLAYING
+          || d->character.get() == ch) {
+        continue;
+      }
 
-			const auto i = d->get_character();
-			if (!i)
-			{
-				continue;
-			}
+      const auto i = d->get_character();
+      if (!i) {
+        continue;
+      }
 
-			if (i->in_room == NOWHERE
-				|| !CAN_SEE(ch, i))
-			{
-				continue;
-			}
+      if (i->in_room == NOWHERE
+          || !CAN_SEE(ch, i)) {
+        continue;
+      }
 
-			if (world[ch->in_room]->zone != world[i->in_room]->zone)
-			{
-				continue;
-			}
+      if (world[ch->in_room]->zone != world[i->in_room]->zone) {
+        continue;
+      }
 
-			sprintf(buf, "%-20s - %s\r\n", GET_NAME(i), world[i->in_room]->name);
-			send_to_char(buf, ch);
-		}
-	}
-	else  		// print only FIRST char, not all.
-	{
-		for (const auto i : character_list)
-		{
-			if (i->in_room == NOWHERE
-				|| i.get() == ch)
-			{
-				continue;
-			}
+      sprintf(buf, "%-20s - %s\r\n", GET_NAME(i), world[i->in_room]->name);
+      send_to_char(buf, ch);
+    }
+  } else        // print only FIRST char, not all.
+  {
+    for (const auto i : character_list) {
+      if (i->in_room == NOWHERE
+          || i.get() == ch) {
+        continue;
+      }
 
-			if (!CAN_SEE(ch, i)
-				|| world[i->in_room]->zone != world[ch->in_room]->zone)
-			{
-				continue;
-			}
+      if (!CAN_SEE(ch, i)
+          || world[i->in_room]->zone != world[ch->in_room]->zone) {
+        continue;
+      }
 
-			if (!isname(arg, i->get_pc_name()))
-			{
-				continue;
-			}
+      if (!isname(arg, i->get_pc_name())) {
+        continue;
+      }
 
-			sprintf(buf, "%-25s - %s\r\n", GET_NAME(i), world[i->in_room]->name);
-			send_to_char(buf, ch);
-			return;
-		}
-		send_to_char("Никого похожего с этим именем нет.\r\n", ch);
-	}
+      sprintf(buf, "%-25s - %s\r\n", GET_NAME(i), world[i->in_room]->name);
+      send_to_char(buf, ch);
+      return;
+    }
+    send_to_char("Никого похожего с этим именем нет.\r\n", ch);
+  }
 }
 
-void print_object_location(int num, const OBJ_DATA * obj, CHAR_DATA * ch)
-{
-	if (num > 0)
-	{
-		sprintf(buf, "%2d. ", num);
-		if(IS_GRGOD(ch))
-		{
-			sprintf(buf2, "[%6d] %-25s - ", GET_OBJ_VNUM(obj), obj->get_short_description().c_str());
-			strcat(buf, buf2);
-		}
-		else
-		{
-			sprintf(buf2, "%-34s - ", obj->get_short_description().c_str());
-			strcat(buf, buf2);
-		}
-	}
-	else
-	{
-		sprintf(buf, "%41s", " - ");
-	}
+void print_object_location(int num, const OBJ_DATA *obj, CHAR_DATA *ch) {
+  if (num > 0) {
+    sprintf(buf, "%2d. ", num);
+    if (IS_GRGOD(ch)) {
+      sprintf(buf2, "[%6d] %-25s - ", GET_OBJ_VNUM(obj), obj->get_short_description().c_str());
+      strcat(buf, buf2);
+    } else {
+      sprintf(buf2, "%-34s - ", obj->get_short_description().c_str());
+      strcat(buf, buf2);
+    }
+  } else {
+    sprintf(buf, "%41s", " - ");
+  }
 
-	if (obj->get_in_room() > NOWHERE)
-	{
-		sprintf(buf + strlen(buf), "[%5d] %s", GET_ROOM_VNUM(obj->get_in_room()), world[obj->get_in_room()]->name);
-		strcat(buf, "\r\n");
-		send_to_char(buf, ch);
-	}
-	else if (obj->get_carried_by())
-	{
-		sprintf(buf + strlen(buf), "затарено %s[%d] в комнате [%d]",
-			PERS(obj->get_carried_by(), ch, 4),
-			GET_MOB_VNUM(obj->get_carried_by()),
-			world[obj->get_carried_by()->in_room]->number);
-		strcat(buf, "\r\n");
-		send_to_char(buf, ch);
-	}
-	else if (obj->get_worn_by())
-	{
-		sprintf(buf + strlen(buf), "надет на %s[%d] в комнате [%d]",
-			PERS(obj->get_worn_by(), ch, 3),
-			GET_MOB_VNUM(obj->get_worn_by()),
-			world[obj->get_worn_by()->in_room]->number);
-		strcat(buf, "\r\n");
-		send_to_char(buf, ch);
-	}
-	else if (obj->get_in_obj())
-	{
-		if (Clan::is_clan_chest(obj->get_in_obj()))// || Clan::is_ingr_chest(obj->get_in_obj())) сделать отдельный поиск
-		{
-			return; // шоб не забивало локейт на мобах/плеерах - по кланам проходим ниже отдельно
-		}
-		else
-		{
-			sprintf(buf + strlen(buf), "лежит в [%d]%s, который находится \r\n",
-				GET_OBJ_VNUM(obj->get_in_obj()), obj->get_in_obj()->get_PName(5).c_str());
-			send_to_char(buf, ch);
-			print_object_location(0, obj->get_in_obj(), ch);
-		}
-	}
-	else
-	{
-		sprintf(buf + strlen(buf), "находится где-то там, далеко-далеко.");
-		strcat(buf, "\r\n");
-		send_to_char(buf, ch);
-	}
+  if (obj->get_in_room() > NOWHERE) {
+    sprintf(buf + strlen(buf), "[%5d] %s", GET_ROOM_VNUM(obj->get_in_room()), world[obj->get_in_room()]->name);
+    strcat(buf, "\r\n");
+    send_to_char(buf, ch);
+  } else if (obj->get_carried_by()) {
+    sprintf(buf + strlen(buf), "затарено %s[%d] в комнате [%d]",
+            PERS(obj->get_carried_by(), ch, 4),
+            GET_MOB_VNUM(obj->get_carried_by()),
+            world[obj->get_carried_by()->in_room]->number);
+    strcat(buf, "\r\n");
+    send_to_char(buf, ch);
+  } else if (obj->get_worn_by()) {
+    sprintf(buf + strlen(buf), "надет на %s[%d] в комнате [%d]",
+            PERS(obj->get_worn_by(), ch, 3),
+            GET_MOB_VNUM(obj->get_worn_by()),
+            world[obj->get_worn_by()->in_room]->number);
+    strcat(buf, "\r\n");
+    send_to_char(buf, ch);
+  } else if (obj->get_in_obj()) {
+    if (Clan::is_clan_chest(obj->get_in_obj()))// || Clan::is_ingr_chest(obj->get_in_obj())) сделать отдельный поиск
+    {
+      return; // шоб не забивало локейт на мобах/плеерах - по кланам проходим ниже отдельно
+    } else {
+      sprintf(buf + strlen(buf), "лежит в [%d]%s, который находится \r\n",
+              GET_OBJ_VNUM(obj->get_in_obj()), obj->get_in_obj()->get_PName(5).c_str());
+      send_to_char(buf, ch);
+      print_object_location(0, obj->get_in_obj(), ch);
+    }
+  } else {
+    sprintf(buf + strlen(buf), "находится где-то там, далеко-далеко.");
+    strcat(buf, "\r\n");
+    send_to_char(buf, ch);
+  }
 }
 
 /**
 * Иммский поиск шмоток по 'где' с проходом как по глобальному списку, так
 * и по спискам хранилищ и почты.
 */
-bool print_imm_where_obj(CHAR_DATA *ch, char *arg, int num)
-{
-	bool found = false;
+bool print_imm_where_obj(CHAR_DATA *ch, char *arg, int num) {
+  bool found = false;
 
-	world_objects.foreach([&](const OBJ_DATA::shared_ptr object)	/* maybe it is possible to create some index instead of linear search */
-	{
-		if (isname(arg, object->get_aliases()))
-		{
-			found = true;
-			print_object_location(num++, object.get(), ch);
-		}
-	});
+  world_objects.foreach([&](const OBJ_DATA::shared_ptr object)    /* maybe it is possible to create some index instead of linear search */
+                        {
+                          if (isname(arg, object->get_aliases())) {
+                            found = true;
+                            print_object_location(num++, object.get(), ch);
+                          }
+                        });
 
-	int tmp_num = num;
-	if (IS_GOD(ch)
-		|| PRF_FLAGGED(ch, PRF_CODERINFO))
-	{
-		tmp_num = Clan::print_spell_locate_object(ch, tmp_num, arg);
-		tmp_num = Depot::print_imm_where_obj(ch, arg, tmp_num);
-		tmp_num = Parcel::print_imm_where_obj(ch, arg, tmp_num);
-	}
+  int tmp_num = num;
+  if (IS_GOD(ch)
+      || PRF_FLAGGED(ch, PRF_CODERINFO)) {
+    tmp_num = Clan::print_spell_locate_object(ch, tmp_num, arg);
+    tmp_num = Depot::print_imm_where_obj(ch, arg, tmp_num);
+    tmp_num = Parcel::print_imm_where_obj(ch, arg, tmp_num);
+  }
 
-	if (!found
-		&& tmp_num == num)
-	{
-		return false;
-	}
-	else
-	{
-		num = tmp_num;
-		return true;
-	}
+  if (!found
+      && tmp_num == num) {
+    return false;
+  } else {
+    num = tmp_num;
+    return true;
+  }
 }
 
-void perform_immort_where(CHAR_DATA * ch, char *arg)
-{
-	DESCRIPTOR_DATA *d;
-	int num = 1, found = 0;
+void perform_immort_where(CHAR_DATA *ch, char *arg) {
+  DESCRIPTOR_DATA *d;
+  int num = 1, found = 0;
 
-	if (!*arg)
-	{
-		if (GET_LEVEL(ch) < LVL_IMPL && !PRF_FLAGGED(ch, PRF_CODERINFO))
-		{
-			send_to_char("Где КТО конкретно?", ch);
-		}
-		else
-		{
-			send_to_char("ИГРОКИ\r\n------\r\n", ch);
-			for (d = descriptor_list; d; d = d->next)
-			{
-				if (STATE(d) == CON_PLAYING)
-				{
-					const auto i = d->get_character();
-					if (i && CAN_SEE(ch, i) && (i->in_room != NOWHERE))
-					{
-						if (d->original)
-						{
-							sprintf(buf, "%-20s - [%5d] %s (in %s)\r\n",
-								GET_NAME(i),
-								GET_ROOM_VNUM(IN_ROOM(d->character)),
-								world[d->character->in_room]->name,
-								GET_NAME(d->character));
-						}
-						else
-						{
-							sprintf(buf, "%-20s - [%5d] %s\r\n", GET_NAME(i),
-								GET_ROOM_VNUM(IN_ROOM(i)), world[i->in_room]->name);
-						}
-						send_to_char(buf, ch);
-					}
-				}
-			}
-		}
-	}
-	else
-	{
-		for (const auto i : character_list)
-		{
-			if (CAN_SEE(ch, i)
-				&& i->in_room != NOWHERE
-				&& isname(arg, i->get_pc_name()))
-			{
-			    ZoneData *zone = &zone_table[world[i->in_room]->zone];
-				found = 1;
-				sprintf(buf, "%s%3d. %-25s - [%5d] %s. Название зоны: '%s'\r\n", IS_NPC(i)? "Моб:  ":"Игрок:", num++, GET_NAME(i),
-						GET_ROOM_VNUM(IN_ROOM(i)), world[IN_ROOM(i)]->name, zone->name);
-				send_to_char(buf, ch);
-			}
-		}
+  if (!*arg) {
+    if (GET_LEVEL(ch) < LVL_IMPL && !PRF_FLAGGED(ch, PRF_CODERINFO)) {
+      send_to_char("Где КТО конкретно?", ch);
+    } else {
+      send_to_char("ИГРОКИ\r\n------\r\n", ch);
+      for (d = descriptor_list; d; d = d->next) {
+        if (STATE(d) == CON_PLAYING) {
+          const auto i = d->get_character();
+          if (i && CAN_SEE(ch, i) && (i->in_room != NOWHERE)) {
+            if (d->original) {
+              sprintf(buf, "%-20s - [%5d] %s (in %s)\r\n",
+                      GET_NAME(i),
+                      GET_ROOM_VNUM(IN_ROOM(d->character)),
+                      world[d->character->in_room]->name,
+                      GET_NAME(d->character));
+            } else {
+              sprintf(buf, "%-20s - [%5d] %s\r\n", GET_NAME(i),
+                      GET_ROOM_VNUM(IN_ROOM(i)), world[i->in_room]->name);
+            }
+            send_to_char(buf, ch);
+          }
+        }
+      }
+    }
+  } else {
+    for (const auto i : character_list) {
+      if (CAN_SEE(ch, i)
+          && i->in_room != NOWHERE
+          && isname(arg, i->get_pc_name())) {
+        ZoneData *zone = &zone_table[world[i->in_room]->zone];
+        found = 1;
+        sprintf(buf,
+                "%s%3d. %-25s - [%5d] %s. Название зоны: '%s'\r\n",
+                IS_NPC(i) ? "Моб:  " : "Игрок:",
+                num++,
+                GET_NAME(i),
+                GET_ROOM_VNUM(IN_ROOM(i)),
+                world[IN_ROOM(i)]->name,
+                zone->name);
+        send_to_char(buf, ch);
+      }
+    }
 
-		if (!print_imm_where_obj(ch, arg, num)
-			&& !found)
-		{
-			send_to_char("Нет ничего похожего.\r\n", ch);
-		}
-	}
+    if (!print_imm_where_obj(ch, arg, num)
+        && !found) {
+      send_to_char("Нет ничего похожего.\r\n", ch);
+    }
+  }
 }
 
-void do_where(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	one_argument(argument, arg);
+void do_where(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  one_argument(argument, arg);
 
-	if (IS_GRGOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-		perform_immort_where(ch, arg);
-	else
-		perform_mortal_where(ch, arg);
+  if (IS_GRGOD(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
+    perform_immort_where(ch, arg);
+  else
+    perform_mortal_where(ch, arg);
 }
 
-void do_levels(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int i;
-	char *ptr = &buf[0];
+void do_levels(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int i;
+  char *ptr = &buf[0];
 
-	if (IS_NPC(ch))
-	{
-		send_to_char("Боги уже придумали ваш уровень.\r\n", ch);
-		return;
-	}
-	*ptr = '\0';
+  if (IS_NPC(ch)) {
+    send_to_char("Боги уже придумали ваш уровень.\r\n", ch);
+    return;
+  }
+  *ptr = '\0';
 
-	ptr += sprintf(ptr, "Уровень          Опыт            Макс на урв.\r\n");
-	for (i = 1; i < LVL_IMMORT; i++)
-	{
-		ptr += sprintf(ptr, "%s[%2d] %13s-%-13s %-13s%s\r\n", (ch->get_level() == i) ? CCICYN(ch, C_NRM) : "", i,
-			thousands_sep(level_exp(ch, i)).c_str(),
-			thousands_sep(level_exp(ch, i + 1) - 1).c_str(),
-			thousands_sep((int) (level_exp(ch, i + 1) - level_exp(ch, i)) / (10 + GET_REMORT(ch))).c_str(),
-			(ch->get_level() == i) ? CCNRM(ch, C_NRM) : "");
-	}
+  ptr += sprintf(ptr, "Уровень          Опыт            Макс на урв.\r\n");
+  for (i = 1; i < LVL_IMMORT; i++) {
+    ptr += sprintf(ptr, "%s[%2d] %13s-%-13s %-13s%s\r\n", (ch->get_level() == i) ? CCICYN(ch, C_NRM) : "", i,
+                   thousands_sep(level_exp(ch, i)).c_str(),
+                   thousands_sep(level_exp(ch, i + 1) - 1).c_str(),
+                   thousands_sep((int) (level_exp(ch, i + 1) - level_exp(ch, i)) / (10 + GET_REMORT(ch))).c_str(),
+                   (ch->get_level() == i) ? CCNRM(ch, C_NRM) : "");
+  }
 
-	ptr += sprintf(ptr, "%s[%2d] %13s               (БЕССМЕРТИЕ)%s\r\n",
-		(ch->get_level() >= LVL_IMMORT) ? CCICYN(ch, C_NRM) : "", LVL_IMMORT,
-		thousands_sep(level_exp(ch, LVL_IMMORT)).c_str(),
-		(ch->get_level() >= LVL_IMMORT) ? CCNRM(ch, C_NRM) : "");
-	page_string(ch->desc, buf, 1);
+  ptr += sprintf(ptr, "%s[%2d] %13s               (БЕССМЕРТИЕ)%s\r\n",
+                 (ch->get_level() >= LVL_IMMORT) ? CCICYN(ch, C_NRM) : "", LVL_IMMORT,
+                 thousands_sep(level_exp(ch, LVL_IMMORT)).c_str(),
+                 (ch->get_level() >= LVL_IMMORT) ? CCNRM(ch, C_NRM) : "");
+  page_string(ch->desc, buf, 1);
 }
 
-void do_consider(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	CHAR_DATA *victim;
-	int diff;
+void do_consider(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *victim;
+  int diff;
 
-	one_argument(argument, buf);
+  one_argument(argument, buf);
 
-	if (!(victim = get_char_vis(ch, buf, FIND_CHAR_ROOM)))
-	{
-		send_to_char("Кого вы хотите оценить?\r\n", ch);
-		return;
-	}
-	if (victim == ch)
-	{
-		send_to_char("Легко! Выберите параметр <Удалить персонаж>!\r\n", ch);
-		return;
-	}
-	if (!IS_NPC(victim))
-	{
-		send_to_char("Оценивайте игроков сами - тут я не советчик.\r\n", ch);
-		return;
-	}
-	diff = (GET_LEVEL(victim) - GET_LEVEL(ch) - GET_REMORT(ch));
+  if (!(victim = get_char_vis(ch, buf, FIND_CHAR_ROOM))) {
+    send_to_char("Кого вы хотите оценить?\r\n", ch);
+    return;
+  }
+  if (victim == ch) {
+    send_to_char("Легко! Выберите параметр <Удалить персонаж>!\r\n", ch);
+    return;
+  }
+  if (!IS_NPC(victim)) {
+    send_to_char("Оценивайте игроков сами - тут я не советчик.\r\n", ch);
+    return;
+  }
+  diff = (GET_LEVEL(victim) - GET_LEVEL(ch) - GET_REMORT(ch));
 
-	if (diff <= -10)
-		send_to_char("Ути-пути, моя рыбонька.\r\n", ch);
-	else if (diff <= -5)
-		send_to_char("\"Сделаем без шуму и пыли!\"\r\n", ch);
-	else if (diff <= -2)
-		send_to_char("Легко.\r\n", ch);
-	else if (diff <= -1)
-		send_to_char("Сравнительно легко.\r\n", ch);
-	else if (diff == 0)
-		send_to_char("Равный поединок!\r\n", ch);
-	else if (diff <= 1)
-		send_to_char("Вам понадобится немного удачи!\r\n", ch);
-	else if (diff <= 2)
-		send_to_char("Вам потребуется везение!\r\n", ch);
-	else if (diff <= 3)
-		send_to_char("Удача и хорошее снаряжение вам сильно пригодятся!\r\n", ch);
-	else if (diff <= 5)
-		send_to_char("Вы берете на себя слишком много.\r\n", ch);
-	else if (diff <= 10)
-		send_to_char("Ладно, войдете еще раз.\r\n", ch);
-	else if (diff <= 100)
-		send_to_char("Срочно к психиатру - вы страдаете манией величия!\r\n", ch);
+  if (diff <= -10)
+    send_to_char("Ути-пути, моя рыбонька.\r\n", ch);
+  else if (diff <= -5)
+    send_to_char("\"Сделаем без шуму и пыли!\"\r\n", ch);
+  else if (diff <= -2)
+    send_to_char("Легко.\r\n", ch);
+  else if (diff <= -1)
+    send_to_char("Сравнительно легко.\r\n", ch);
+  else if (diff == 0)
+    send_to_char("Равный поединок!\r\n", ch);
+  else if (diff <= 1)
+    send_to_char("Вам понадобится немного удачи!\r\n", ch);
+  else if (diff <= 2)
+    send_to_char("Вам потребуется везение!\r\n", ch);
+  else if (diff <= 3)
+    send_to_char("Удача и хорошее снаряжение вам сильно пригодятся!\r\n", ch);
+  else if (diff <= 5)
+    send_to_char("Вы берете на себя слишком много.\r\n", ch);
+  else if (diff <= 10)
+    send_to_char("Ладно, войдете еще раз.\r\n", ch);
+  else if (diff <= 100)
+    send_to_char("Срочно к психиатру - вы страдаете манией величия!\r\n", ch);
 
 }
 
-void do_diagnose(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	CHAR_DATA *vict;
+void do_diagnose(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *vict;
 
-	one_argument(argument, buf);
+  one_argument(argument, buf);
 
-	if (*buf)
-	{
-		if (!(vict = get_char_vis(ch, buf, FIND_CHAR_ROOM)))
-			send_to_char(NOPERSON, ch);
-		else
-			diag_char_to_char(vict, ch);
-	}
-	else
-	{
-		if (ch->get_fighting())
-			diag_char_to_char(ch->get_fighting(), ch);
-		else
-			send_to_char("На кого вы хотите взглянуть?\r\n", ch);
-	}
+  if (*buf) {
+    if (!(vict = get_char_vis(ch, buf, FIND_CHAR_ROOM)))
+      send_to_char(NOPERSON, ch);
+    else
+      diag_char_to_char(vict, ch);
+  } else {
+    if (ch->get_fighting())
+      diag_char_to_char(ch->get_fighting(), ch);
+    else
+      send_to_char("На кого вы хотите взглянуть?\r\n", ch);
+  }
 }
 
-const char *ctypes[] = { "выключен", "простой", "обычный", "полный", "\n" };
+const char *ctypes[] = {"выключен", "простой", "обычный", "полный", "\n"};
 
-void do_toggle(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	if (IS_NPC(ch))
-		return;
-	if (GET_WIMP_LEV(ch) == 0)
-		strcpy(buf2, "нет");
-	else
-		sprintf(buf2, "%-3d", GET_WIMP_LEV(ch));
+void do_toggle(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  if (IS_NPC(ch))
+    return;
+  if (GET_WIMP_LEV(ch) == 0)
+    strcpy(buf2, "нет");
+  else
+    sprintf(buf2, "%-3d", GET_WIMP_LEV(ch));
 
-	if (GET_LEVEL(ch) >= LVL_IMMORT || PRF_FLAGGED(ch, PRF_CODERINFO))
-	{
-	snprintf(buf, MAX_STRING_LENGTH,
-				" Нет агров     : %-3s     "
-				" Супервидение  : %-3s     "
-				" Флаги комнат  : %-3s \r\n"
-				" Частный режим : %-3s     "
-				" Замедление    : %-3s     "
-				" Кодер         : %-3s \r\n"
-				" Опечатки      : %-3s \r\n",
-				ONOFF(PRF_FLAGGED(ch, PRF_NOHASSLE)),
-				ONOFF(PRF_FLAGGED(ch, PRF_HOLYLIGHT)),
-				ONOFF(PRF_FLAGGED(ch, PRF_ROOMFLAGS)),
-				ONOFF(PRF_FLAGGED(ch, PRF_NOWIZ)),
-				ONOFF(nameserver_is_slow),
-				ONOFF(PRF_FLAGGED(ch, PRF_CODERINFO)),
-				ONOFF(PRF_FLAGGED(ch, PRF_MISPRINT)));
-		send_to_char(buf, ch);
-	}
+  if (GET_LEVEL(ch) >= LVL_IMMORT || PRF_FLAGGED(ch, PRF_CODERINFO)) {
+    snprintf(buf, MAX_STRING_LENGTH,
+             " Нет агров     : %-3s     "
+             " Супервидение  : %-3s     "
+             " Флаги комнат  : %-3s \r\n"
+             " Частный режим : %-3s     "
+             " Замедление    : %-3s     "
+             " Кодер         : %-3s \r\n"
+             " Опечатки      : %-3s \r\n",
+             ONOFF(PRF_FLAGGED(ch, PRF_NOHASSLE)),
+             ONOFF(PRF_FLAGGED(ch, PRF_HOLYLIGHT)),
+             ONOFF(PRF_FLAGGED(ch, PRF_ROOMFLAGS)),
+             ONOFF(PRF_FLAGGED(ch, PRF_NOWIZ)),
+             ONOFF(nameserver_is_slow),
+             ONOFF(PRF_FLAGGED(ch, PRF_CODERINFO)),
+             ONOFF(PRF_FLAGGED(ch, PRF_MISPRINT)));
+    send_to_char(buf, ch);
+  }
 
-	snprintf(buf, MAX_STRING_LENGTH,
-			" Автовыходы    : %-3s     "
-			" Краткий режим : %-3s     "
-			" Сжатый режим  : %-3s \r\n"
-			" Повтор команд : %-3s     "
-			" Обращения     : %-3s     "
-			" Цвет          : %-8s \r\n"
-			" Кто-то        : %-6s  "
-			" Болтать       : %-3s     "
-			" Орать         : %-3s \r\n"
-			" Аукцион       : %-3s     "
-			" Базар         : %-3s     "
-			" Автозаучивание: %-3s \r\n"
-			" Призыв        : %-3s     "
-			" Автозавершение: %-3s     "
-			" Группа (вид)  : %-7s \r\n"
-			" Без двойников : %-3s     "
-			" Автопомощь    : %-3s     "
-			" Автодележ     : %-3s \r\n"
-			" Автограбеж    : %-7s "
-			" Брать куны    : %-3s     "
-			" Арена         : %-3s \r\n"
-			" Трусость      : %-3s     "
-			" Ширина экрана : %-3d     "
-			" Высота экрана : %-3d \r\n"
-			" Сжатие        : %-6s  "
-			" Новости (вид) : %-5s   "
-			" Доски         : %-3s \r\n"
-			" Хранилище     : %-8s"
-			" Пклист        : %-3s     "
-			" Политика      : %-3s \r\n"
-			" Пкформат      : %-6s  "
-			" Соклановцы    : %-8s"
-			" Оффтоп        : %-3s \r\n"
-			" Потеря связи  : %-3s     "
-			" Ингредиенты   : %-3s     "
-			" Вспомнить     : %-3u \r\n",
-			ONOFF(PRF_FLAGGED(ch, PRF_AUTOEXIT)),
-			ONOFF(PRF_FLAGGED(ch, PRF_BRIEF)),
-			ONOFF(PRF_FLAGGED(ch, PRF_COMPACT)),
-			YESNO(!PRF_FLAGGED(ch, PRF_NOREPEAT)),
-			ONOFF(!PRF_FLAGGED(ch, PRF_NOTELL)),
-			ctypes[COLOR_LEV(ch)],
-			PRF_FLAGGED(ch, PRF_NOINVISTELL) ? "нельзя" : "можно",
-			ONOFF(!PRF_FLAGGED(ch, PRF_NOGOSS)),
-			ONOFF(!PRF_FLAGGED(ch, PRF_NOHOLLER)),
-			ONOFF(!PRF_FLAGGED(ch, PRF_NOAUCT)),
-			ONOFF(!PRF_FLAGGED(ch, PRF_NOEXCHANGE)),
-			ONOFF(PRF_FLAGGED(ch, PRF_AUTOMEM)),
-			ONOFF(PRF_FLAGGED(ch, PRF_SUMMONABLE)),
-			ONOFF(PRF_FLAGGED(ch, PRF_GOAHEAD)),
-			PRF_FLAGGED(ch, PRF_SHOWGROUP) ? "полный" : "краткий",
-			ONOFF(PRF_FLAGGED(ch, PRF_NOCLONES)),
-			ONOFF(PRF_FLAGGED(ch, PRF_AUTOASSIST)),
-			ONOFF(PRF_FLAGGED(ch, PRF_AUTOSPLIT)),
-			PRF_FLAGGED(ch, PRF_AUTOLOOT) ? PRF_FLAGGED(ch, PRF_NOINGR_LOOT) ? "NO-INGR" : "ALL    " : "OFF    ",
-			ONOFF(PRF_FLAGGED(ch, PRF_AUTOMONEY)),
-			ONOFF(!PRF_FLAGGED(ch, PRF_NOARENA)),
-			buf2,
-			STRING_LENGTH(ch),
-			STRING_WIDTH(ch),
+  snprintf(buf, MAX_STRING_LENGTH,
+           " Автовыходы    : %-3s     "
+           " Краткий режим : %-3s     "
+           " Сжатый режим  : %-3s \r\n"
+           " Повтор команд : %-3s     "
+           " Обращения     : %-3s     "
+           " Цвет          : %-8s \r\n"
+           " Кто-то        : %-6s  "
+           " Болтать       : %-3s     "
+           " Орать         : %-3s \r\n"
+           " Аукцион       : %-3s     "
+           " Базар         : %-3s     "
+           " Автозаучивание: %-3s \r\n"
+           " Призыв        : %-3s     "
+           " Автозавершение: %-3s     "
+           " Группа (вид)  : %-7s \r\n"
+           " Без двойников : %-3s     "
+           " Автопомощь    : %-3s     "
+           " Автодележ     : %-3s \r\n"
+           " Автограбеж    : %-7s "
+           " Брать куны    : %-3s     "
+           " Арена         : %-3s \r\n"
+           " Трусость      : %-3s     "
+           " Ширина экрана : %-3d     "
+           " Высота экрана : %-3d \r\n"
+           " Сжатие        : %-6s  "
+           " Новости (вид) : %-5s   "
+           " Доски         : %-3s \r\n"
+           " Хранилище     : %-8s"
+           " Пклист        : %-3s     "
+           " Политика      : %-3s \r\n"
+           " Пкформат      : %-6s  "
+           " Соклановцы    : %-8s"
+           " Оффтоп        : %-3s \r\n"
+           " Потеря связи  : %-3s     "
+           " Ингредиенты   : %-3s     "
+           " Вспомнить     : %-3u \r\n",
+           ONOFF(PRF_FLAGGED(ch, PRF_AUTOEXIT)),
+           ONOFF(PRF_FLAGGED(ch, PRF_BRIEF)),
+           ONOFF(PRF_FLAGGED(ch, PRF_COMPACT)),
+           YESNO(!PRF_FLAGGED(ch, PRF_NOREPEAT)),
+           ONOFF(!PRF_FLAGGED(ch, PRF_NOTELL)),
+           ctypes[COLOR_LEV(ch)],
+           PRF_FLAGGED(ch, PRF_NOINVISTELL) ? "нельзя" : "можно",
+           ONOFF(!PRF_FLAGGED(ch, PRF_NOGOSS)),
+           ONOFF(!PRF_FLAGGED(ch, PRF_NOHOLLER)),
+           ONOFF(!PRF_FLAGGED(ch, PRF_NOAUCT)),
+           ONOFF(!PRF_FLAGGED(ch, PRF_NOEXCHANGE)),
+           ONOFF(PRF_FLAGGED(ch, PRF_AUTOMEM)),
+           ONOFF(PRF_FLAGGED(ch, PRF_SUMMONABLE)),
+           ONOFF(PRF_FLAGGED(ch, PRF_GOAHEAD)),
+           PRF_FLAGGED(ch, PRF_SHOWGROUP) ? "полный" : "краткий",
+           ONOFF(PRF_FLAGGED(ch, PRF_NOCLONES)),
+           ONOFF(PRF_FLAGGED(ch, PRF_AUTOASSIST)),
+           ONOFF(PRF_FLAGGED(ch, PRF_AUTOSPLIT)),
+           PRF_FLAGGED(ch, PRF_AUTOLOOT) ? PRF_FLAGGED(ch, PRF_NOINGR_LOOT) ? "NO-INGR" : "ALL    " : "OFF    ",
+           ONOFF(PRF_FLAGGED(ch, PRF_AUTOMONEY)),
+           ONOFF(!PRF_FLAGGED(ch, PRF_NOARENA)),
+           buf2,
+           STRING_LENGTH(ch),
+           STRING_WIDTH(ch),
 #if defined(HAVE_ZLIB)
-			ch->desc->deflate == NULL ? "нет" : (ch->desc->mccp_version == 2 ? "MCCPv2" : "MCCPv1"),
+           ch->desc->deflate == NULL ? "нет" : (ch->desc->mccp_version == 2 ? "MCCPv2" : "MCCPv1"),
 #else
-			"N/A",
+      "N/A",
 #endif
-			PRF_FLAGGED(ch, PRF_NEWS_MODE) ? "доска" : "лента",
-			ONOFF(PRF_FLAGGED(ch, PRF_BOARD_MODE)),
-			GetChestMode(ch).c_str(),
-			ONOFF(PRF_FLAGGED(ch, PRF_PKL_MODE)),
-			ONOFF(PRF_FLAGGED(ch, PRF_POLIT_MODE)),
-			PRF_FLAGGED(ch, PRF_PKFORMAT_MODE) ? "краткий" : "полный",
-			ONOFF(PRF_FLAGGED(ch, PRF_WORKMATE_MODE)),
-			ONOFF(PRF_FLAGGED(ch, PRF_OFFTOP_MODE)),
-			ONOFF(PRF_FLAGGED(ch, PRF_ANTIDC_MODE)),
-			ONOFF(PRF_FLAGGED(ch, PRF_NOINGR_MODE)),
-			ch->remember_get_num());
-	send_to_char(buf, ch);
-	if (NOTIFY_EXCH_PRICE(ch) > 0)
-	{
-		sprintf(buf,  " Уведомления   : %-7ld ", NOTIFY_EXCH_PRICE(ch));
-	}
-	else
-	{
-		sprintf(buf,  " Уведомления   : %-7s ", "Нет");
-	}
-	send_to_char(buf, ch);
-	snprintf(buf, MAX_STRING_LENGTH,
-		" Карта         : %-3s     "
-		" Вход в зону   : %-3s   \r\n"
-		" Магщиты (вид) : %-8s"
-		" Автопризыв    : %-5s   "
-		" Маппер        : %-3s   \r\n"
-		" Контроль IP   : %-6s  ",
-		ONOFF(PRF_FLAGGED(ch, PRF_DRAW_MAP)),
-		ONOFF(PRF_FLAGGED(ch, PRF_ENTER_ZONE)),
-		(PRF_FLAGGED(ch, PRF_BRIEF_SHIELDS) ? "краткий" : "полный"),
-		ONOFF(PRF_FLAGGED(ch, PRF_AUTO_NOSUMMON)),
-		ONOFF(PRF_FLAGGED(ch, PRF_MAPPER)),
-		ONOFF(PRF_FLAGGED(ch, PRF_IPCONTROL)));
-	send_to_char(buf, ch);
-	if (GET_GOD_FLAG(ch, GF_TESTER))
-		sprintf(buf, " Тестер        : %-3s\r\n", ONOFF(PRF_FLAGGED(ch, PRF_TESTER)));
-	else
-		sprintf(buf, "\r\n");
-	send_to_char(buf, ch);
+           PRF_FLAGGED(ch, PRF_NEWS_MODE) ? "доска" : "лента",
+           ONOFF(PRF_FLAGGED(ch, PRF_BOARD_MODE)),
+           GetChestMode(ch).c_str(),
+           ONOFF(PRF_FLAGGED(ch, PRF_PKL_MODE)),
+           ONOFF(PRF_FLAGGED(ch, PRF_POLIT_MODE)),
+           PRF_FLAGGED(ch, PRF_PKFORMAT_MODE) ? "краткий" : "полный",
+           ONOFF(PRF_FLAGGED(ch, PRF_WORKMATE_MODE)),
+           ONOFF(PRF_FLAGGED(ch, PRF_OFFTOP_MODE)),
+           ONOFF(PRF_FLAGGED(ch, PRF_ANTIDC_MODE)),
+           ONOFF(PRF_FLAGGED(ch, PRF_NOINGR_MODE)),
+           ch->remember_get_num());
+  send_to_char(buf, ch);
+  if (NOTIFY_EXCH_PRICE(ch) > 0) {
+    sprintf(buf, " Уведомления   : %-7ld ", NOTIFY_EXCH_PRICE(ch));
+  } else {
+    sprintf(buf, " Уведомления   : %-7s ", "Нет");
+  }
+  send_to_char(buf, ch);
+  snprintf(buf, MAX_STRING_LENGTH,
+           " Карта         : %-3s     "
+           " Вход в зону   : %-3s   \r\n"
+           " Магщиты (вид) : %-8s"
+           " Автопризыв    : %-5s   "
+           " Маппер        : %-3s   \r\n"
+           " Контроль IP   : %-6s  ",
+           ONOFF(PRF_FLAGGED(ch, PRF_DRAW_MAP)),
+           ONOFF(PRF_FLAGGED(ch, PRF_ENTER_ZONE)),
+           (PRF_FLAGGED(ch, PRF_BRIEF_SHIELDS) ? "краткий" : "полный"),
+           ONOFF(PRF_FLAGGED(ch, PRF_AUTO_NOSUMMON)),
+           ONOFF(PRF_FLAGGED(ch, PRF_MAPPER)),
+           ONOFF(PRF_FLAGGED(ch, PRF_IPCONTROL)));
+  send_to_char(buf, ch);
+  if (GET_GOD_FLAG(ch, GF_TESTER))
+    sprintf(buf, " Тестер        : %-3s\r\n", ONOFF(PRF_FLAGGED(ch, PRF_TESTER)));
+  else
+    sprintf(buf, "\r\n");
+  send_to_char(buf, ch);
 }
 
-void do_zone(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	if (ch->desc
-		&& !(IS_DARK(ch->in_room) && !CAN_SEE_IN_DARK(ch) && !can_use_feat(ch, DARK_READING_FEAT))
-		&& !AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-	{
-		MapSystem::print_map(ch);
-	}
+void do_zone(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  if (ch->desc
+      && !(IS_DARK(ch->in_room) && !CAN_SEE_IN_DARK(ch) && !can_use_feat(ch, DARK_READING_FEAT))
+      && !AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    MapSystem::print_map(ch);
+  }
 
-	print_zone_info(ch);
+  print_zone_info(ch);
 
-	if ((IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
-		&& zone_table[world[ch->in_room]->zone].comment)
-	{
-		send_to_char(ch, "Комментарий: %s.\r\n",
-			zone_table[world[ch->in_room]->zone].comment);
-	}
+  if ((IS_IMMORTAL(ch) || PRF_FLAGGED(ch, PRF_CODERINFO))
+      && zone_table[world[ch->in_room]->zone].comment) {
+    send_to_char(ch, "Комментарий: %s.\r\n",
+                 zone_table[world[ch->in_room]->zone].comment);
+  }
 }
 
-
-struct sort_struct
-{
-	int sort_pos;
-	byte is_social;
+struct sort_struct {
+  int sort_pos;
+  byte is_social;
 } *cmd_sort_info = NULL;
 
 int num_of_cmds;
 
+void sort_commands(void) {
+  int a, b, tmp;
 
-void sort_commands(void)
-{
-	int a, b, tmp;
+  num_of_cmds = 0;
 
-	num_of_cmds = 0;
+  // first, count commands (num_of_commands is actually one greater than the
+  // number of commands; it inclues the '\n'.
 
-	 // first, count commands (num_of_commands is actually one greater than the
-	 // number of commands; it inclues the '\n'.
+  while (*cmd_info[num_of_cmds].command != '\n')
+    num_of_cmds++;
 
-	while (*cmd_info[num_of_cmds].command != '\n')
-		num_of_cmds++;
+  // create data array
+  CREATE(cmd_sort_info, num_of_cmds);
 
-	// create data array
-	CREATE(cmd_sort_info, num_of_cmds);
+  // initialize it
+  for (a = 1; a < num_of_cmds; a++) {
+    cmd_sort_info[a].sort_pos = a;
+    cmd_sort_info[a].is_social = FALSE;
+  }
 
-	// initialize it
-	for (a = 1; a < num_of_cmds; a++)
-	{
-		cmd_sort_info[a].sort_pos = a;
-		cmd_sort_info[a].is_social = FALSE;
-	}
+  // the infernal special case
+  cmd_sort_info[find_command("insult")].is_social = TRUE;
 
-	// the infernal special case
-	cmd_sort_info[find_command("insult")].is_social = TRUE;
-
-	// Sort.  'a' starts at 1, not 0, to remove 'RESERVED'
-	for (a = 1; a < num_of_cmds - 1; a++)
-		for (b = a + 1; b < num_of_cmds; b++)
-			if (strcmp(cmd_info[cmd_sort_info[a].sort_pos].command,
-					   cmd_info[cmd_sort_info[b].sort_pos].command) > 0)
-			{
-				tmp = cmd_sort_info[a].sort_pos;
-				cmd_sort_info[a].sort_pos = cmd_sort_info[b].sort_pos;
-				cmd_sort_info[b].sort_pos = tmp;
-			}
+  // Sort.  'a' starts at 1, not 0, to remove 'RESERVED'
+  for (a = 1; a < num_of_cmds - 1; a++)
+    for (b = a + 1; b < num_of_cmds; b++)
+      if (strcmp(cmd_info[cmd_sort_info[a].sort_pos].command,
+                 cmd_info[cmd_sort_info[b].sort_pos].command) > 0) {
+        tmp = cmd_sort_info[a].sort_pos;
+        cmd_sort_info[a].sort_pos = cmd_sort_info[b].sort_pos;
+        cmd_sort_info[b].sort_pos = tmp;
+      }
 }
 
-void do_commands(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
-{
-	int no, i, cmd_num, num_of;
-	int wizhelp = 0, socials = 0;
-	CHAR_DATA *vict = ch;
+void do_commands(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  int no, i, cmd_num, num_of;
+  int wizhelp = 0, socials = 0;
+  CHAR_DATA *vict = ch;
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
-	if (subcmd == SCMD_SOCIALS)
-		socials = 1;
-	else if (subcmd == SCMD_WIZHELP)
-		wizhelp = 1;
+  if (subcmd == SCMD_SOCIALS)
+    socials = 1;
+  else if (subcmd == SCMD_WIZHELP)
+    wizhelp = 1;
 
-	sprintf(buf, "Следующие %s%s доступны %s:\r\n",
-			wizhelp ? "привилегированные " : "",
-			socials ? "социалы" : "команды", vict == ch ? "вам" : GET_PAD(vict, 2));
+  sprintf(buf, "Следующие %s%s доступны %s:\r\n",
+          wizhelp ? "привилегированные " : "",
+          socials ? "социалы" : "команды", vict == ch ? "вам" : GET_PAD(vict, 2));
 
-	if (socials)
-		num_of = number_of_social_commands;
-	else
-		num_of = num_of_cmds - 1;
+  if (socials)
+    num_of = number_of_social_commands;
+  else
+    num_of = num_of_cmds - 1;
 
-	// cmd_num starts at 1, not 0, to remove 'RESERVED'
-	for (no = 1, cmd_num = socials ? 0 : 1; cmd_num < num_of; cmd_num++)
-		if (socials)
-		{
-			sprintf(buf + strlen(buf), "%-19s", soc_keys_list[cmd_num].keyword);
-			if (!(no % 4))
-				strcat(buf, "\r\n");
-			no++;
-		}
-		else
-		{
-			i = cmd_sort_info[cmd_num].sort_pos;
-			if (cmd_info[i].minimum_level >= 0
-					&& (Privilege::can_do_priv(vict, std::string(cmd_info[i].command), i, 0))
-					&& (cmd_info[i].minimum_level >= LVL_IMMORT) == wizhelp
-					&& (wizhelp || socials == cmd_sort_info[i].is_social))
-			{
-				sprintf(buf + strlen(buf), "%-15s", cmd_info[i].command);
-				if (!(no % 5))
-					strcat(buf, "\r\n");
-				no++;
-			}
-		}
+  // cmd_num starts at 1, not 0, to remove 'RESERVED'
+  for (no = 1, cmd_num = socials ? 0 : 1; cmd_num < num_of; cmd_num++)
+    if (socials) {
+      sprintf(buf + strlen(buf), "%-19s", soc_keys_list[cmd_num].keyword);
+      if (!(no % 4))
+        strcat(buf, "\r\n");
+      no++;
+    } else {
+      i = cmd_sort_info[cmd_num].sort_pos;
+      if (cmd_info[i].minimum_level >= 0
+          && (Privilege::can_do_priv(vict, std::string(cmd_info[i].command), i, 0))
+          && (cmd_info[i].minimum_level >= LVL_IMMORT) == wizhelp
+          && (wizhelp || socials == cmd_sort_info[i].is_social)) {
+        sprintf(buf + strlen(buf), "%-15s", cmd_info[i].command);
+        if (!(no % 5))
+          strcat(buf, "\r\n");
+        no++;
+      }
+    }
 
-	strcat(buf, "\r\n");
-	send_to_char(buf, ch);
+  strcat(buf, "\r\n");
+  send_to_char(buf, ch);
 }
 
-std::array<EAffectFlag, 3> hiding = { EAffectFlag::AFF_SNEAK, EAffectFlag::AFF_HIDE, EAffectFlag::AFF_CAMOUFLAGE };
+std::array<EAffectFlag, 3> hiding = {EAffectFlag::AFF_SNEAK, EAffectFlag::AFF_HIDE, EAffectFlag::AFF_CAMOUFLAGE};
 
-void do_affects(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	char sp_name[MAX_STRING_LENGTH];
+void do_affects(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  char sp_name[MAX_STRING_LENGTH];
 
-	// Show the bitset without "hiding" etc.
-	auto aff_copy = ch->char_specials.saved.affected_by;
-	for (auto j : hiding)
-	{
-		aff_copy.unset(j);
-	}
+  // Show the bitset without "hiding" etc.
+  auto aff_copy = ch->char_specials.saved.affected_by;
+  for (auto j : hiding) {
+    aff_copy.unset(j);
+  }
 
-	aff_copy.sprintbits(affected_bits, buf2, ",");
-	snprintf(buf, MAX_STRING_LENGTH, "Аффекты: %s%s%s\r\n", CCIYEL(ch, C_NRM), buf2, CCNRM(ch, C_NRM));
-	send_to_char(buf, ch);
+  aff_copy.sprintbits(affected_bits, buf2, ",");
+  snprintf(buf, MAX_STRING_LENGTH, "Аффекты: %s%s%s\r\n", CCIYEL(ch, C_NRM), buf2, CCNRM(ch, C_NRM));
+  send_to_char(buf, ch);
 
-	// Routine to show what spells a char is affected by
-	if (!ch->affected.empty())
-	{
-		for (auto affect_i = ch->affected.begin(); affect_i != ch->affected.end(); ++affect_i)
-		{
-			const auto aff = *affect_i;
+  // Routine to show what spells a char is affected by
+  if (!ch->affected.empty()) {
+    for (auto affect_i = ch->affected.begin(); affect_i != ch->affected.end(); ++affect_i) {
+      const auto aff = *affect_i;
 
-			if (aff->type == SPELL_SOLOBONUS)
-			{
-				continue;
-			}
+      if (aff->type == SPELL_SOLOBONUS) {
+        continue;
+      }
 
-			*buf2 = '\0';
-			strcpy(sp_name, spell_name(aff->type));
-			int mod = 0;
-			if (aff->battleflag == AF_PULSEDEC)
-			{
-				mod = aff->duration / 51; //если в пульсах приводим к тикам 25.5 в сек 2 минуты
-			}
-			else
-			{
-				mod = aff->duration;
-			}
-			(mod + 1) / SECS_PER_MUD_HOUR
-				? sprintf(buf2, "(%d %s)", (mod + 1) / SECS_PER_MUD_HOUR + 1, desc_count((mod + 1) / SECS_PER_MUD_HOUR + 1, WHAT_HOUR))
-				: sprintf(buf2, "(менее часа)");
-			snprintf(buf, MAX_STRING_LENGTH, "%s%s%-21s %-12s%s ",
-					*sp_name == '!' ? "Состояние  : " : "Заклинание : ",
-					CCICYN(ch, C_NRM), sp_name, buf2, CCNRM(ch, C_NRM));
-			*buf2 = '\0';
-			if (!IS_IMMORTAL(ch))
-			{
-				auto next_affect_i = affect_i;
-				++next_affect_i;
-				if (next_affect_i != ch->affected.end())
-				{
-					const auto& next_affect = *next_affect_i;
-					if (aff->type == next_affect->type)
-					{
-						continue;
-					}
-				}
-			}
-			else
-			{
-				if (aff->modifier)
-				{
-					sprintf(buf2, "%-3d к параметру: %s", aff->modifier, apply_types[(int) aff->location]);
-					strcat(buf, buf2);
-				}
-				if (aff->bitvector)
-				{
-					if (*buf2)
-					{
-						strcat(buf, ", устанавливает ");
-					}
-					else
-					{
-						strcat(buf, "устанавливает ");
-					}
-					strcat(buf, CCIRED(ch, C_NRM));
-					sprintbit(aff->bitvector, affected_bits, buf2);
-					strcat(buf, buf2);
-					strcat(buf, CCNRM(ch, C_NRM));
-				}
-			}
-			send_to_char(strcat(buf, "\r\n"), ch);
-		}
+      *buf2 = '\0';
+      strcpy(sp_name, spell_name(aff->type));
+      int mod = 0;
+      if (aff->battleflag == AF_PULSEDEC) {
+        mod = aff->duration / 51; //если в пульсах приводим к тикам 25.5 в сек 2 минуты
+      } else {
+        mod = aff->duration;
+      }
+      (mod + 1) / SECS_PER_MUD_HOUR
+      ? sprintf(buf2,
+                "(%d %s)",
+                (mod + 1) / SECS_PER_MUD_HOUR + 1,
+                desc_count((mod + 1) / SECS_PER_MUD_HOUR + 1, WHAT_HOUR))
+      : sprintf(buf2, "(менее часа)");
+      snprintf(buf, MAX_STRING_LENGTH, "%s%s%-21s %-12s%s ",
+               *sp_name == '!' ? "Состояние  : " : "Заклинание : ",
+               CCICYN(ch, C_NRM), sp_name, buf2, CCNRM(ch, C_NRM));
+      *buf2 = '\0';
+      if (!IS_IMMORTAL(ch)) {
+        auto next_affect_i = affect_i;
+        ++next_affect_i;
+        if (next_affect_i != ch->affected.end()) {
+          const auto &next_affect = *next_affect_i;
+          if (aff->type == next_affect->type) {
+            continue;
+          }
+        }
+      } else {
+        if (aff->modifier) {
+          sprintf(buf2, "%-3d к параметру: %s", aff->modifier, apply_types[(int) aff->location]);
+          strcat(buf, buf2);
+        }
+        if (aff->bitvector) {
+          if (*buf2) {
+            strcat(buf, ", устанавливает ");
+          } else {
+            strcat(buf, "устанавливает ");
+          }
+          strcat(buf, CCIRED(ch, C_NRM));
+          sprintbit(aff->bitvector, affected_bits, buf2);
+          strcat(buf, buf2);
+          strcat(buf, CCNRM(ch, C_NRM));
+        }
+      }
+      send_to_char(strcat(buf, "\r\n"), ch);
+    }
 // отображение наград
-		for (const auto& aff : ch->affected) {
-			if (aff->type == SPELL_SOLOBONUS) {
-				int mod;
-				if (aff->battleflag == AF_PULSEDEC)
-				{
-					mod = aff->duration / 51; //если в пульсах приводим к тикам	25.5 в сек 2 минуты
-				}
-				else
-				{
-					mod = aff->duration;
-				}
-				(mod + 1) / SECS_PER_MUD_HOUR
-					? sprintf(buf2, "(%d %s)", (mod + 1) / SECS_PER_MUD_HOUR + 1, desc_count((mod + 1) / SECS_PER_MUD_HOUR + 1, WHAT_HOUR))
-					: sprintf(buf2, "(менее часа)");
-				snprintf(buf, MAX_STRING_LENGTH, "Заклинание : %s%-21s %-12s%s ", CCICYN(ch, C_NRM),  "награда",  buf2, CCNRM(ch, C_NRM));
-				*buf2 = '\0';
-				if (aff->modifier) {
-					sprintf(buf2, "%s%-3d к параметру: %s%s%s",(aff->modifier > 0)? "+": "", 
-					aff->modifier, CCIRED(ch, C_NRM), apply_types[(int) aff->location], CCNRM(ch, C_NRM));
-					strcat(buf, buf2);
-				}
-				send_to_char(strcat(buf, "\r\n"), ch);
-			}
-		}
-	}
+    for (const auto &aff : ch->affected) {
+      if (aff->type == SPELL_SOLOBONUS) {
+        int mod;
+        if (aff->battleflag == AF_PULSEDEC) {
+          mod = aff->duration / 51; //если в пульсах приводим к тикам	25.5 в сек 2 минуты
+        } else {
+          mod = aff->duration;
+        }
+        (mod + 1) / SECS_PER_MUD_HOUR
+        ? sprintf(buf2,
+                  "(%d %s)",
+                  (mod + 1) / SECS_PER_MUD_HOUR + 1,
+                  desc_count((mod + 1) / SECS_PER_MUD_HOUR + 1, WHAT_HOUR))
+        : sprintf(buf2, "(менее часа)");
+        snprintf(buf,
+                 MAX_STRING_LENGTH,
+                 "Заклинание : %s%-21s %-12s%s ",
+                 CCICYN(ch, C_NRM),
+                 "награда",
+                 buf2,
+                 CCNRM(ch, C_NRM));
+        *buf2 = '\0';
+        if (aff->modifier) {
+          sprintf(buf2, "%s%-3d к параметру: %s%s%s", (aff->modifier > 0) ? "+" : "",
+                  aff->modifier, CCIRED(ch, C_NRM), apply_types[(int) aff->location], CCNRM(ch, C_NRM));
+          strcat(buf, buf2);
+        }
+        send_to_char(strcat(buf, "\r\n"), ch);
+      }
+    }
+  }
 
-	if (ch->is_morphed())
-	{
-		*buf2 = '\0';
-		send_to_char("Автоаффекты звериной формы: " , ch);
-		const IMorph::affects_list_t& affs = ch->GetMorphAffects();
-		for (IMorph::affects_list_t::const_iterator it = affs.begin(); it != affs.end();)
-		{
-			sprintbit(to_underlying(*it), affected_bits, buf2);
-			send_to_char(string(CCIYEL(ch, C_NRM))+ string(buf2)+ string(CCNRM(ch, C_NRM)), ch);
-			if (++it != affs.end())
-			{
-				send_to_char(", ", ch);
-			}
-		}
-	}
+  if (ch->is_morphed()) {
+    *buf2 = '\0';
+    send_to_char("Автоаффекты звериной формы: ", ch);
+    const IMorph::affects_list_t &affs = ch->GetMorphAffects();
+    for (IMorph::affects_list_t::const_iterator it = affs.begin(); it != affs.end();) {
+      sprintbit(to_underlying(*it), affected_bits, buf2);
+      send_to_char(string(CCIYEL(ch, C_NRM)) + string(buf2) + string(CCNRM(ch, C_NRM)), ch);
+      if (++it != affs.end()) {
+        send_to_char(", ", ch);
+      }
+    }
+  }
 }
 
 // Create web-page with users list
-void make_who2html(void)
-{
-	FILE *opf;
-	DESCRIPTOR_DATA *d;
+void make_who2html(void) {
+  FILE *opf;
+  DESCRIPTOR_DATA *d;
 
-	int imms_num = 0, morts_num = 0;
+  int imms_num = 0, morts_num = 0;
 
-	char *imms = NULL;
-	char *morts = NULL;
-	char *buffer = NULL;
+  char *imms = NULL;
+  char *morts = NULL;
+  char *buffer = NULL;
 
-	if ((opf = fopen(WHOLIST_FILE, "w")) == 0)
-		return;		// or log it ? *shrug*
-	fprintf(opf, "<HTML><HEAD><TITLE>Кто сейчас в Былинах?</TITLE></HEAD>\n");
-	fprintf(opf, "<BODY><H1>Кто сейчас живет в Былинах?</H1><HR>\n");
+  if ((opf = fopen(WHOLIST_FILE, "w")) == 0)
+    return;        // or log it ? *shrug*
+  fprintf(opf, "<HTML><HEAD><TITLE>Кто сейчас в Былинах?</TITLE></HEAD>\n");
+  fprintf(opf, "<BODY><H1>Кто сейчас живет в Былинах?</H1><HR>\n");
 
-	sprintf(buf, "БОГИ <BR> \r\n");
-	imms = str_add(imms, buf);
+  sprintf(buf, "БОГИ <BR> \r\n");
+  imms = str_add(imms, buf);
 
-	sprintf(buf, "<BR>Игроки<BR> \r\n  ");
-	morts = str_add(morts, buf);
+  sprintf(buf, "<BR>Игроки<BR> \r\n  ");
+  morts = str_add(morts, buf);
 
-	for (d = descriptor_list; d; d = d->next)
-	{
-		if (STATE(d) == CON_PLAYING
-			&& GET_INVIS_LEV(d->character) < 31)
-		{
-			const auto ch = d->character;
-			sprintf(buf, "%s <BR> \r\n ", ch->race_or_title().c_str());
+  for (d = descriptor_list; d; d = d->next) {
+    if (STATE(d) == CON_PLAYING
+        && GET_INVIS_LEV(d->character) < 31) {
+      const auto ch = d->character;
+      sprintf(buf, "%s <BR> \r\n ", ch->race_or_title().c_str());
 
-			if (IS_IMMORTAL(ch))
-			{
-				imms_num++;
-				imms = str_add(imms, buf);
-			}
-			else
-			{
-				morts_num++;
-				morts = str_add(morts, buf);
-			}
-		}
-	}
+      if (IS_IMMORTAL(ch)) {
+        imms_num++;
+        imms = str_add(imms, buf);
+      } else {
+        morts_num++;
+        morts = str_add(morts, buf);
+      }
+    }
+  }
 
-	if (morts_num + imms_num == 0)
-	{
-		sprintf(buf, "Все ушли на фронт! <BR>");
-		buffer = str_add(buffer, buf);
-	}
-	else
-	{
-		if (imms_num > 0)
-			buffer = str_add(buffer, imms);
-		if (morts_num > 0)
-			buffer = str_add(buffer, morts);
-		buffer = str_add(buffer, " <BR> \r\n Всего :");
-		if (imms_num)
-		{
-			// sprintf(buf+strlen(buf)," бессмертных %d",imms_num);
-			sprintf(buf, " бессмертных %d", imms_num);
-			buffer = str_add(buffer, buf);
-		}
-		if (morts_num)
-		{
-			// sprintf(buf+strlen(buf)," смертных %d",morts_num);
-			sprintf(buf, " смертных %d", morts_num);
-			buffer = str_add(buffer, buf);
-		}
+  if (morts_num + imms_num == 0) {
+    sprintf(buf, "Все ушли на фронт! <BR>");
+    buffer = str_add(buffer, buf);
+  } else {
+    if (imms_num > 0)
+      buffer = str_add(buffer, imms);
+    if (morts_num > 0)
+      buffer = str_add(buffer, morts);
+    buffer = str_add(buffer, " <BR> \r\n Всего :");
+    if (imms_num) {
+      // sprintf(buf+strlen(buf)," бессмертных %d",imms_num);
+      sprintf(buf, " бессмертных %d", imms_num);
+      buffer = str_add(buffer, buf);
+    }
+    if (morts_num) {
+      // sprintf(buf+strlen(buf)," смертных %d",morts_num);
+      sprintf(buf, " смертных %d", morts_num);
+      buffer = str_add(buffer, buf);
+    }
 
-		buffer = str_add(buffer, ".\n");
-	}
+    buffer = str_add(buffer, ".\n");
+  }
 
-	fprintf(opf, "%s", buffer);
+  fprintf(opf, "%s", buffer);
 
-	free(buffer);
-	free(imms);
-	free(morts);
+  free(buffer);
+  free(imms);
+  free(morts);
 
-
-	fprintf(opf, "<HR></BODY></HTML>\n");
-	fclose(opf);
+  fprintf(opf, "<HR></BODY></HTML>\n");
+  fclose(opf);
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/act.informative.cpp
+++ b/src/act.informative.cpp
@@ -2004,9 +2004,9 @@ void look_in_direction(CHAR_DATA *ch, int dir, int info_is) {
         send_to_char("&R&q", ch);
         count = 0;
         for (const auto tch : world[rdata->to_room()]->people) {
-          percent = number(1, skill_info[SKILL_LOOKING].max_percent);
-          probe = calculate_skill(ch, SKILL_LOOKING, tch);
-          train_skill(ch, SKILL_LOOKING, probe >= percent, tch);
+          percent = number(1, skill_info[SKILL_LOOKING].fail_percent);
+          probe = CalcCurrentSkill(ch, SKILL_LOOKING, tch);
+          TrainSkill(ch, SKILL_LOOKING, probe >= percent, tch);
           if (HERE(tch) && INVIS_OK(ch, tch) && probe >= percent
               && (percent < 100 || IS_IMMORTAL(ch))) {
             // Если моб не вещь и смотрящий не им
@@ -2056,9 +2056,9 @@ void hear_in_direction(CHAR_DATA *ch, int dir, int info_is) {
     send_to_char(buf, ch);
     count = 0;
     for (const auto tch : world[rdata->to_room()]->people) {
-      percent = number(1, skill_info[SKILL_HEARING].max_percent);
-      probe = calculate_skill(ch, SKILL_HEARING, tch);
-      train_skill(ch, SKILL_HEARING, probe >= percent, tch);
+      percent = number(1, skill_info[SKILL_HEARING].fail_percent);
+      probe = CalcCurrentSkill(ch, SKILL_HEARING, tch);
+      TrainSkill(ch, SKILL_HEARING, probe >= percent, tch);
       // Если сражаются то слышем только борьбу.
       if (tch->get_fighting()) {
         if (IS_NPC(tch)) {
@@ -2439,9 +2439,9 @@ bool look_at_target(CHAR_DATA *ch, char *arg, int subcmd) {
     look_at_char(found_char, ch);
     if (ch != found_char) {
       if (subcmd == SCMD_LOOK_HIDE && ch->get_skill(SKILL_LOOK_HIDE) > 0) {
-        fnum = number(1, skill_info[SKILL_LOOK_HIDE].max_percent);
-        found = calculate_skill(ch, SKILL_LOOK_HIDE, found_char);
-        train_skill(ch, SKILL_LOOK_HIDE, found < fnum, found_char);
+        fnum = number(1, skill_info[SKILL_LOOK_HIDE].fail_percent);
+        found = CalcCurrentSkill(ch, SKILL_LOOK_HIDE, found_char);
+        TrainSkill(ch, SKILL_LOOK_HIDE, found < fnum, found_char);
         if (!WAITLESS(ch))
           WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
         if (found >= fnum && (fnum < 100 || IS_IMMORTAL(ch)) && !IS_IMMORTAL(found_char))
@@ -2503,7 +2503,7 @@ void skip_hide_on_look(CHAR_DATA *ch) {
   if (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE) &&
       ((!ch->get_skill(SKILL_LOOK_HIDE) ||
           ((number(1, 100) -
-              calculate_skill(ch, SKILL_LOOK_HIDE, 0) - 2 * (ch->get_wis() - 9)) > 0)))) {
+              CalcCurrentSkill(ch, SKILL_LOOK_HIDE, 0) - 2 * (ch->get_wis() - 9)) > 0)))) {
     affect_from_char(ch, SPELL_HIDE);
     if (!AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE)) {
       send_to_char("Вы прекратили прятаться.\r\n", ch);

--- a/src/act.item.cpp
+++ b/src/act.item.cpp
@@ -55,37 +55,37 @@ extern CHAR_DATA *mob_proto;
 extern struct house_control_rec house_control[];
 extern std::array<int, MAX_MOB_LEVEL / 11 + 1> animals_levels;
 // from act.informative.cpp
-char *find_exdesc(char *word, const EXTRA_DESCR_DATA::shared_ptr& list);
+char *find_exdesc(char *word, const EXTRA_DESCR_DATA::shared_ptr &list);
 
 // local functions
-int can_take_obj(CHAR_DATA * ch, OBJ_DATA * obj);
+int can_take_obj(CHAR_DATA *ch, OBJ_DATA *obj);
 void get_check_money(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *cont);
-int perform_get_from_room(CHAR_DATA * ch, OBJ_DATA * obj);
-void get_from_room(CHAR_DATA * ch, char *arg, int amount);
-void perform_give_gold(CHAR_DATA * ch, CHAR_DATA * vict, int amount);
-void perform_give(CHAR_DATA * ch, CHAR_DATA * vict, OBJ_DATA * obj);
-void perform_drop(CHAR_DATA * ch, OBJ_DATA * obj);
-void perform_drop_gold(CHAR_DATA * ch, int amount);
-CHAR_DATA *give_find_vict(CHAR_DATA * ch, char *arg);
-void weight_change_object(OBJ_DATA * obj, int weight);
-int perform_put(CHAR_DATA * ch, OBJ_DATA::shared_ptr obj, OBJ_DATA * cont);
-void get_from_container(CHAR_DATA * ch, OBJ_DATA * cont, char *arg, int mode, int amount, bool autoloot);
-void perform_wear(CHAR_DATA * ch, OBJ_DATA * obj, int where);
-int find_eq_pos(CHAR_DATA * ch, OBJ_DATA * obj, char *arg);
-bool perform_get_from_container(CHAR_DATA * ch, OBJ_DATA * obj, OBJ_DATA * cont, int mode);
-void perform_remove(CHAR_DATA * ch, int pos);
-int invalid_anti_class(CHAR_DATA * ch, const OBJ_DATA * obj);
-void feed_charmice(CHAR_DATA * ch, char *arg);
-int get_player_charms(CHAR_DATA * ch, int spellnum);
-OBJ_DATA *create_skin(CHAR_DATA * mob);
-int invalid_unique(CHAR_DATA * ch, const OBJ_DATA * obj);
+int perform_get_from_room(CHAR_DATA *ch, OBJ_DATA *obj);
+void get_from_room(CHAR_DATA *ch, char *arg, int amount);
+void perform_give_gold(CHAR_DATA *ch, CHAR_DATA *vict, int amount);
+void perform_give(CHAR_DATA *ch, CHAR_DATA *vict, OBJ_DATA *obj);
+void perform_drop(CHAR_DATA *ch, OBJ_DATA *obj);
+void perform_drop_gold(CHAR_DATA *ch, int amount);
+CHAR_DATA *give_find_vict(CHAR_DATA *ch, char *arg);
+void weight_change_object(OBJ_DATA *obj, int weight);
+int perform_put(CHAR_DATA *ch, OBJ_DATA::shared_ptr obj, OBJ_DATA *cont);
+void get_from_container(CHAR_DATA *ch, OBJ_DATA *cont, char *arg, int mode, int amount, bool autoloot);
+void perform_wear(CHAR_DATA *ch, OBJ_DATA *obj, int where);
+int find_eq_pos(CHAR_DATA *ch, OBJ_DATA *obj, char *arg);
+bool perform_get_from_container(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *cont, int mode);
+void perform_remove(CHAR_DATA *ch, int pos);
+int invalid_anti_class(CHAR_DATA *ch, const OBJ_DATA *obj);
+void feed_charmice(CHAR_DATA *ch, char *arg);
+int get_player_charms(CHAR_DATA *ch, int spellnum);
+OBJ_DATA *create_skin(CHAR_DATA *mob);
+int invalid_unique(CHAR_DATA *ch, const OBJ_DATA *obj);
 bool unique_stuff(const CHAR_DATA *ch, const OBJ_DATA *obj);
 
 // from class.cpp
-int invalid_no_class(CHAR_DATA * ch, const OBJ_DATA * obj);
+int invalid_no_class(CHAR_DATA *ch, const OBJ_DATA *obj);
 
 void do_split(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
-void do_split(CHAR_DATA *ch, char *argument, int cmd, int subcmd,int currency);
+void do_split(CHAR_DATA *ch, char *argument, int cmd, int subcmd, int currency);
 void do_remove(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_put(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_get(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
@@ -105,699 +105,610 @@ void do_refill(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 // чтобы словить невозможность положить в клан-сундук,
 // иначе при пол все сун будет спам на каждый предмет, мол низя
 // 0 - все ок, 1 - нельзя положить и дальше не обрабатывать (для кланов), 2 - нельзя положить и идти дальше
-int perform_put(CHAR_DATA * ch, OBJ_DATA::shared_ptr obj, OBJ_DATA * cont) {
-	if (!bloody::handle_transfer(ch, NULL, obj.get(), cont)) {
-		return 2;
-	}
+int perform_put(CHAR_DATA *ch, OBJ_DATA::shared_ptr obj, OBJ_DATA *cont) {
+  if (!bloody::handle_transfer(ch, NULL, obj.get(), cont)) {
+    return 2;
+  }
 
-	if (!drop_otrigger(obj.get(), ch)) {
-		return 2;
-	}
+  if (!drop_otrigger(obj.get(), ch)) {
+    return 2;
+  }
 
-	if (!put_otrigger(obj.get(), ch, cont)) {
-		return 2;
-	}
+  if (!put_otrigger(obj.get(), ch, cont)) {
+    return 2;
+  }
 
-	// если кладем в клановый сундук
-	if (Clan::is_clan_chest(cont)) {
-		if (!Clan::PutChest(ch, obj.get(), cont)) {
-			return 1;
-		}
-		return 0;
-	}
+  // если кладем в клановый сундук
+  if (Clan::is_clan_chest(cont)) {
+    if (!Clan::PutChest(ch, obj.get(), cont)) {
+      return 1;
+    }
+    return 0;
+  }
 
-	// клан-хранилище под ингры
-	if (ClanSystem::is_ingr_chest(cont)) {
-		if (!Clan::put_ingr_chest(ch, obj.get(), cont)) {
-			return 1;
-		}
-		return 0;
-	}
+  // клан-хранилище под ингры
+  if (ClanSystem::is_ingr_chest(cont)) {
+    if (!Clan::put_ingr_chest(ch, obj.get(), cont)) {
+      return 1;
+    }
+    return 0;
+  }
 
-	// персональный сундук
-	if (Depot::is_depot(cont)) {
-		if (!Depot::put_depot(ch, obj)) {
-			return 1;
-		}
-		return 0;
-	}
+  // персональный сундук
+  if (Depot::is_depot(cont)) {
+    if (!Depot::put_depot(ch, obj)) {
+      return 1;
+    }
+    return 0;
+  }
 
-	if (GET_OBJ_WEIGHT(cont) + GET_OBJ_WEIGHT(obj) > GET_OBJ_VAL(cont, 0)) {
-		act("$O : $o не помещается туда.", FALSE, ch, obj.get(), cont, TO_CHAR);
-	}
-	else if (obj->get_type() == OBJ_DATA::ITEM_CONTAINER) {
-		act("Невозможно положить контейнер в контейнер.", FALSE, ch, 0, 0, TO_CHAR);
-	}
-	else if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
-		act("Неведомая сила помешала положить $o3 в $O3.", FALSE, ch, obj.get(), cont, TO_CHAR);
-	}
-	else if (obj->get_extra_flag(EExtraFlag::ITEM_ZONEDECAY) || obj->get_type() == OBJ_DATA::ITEM_KEY) {
-		act("Неведомая сила помешала положить $o3 в $O3.", FALSE, ch, obj.get(), cont, TO_CHAR);
-	}
-	else {
-		obj_from_char(obj.get());
-		// чтобы там по 1 куне гор не было, чару тож возвращается на счет, а не в инвентарь кучкой
-		if (obj->get_type() == OBJ_DATA::ITEM_MONEY && obj->get_vnum() == -1) {
-			OBJ_DATA *temp, *obj_next;
-			for (temp = cont->get_contains(); temp; temp = obj_next) {
-				obj_next = temp->get_next_content();
-				if (GET_OBJ_TYPE(temp) == OBJ_DATA::ITEM_MONEY) {
-					// тут можно просто в поле прибавить, но там описание для кун разное от кол-ва
-					int money = GET_OBJ_VAL(temp, 0);
-					money += GET_OBJ_VAL(obj, 0);
-					obj_from_obj(temp);
-					extract_obj(temp);
-					obj_from_obj(obj.get());
-					extract_obj(obj.get());
-					obj = create_money(money);
-					if (!obj) {
-						return 0;
-					}
-					break;
-				}
-			}
-		}
+  if (GET_OBJ_WEIGHT(cont) + GET_OBJ_WEIGHT(obj) > GET_OBJ_VAL(cont, 0)) {
+    act("$O : $o не помещается туда.", FALSE, ch, obj.get(), cont, TO_CHAR);
+  } else if (obj->get_type() == OBJ_DATA::ITEM_CONTAINER) {
+    act("Невозможно положить контейнер в контейнер.", FALSE, ch, 0, 0, TO_CHAR);
+  } else if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
+    act("Неведомая сила помешала положить $o3 в $O3.", FALSE, ch, obj.get(), cont, TO_CHAR);
+  } else if (obj->get_extra_flag(EExtraFlag::ITEM_ZONEDECAY) || obj->get_type() == OBJ_DATA::ITEM_KEY) {
+    act("Неведомая сила помешала положить $o3 в $O3.", FALSE, ch, obj.get(), cont, TO_CHAR);
+  } else {
+    obj_from_char(obj.get());
+    // чтобы там по 1 куне гор не было, чару тож возвращается на счет, а не в инвентарь кучкой
+    if (obj->get_type() == OBJ_DATA::ITEM_MONEY && obj->get_vnum() == -1) {
+      OBJ_DATA *temp, *obj_next;
+      for (temp = cont->get_contains(); temp; temp = obj_next) {
+        obj_next = temp->get_next_content();
+        if (GET_OBJ_TYPE(temp) == OBJ_DATA::ITEM_MONEY) {
+          // тут можно просто в поле прибавить, но там описание для кун разное от кол-ва
+          int money = GET_OBJ_VAL(temp, 0);
+          money += GET_OBJ_VAL(obj, 0);
+          obj_from_obj(temp);
+          extract_obj(temp);
+          obj_from_obj(obj.get());
+          extract_obj(obj.get());
+          obj = create_money(money);
+          if (!obj) {
+            return 0;
+          }
+          break;
+        }
+      }
+    }
 
+    obj_to_obj(obj.get(), cont);
 
-		obj_to_obj(obj.get(), cont);
+    act("$n положил$g $o3 в $O3.", TRUE, ch, obj.get(), cont, TO_ROOM | TO_ARENA_LISTEN);
 
-		act("$n положил$g $o3 в $O3.", TRUE, ch, obj.get(), cont, TO_ROOM | TO_ARENA_LISTEN);
-
-		// Yes, I realize this is strange until we have auto-equip on rent. -gg
-		if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP) && !cont->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
-			cont->set_extra_flag(EExtraFlag::ITEM_NODROP);
-			act("Вы почувствовали что-то странное, когда положили $o3 в $O3.",
-				FALSE, ch, obj.get(), cont, TO_CHAR);
-		}
-		else
-			act("Вы положили $o3 в $O3.", FALSE, ch, obj.get(), cont, TO_CHAR);
-		return 0;
-	}
-	return 2;
+    // Yes, I realize this is strange until we have auto-equip on rent. -gg
+    if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP) && !cont->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
+      cont->set_extra_flag(EExtraFlag::ITEM_NODROP);
+      act("Вы почувствовали что-то странное, когда положили $o3 в $O3.",
+          FALSE, ch, obj.get(), cont, TO_CHAR);
+    } else
+      act("Вы положили $o3 в $O3.", FALSE, ch, obj.get(), cont, TO_CHAR);
+    return 0;
+  }
+  return 2;
 }
 const int effects_l[5][40][2]{
-	{{0,0}},
-	{{0,	26}, // количество строк
-	{APPLY_ABSORBE,	5},
-	{APPLY_C1,	3},
-	{APPLY_C2,	3},
-	{APPLY_C3,	2},
-	{APPLY_C4,	2},
-	{APPLY_C5,	1},
-	{APPLY_C6,	1},
-	{APPLY_CAST_SUCCESS,	3},
-	{APPLY_HIT,	20},
-	{APPLY_HITREG,	35},
-	{APPLY_INITIATIVE,	5},
-	{APPLY_MANAREG,	15},
-	{APPLY_MORALE,	5},
-	{APPLY_MOVE,	35},
-	{APPLY_RESIST_AIR,	15},
-	{APPLY_RESIST_EARTH,	15},
-	{APPLY_RESIST_FIRE,	15},
-	{APPLY_RESIST_IMMUNITY,	5},
-	{APPLY_RESIST_MIND,	5},
-	{APPLY_RESIST_VITALITY,	5},
-	{APPLY_RESIST_WATER,	15},
-	{APPLY_SAVING_CRITICAL,	-5},
-	{APPLY_SAVING_REFLEX,	-5},
-	{APPLY_SAVING_STABILITY,	-5},
-	{APPLY_SAVING_WILL,	-5},
-	{APPLY_SIZE,	10},
-	{APPLY_RESIST_DARK , 15},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0}},
-	{{0,	37},
-	{APPLY_ABSORBE,	10},
-	{APPLY_C1,	3},
-	{APPLY_C2,	3},
-	{APPLY_C3,	3},
-	{APPLY_C4,	3},
-	{APPLY_C5,	2},
-	{APPLY_C6,	2},
-	{APPLY_C7,	2},
-	{APPLY_C8,	1},
-	{APPLY_C9,	1},
-	{APPLY_CAST_SUCCESS,	5},
-	{APPLY_CHA,	1},
-	{APPLY_CON,	1},
-	{APPLY_DAMROLL,	2},
-	{APPLY_DEX,	1},
-	{APPLY_HIT,	30},
-	{APPLY_HITREG,	55},
-	{APPLY_HITROLL,	2},
-	{APPLY_INITIATIVE,	10},
-	{APPLY_INT,	1},
-	{APPLY_MANAREG,	30},
-	{APPLY_MORALE,	7},
-	{APPLY_MOVE,	55},
-	{APPLY_RESIST_AIR,	25},
-	{APPLY_RESIST_EARTH,	25},
-	{APPLY_RESIST_FIRE,	25},
-	{APPLY_RESIST_IMMUNITY,	10},
-	{APPLY_RESIST_MIND,	10},
-	{APPLY_RESIST_VITALITY,	10},
-	{APPLY_RESIST_WATER,	25},
-	{APPLY_SAVING_CRITICAL,	-10},
-	{APPLY_SAVING_REFLEX,	-10},
-	{APPLY_SAVING_STABILITY,	-10},
-	{APPLY_SAVING_WILL,	-10},
-	{APPLY_SIZE,	15},
-	{APPLY_STR,	1},
-	{APPLY_WIS,	1},
-	{0 , 0},
-	{0 , 0}},
-	{{0,	23},
-	{APPLY_ABSORBE,	15},
-	{APPLY_C8,	2},
-	{APPLY_C9,	2},
-	{APPLY_CAST_SUCCESS,	7},
-	{APPLY_CHA,	2},
-	{APPLY_CON,	2},
-	{APPLY_DAMROLL,	3},
-	{APPLY_DEX,	2},
-	{APPLY_HIT,	45},
-	{APPLY_HITROLL,	3},
-	{APPLY_INITIATIVE,	15},
-	{APPLY_INT,	2},
-	{APPLY_MORALE,	9},
-	{APPLY_RESIST_IMMUNITY,	15},
-	{APPLY_RESIST_MIND,	15},
-	{APPLY_RESIST_VITALITY,	15},
-	{APPLY_SAVING_CRITICAL,	-15},
-	{APPLY_SAVING_REFLEX,	-15},
-	{APPLY_SAVING_STABILITY,	-15},
-	{APPLY_SAVING_WILL,	-15},
-	{APPLY_SIZE,	20},
-	{APPLY_STR,	2},
-	{APPLY_WIS,	2},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0}},
-	{{0,		21},
-	{APPLY_ABSORBE,	20},
-	{APPLY_CAST_SUCCESS,	10},
-	{APPLY_CHA,	2},
-	{APPLY_CON,	2},
-	{APPLY_DAMROLL,	4},
-	{APPLY_DEX,	2},
-	{APPLY_HIT,	60},
-	{APPLY_HITROLL,	4},
-	{APPLY_INITIATIVE,	20},
-	{APPLY_INT,	2},
-	{APPLY_MORALE,	12},
-	{APPLY_MR,	3},
-	{APPLY_RESIST_IMMUNITY,	20},
-	{APPLY_RESIST_MIND,	20},
-	{APPLY_RESIST_VITALITY,	20},
-	{APPLY_SAVING_CRITICAL,	-20},
-	{APPLY_SAVING_REFLEX,	-20},
-	{APPLY_SAVING_STABILITY,	-20},
-	{APPLY_SAVING_WILL,	-20},
-	{APPLY_STR,	2},
-	{APPLY_WIS,	2},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0},
-	{0 , 0}}
+    {{0, 0}},
+    {{0, 26}, // количество строк
+     {APPLY_ABSORBE, 5},
+     {APPLY_C1, 3},
+     {APPLY_C2, 3},
+     {APPLY_C3, 2},
+     {APPLY_C4, 2},
+     {APPLY_C5, 1},
+     {APPLY_C6, 1},
+     {APPLY_CAST_SUCCESS, 3},
+     {APPLY_HIT, 20},
+     {APPLY_HITREG, 35},
+     {APPLY_INITIATIVE, 5},
+     {APPLY_MANAREG, 15},
+     {APPLY_MORALE, 5},
+     {APPLY_MOVE, 35},
+     {APPLY_RESIST_AIR, 15},
+     {APPLY_RESIST_EARTH, 15},
+     {APPLY_RESIST_FIRE, 15},
+     {APPLY_RESIST_IMMUNITY, 5},
+     {APPLY_RESIST_MIND, 5},
+     {APPLY_RESIST_VITALITY, 5},
+     {APPLY_RESIST_WATER, 15},
+     {APPLY_SAVING_CRITICAL, -5},
+     {APPLY_SAVING_REFLEX, -5},
+     {APPLY_SAVING_STABILITY, -5},
+     {APPLY_SAVING_WILL, -5},
+     {APPLY_SIZE, 10},
+     {APPLY_RESIST_DARK, 15},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0}},
+    {{0, 37},
+     {APPLY_ABSORBE, 10},
+     {APPLY_C1, 3},
+     {APPLY_C2, 3},
+     {APPLY_C3, 3},
+     {APPLY_C4, 3},
+     {APPLY_C5, 2},
+     {APPLY_C6, 2},
+     {APPLY_C7, 2},
+     {APPLY_C8, 1},
+     {APPLY_C9, 1},
+     {APPLY_CAST_SUCCESS, 5},
+     {APPLY_CHA, 1},
+     {APPLY_CON, 1},
+     {APPLY_DAMROLL, 2},
+     {APPLY_DEX, 1},
+     {APPLY_HIT, 30},
+     {APPLY_HITREG, 55},
+     {APPLY_HITROLL, 2},
+     {APPLY_INITIATIVE, 10},
+     {APPLY_INT, 1},
+     {APPLY_MANAREG, 30},
+     {APPLY_MORALE, 7},
+     {APPLY_MOVE, 55},
+     {APPLY_RESIST_AIR, 25},
+     {APPLY_RESIST_EARTH, 25},
+     {APPLY_RESIST_FIRE, 25},
+     {APPLY_RESIST_IMMUNITY, 10},
+     {APPLY_RESIST_MIND, 10},
+     {APPLY_RESIST_VITALITY, 10},
+     {APPLY_RESIST_WATER, 25},
+     {APPLY_SAVING_CRITICAL, -10},
+     {APPLY_SAVING_REFLEX, -10},
+     {APPLY_SAVING_STABILITY, -10},
+     {APPLY_SAVING_WILL, -10},
+     {APPLY_SIZE, 15},
+     {APPLY_STR, 1},
+     {APPLY_WIS, 1},
+     {0, 0},
+     {0, 0}},
+    {{0, 23},
+     {APPLY_ABSORBE, 15},
+     {APPLY_C8, 2},
+     {APPLY_C9, 2},
+     {APPLY_CAST_SUCCESS, 7},
+     {APPLY_CHA, 2},
+     {APPLY_CON, 2},
+     {APPLY_DAMROLL, 3},
+     {APPLY_DEX, 2},
+     {APPLY_HIT, 45},
+     {APPLY_HITROLL, 3},
+     {APPLY_INITIATIVE, 15},
+     {APPLY_INT, 2},
+     {APPLY_MORALE, 9},
+     {APPLY_RESIST_IMMUNITY, 15},
+     {APPLY_RESIST_MIND, 15},
+     {APPLY_RESIST_VITALITY, 15},
+     {APPLY_SAVING_CRITICAL, -15},
+     {APPLY_SAVING_REFLEX, -15},
+     {APPLY_SAVING_STABILITY, -15},
+     {APPLY_SAVING_WILL, -15},
+     {APPLY_SIZE, 20},
+     {APPLY_STR, 2},
+     {APPLY_WIS, 2},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0}},
+    {{0, 21},
+     {APPLY_ABSORBE, 20},
+     {APPLY_CAST_SUCCESS, 10},
+     {APPLY_CHA, 2},
+     {APPLY_CON, 2},
+     {APPLY_DAMROLL, 4},
+     {APPLY_DEX, 2},
+     {APPLY_HIT, 60},
+     {APPLY_HITROLL, 4},
+     {APPLY_INITIATIVE, 20},
+     {APPLY_INT, 2},
+     {APPLY_MORALE, 12},
+     {APPLY_MR, 3},
+     {APPLY_RESIST_IMMUNITY, 20},
+     {APPLY_RESIST_MIND, 20},
+     {APPLY_RESIST_VITALITY, 20},
+     {APPLY_SAVING_CRITICAL, -20},
+     {APPLY_SAVING_REFLEX, -20},
+     {APPLY_SAVING_STABILITY, -20},
+     {APPLY_SAVING_WILL, -20},
+     {APPLY_STR, 2},
+     {APPLY_WIS, 2},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0},
+     {0, 0}}
 
 };
 
-OBJ_DATA *create_skin(CHAR_DATA *mob, CHAR_DATA *ch)
-{
-	int vnum, i, k = 0, num, effect;
-	bool concidence;
-	const int vnum_skin_prototype = 1660;
+OBJ_DATA *create_skin(CHAR_DATA *mob, CHAR_DATA *ch) {
+  int vnum, i, k = 0, num, effect;
+  bool concidence;
+  const int vnum_skin_prototype = 1660;
 
-	vnum = vnum_skin_prototype + MIN((int)(GET_LEVEL(mob) / 5), 9);
-	const auto skin = world_objects.create_from_prototype_by_vnum(vnum);
-	if (!skin)
-	{
-		mudlog("Неверно задан номер прототипа для освежевания в act.item.cpp::create_skin!",
-			   NRM, LVL_GRGOD, ERRLOG, TRUE);
-		return NULL;
-	}
+  vnum = vnum_skin_prototype + MIN((int) (GET_LEVEL(mob) / 5), 9);
+  const auto skin = world_objects.create_from_prototype_by_vnum(vnum);
+  if (!skin) {
+    mudlog("Неверно задан номер прототипа для освежевания в act.item.cpp::create_skin!",
+           NRM, LVL_GRGOD, ERRLOG, TRUE);
+    return NULL;
+  }
 
-	skin->set_val(3, int(GET_LEVEL(mob) / 11)); // установим уровень шкуры, топовая 44+
-	skin->set_parent(GET_MOB_VNUM(mob));
-	trans_obj_name(skin.get(), mob); // переносим падежи
-	for (i = 1; i <= GET_OBJ_VAL(skin, 3); i++) // топовая шкура до 4х афектов
-	{
-		if ((k == 1) && (number(1, 100) >= 35))
-		{
-			continue;
-		}
-		if ((k == 2) && (number(1, 100) >= 20))
-		{
-			continue;
-		}
-		if ((k == 3) && (number(1, 100) >= 10))
-		{
-			continue;
-		}
+  skin->set_val(3, int(GET_LEVEL(mob) / 11)); // установим уровень шкуры, топовая 44+
+  skin->set_parent(GET_MOB_VNUM(mob));
+  trans_obj_name(skin.get(), mob); // переносим падежи
+  for (i = 1; i <= GET_OBJ_VAL(skin, 3); i++) // топовая шкура до 4х афектов
+  {
+    if ((k == 1) && (number(1, 100) >= 35)) {
+      continue;
+    }
+    if ((k == 2) && (number(1, 100) >= 20)) {
+      continue;
+    }
+    if ((k == 3) && (number(1, 100) >= 10)) {
+      continue;
+    }
 
-		{
-			concidence = true;
-			while (concidence)
-			{
-				num = number(1, effects_l[GET_OBJ_VAL(skin, 3)][0][1]);
-				concidence = false;
-				for (int n = 0; n <= k && i > 1; n++)
-				{
-					if (effects_l[GET_OBJ_VAL(skin, 3)][num][0] == (skin)->get_affected(n).location)
-					{
-						concidence = true;
-					}
-				}
-			}
-			auto location = effects_l[GET_OBJ_VAL(skin, 3)][num][0];
-			effect = effects_l[GET_OBJ_VAL(skin, 3)][num][1];
-			if (number(0, 1000) <= (250 / (GET_OBJ_VAL(skin, 3) + 1))) //  чем круче шкура тем реже  отрицательный аффект
-			{
-				effect *= -1;
-			}
-			skin->set_affected(k, static_cast<EApplyLocation>(location), effect);
-			k++;
-		}
-	}
+    {
+      concidence = true;
+      while (concidence) {
+        num = number(1, effects_l[GET_OBJ_VAL(skin, 3)][0][1]);
+        concidence = false;
+        for (int n = 0; n <= k && i > 1; n++) {
+          if (effects_l[GET_OBJ_VAL(skin, 3)][num][0] == (skin)->get_affected(n).location) {
+            concidence = true;
+          }
+        }
+      }
+      auto location = effects_l[GET_OBJ_VAL(skin, 3)][num][0];
+      effect = effects_l[GET_OBJ_VAL(skin, 3)][num][1];
+      if (number(0, 1000) <= (250 / (GET_OBJ_VAL(skin, 3) + 1))) //  чем круче шкура тем реже  отрицательный аффект
+      {
+        effect *= -1;
+      }
+      skin->set_affected(k, static_cast<EApplyLocation>(location), effect);
+      k++;
+    }
+  }
 
-	skin->set_cost(GET_LEVEL(mob) * number(2, MAX(3, 3 * k)));
-	skin->set_val(2, 95); //оставил 5% фейла переноса аффектов на создаваемую шмотку
+  skin->set_cost(GET_LEVEL(mob) * number(2, MAX(3, 3 * k)));
+  skin->set_val(2, 95); //оставил 5% фейла переноса аффектов на создаваемую шмотку
 
-	act("$n умело срезал$g $o3.", FALSE, ch, skin.get(), 0, TO_ROOM | TO_ARENA_LISTEN);
-	act("Вы умело срезали $o3.", FALSE, ch, skin.get(), 0, TO_CHAR);
+  act("$n умело срезал$g $o3.", FALSE, ch, skin.get(), 0, TO_ROOM | TO_ARENA_LISTEN);
+  act("Вы умело срезали $o3.", FALSE, ch, skin.get(), 0, TO_CHAR);
 
-	//ставим флажок "не зависит от прототипа"
-	skin->set_extra_flag(EExtraFlag::ITEM_NOT_DEPEND_RPOTO);
-	return skin.get();
+  //ставим флажок "не зависит от прототипа"
+  skin->set_extra_flag(EExtraFlag::ITEM_NOT_DEPEND_RPOTO);
+  return skin.get();
 }
 
-void do_put(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	char arg1[MAX_INPUT_LENGTH];
-	char arg2[MAX_INPUT_LENGTH];
-	char arg3[MAX_INPUT_LENGTH];
-	char arg4[MAX_INPUT_LENGTH];
-	OBJ_DATA *next_obj, *cont;
-	CHAR_DATA *tmp_char;
-	int obj_dotmode, cont_dotmode, found = 0, howmany = 1, money_mode = FALSE;
-	char *theobj, *thecont, *theplace;
-	int where_bits = FIND_OBJ_INV | FIND_OBJ_EQUIP | FIND_OBJ_ROOM;
+void do_put(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  char arg1[MAX_INPUT_LENGTH];
+  char arg2[MAX_INPUT_LENGTH];
+  char arg3[MAX_INPUT_LENGTH];
+  char arg4[MAX_INPUT_LENGTH];
+  OBJ_DATA *next_obj, *cont;
+  CHAR_DATA *tmp_char;
+  int obj_dotmode, cont_dotmode, found = 0, howmany = 1, money_mode = FALSE;
+  char *theobj, *thecont, *theplace;
+  int where_bits = FIND_OBJ_INV | FIND_OBJ_EQUIP | FIND_OBJ_ROOM;
 
+  argument = two_arguments(argument, arg1, arg2);
+  argument = two_arguments(argument, arg3, arg4);
 
-	argument = two_arguments(argument, arg1, arg2);
-	argument = two_arguments(argument, arg3, arg4);
+  if (is_number(arg1)) {
+    howmany = atoi(arg1);
+    theobj = arg2;
+    thecont = arg3;
+    theplace = arg4;
+  } else {
+    theobj = arg1;
+    thecont = arg2;
+    theplace = arg3;
+  }
 
-	if (is_number(arg1))
-	{
-		howmany = atoi(arg1);
-		theobj = arg2;
-		thecont = arg3;
-		theplace = arg4;
-	}
-	else
-	{
-		theobj = arg1;
-		thecont = arg2;
-		theplace = arg3;
-	}
+  if (isname(theplace, "земля комната room ground"))
+    where_bits = FIND_OBJ_ROOM;
+  else if (isname(theplace, "инвентарь inventory"))
+    where_bits = FIND_OBJ_INV;
+  else if (isname(theplace, "экипировка equipment"))
+    where_bits = FIND_OBJ_EQUIP;
 
-	if (isname(theplace, "земля комната room ground"))
-		where_bits = FIND_OBJ_ROOM;
-	else if (isname(theplace, "инвентарь inventory"))
-		where_bits = FIND_OBJ_INV;
-	else if (isname(theplace, "экипировка equipment"))
-		where_bits = FIND_OBJ_EQUIP;
+  if (theobj && (!strn_cmp("coin", theobj, 4) || !strn_cmp("кун", theobj, 3))) {
+    money_mode = TRUE;
+    if (howmany <= 0) {
+      send_to_char("Следует указать чиста конкретную сумму.\r\n", ch);
+      return;
+    }
+    if (ch->get_gold() < howmany) {
+      send_to_char("Нет у вас такой суммы.\r\n", ch);
+      return;
+    }
+    obj_dotmode = FIND_INDIV;
+  } else
+    obj_dotmode = find_all_dots(theobj);
 
+  cont_dotmode = find_all_dots(thecont);
 
-	if (theobj && (!strn_cmp("coin", theobj, 4) || !strn_cmp("кун", theobj, 3)))
-	{
-		money_mode = TRUE;
-		if (howmany <= 0)
-		{
-			send_to_char("Следует указать чиста конкретную сумму.\r\n", ch);
-			return;
-		}
-		if (ch->get_gold() < howmany)
-		{
-			send_to_char("Нет у вас такой суммы.\r\n", ch);
-			return;
-		}
-		obj_dotmode = FIND_INDIV;
-	}
-	else
-		obj_dotmode = find_all_dots(theobj);
+  if (!*theobj)
+    send_to_char("Положить что и куда?\r\n", ch);
+  else if (cont_dotmode != FIND_INDIV)
+    send_to_char("Вы можете положить вещь только в один контейнер.\r\n", ch);
+  else if (!*thecont) {
+    sprintf(buf, "Куда вы хотите положить '%s'?\r\n", theobj);
+    send_to_char(buf, ch);
+  } else {
+    generic_find(thecont, where_bits, ch, &tmp_char, &cont);
+    if (!cont) {
+      sprintf(buf, "Вы не видите здесь '%s'.\r\n", thecont);
+      send_to_char(buf, ch);
+    } else if (GET_OBJ_TYPE(cont) != OBJ_DATA::ITEM_CONTAINER) {
+      act("В $o3 нельзя ничего положить.", FALSE, ch, cont, 0, TO_CHAR);
+    } else if (OBJVAL_FLAGGED(cont, CONT_CLOSED)) {
+      act("$o0 закрыт$A!", FALSE, ch, cont, 0, TO_CHAR);
+    } else {
+      if (obj_dotmode == FIND_INDIV)    // put <obj> <container>
+      {
+        if (money_mode) {
+          if (ROOM_FLAGGED(ch->in_room, ROOM_NOITEM)) {
+            act("Неведомая сила помешала вам сделать это!!", FALSE,
+                ch, 0, 0, TO_CHAR);
+            return;
+          }
 
-	cont_dotmode = find_all_dots(thecont);
+          const auto obj = create_money(howmany);
 
-	if (!*theobj)
-		send_to_char("Положить что и куда?\r\n", ch);
-	else if (cont_dotmode != FIND_INDIV)
-		send_to_char("Вы можете положить вещь только в один контейнер.\r\n", ch);
-	else if (!*thecont)
-	{
-		sprintf(buf, "Куда вы хотите положить '%s'?\r\n", theobj);
-		send_to_char(buf, ch);
-	}
-	else
-	{
-		generic_find(thecont, where_bits, ch, &tmp_char, &cont);
-		if (!cont)
-		{
-			sprintf(buf, "Вы не видите здесь '%s'.\r\n", thecont);
-			send_to_char(buf, ch);
-		}
-		else if (GET_OBJ_TYPE(cont) != OBJ_DATA::ITEM_CONTAINER)
-		{
-			act("В $o3 нельзя ничего положить.", FALSE, ch, cont, 0, TO_CHAR);
-		}
-		else if (OBJVAL_FLAGGED(cont, CONT_CLOSED))
-		{
-			act("$o0 закрыт$A!", FALSE, ch, cont, 0, TO_CHAR);
-		}
-		else
-		{
-			if (obj_dotmode == FIND_INDIV)  	// put <obj> <container>
-			{
-				if (money_mode)
-				{
-					if (ROOM_FLAGGED(ch->in_room, ROOM_NOITEM))
-					{
-						act("Неведомая сила помешала вам сделать это!!", FALSE,
-							ch, 0, 0, TO_CHAR);
-						return;
-					}
+          if (!obj) {
+            return;
+          }
 
-					const auto obj = create_money(howmany);
+          obj_to_char(obj.get(), ch);
+          ch->remove_gold(howmany);
 
-					if (!obj)
-					{
-						return;
-					}
+          // если положить не удалось - возвращаем все взад
+          if (perform_put(ch, obj, cont)) {
+            obj_from_char(obj.get());
+            extract_obj(obj.get());
+            ch->add_gold(howmany);
+            return;
+          }
+        } else {
+          auto obj = get_obj_in_list_vis(ch, theobj, ch->carrying);
+          if (!obj) {
+            sprintf(buf, "У вас нет '%s'.\r\n", theobj);
+            send_to_char(buf, ch);
+          } else if (obj == cont) {
+            send_to_char("Вам будет трудно запихнуть вещь саму в себя.\r\n", ch);
+          } else {
+            OBJ_DATA *next_obj;
+            while (obj && howmany--) {
+              next_obj = obj->get_next_content();
+              const auto object_ptr = world_objects.get_by_raw_ptr(obj);
+              if (perform_put(ch, object_ptr, cont) == 1) {
+                return;
+              }
+              obj = get_obj_in_list_vis(ch, theobj, next_obj);
+            }
+          }
+        }
+      } else {
+        for (auto obj = ch->carrying; obj; obj = next_obj) {
+          next_obj = obj->get_next_content();
+          if (obj != cont
+              && CAN_SEE_OBJ(ch, obj)
+              && (obj_dotmode == FIND_ALL
+                  || isname(theobj, obj->get_aliases())
+                  || CHECK_CUSTOM_LABEL(theobj, obj, ch))) {
+            found = 1;
+            const auto object_ptr = world_objects.get_by_raw_ptr(obj);
+            if (perform_put(ch, object_ptr, cont) == 1) {
+              return;
+            }
+          }
+        }
 
-					obj_to_char(obj.get(), ch);
-					ch->remove_gold(howmany);
-
-					// если положить не удалось - возвращаем все взад
-					if (perform_put(ch, obj, cont))
-					{
-						obj_from_char(obj.get());
-						extract_obj(obj.get());
-						ch->add_gold(howmany);
-						return;
-					}
-				}
-				else
-				{
-					auto obj = get_obj_in_list_vis(ch, theobj, ch->carrying);
-					if (!obj)
-					{
-						sprintf(buf, "У вас нет '%s'.\r\n", theobj);
-						send_to_char(buf, ch);
-					}
-					else if (obj == cont)
-					{
-						send_to_char("Вам будет трудно запихнуть вещь саму в себя.\r\n", ch);
-					}
-					else
-					{
-						OBJ_DATA *next_obj;
-						while (obj && howmany--)
-						{
-							next_obj = obj->get_next_content();
-							const auto object_ptr = world_objects.get_by_raw_ptr(obj);
-							if (perform_put(ch, object_ptr, cont) == 1)
-							{
-								return;
-							}
-							obj = get_obj_in_list_vis(ch, theobj, next_obj);
-						}
-					}
-				}
-			}
-			else
-			{
-				for (auto obj = ch->carrying; obj; obj = next_obj)
-				{
-					next_obj = obj->get_next_content();
-					if (obj != cont
-						&& CAN_SEE_OBJ(ch, obj)
-						&& (obj_dotmode == FIND_ALL
-							|| isname(theobj, obj->get_aliases())
-							|| CHECK_CUSTOM_LABEL(theobj, obj, ch)))
-					{
-						found = 1;
-						const auto object_ptr = world_objects.get_by_raw_ptr(obj);
-						if (perform_put(ch, object_ptr, cont) == 1)
-						{
-							return;
-						}
-					}
-				}
-
-				if (!found)
-				{
-					if (obj_dotmode == FIND_ALL)
-						send_to_char
-						("Чтобы положить что-то ненужное нужно купить что-то ненужное.\r\n",
-						 ch);
-					else
-					{
-						sprintf(buf, "Вы не видите ничего похожего на '%s'.\r\n", theobj);
-						send_to_char(buf, ch);
-					}
-				}
-			}
-		}
-	}
+        if (!found) {
+          if (obj_dotmode == FIND_ALL)
+            send_to_char
+                ("Чтобы положить что-то ненужное нужно купить что-то ненужное.\r\n",
+                 ch);
+          else {
+            sprintf(buf, "Вы не видите ничего похожего на '%s'.\r\n", theobj);
+            send_to_char(buf, ch);
+          }
+        }
+      }
+    }
+  }
 }
 
 //переложить стрелы из пучка стрел
 //в колчан
-void do_refill(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	char arg1[MAX_INPUT_LENGTH];
-	char arg2[MAX_INPUT_LENGTH];
-	OBJ_DATA *from_obj = NULL, *to_obj = NULL;
+void do_refill(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  char arg1[MAX_INPUT_LENGTH];
+  char arg2[MAX_INPUT_LENGTH];
+  OBJ_DATA *from_obj = NULL, *to_obj = NULL;
 
-	argument = two_arguments(argument, arg1, arg2);
+  argument = two_arguments(argument, arg1, arg2);
 
-	if (!*arg1)  	// No arguments //
-	{
-		send_to_char("Откуда брать стрелы?\r\n", ch);
-		return;
-	}
-	if (!(from_obj = get_obj_in_list_vis(ch, arg1, ch->carrying)))
-	{
-		send_to_char("У вас нет этого!\r\n", ch);
-		return;
-	}
-	if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_MAGIC_ARROW)
-	{
-		send_to_char("И как вы себе это представляете?\r\n", ch);
-		return;
-	}
- 	if (GET_OBJ_VAL(from_obj, 1) == 0)
-	{
-		act("Пусто.", FALSE, ch, from_obj, 0, TO_CHAR);
-		return;
-	}
-	if (!*arg2)
-	{
-		send_to_char("Куда вы хотите их засунуть?\r\n", ch);
-		return;
-	}
-	if (!(to_obj = get_obj_in_list_vis(ch, arg2, ch->carrying)))
-	{
-		send_to_char("Вы не можете этого найти!\r\n", ch);
-		return;
-	}
-	if (!((GET_OBJ_TYPE(to_obj) == OBJ_DATA::ITEM_MAGIC_CONTAINER) || GET_OBJ_TYPE(to_obj) == OBJ_DATA::ITEM_MAGIC_ARROW))
-	{
-		send_to_char("Вы не сможете в это сложить стрелы.\r\n", ch);
-		return;
-	}
+  if (!*arg1)    // No arguments //
+  {
+    send_to_char("Откуда брать стрелы?\r\n", ch);
+    return;
+  }
+  if (!(from_obj = get_obj_in_list_vis(ch, arg1, ch->carrying))) {
+    send_to_char("У вас нет этого!\r\n", ch);
+    return;
+  }
+  if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_MAGIC_ARROW) {
+    send_to_char("И как вы себе это представляете?\r\n", ch);
+    return;
+  }
+  if (GET_OBJ_VAL(from_obj, 1) == 0) {
+    act("Пусто.", FALSE, ch, from_obj, 0, TO_CHAR);
+    return;
+  }
+  if (!*arg2) {
+    send_to_char("Куда вы хотите их засунуть?\r\n", ch);
+    return;
+  }
+  if (!(to_obj = get_obj_in_list_vis(ch, arg2, ch->carrying))) {
+    send_to_char("Вы не можете этого найти!\r\n", ch);
+    return;
+  }
+  if (!((GET_OBJ_TYPE(to_obj) == OBJ_DATA::ITEM_MAGIC_CONTAINER)
+      || GET_OBJ_TYPE(to_obj) == OBJ_DATA::ITEM_MAGIC_ARROW)) {
+    send_to_char("Вы не сможете в это сложить стрелы.\r\n", ch);
+    return;
+  }
 
-	if (to_obj == from_obj)
-	{
-		send_to_char("Нечем заняться? На печи ездить еще не научились?\r\n", ch);
-		return;
-	}
+  if (to_obj == from_obj) {
+    send_to_char("Нечем заняться? На печи ездить еще не научились?\r\n", ch);
+    return;
+  }
 
-	if (GET_OBJ_VAL(to_obj, 2) >= GET_OBJ_VAL(to_obj, 1))
-	{
-		send_to_char("Там нет места.\r\n", ch);
-		return;
-	}
-        else //вроде прошли все проверки. начинаем перекладывать
-        {
-            if (GET_OBJ_VAL(from_obj, 0) != GET_OBJ_VAL(to_obj, 0))
-            {
-                    send_to_char("Хамово ремесло еще не известно на руси.\r\n", ch);
-                    return;
-            }
-            int t1 = GET_OBJ_VAL(from_obj, 3);  // количество зарядов
-            int t2 = GET_OBJ_VAL(to_obj, 3);
-            int delta = (GET_OBJ_VAL(to_obj, 2) - GET_OBJ_VAL(to_obj, 3));
-            if (delta >= t1) //объем колчана больше пучка
-            {
-                to_obj->add_val(2, t1);
-		send_to_char("Вы аккуратно сложили стрелы в колчан.\r\n", ch);
-		extract_obj(from_obj);
-		return;
-            }
-            else
-            {
-                to_obj->add_val(2, (t2-GET_OBJ_VAL(to_obj, 2)));
-		send_to_char("Вы аккуратно переложили несколько стрел в колчан.\r\n", ch);
-		from_obj->add_val(2, (GET_OBJ_VAL(to_obj, 2)-t2));
-		return;
-            }
-        }
+  if (GET_OBJ_VAL(to_obj, 2) >= GET_OBJ_VAL(to_obj, 1)) {
+    send_to_char("Там нет места.\r\n", ch);
+    return;
+  } else //вроде прошли все проверки. начинаем перекладывать
+  {
+    if (GET_OBJ_VAL(from_obj, 0) != GET_OBJ_VAL(to_obj, 0)) {
+      send_to_char("Хамово ремесло еще не известно на руси.\r\n", ch);
+      return;
+    }
+    int t1 = GET_OBJ_VAL(from_obj, 3);  // количество зарядов
+    int t2 = GET_OBJ_VAL(to_obj, 3);
+    int delta = (GET_OBJ_VAL(to_obj, 2) - GET_OBJ_VAL(to_obj, 3));
+    if (delta >= t1) //объем колчана больше пучка
+    {
+      to_obj->add_val(2, t1);
+      send_to_char("Вы аккуратно сложили стрелы в колчан.\r\n", ch);
+      extract_obj(from_obj);
+      return;
+    } else {
+      to_obj->add_val(2, (t2 - GET_OBJ_VAL(to_obj, 2)));
+      send_to_char("Вы аккуратно переложили несколько стрел в колчан.\r\n", ch);
+      from_obj->add_val(2, (GET_OBJ_VAL(to_obj, 2) - t2));
+      return;
+    }
+  }
 
-
-	send_to_char("С таким успехом надо пополнять соседние камни, для разговоров по ним.\r\n", ch);
-	return ;
+  send_to_char("С таким успехом надо пополнять соседние камни, для разговоров по ним.\r\n", ch);
+  return;
 
 }
 
-
-int can_take_obj(CHAR_DATA * ch, OBJ_DATA * obj)
-{
-	if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch)
-		&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_MONEY)
-	{
-		act("$p: Вы не могете нести столько вещей.", FALSE, ch, obj, 0, TO_CHAR);
-		return (0);
-	}
-	else if ((IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(obj)) > CAN_CARRY_W(ch)
-		&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_MONEY)
-	{
-		act("$p: Вы не в состоянии нести еще и $S.", FALSE, ch, obj, 0, TO_CHAR);
-		return (0);
-	}
-	else if (!(CAN_WEAR(obj, EWearFlag::ITEM_WEAR_TAKE)))
-	{
-		act("$p: Вы не можете взять $S.", FALSE, ch, obj, 0, TO_CHAR);
-		return (0);
-	}
-	else if (invalid_anti_class(ch, obj))
-	{
-		act("$p: Эта вещь не предназначена для вас!", FALSE, ch, obj, 0, TO_CHAR);
-		return (0);
-	}
-	else if (NamedStuff::check_named(ch, obj, 0))
-	{
-		if(!NamedStuff::wear_msg(ch, obj))
-			act("$p: Эта вещь не предназначена для вас!", FALSE, ch, obj, 0, TO_CHAR);
-		return (0);
-	}
-	return (1);
+int can_take_obj(CHAR_DATA *ch, OBJ_DATA *obj) {
+  if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch)
+      && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_MONEY) {
+    act("$p: Вы не могете нести столько вещей.", FALSE, ch, obj, 0, TO_CHAR);
+    return (0);
+  } else if ((IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(obj)) > CAN_CARRY_W(ch)
+      && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_MONEY) {
+    act("$p: Вы не в состоянии нести еще и $S.", FALSE, ch, obj, 0, TO_CHAR);
+    return (0);
+  } else if (!(CAN_WEAR(obj, EWearFlag::ITEM_WEAR_TAKE))) {
+    act("$p: Вы не можете взять $S.", FALSE, ch, obj, 0, TO_CHAR);
+    return (0);
+  } else if (invalid_anti_class(ch, obj)) {
+    act("$p: Эта вещь не предназначена для вас!", FALSE, ch, obj, 0, TO_CHAR);
+    return (0);
+  } else if (NamedStuff::check_named(ch, obj, 0)) {
+    if (!NamedStuff::wear_msg(ch, obj))
+      act("$p: Эта вещь не предназначена для вас!", FALSE, ch, obj, 0, TO_CHAR);
+    return (0);
+  }
+  return (1);
 }
 
 /// считаем сколько у ch в группе еще игроков (не мобов)
-int other_pc_in_group(CHAR_DATA *ch)
-{
-	int num = 0;
-	CHAR_DATA *k = ch->has_master() ? ch->get_master() : ch;
-	for (follow_type *f = k->followers; f; f = f->next)
-	{
-		if (AFF_FLAGGED(f->follower, EAffectFlag::AFF_GROUP)
-			&& !IS_NPC(f->follower)
-			&& IN_ROOM(f->follower) == ch->in_room)
-		{
-			++num;
-		}
-	}
-	return num;
+int other_pc_in_group(CHAR_DATA *ch) {
+  int num = 0;
+  CHAR_DATA *k = ch->has_master() ? ch->get_master() : ch;
+  for (follow_type *f = k->followers; f; f = f->next) {
+    if (AFF_FLAGGED(f->follower, EAffectFlag::AFF_GROUP)
+        && !IS_NPC(f->follower)
+        && IN_ROOM(f->follower) == ch->in_room) {
+      ++num;
+    }
+  }
+  return num;
 }
 
-void split_or_clan_tax(CHAR_DATA *ch, long amount)
-{
-	if (IS_AFFECTED(ch, AFF_GROUP)
-		&& other_pc_in_group(ch) > 0
-		&& PRF_FLAGGED(ch, PRF_AUTOSPLIT))
-	{
-		char buf_[MAX_INPUT_LENGTH];
-		snprintf(buf_, sizeof(buf_), "%ld", amount);
-		do_split(ch, buf_, 0, 0);
-	}
-	else
-	{
-		long tax = ClanSystem::do_gold_tax(ch, amount);
-		ch->remove_gold(tax);
-	}
+void split_or_clan_tax(CHAR_DATA *ch, long amount) {
+  if (IS_AFFECTED(ch, AFF_GROUP)
+      && other_pc_in_group(ch) > 0
+      && PRF_FLAGGED(ch, PRF_AUTOSPLIT)) {
+    char buf_[MAX_INPUT_LENGTH];
+    snprintf(buf_, sizeof(buf_), "%ld", amount);
+    do_split(ch, buf_, 0, 0);
+  } else {
+    long tax = ClanSystem::do_gold_tax(ch, amount);
+    ch->remove_gold(tax);
+  }
 }
 
+void get_check_money(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *cont) {
 
-void get_check_money(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *cont)
-{
+  if (system_obj::is_purse(obj) && GET_OBJ_VAL(obj, 3) == ch->get_uid()) {
+    system_obj::process_open_purse(ch, obj);
+    return;
+  }
 
-	if (system_obj::is_purse(obj) && GET_OBJ_VAL(obj, 3) == ch->get_uid())
-	{
-		system_obj::process_open_purse(ch, obj);
-		return;
-	}
+  const int value = GET_OBJ_VAL(obj, 0);
+  const int curr_type = GET_OBJ_VAL(obj, 1);
 
-	const int value = GET_OBJ_VAL(obj, 0);
-	const int curr_type = GET_OBJ_VAL(obj, 1);
+  if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_MONEY
+      || value <= 0) {
+    return;
+  }
 
-	if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_MONEY
-		|| value <= 0)
-	{
-		return;
-	}
-
-	if (curr_type == currency::ICE) {
-		sprintf(buf, "Это составило %d %s.\r\n", value, desc_count(value, WHAT_ICEu));
-		send_to_char(buf, ch);
-		ch->add_ice_currency(value);
-		//Делить лед ВСЕГДА!
-		if (IS_AFFECTED(ch, AFF_GROUP) && other_pc_in_group(ch) > 0) {
-			char local_buf[256];
-			sprintf(local_buf, "%d", value);
-			do_split(ch, local_buf, 0, 0,curr_type);
-		}
-		extract_obj(obj);
-		return;
-	}
+  if (curr_type == currency::ICE) {
+    sprintf(buf, "Это составило %d %s.\r\n", value, desc_count(value, WHAT_ICEu));
+    send_to_char(buf, ch);
+    ch->add_ice_currency(value);
+    //Делить лед ВСЕГДА!
+    if (IS_AFFECTED(ch, AFF_GROUP) && other_pc_in_group(ch) > 0) {
+      char local_buf[256];
+      sprintf(local_buf, "%d", value);
+      do_split(ch, local_buf, 0, 0, curr_type);
+    }
+    extract_obj(obj);
+    return;
+  }
 
 // Все что неизвестно - куны (для совместимости)
 /*	if (curr_type != currency::GOLD) {
@@ -805,27 +716,29 @@ void get_check_money(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *cont)
 		return;
 	}
 */
-	sprintf(buf, "Это составило %d %s.\r\n", value, desc_count(value, WHAT_MONEYu));
-	send_to_char(buf, ch);
+  sprintf(buf, "Это составило %d %s.\r\n", value, desc_count(value, WHAT_MONEYu));
+  send_to_char(buf, ch);
 
-	// все, что делится на группу - идет через налог (из кошельков не делится)
-	if (IS_AFFECTED(ch, AFF_GROUP) && other_pc_in_group(ch) > 0
-		&& PRF_FLAGGED(ch, PRF_AUTOSPLIT)
-		&& (!cont || !system_obj::is_purse(cont)))
-	{
-		// добавляем бабло, пишем в лог, клан-налог снимаем
-		// только по факту деления на группу в do_split()
-		ch->add_gold(value);
-		sprintf(buf, "<%s> {%d} заработал %d %s в группе.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), value,desc_count(value, WHAT_MONEYu));
-		mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-		char local_buf[256];
-		sprintf(local_buf, "%d", value);
-		do_split(ch, local_buf, 0, 0);
-	}
-	else if ((cont && IS_MOB_CORPSE(cont)) || GET_OBJ_VNUM(obj) != -1)
-	{
-		// лут из трупа моба или из предметов-денег с внумом
-		// (предметы-награды в зонах) - снимаем клан-налог
+  // все, что делится на группу - идет через налог (из кошельков не делится)
+  if (IS_AFFECTED(ch, AFF_GROUP) && other_pc_in_group(ch) > 0
+      && PRF_FLAGGED(ch, PRF_AUTOSPLIT)
+      && (!cont || !system_obj::is_purse(cont))) {
+    // добавляем бабло, пишем в лог, клан-налог снимаем
+    // только по факту деления на группу в do_split()
+    ch->add_gold(value);
+    sprintf(buf,
+            "<%s> {%d} заработал %d %s в группе.",
+            ch->get_name().c_str(),
+            GET_ROOM_VNUM(ch->in_room),
+            value,
+            desc_count(value, WHAT_MONEYu));
+    mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+    char local_buf[256];
+    sprintf(local_buf, "%d", value);
+    do_split(ch, local_buf, 0, 0);
+  } else if ((cont && IS_MOB_CORPSE(cont)) || GET_OBJ_VNUM(obj) != -1) {
+    // лут из трупа моба или из предметов-денег с внумом
+    // (предметы-награды в зонах) - снимаем клан-налог
 /*		int mob_num = GET_OBJ_VAL(cont, 2);
 		CHAR_DATA *mob;
 		if (mob_num  <= 0)
@@ -841,3071 +754,2516 @@ void get_check_money(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *cont)
 			extract_char(mob, FALSE);
 		}
 */
-		sprintf(buf, "%s заработал %d  %s.", ch->get_name().c_str(),  value,desc_count(value, WHAT_MONEYu));
-		mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-		ch->add_gold(value, true, true);
-	}
-	else
-	{
-		sprintf(buf, "<%s> {%d} как-то получил %d  %s.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), value,desc_count(value, WHAT_MONEYu));
-		mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-		ch->add_gold(value);
-	}
+    sprintf(buf, "%s заработал %d  %s.", ch->get_name().c_str(), value, desc_count(value, WHAT_MONEYu));
+    mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+    ch->add_gold(value, true, true);
+  } else {
+    sprintf(buf,
+            "<%s> {%d} как-то получил %d  %s.",
+            ch->get_name().c_str(),
+            GET_ROOM_VNUM(ch->in_room),
+            value,
+            desc_count(value, WHAT_MONEYu));
+    mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+    ch->add_gold(value);
+  }
 
-	obj_from_char(obj);
-	extract_obj(obj);
+  obj_from_char(obj);
+  extract_obj(obj);
 }
-
 
 // return 0 - чтобы словить невозможность взять из клан-сундука,
 // иначе при вз все сун будет спам на каждый предмет, мол низя
-bool perform_get_from_container(CHAR_DATA * ch, OBJ_DATA * obj, OBJ_DATA * cont, int mode)
-{
-	if (!bloody::handle_transfer(NULL, ch, obj))
-		return false;
-	if ((mode == FIND_OBJ_INV || mode == FIND_OBJ_ROOM || mode == FIND_OBJ_EQUIP) && can_take_obj(ch, obj) && get_otrigger(obj, ch))
-	{
-		// если берем из клан-сундука
-		if (Clan::is_clan_chest(cont))
-		{
-			if (!Clan::TakeChest(ch, obj, cont))
-			{
-				return 0;
-			}
-			return 1;
-		}
-		// клан-хранилище ингров
-		if (ClanSystem::is_ingr_chest(cont))
-		{
-			if (!Clan::take_ingr_chest(ch, obj, cont))
-			{
-				return 0;
-			}
-			return 1;
-		}
-		obj_from_obj(obj);
-		obj_to_char(obj, ch);
-		if (obj->get_carried_by() == ch)
-		{
-			if (bloody::is_bloody(obj))
-			{
-				act("Вы взяли $o3 из $O1, испачкав свои руки кровью!", FALSE, ch, obj, cont, TO_CHAR);
-				act("$n взял$g $o3 из $O1, испачкав руки кровью.", TRUE, ch, obj, cont, TO_ROOM | TO_ARENA_LISTEN);
-			} else
-			{
-				act("Вы взяли $o3 из $O1.", FALSE, ch, obj, cont, TO_CHAR);
-				act("$n взял$g $o3 из $O1.", TRUE, ch, obj, cont, TO_ROOM | TO_ARENA_LISTEN);
-			}
-			get_check_money(ch, obj, cont);
-		}
-	}
-	return 1;
+bool perform_get_from_container(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *cont, int mode) {
+  if (!bloody::handle_transfer(NULL, ch, obj))
+    return false;
+  if ((mode == FIND_OBJ_INV || mode == FIND_OBJ_ROOM || mode == FIND_OBJ_EQUIP) && can_take_obj(ch, obj)
+      && get_otrigger(obj, ch)) {
+    // если берем из клан-сундука
+    if (Clan::is_clan_chest(cont)) {
+      if (!Clan::TakeChest(ch, obj, cont)) {
+        return 0;
+      }
+      return 1;
+    }
+    // клан-хранилище ингров
+    if (ClanSystem::is_ingr_chest(cont)) {
+      if (!Clan::take_ingr_chest(ch, obj, cont)) {
+        return 0;
+      }
+      return 1;
+    }
+    obj_from_obj(obj);
+    obj_to_char(obj, ch);
+    if (obj->get_carried_by() == ch) {
+      if (bloody::is_bloody(obj)) {
+        act("Вы взяли $o3 из $O1, испачкав свои руки кровью!", FALSE, ch, obj, cont, TO_CHAR);
+        act("$n взял$g $o3 из $O1, испачкав руки кровью.", TRUE, ch, obj, cont, TO_ROOM | TO_ARENA_LISTEN);
+      } else {
+        act("Вы взяли $o3 из $O1.", FALSE, ch, obj, cont, TO_CHAR);
+        act("$n взял$g $o3 из $O1.", TRUE, ch, obj, cont, TO_ROOM | TO_ARENA_LISTEN);
+      }
+      get_check_money(ch, obj, cont);
+    }
+  }
+  return 1;
 }
 
 // *\param autoloot - true только при взятии шмоток из трупа в режиме автограбежа
-void get_from_container(CHAR_DATA * ch, OBJ_DATA * cont, char *arg, int mode, int howmany, bool autoloot)
-{
-	if (Depot::is_depot(cont))
-	{
-		Depot::take_depot(ch, arg, howmany);
-		return;
-	}
+void get_from_container(CHAR_DATA *ch, OBJ_DATA *cont, char *arg, int mode, int howmany, bool autoloot) {
+  if (Depot::is_depot(cont)) {
+    Depot::take_depot(ch, arg, howmany);
+    return;
+  }
 
-	OBJ_DATA *obj, *next_obj;
-	int obj_dotmode, found = 0;
+  OBJ_DATA *obj, *next_obj;
+  int obj_dotmode, found = 0;
 
-	obj_dotmode = find_all_dots(arg);
-	if (OBJVAL_FLAGGED(cont, CONT_CLOSED))
-		act("$o закрыт$A.", FALSE, ch, cont, 0, TO_CHAR);
-	else if (obj_dotmode == FIND_INDIV)
-	{
-		if (!(obj = get_obj_in_list_vis(ch, arg, cont->get_contains())))
-		{
-			sprintf(buf, "Вы не видите '%s' в $o5.", arg);
-			act(buf, FALSE, ch, cont, 0, TO_CHAR);
-		}
-		else
-		{
-			OBJ_DATA *obj_next;
-			while (obj && howmany--)
-			{
-				obj_next = obj->get_next_content();
-				if (!perform_get_from_container(ch, obj, cont, mode))
-					return;
-				obj = get_obj_in_list_vis(ch, arg, obj_next);
-			}
-		}
-	}
-	else
-	{
-		if (obj_dotmode == FIND_ALLDOT && !*arg)
-		{
-			send_to_char("Взять что \"все\"?\r\n", ch);
-			return;
-		}
-		for (obj = cont->get_contains(); obj; obj = next_obj)
-		{
-			next_obj = obj->get_next_content();
-			if (CAN_SEE_OBJ(ch, obj)
-				&& (obj_dotmode == FIND_ALL
-					|| isname(arg, obj->get_aliases())
-					|| CHECK_CUSTOM_LABEL(arg, obj, ch)))
-			{
-				if (autoloot
-					&& (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT
-						|| GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_MING)
-					&& PRF_FLAGGED(ch, PRF_NOINGR_LOOT))
-				{
-					continue;
-				}
-				found = 1;
-				if (!perform_get_from_container(ch, obj, cont, mode))
-				{
-					return;
-				}
-			}
-		}
-		if (!found)
-		{
-			if (obj_dotmode == FIND_ALL)
-				act("$o пуст$A.", FALSE, ch, cont, 0, TO_CHAR);
-			else
-			{
-				sprintf(buf, "Вы не видите ничего похожего на '%s' в $o5.", arg);
-				act(buf, FALSE, ch, cont, 0, TO_CHAR);
-			}
-		}
-	}
+  obj_dotmode = find_all_dots(arg);
+  if (OBJVAL_FLAGGED(cont, CONT_CLOSED))
+    act("$o закрыт$A.", FALSE, ch, cont, 0, TO_CHAR);
+  else if (obj_dotmode == FIND_INDIV) {
+    if (!(obj = get_obj_in_list_vis(ch, arg, cont->get_contains()))) {
+      sprintf(buf, "Вы не видите '%s' в $o5.", arg);
+      act(buf, FALSE, ch, cont, 0, TO_CHAR);
+    } else {
+      OBJ_DATA *obj_next;
+      while (obj && howmany--) {
+        obj_next = obj->get_next_content();
+        if (!perform_get_from_container(ch, obj, cont, mode))
+          return;
+        obj = get_obj_in_list_vis(ch, arg, obj_next);
+      }
+    }
+  } else {
+    if (obj_dotmode == FIND_ALLDOT && !*arg) {
+      send_to_char("Взять что \"все\"?\r\n", ch);
+      return;
+    }
+    for (obj = cont->get_contains(); obj; obj = next_obj) {
+      next_obj = obj->get_next_content();
+      if (CAN_SEE_OBJ(ch, obj)
+          && (obj_dotmode == FIND_ALL
+              || isname(arg, obj->get_aliases())
+              || CHECK_CUSTOM_LABEL(arg, obj, ch))) {
+        if (autoloot
+            && (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT
+                || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_MING)
+            && PRF_FLAGGED(ch, PRF_NOINGR_LOOT)) {
+          continue;
+        }
+        found = 1;
+        if (!perform_get_from_container(ch, obj, cont, mode)) {
+          return;
+        }
+      }
+    }
+    if (!found) {
+      if (obj_dotmode == FIND_ALL)
+        act("$o пуст$A.", FALSE, ch, cont, 0, TO_CHAR);
+      else {
+        sprintf(buf, "Вы не видите ничего похожего на '%s' в $o5.", arg);
+        act(buf, FALSE, ch, cont, 0, TO_CHAR);
+      }
+    }
+  }
 }
 
-
-int perform_get_from_room(CHAR_DATA * ch, OBJ_DATA * obj)
-{
-	if (can_take_obj(ch, obj) && get_otrigger(obj, ch) && bloody::handle_transfer(NULL, ch, obj))
-	{
-		obj_from_room(obj);
-		obj_to_char(obj, ch);
-		if (obj->get_carried_by() == ch)
-		{
-			if (bloody::is_bloody(obj))
-			{
-				act("Вы подняли $o3, испачкав свои руки кровью!", FALSE, ch, obj, 0, TO_CHAR);
-				act("$n поднял$g $o3, испачкав руки кровью.", TRUE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-			} else {
-				act("Вы подняли $o3.", FALSE, ch, obj, 0, TO_CHAR);
-				act("$n поднял$g $o3.", TRUE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-			}
-			get_check_money(ch, obj, 0);
-			return (1);
-		}
-	}
-	return (0);
+int perform_get_from_room(CHAR_DATA *ch, OBJ_DATA *obj) {
+  if (can_take_obj(ch, obj) && get_otrigger(obj, ch) && bloody::handle_transfer(NULL, ch, obj)) {
+    obj_from_room(obj);
+    obj_to_char(obj, ch);
+    if (obj->get_carried_by() == ch) {
+      if (bloody::is_bloody(obj)) {
+        act("Вы подняли $o3, испачкав свои руки кровью!", FALSE, ch, obj, 0, TO_CHAR);
+        act("$n поднял$g $o3, испачкав руки кровью.", TRUE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      } else {
+        act("Вы подняли $o3.", FALSE, ch, obj, 0, TO_CHAR);
+        act("$n поднял$g $o3.", TRUE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      }
+      get_check_money(ch, obj, 0);
+      return (1);
+    }
+  }
+  return (0);
 }
 
+void get_from_room(CHAR_DATA *ch, char *arg, int howmany) {
+  OBJ_DATA *obj, *next_obj;
+  int dotmode, found = 0;
 
-void get_from_room(CHAR_DATA * ch, char *arg, int howmany)
-{
-	OBJ_DATA *obj, *next_obj;
-	int dotmode, found = 0;
+  // Are they trying to take something in a room extra description?
+  if (find_exdesc(arg, world[ch->in_room]->ex_description) != NULL) {
+    send_to_char("Вы не можете это взять.\r\n", ch);
+    return;
+  }
 
-	// Are they trying to take something in a room extra description?
-	if (find_exdesc(arg, world[ch->in_room]->ex_description) != NULL)
-	{
-		send_to_char("Вы не можете это взять.\r\n", ch);
-		return;
-	}
+  dotmode = find_all_dots(arg);
 
-	dotmode = find_all_dots(arg);
-
-	if (dotmode == FIND_INDIV)
-	{
-		if (!(obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents)))
-		{
-			sprintf(buf, "Вы не видите здесь '%s'.\r\n", arg);
-			send_to_char(buf, ch);
-		}
-		else
-		{
-			OBJ_DATA *obj_next;
-			while (obj && howmany--)
-			{
-				obj_next = obj->get_next_content();
-				perform_get_from_room(ch, obj);
-				obj = get_obj_in_list_vis(ch, arg, obj_next);
-			}
-		}
-	}
-	else
-	{
-		if (dotmode == FIND_ALLDOT && !*arg)
-		{
-			send_to_char("Взять что \"все\"?\r\n", ch);
-			return;
-		}
-		for (obj = world[ch->in_room]->contents; obj; obj = next_obj)
-		{
-			next_obj = obj->get_next_content();
-			if (CAN_SEE_OBJ(ch, obj)
-				&& (dotmode == FIND_ALL
-					|| isname(arg, obj->get_aliases())
-					|| CHECK_CUSTOM_LABEL(arg, obj, ch)))
-			{
-				found = 1;
-				perform_get_from_room(ch, obj);
-			}
-		}
-		if (!found)
-		{
-			if (dotmode == FIND_ALL)
-			{
-				send_to_char("Похоже, здесь ничего нет.\r\n", ch);
-			}
-			else
-			{
-				sprintf(buf, "Вы не нашли здесь '%s'.\r\n", arg);
-				send_to_char(buf, ch);
-			}
-		}
-	}
+  if (dotmode == FIND_INDIV) {
+    if (!(obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents))) {
+      sprintf(buf, "Вы не видите здесь '%s'.\r\n", arg);
+      send_to_char(buf, ch);
+    } else {
+      OBJ_DATA *obj_next;
+      while (obj && howmany--) {
+        obj_next = obj->get_next_content();
+        perform_get_from_room(ch, obj);
+        obj = get_obj_in_list_vis(ch, arg, obj_next);
+      }
+    }
+  } else {
+    if (dotmode == FIND_ALLDOT && !*arg) {
+      send_to_char("Взять что \"все\"?\r\n", ch);
+      return;
+    }
+    for (obj = world[ch->in_room]->contents; obj; obj = next_obj) {
+      next_obj = obj->get_next_content();
+      if (CAN_SEE_OBJ(ch, obj)
+          && (dotmode == FIND_ALL
+              || isname(arg, obj->get_aliases())
+              || CHECK_CUSTOM_LABEL(arg, obj, ch))) {
+        found = 1;
+        perform_get_from_room(ch, obj);
+      }
+    }
+    if (!found) {
+      if (dotmode == FIND_ALL) {
+        send_to_char("Похоже, здесь ничего нет.\r\n", ch);
+      } else {
+        sprintf(buf, "Вы не нашли здесь '%s'.\r\n", arg);
+        send_to_char(buf, ch);
+      }
+    }
+  }
 }
 
-void do_mark(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	char arg1[MAX_INPUT_LENGTH];
-	char arg2[MAX_INPUT_LENGTH];
+void do_mark(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  char arg1[MAX_INPUT_LENGTH];
+  char arg2[MAX_INPUT_LENGTH];
 
-	int cont_dotmode, found = 0;
-	OBJ_DATA *cont;
-	CHAR_DATA *tmp_char;
+  int cont_dotmode, found = 0;
+  OBJ_DATA *cont;
+  CHAR_DATA *tmp_char;
 
-	argument = two_arguments(argument, arg1, arg2);
+  argument = two_arguments(argument, arg1, arg2);
 
-	if (!*arg1)
-	{
-		send_to_char("Что вы хотите маркировать?\r\n", ch);
-	}
-	else if (!*arg2 || !is_number(arg2))
-	{
-		send_to_char("Не указан или неверный маркер.\r\n", ch);
-	}
-	else
-	{
-		cont_dotmode = find_all_dots(arg1);
-		if (cont_dotmode == FIND_INDIV)
-		{
-			generic_find(arg1, FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP, ch, &tmp_char, &cont);
-			if (!cont)
-			{
-				sprintf(buf, "У вас нет '%s'.\r\n", arg1);
-				send_to_char(buf, ch);
-				return;
-			}
-			cont->set_owner(atoi(arg2));
-			act("Вы пометили $o3.", FALSE, ch, cont, 0, TO_CHAR);
-		}
-		else
-		{
-			if (cont_dotmode == FIND_ALLDOT && !*arg1)
-			{
-				send_to_char("Пометить что \"все\"?\r\n", ch);
-				return;
-			}
-			for (cont = ch->carrying; cont; cont = cont->get_next_content())
-			{
-				if (CAN_SEE_OBJ(ch, cont)
-					&& (cont_dotmode == FIND_ALL
-						|| isname(arg1, cont->get_aliases())))
-				{
-					cont->set_owner(atoi(arg2));
-					act("Вы пометили $o3.", FALSE, ch, cont, 0, TO_CHAR);
-					found = TRUE;
-				}
-			}
-			for (cont = world[ch->in_room]->contents; cont; cont = cont->get_next_content())
-			{
-				if (CAN_SEE_OBJ(ch, cont)
-					&& (cont_dotmode == FIND_ALL
-						|| isname(arg2, cont->get_aliases())))
-				{
-					cont->set_owner(atoi(arg2));
-					act("Вы пометили $o3.", FALSE, ch, cont, 0, TO_CHAR);
-					found = TRUE;
-				}
-			}
-			if (!found)
-			{
-				if (cont_dotmode == FIND_ALL)
-				{
-					send_to_char("Вы не смогли найти ничего для маркировки.\r\n", ch);
-				}
-				else
-				{
-					sprintf(buf, "Вы что-то не видите здесь '%s'.\r\n", arg1);
-					send_to_char(buf, ch);
-				}
-			}
-		}
-	}
+  if (!*arg1) {
+    send_to_char("Что вы хотите маркировать?\r\n", ch);
+  } else if (!*arg2 || !is_number(arg2)) {
+    send_to_char("Не указан или неверный маркер.\r\n", ch);
+  } else {
+    cont_dotmode = find_all_dots(arg1);
+    if (cont_dotmode == FIND_INDIV) {
+      generic_find(arg1, FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP, ch, &tmp_char, &cont);
+      if (!cont) {
+        sprintf(buf, "У вас нет '%s'.\r\n", arg1);
+        send_to_char(buf, ch);
+        return;
+      }
+      cont->set_owner(atoi(arg2));
+      act("Вы пометили $o3.", FALSE, ch, cont, 0, TO_CHAR);
+    } else {
+      if (cont_dotmode == FIND_ALLDOT && !*arg1) {
+        send_to_char("Пометить что \"все\"?\r\n", ch);
+        return;
+      }
+      for (cont = ch->carrying; cont; cont = cont->get_next_content()) {
+        if (CAN_SEE_OBJ(ch, cont)
+            && (cont_dotmode == FIND_ALL
+                || isname(arg1, cont->get_aliases()))) {
+          cont->set_owner(atoi(arg2));
+          act("Вы пометили $o3.", FALSE, ch, cont, 0, TO_CHAR);
+          found = TRUE;
+        }
+      }
+      for (cont = world[ch->in_room]->contents; cont; cont = cont->get_next_content()) {
+        if (CAN_SEE_OBJ(ch, cont)
+            && (cont_dotmode == FIND_ALL
+                || isname(arg2, cont->get_aliases()))) {
+          cont->set_owner(atoi(arg2));
+          act("Вы пометили $o3.", FALSE, ch, cont, 0, TO_CHAR);
+          found = TRUE;
+        }
+      }
+      if (!found) {
+        if (cont_dotmode == FIND_ALL) {
+          send_to_char("Вы не смогли найти ничего для маркировки.\r\n", ch);
+        } else {
+          sprintf(buf, "Вы что-то не видите здесь '%s'.\r\n", arg1);
+          send_to_char(buf, ch);
+        }
+      }
+    }
+  }
 }
 
-void do_get(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	char arg1[MAX_INPUT_LENGTH];
-	char arg2[MAX_INPUT_LENGTH];
-	char arg3[MAX_INPUT_LENGTH];
-	char arg4[MAX_INPUT_LENGTH];
-	char *theobj, *thecont, *theplace;
-	int where_bits = FIND_OBJ_INV | FIND_OBJ_EQUIP | FIND_OBJ_ROOM;
+void do_get(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  char arg1[MAX_INPUT_LENGTH];
+  char arg2[MAX_INPUT_LENGTH];
+  char arg3[MAX_INPUT_LENGTH];
+  char arg4[MAX_INPUT_LENGTH];
+  char *theobj, *thecont, *theplace;
+  int where_bits = FIND_OBJ_INV | FIND_OBJ_EQUIP | FIND_OBJ_ROOM;
 
-	int cont_dotmode, found = 0, mode, amount = 1;
-	OBJ_DATA *cont;
-	CHAR_DATA *tmp_char;
+  int cont_dotmode, found = 0, mode, amount = 1;
+  OBJ_DATA *cont;
+  CHAR_DATA *tmp_char;
 
-	argument = two_arguments(argument, arg1, arg2);
-	argument = two_arguments(argument, arg3, arg4);
+  argument = two_arguments(argument, arg1, arg2);
+  argument = two_arguments(argument, arg3, arg4);
 
-	if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch))
-		send_to_char("У вас заняты руки!\r\n", ch);
-	else if (!*arg1)
-		send_to_char("Что вы хотите взять?\r\n", ch);
-	else if (!*arg2 || isname(arg2, "земля комната ground room"))
-		get_from_room(ch, arg1, 1);
-	else if (is_number(arg1) && (!*arg3 || isname(arg3, "земля комната ground room")))
-		get_from_room(ch, arg2, atoi(arg1));
-	else if ((!*arg3 && isname(arg2, "инвентарь экипировка inventory equipment")) ||
-			 (is_number(arg1) && !*arg4 && isname(arg3, "инвентарь экипировка inventory equipment")))
-		send_to_char("Вы уже подобрали этот предмет!\r\n", ch);
-	else
-	{
-		if (is_number(arg1))
-		{
-			amount = atoi(arg1);
-			theobj = arg2;
-			thecont = arg3;
-			theplace = arg4;
-		}
-		else
-		{
-			theobj = arg1;
-			thecont = arg2;
-			theplace = arg3;
-		}
+  if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch))
+    send_to_char("У вас заняты руки!\r\n", ch);
+  else if (!*arg1)
+    send_to_char("Что вы хотите взять?\r\n", ch);
+  else if (!*arg2 || isname(arg2, "земля комната ground room"))
+    get_from_room(ch, arg1, 1);
+  else if (is_number(arg1) && (!*arg3 || isname(arg3, "земля комната ground room")))
+    get_from_room(ch, arg2, atoi(arg1));
+  else if ((!*arg3 && isname(arg2, "инвентарь экипировка inventory equipment")) ||
+      (is_number(arg1) && !*arg4 && isname(arg3, "инвентарь экипировка inventory equipment")))
+    send_to_char("Вы уже подобрали этот предмет!\r\n", ch);
+  else {
+    if (is_number(arg1)) {
+      amount = atoi(arg1);
+      theobj = arg2;
+      thecont = arg3;
+      theplace = arg4;
+    } else {
+      theobj = arg1;
+      thecont = arg2;
+      theplace = arg3;
+    }
 
+    if (isname(theplace, "земля комната room ground"))
+      where_bits = FIND_OBJ_ROOM;
+    else if (isname(theplace, "инвентарь inventory"))
+      where_bits = FIND_OBJ_INV;
+    else if (isname(theplace, "экипировка equipment"))
+      where_bits = FIND_OBJ_EQUIP;
 
-		if (isname(theplace, "земля комната room ground"))
-			where_bits = FIND_OBJ_ROOM;
-		else if (isname(theplace, "инвентарь inventory"))
-			where_bits = FIND_OBJ_INV;
-		else if (isname(theplace, "экипировка equipment"))
-			where_bits = FIND_OBJ_EQUIP;
-
-		cont_dotmode = find_all_dots(thecont);
-		if (cont_dotmode == FIND_INDIV)
-		{
-			mode = generic_find(thecont, where_bits, ch, &tmp_char, &cont);
-			if (!cont)
-			{
-				sprintf(buf, "Вы не видите '%s'.\r\n", arg2);
-				send_to_char(buf, ch);
-			}
-			else if (GET_OBJ_TYPE(cont) != OBJ_DATA::ITEM_CONTAINER)
-			{
-				act("$o - не контейнер.", FALSE, ch, cont, 0, TO_CHAR);
-			}
-			else
-			{
-				get_from_container(ch, cont, theobj, mode, amount, false);
-			}
-		}
-		else
-		{
-			if (cont_dotmode == FIND_ALLDOT
-				&& !*thecont)
-			{
-				send_to_char("Взять из чего \"всего\"?\r\n", ch);
-				return;
-			}
-			for (cont = ch->carrying; cont && IS_SET(where_bits, FIND_OBJ_INV); cont = cont->get_next_content())
-			{
-				if (CAN_SEE_OBJ(ch, cont)
-					&& (cont_dotmode == FIND_ALL
-						|| isname(thecont, cont->get_aliases())
-						|| CHECK_CUSTOM_LABEL(thecont, cont, ch)))
-				{
-					if (GET_OBJ_TYPE(cont) == OBJ_DATA::ITEM_CONTAINER)
-					{
-						found = 1;
-						get_from_container(ch, cont, theobj, FIND_OBJ_INV, amount, false);
-					}
-					else if (cont_dotmode == FIND_ALLDOT)
-					{
-						found = 1;
-						act("$o - не контейнер.", FALSE, ch, cont, 0, TO_CHAR);
-					}
-				}
-			}
-			for (cont = world[ch->in_room]->contents; cont && IS_SET(where_bits, FIND_OBJ_ROOM); cont = cont->get_next_content())
-			{
-				if (CAN_SEE_OBJ(ch, cont)
-					&& (cont_dotmode == FIND_ALL
-						|| isname(thecont, cont->get_aliases())
-						|| CHECK_CUSTOM_LABEL(thecont, cont, ch)))
-				{
-					if (GET_OBJ_TYPE(cont) == OBJ_DATA::ITEM_CONTAINER)
-					{
-						get_from_container(ch, cont, theobj, FIND_OBJ_ROOM, amount, false);
-						found = 1;
-					}
-					else if (cont_dotmode == FIND_ALLDOT)
-					{
-						act("$o - не контейнер.", FALSE, ch, cont, 0, TO_CHAR);
-						found = 1;
-					}
-				}
-			}
-			if (!found)
-			{
-				if (cont_dotmode == FIND_ALL)
-				{
-					send_to_char("Вы не смогли найти ни одного контейнера.\r\n", ch);
-				}
-				else
-				{
-					sprintf(buf, "Вы что-то не видите здесь '%s'.\r\n", thecont);
-					send_to_char(buf, ch);
-				}
-			}
-		}
-	}
+    cont_dotmode = find_all_dots(thecont);
+    if (cont_dotmode == FIND_INDIV) {
+      mode = generic_find(thecont, where_bits, ch, &tmp_char, &cont);
+      if (!cont) {
+        sprintf(buf, "Вы не видите '%s'.\r\n", arg2);
+        send_to_char(buf, ch);
+      } else if (GET_OBJ_TYPE(cont) != OBJ_DATA::ITEM_CONTAINER) {
+        act("$o - не контейнер.", FALSE, ch, cont, 0, TO_CHAR);
+      } else {
+        get_from_container(ch, cont, theobj, mode, amount, false);
+      }
+    } else {
+      if (cont_dotmode == FIND_ALLDOT
+          && !*thecont) {
+        send_to_char("Взять из чего \"всего\"?\r\n", ch);
+        return;
+      }
+      for (cont = ch->carrying; cont && IS_SET(where_bits, FIND_OBJ_INV); cont = cont->get_next_content()) {
+        if (CAN_SEE_OBJ(ch, cont)
+            && (cont_dotmode == FIND_ALL
+                || isname(thecont, cont->get_aliases())
+                || CHECK_CUSTOM_LABEL(thecont, cont, ch))) {
+          if (GET_OBJ_TYPE(cont) == OBJ_DATA::ITEM_CONTAINER) {
+            found = 1;
+            get_from_container(ch, cont, theobj, FIND_OBJ_INV, amount, false);
+          } else if (cont_dotmode == FIND_ALLDOT) {
+            found = 1;
+            act("$o - не контейнер.", FALSE, ch, cont, 0, TO_CHAR);
+          }
+        }
+      }
+      for (cont = world[ch->in_room]->contents; cont && IS_SET(where_bits, FIND_OBJ_ROOM);
+           cont = cont->get_next_content()) {
+        if (CAN_SEE_OBJ(ch, cont)
+            && (cont_dotmode == FIND_ALL
+                || isname(thecont, cont->get_aliases())
+                || CHECK_CUSTOM_LABEL(thecont, cont, ch))) {
+          if (GET_OBJ_TYPE(cont) == OBJ_DATA::ITEM_CONTAINER) {
+            get_from_container(ch, cont, theobj, FIND_OBJ_ROOM, amount, false);
+            found = 1;
+          } else if (cont_dotmode == FIND_ALLDOT) {
+            act("$o - не контейнер.", FALSE, ch, cont, 0, TO_CHAR);
+            found = 1;
+          }
+        }
+      }
+      if (!found) {
+        if (cont_dotmode == FIND_ALL) {
+          send_to_char("Вы не смогли найти ни одного контейнера.\r\n", ch);
+        } else {
+          sprintf(buf, "Вы что-то не видите здесь '%s'.\r\n", thecont);
+          send_to_char(buf, ch);
+        }
+      }
+    }
+  }
 }
 
-void perform_drop_gold(CHAR_DATA * ch, int amount)
-{
-	if (amount <= 0)
-	{
-		send_to_char("Да, похоже вы слишком переиграли сегодня.\r\n", ch);
-	}
-	else if (ch->get_gold() < amount)
-	{
-		send_to_char("У вас нет такой суммы!\r\n", ch);
-	}
-	else
-	{
-		WAIT_STATE(ch, PULSE_VIOLENCE);	// to prevent coin-bombing
-		if (ROOM_FLAGGED(ch->in_room, ROOM_NOITEM))
-		{
-			act("Неведомая сила помешала вам сделать это!", FALSE, ch, 0, 0, TO_CHAR);
-			return;
-		}
-		//Находим сначала кучку в комнате
-		int additional_amount = 0;
-		OBJ_DATA* next_obj;
-		for (OBJ_DATA* existing_obj = world[ch->in_room]->contents; existing_obj; existing_obj = next_obj)
-		{
-			next_obj = existing_obj->get_next_content();
-			if (GET_OBJ_TYPE(existing_obj) == OBJ_DATA::ITEM_MONEY && GET_OBJ_VAL(existing_obj, 1) == currency::GOLD)
-			{
-				//Запоминаем стоимость существующей кучки и удаляем ее
-				additional_amount = GET_OBJ_VAL(existing_obj, 0);
-				obj_from_room(existing_obj);
-				extract_obj(existing_obj);
-			}
-		}
+void perform_drop_gold(CHAR_DATA *ch, int amount) {
+  if (amount <= 0) {
+    send_to_char("Да, похоже вы слишком переиграли сегодня.\r\n", ch);
+  } else if (ch->get_gold() < amount) {
+    send_to_char("У вас нет такой суммы!\r\n", ch);
+  } else {
+    WAIT_STATE(ch, PULSE_VIOLENCE);    // to prevent coin-bombing
+    if (ROOM_FLAGGED(ch->in_room, ROOM_NOITEM)) {
+      act("Неведомая сила помешала вам сделать это!", FALSE, ch, 0, 0, TO_CHAR);
+      return;
+    }
+    //Находим сначала кучку в комнате
+    int additional_amount = 0;
+    OBJ_DATA *next_obj;
+    for (OBJ_DATA *existing_obj = world[ch->in_room]->contents; existing_obj; existing_obj = next_obj) {
+      next_obj = existing_obj->get_next_content();
+      if (GET_OBJ_TYPE(existing_obj) == OBJ_DATA::ITEM_MONEY && GET_OBJ_VAL(existing_obj, 1) == currency::GOLD) {
+        //Запоминаем стоимость существующей кучки и удаляем ее
+        additional_amount = GET_OBJ_VAL(existing_obj, 0);
+        obj_from_room(existing_obj);
+        extract_obj(existing_obj);
+      }
+    }
 
-		const auto obj = create_money(amount+additional_amount);
-		int result = drop_wtrigger(obj.get(), ch);
+    const auto obj = create_money(amount + additional_amount);
+    int result = drop_wtrigger(obj.get(), ch);
 
-		if (!result)
-		{
-			extract_obj(obj.get());
-			return;
-		}
+    if (!result) {
+      extract_obj(obj.get());
+      return;
+    }
 
-		// Если этот моб трупа не оставит, то не выводить сообщение иначе ужасно коряво смотрится в бою и в тригах
-		if (!IS_NPC(ch) || !MOB_FLAGGED(ch, MOB_CORPSE))
-		{
-			send_to_char(ch, "Вы бросили %d %s на землю.\r\n",
-				amount, desc_count(amount, WHAT_MONEYu));
-			sprintf(buf, "<%s> {%d} выбросил %d %s на землю.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), amount, desc_count(amount, WHAT_MONEYu));
-			mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-			sprintf(buf, "$n бросил$g %s на землю.", money_desc(amount, 3));
-			act(buf, TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		}
-		obj_to_room(obj.get(), ch->in_room);
+    // Если этот моб трупа не оставит, то не выводить сообщение иначе ужасно коряво смотрится в бою и в тригах
+    if (!IS_NPC(ch) || !MOB_FLAGGED(ch, MOB_CORPSE)) {
+      send_to_char(ch, "Вы бросили %d %s на землю.\r\n",
+                   amount, desc_count(amount, WHAT_MONEYu));
+      sprintf(buf,
+              "<%s> {%d} выбросил %d %s на землю.",
+              ch->get_name().c_str(),
+              GET_ROOM_VNUM(ch->in_room),
+              amount,
+              desc_count(amount, WHAT_MONEYu));
+      mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+      sprintf(buf, "$n бросил$g %s на землю.", money_desc(amount, 3));
+      act(buf, TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+    }
+    obj_to_room(obj.get(), ch->in_room);
 
-		ch->remove_gold(amount);
-	}
+    ch->remove_gold(amount);
+  }
 }
 
 const char *drop_op[3] =
-{
-	"бросить", "бросили", "бросил"
-};
+    {
+        "бросить", "бросили", "бросил"
+    };
 
-void perform_drop(CHAR_DATA * ch, OBJ_DATA * obj)
-{
-	if (!drop_otrigger(obj, ch))
-		return;
-	if (!bloody::handle_transfer(ch, NULL, obj))
-		return;
-	if (!drop_wtrigger(obj, ch))
-		return;
+void perform_drop(CHAR_DATA *ch, OBJ_DATA *obj) {
+  if (!drop_otrigger(obj, ch))
+    return;
+  if (!bloody::handle_transfer(ch, NULL, obj))
+    return;
+  if (!drop_wtrigger(obj, ch))
+    return;
 
-	if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP))
-	{
-		sprintf(buf, "Вы не можете %s $o3!", drop_op[0]);
-		act(buf, FALSE, ch, obj, 0, TO_CHAR);
-		return;
-	}
-	sprintf(buf, "Вы %s $o3.", drop_op[1]);
-	act(buf, FALSE, ch, obj, 0, TO_CHAR);
-	sprintf(buf, "$n %s$g $o3.", drop_op[2]);
-	act(buf, TRUE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-	obj_from_char(obj);
+  if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
+    sprintf(buf, "Вы не можете %s $o3!", drop_op[0]);
+    act(buf, FALSE, ch, obj, 0, TO_CHAR);
+    return;
+  }
+  sprintf(buf, "Вы %s $o3.", drop_op[1]);
+  act(buf, FALSE, ch, obj, 0, TO_CHAR);
+  sprintf(buf, "$n %s$g $o3.", drop_op[2]);
+  act(buf, TRUE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+  obj_from_char(obj);
 
-	obj_to_room(obj, ch->in_room);
-	obj_decay(obj);
+  obj_to_room(obj, ch->in_room);
+  obj_decay(obj);
 }
 
-void do_drop(CHAR_DATA *ch, char* argument, int/* cmd*/, int /*subcmd*/)
-{
-	OBJ_DATA *obj, *next_obj;
+void do_drop(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/) {
+  OBJ_DATA *obj, *next_obj;
 
-	argument = one_argument(argument, arg);
+  argument = one_argument(argument, arg);
 
-	if (!*arg)
-	{
-		sprintf(buf, "Что вы хотите %s?\r\n", drop_op[0]);
-		send_to_char(buf, ch);
-		return;
-	}
-	else if (is_number(arg))
-	{
-		int multi = atoi(arg);
-		one_argument(argument, arg);
-		if (!str_cmp("coins", arg) || !str_cmp("coin", arg) || !str_cmp("кун", arg) || !str_cmp("денег", arg))
-			perform_drop_gold(ch, multi);
-		else if (multi <= 0)
-			send_to_char("Не имеет смысла.\r\n", ch);
-		else if (!*arg)
-		{
-			sprintf(buf, "%s %d чего?\r\n", drop_op[0], multi);
-			send_to_char(buf, ch);
-		}
-		else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-		{
-			snprintf(buf, MAX_INPUT_LENGTH, "У вас нет ничего похожего на %s.\r\n", arg);
-			send_to_char(buf, ch);
-		}
-		else
-		{
-			do
-			{
-				next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
-				perform_drop(ch, obj);
-				obj = next_obj;
-			}
-			while (obj && --multi);
-		}
-	}
-	else
-	{
-		const auto dotmode = find_all_dots(arg);
-		// Can't junk or donate all
-		if (dotmode == FIND_ALL)
-		{
-			if (!ch->carrying)
-				send_to_char("А у вас ничего и нет.\r\n", ch);
-			else
-				for (obj = ch->carrying; obj; obj = next_obj)
-				{
-					next_obj = obj->get_next_content();
-					perform_drop(ch, obj);
-				}
-		}
-		else if (dotmode == FIND_ALLDOT)
-		{
-			if (!*arg)
-			{
-				sprintf(buf, "%s \"все\" какого типа предметов?\r\n", drop_op[0]);
-				send_to_char(buf, ch);
-				return;
-			}
-			if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-			{
-				snprintf(buf, MAX_INPUT_LENGTH, "У вас нет ничего похожего на '%s'.\r\n", arg);
-				send_to_char(buf, ch);
-			}
-			while (obj)
-			{
-				next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
-				perform_drop(ch, obj);
-				obj = next_obj;
-			}
-		}
-		else
-		{
-			if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-			{
-				snprintf(buf, MAX_INPUT_LENGTH, "У вас нет '%s'.\r\n", arg);
-				send_to_char(buf, ch);
-			}
-			else
-				perform_drop(ch, obj);
-		}
-	}
+  if (!*arg) {
+    sprintf(buf, "Что вы хотите %s?\r\n", drop_op[0]);
+    send_to_char(buf, ch);
+    return;
+  } else if (is_number(arg)) {
+    int multi = atoi(arg);
+    one_argument(argument, arg);
+    if (!str_cmp("coins", arg) || !str_cmp("coin", arg) || !str_cmp("кун", arg) || !str_cmp("денег", arg))
+      perform_drop_gold(ch, multi);
+    else if (multi <= 0)
+      send_to_char("Не имеет смысла.\r\n", ch);
+    else if (!*arg) {
+      sprintf(buf, "%s %d чего?\r\n", drop_op[0], multi);
+      send_to_char(buf, ch);
+    } else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+      snprintf(buf, MAX_INPUT_LENGTH, "У вас нет ничего похожего на %s.\r\n", arg);
+      send_to_char(buf, ch);
+    } else {
+      do {
+        next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
+        perform_drop(ch, obj);
+        obj = next_obj;
+      } while (obj && --multi);
+    }
+  } else {
+    const auto dotmode = find_all_dots(arg);
+    // Can't junk or donate all
+    if (dotmode == FIND_ALL) {
+      if (!ch->carrying)
+        send_to_char("А у вас ничего и нет.\r\n", ch);
+      else
+        for (obj = ch->carrying; obj; obj = next_obj) {
+          next_obj = obj->get_next_content();
+          perform_drop(ch, obj);
+        }
+    } else if (dotmode == FIND_ALLDOT) {
+      if (!*arg) {
+        sprintf(buf, "%s \"все\" какого типа предметов?\r\n", drop_op[0]);
+        send_to_char(buf, ch);
+        return;
+      }
+      if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+        snprintf(buf, MAX_INPUT_LENGTH, "У вас нет ничего похожего на '%s'.\r\n", arg);
+        send_to_char(buf, ch);
+      }
+      while (obj) {
+        next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
+        perform_drop(ch, obj);
+        obj = next_obj;
+      }
+    } else {
+      if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+        snprintf(buf, MAX_INPUT_LENGTH, "У вас нет '%s'.\r\n", arg);
+        send_to_char(buf, ch);
+      } else
+        perform_drop(ch, obj);
+    }
+  }
 }
 
-void perform_give(CHAR_DATA * ch, CHAR_DATA * vict, OBJ_DATA * obj) {
-	if (!bloody::handle_transfer(ch, vict, obj))
-		return;
-	if (ROOM_FLAGGED(ch->in_room, ROOM_NOITEM) && !IS_GOD(ch)) {
-		act("Неведомая сила помешала вам сделать это!", FALSE, ch, 0, 0, TO_CHAR);
-		return;
-	}
-	if (NPC_FLAGGED(vict, NPC_NOTAKEITEMS)) {
-		act("$N не нуждается в ваших подачках, своего барахла навалом.", FALSE, ch, 0, vict, TO_CHAR);
-		return;
-	}
-	if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
-		act("Вы не можете передать $o3!", FALSE, ch, obj, 0, TO_CHAR);
-		return;
-	}
-	if (IS_CARRYING_N(vict) >= CAN_CARRY_N(vict)) {
-		act("У $N1 заняты руки.", FALSE, ch, 0, vict, TO_CHAR);
-		return;
-	}
-	if (GET_OBJ_WEIGHT(obj) + IS_CARRYING_W(vict) > CAN_CARRY_W(vict)) {
-		act("$E не может нести такой вес.", FALSE, ch, 0, vict, TO_CHAR);
-		return;
-	}
-	if (!give_otrigger(obj, ch, vict)) {
-		act("$E не хочет иметь дело с этой вещью.", FALSE, ch, 0, vict, TO_CHAR);
-		return;
-	}
+void perform_give(CHAR_DATA *ch, CHAR_DATA *vict, OBJ_DATA *obj) {
+  if (!bloody::handle_transfer(ch, vict, obj))
+    return;
+  if (ROOM_FLAGGED(ch->in_room, ROOM_NOITEM) && !IS_GOD(ch)) {
+    act("Неведомая сила помешала вам сделать это!", FALSE, ch, 0, 0, TO_CHAR);
+    return;
+  }
+  if (NPC_FLAGGED(vict, NPC_NOTAKEITEMS)) {
+    act("$N не нуждается в ваших подачках, своего барахла навалом.", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
+  if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
+    act("Вы не можете передать $o3!", FALSE, ch, obj, 0, TO_CHAR);
+    return;
+  }
+  if (IS_CARRYING_N(vict) >= CAN_CARRY_N(vict)) {
+    act("У $N1 заняты руки.", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
+  if (GET_OBJ_WEIGHT(obj) + IS_CARRYING_W(vict) > CAN_CARRY_W(vict)) {
+    act("$E не может нести такой вес.", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
+  if (!give_otrigger(obj, ch, vict)) {
+    act("$E не хочет иметь дело с этой вещью.", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
 
-	if (!receive_mtrigger(vict, ch, obj)) {
-		act("$E не хочет иметь дело с этой вещью.", FALSE, ch, 0, vict, TO_CHAR);
-		return;
-	}
+  if (!receive_mtrigger(vict, ch, obj)) {
+    act("$E не хочет иметь дело с этой вещью.", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
 
-	act("Вы дали $o3 $N2.", FALSE, ch, obj, vict, TO_CHAR);
-	act("$n дал$g вам $o3.", FALSE, ch, obj, vict, TO_VICT);
-	act("$n дал$g $o3 $N2.", TRUE, ch, obj, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+  act("Вы дали $o3 $N2.", FALSE, ch, obj, vict, TO_CHAR);
+  act("$n дал$g вам $o3.", FALSE, ch, obj, vict, TO_VICT);
+  act("$n дал$g $o3 $N2.", TRUE, ch, obj, vict, TO_NOTVICT | TO_ARENA_LISTEN);
 
-	if (!world_objects.get_by_raw_ptr(obj)) {
-		return;	// object has been removed from world during script execution.
-	}
+  if (!world_objects.get_by_raw_ptr(obj)) {
+    return;    // object has been removed from world during script execution.
+  }
 
-	obj_from_char(obj);
-	obj_to_char(obj, vict);
+  obj_from_char(obj);
+  obj_to_char(obj, vict);
 
-	// передача объектов-денег и кошельков
-	get_check_money(vict, obj, 0);
+  // передача объектов-денег и кошельков
+  get_check_money(vict, obj, 0);
 
-	if (!IS_NPC(ch) && !IS_NPC(vict)) {
-		ObjSaveSync::add(ch->get_uid(), vict->get_uid(), ObjSaveSync::CHAR_SAVE);
-	}
+  if (!IS_NPC(ch) && !IS_NPC(vict)) {
+    ObjSaveSync::add(ch->get_uid(), vict->get_uid(), ObjSaveSync::CHAR_SAVE);
+  }
 }
 
 // utility function for give
-CHAR_DATA *give_find_vict(CHAR_DATA * ch, char *arg)
-{
-	CHAR_DATA *vict;
+CHAR_DATA *give_find_vict(CHAR_DATA *ch, char *arg) {
+  CHAR_DATA *vict;
 
-	if (!*arg)
-	{
-		send_to_char("Кому?\r\n", ch);
-		return (NULL);
-	}
-	else if (!(vict = get_char_vis(ch, arg, FIND_CHAR_ROOM)))
-	{
-		send_to_char(NOPERSON, ch);
-		return (NULL);
-	}
-	else if (vict == ch)
-	{
-		send_to_char("Вы переложили ЭТО из одного кармана в другой.\r\n", ch);
-		return (NULL);
-	}
-	else
-		return (vict);
+  if (!*arg) {
+    send_to_char("Кому?\r\n", ch);
+    return (NULL);
+  } else if (!(vict = get_char_vis(ch, arg, FIND_CHAR_ROOM))) {
+    send_to_char(NOPERSON, ch);
+    return (NULL);
+  } else if (vict == ch) {
+    send_to_char("Вы переложили ЭТО из одного кармана в другой.\r\n", ch);
+    return (NULL);
+  } else
+    return (vict);
 }
 
-
-void perform_give_gold(CHAR_DATA * ch, CHAR_DATA * vict, int amount)
-{
-	if (amount <= 0)
-	{
-		send_to_char("Ха-ха-ха (3 раза)...\r\n", ch);
-		return;
-	}
-	if (ch->get_gold() < amount && (IS_NPC(ch) || !IS_IMPL(ch)))
-	{
-		send_to_char("И откуда вы их взять собираетесь?\r\n", ch);
-		return;
-	}
-	if (ROOM_FLAGGED(ch->in_room, ROOM_NOITEM) && !IS_GOD(ch))
-	{
-		act("Неведомая сила помешала вам сделать это!", FALSE, ch, 0, 0, TO_CHAR);
-		return;
-	}
-	send_to_char(OK, ch);
-	sprintf(buf, "$n дал$g вам %d %s.", amount, desc_count(amount, WHAT_MONEYu));
-	act(buf, FALSE, ch, 0, vict, TO_VICT);
-	sprintf(buf, "$n дал$g %s $N2.", money_desc(amount, 3));
-	act(buf, TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-	if (!(IS_NPC(ch) || IS_NPC(vict)))
-	{
-		sprintf(buf, "<%s> {%d} передал %d кун при личной встрече c %s.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), amount, GET_PAD(vict, 4));
-		mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-	}
-	if (IS_NPC(ch) || !IS_IMPL(ch))
-	{
-		ch->remove_gold(amount);
-	}
-	// если денег дает моб - снимаем клан-налог
-	if (IS_NPC(ch) && !IS_CHARMICE(ch))
-	{
-		vict->add_gold(amount);
-		split_or_clan_tax(vict, amount);
-	}
-	else
-	{
-		vict->add_gold(amount);
-	}
-	bribe_mtrigger(vict, ch, amount);
+void perform_give_gold(CHAR_DATA *ch, CHAR_DATA *vict, int amount) {
+  if (amount <= 0) {
+    send_to_char("Ха-ха-ха (3 раза)...\r\n", ch);
+    return;
+  }
+  if (ch->get_gold() < amount && (IS_NPC(ch) || !IS_IMPL(ch))) {
+    send_to_char("И откуда вы их взять собираетесь?\r\n", ch);
+    return;
+  }
+  if (ROOM_FLAGGED(ch->in_room, ROOM_NOITEM) && !IS_GOD(ch)) {
+    act("Неведомая сила помешала вам сделать это!", FALSE, ch, 0, 0, TO_CHAR);
+    return;
+  }
+  send_to_char(OK, ch);
+  sprintf(buf, "$n дал$g вам %d %s.", amount, desc_count(amount, WHAT_MONEYu));
+  act(buf, FALSE, ch, 0, vict, TO_VICT);
+  sprintf(buf, "$n дал$g %s $N2.", money_desc(amount, 3));
+  act(buf, TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+  if (!(IS_NPC(ch) || IS_NPC(vict))) {
+    sprintf(buf,
+            "<%s> {%d} передал %d кун при личной встрече c %s.",
+            ch->get_name().c_str(),
+            GET_ROOM_VNUM(ch->in_room),
+            amount,
+            GET_PAD(vict, 4));
+    mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+  }
+  if (IS_NPC(ch) || !IS_IMPL(ch)) {
+    ch->remove_gold(amount);
+  }
+  // если денег дает моб - снимаем клан-налог
+  if (IS_NPC(ch) && !IS_CHARMICE(ch)) {
+    vict->add_gold(amount);
+    split_or_clan_tax(vict, amount);
+  } else {
+    vict->add_gold(amount);
+  }
+  bribe_mtrigger(vict, ch, amount);
 }
 
-void do_give(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	int amount, dotmode;
-	CHAR_DATA *vict;
-	OBJ_DATA *obj, *next_obj;
+void do_give(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  int amount, dotmode;
+  CHAR_DATA *vict;
+  OBJ_DATA *obj, *next_obj;
 
-	argument = one_argument(argument, arg);
+  argument = one_argument(argument, arg);
 
-	if (!*arg)
-		send_to_char("Дать что и кому?\r\n", ch);
-	else if (is_number(arg))
-	{
-		amount = atoi(arg);
-		argument = one_argument(argument, arg);
-		if (!strn_cmp("coin", arg, 4) || !strn_cmp("кун", arg, 5) || !str_cmp("денег", arg))
-		{
-			one_argument(argument, arg);
-			if ((vict = give_find_vict(ch, arg)) != NULL)
-				perform_give_gold(ch, vict, amount);
-			return;
-		}
-		else if (!*arg)  	// Give multiple code.
-		{
-			sprintf(buf, "Чего %d вы хотите дать?\r\n", amount);
-			send_to_char(buf, ch);
-		}
-		else if (!(vict = give_find_vict(ch, argument)))
-		{
-			return;
-		}
-		else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-		{
-			snprintf(buf, MAX_INPUT_LENGTH, "У вас нет '%s'.\r\n", arg);
-			send_to_char(buf, ch);
-		}
-		else
-		{
-			while (obj && amount--)
-			{
-				next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
-				perform_give(ch, vict, obj);
-				obj = next_obj;
-			}
-		}
-	}
-	else
-	{
-		one_argument(argument, buf1);
-		if (!(vict = give_find_vict(ch, buf1)))
-			return;
-		dotmode = find_all_dots(arg);
-		if (dotmode == FIND_INDIV)
-		{
-			if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-			{
-				snprintf(buf, MAX_INPUT_LENGTH, "У вас нет '%s'.\r\n", arg);
-				send_to_char(buf, ch);
-			}
-			else
-				perform_give(ch, vict, obj);
-		}
-		else
-		{
-			if (dotmode == FIND_ALLDOT && !*arg)
-			{
-				send_to_char("Дать \"все\" какого типа предметов?\r\n", ch);
-				return;
-			}
-			if (!ch->carrying)
-				send_to_char("У вас ведь ничего нет.\r\n", ch);
-			else
-			{
-				bool has_items = false;
-				for (obj = ch->carrying; obj; obj = next_obj)
-				{
-					next_obj = obj->get_next_content();
-					if (CAN_SEE_OBJ(ch, obj)
-						&& (dotmode == FIND_ALL
-							|| isname(arg, obj->get_aliases())
-							|| CHECK_CUSTOM_LABEL(arg, obj, ch)))
-					{
-						perform_give(ch, vict, obj);
-						has_items = true;
-					}
-				}
-				if (!has_items)
-				{
-					send_to_char(ch, "У вас нет '%s'.\r\n", arg);
-				}
-			}
-		}
-	}
+  if (!*arg)
+    send_to_char("Дать что и кому?\r\n", ch);
+  else if (is_number(arg)) {
+    amount = atoi(arg);
+    argument = one_argument(argument, arg);
+    if (!strn_cmp("coin", arg, 4) || !strn_cmp("кун", arg, 5) || !str_cmp("денег", arg)) {
+      one_argument(argument, arg);
+      if ((vict = give_find_vict(ch, arg)) != NULL)
+        perform_give_gold(ch, vict, amount);
+      return;
+    } else if (!*arg)    // Give multiple code.
+    {
+      sprintf(buf, "Чего %d вы хотите дать?\r\n", amount);
+      send_to_char(buf, ch);
+    } else if (!(vict = give_find_vict(ch, argument))) {
+      return;
+    } else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+      snprintf(buf, MAX_INPUT_LENGTH, "У вас нет '%s'.\r\n", arg);
+      send_to_char(buf, ch);
+    } else {
+      while (obj && amount--) {
+        next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
+        perform_give(ch, vict, obj);
+        obj = next_obj;
+      }
+    }
+  } else {
+    one_argument(argument, buf1);
+    if (!(vict = give_find_vict(ch, buf1)))
+      return;
+    dotmode = find_all_dots(arg);
+    if (dotmode == FIND_INDIV) {
+      if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+        snprintf(buf, MAX_INPUT_LENGTH, "У вас нет '%s'.\r\n", arg);
+        send_to_char(buf, ch);
+      } else
+        perform_give(ch, vict, obj);
+    } else {
+      if (dotmode == FIND_ALLDOT && !*arg) {
+        send_to_char("Дать \"все\" какого типа предметов?\r\n", ch);
+        return;
+      }
+      if (!ch->carrying)
+        send_to_char("У вас ведь ничего нет.\r\n", ch);
+      else {
+        bool has_items = false;
+        for (obj = ch->carrying; obj; obj = next_obj) {
+          next_obj = obj->get_next_content();
+          if (CAN_SEE_OBJ(ch, obj)
+              && (dotmode == FIND_ALL
+                  || isname(arg, obj->get_aliases())
+                  || CHECK_CUSTOM_LABEL(arg, obj, ch))) {
+            perform_give(ch, vict, obj);
+            has_items = true;
+          }
+        }
+        if (!has_items) {
+          send_to_char(ch, "У вас нет '%s'.\r\n", arg);
+        }
+      }
+    }
+  }
 }
 
+void weight_change_object(OBJ_DATA *obj, int weight) {
+  OBJ_DATA *tmp_obj;
+  CHAR_DATA *tmp_ch;
 
-
-void weight_change_object(OBJ_DATA * obj, int weight)
-{
-	OBJ_DATA *tmp_obj;
-	CHAR_DATA *tmp_ch;
-
-	if (obj->get_in_room() != NOWHERE)
-	{
-		obj->set_weight(MAX(1, GET_OBJ_WEIGHT(obj) + weight));
-	}
-	else if ((tmp_ch = obj->get_carried_by()))
-	{
-		obj_from_char(obj);
-		obj->set_weight(MAX(1, GET_OBJ_WEIGHT(obj) + weight));
-		obj_to_char(obj, tmp_ch);
-	}
-	else if ((tmp_obj = obj->get_in_obj()))
-	{
-		obj_from_obj(obj);
-		obj->set_weight(MAX(1, GET_OBJ_WEIGHT(obj) + weight));
-		obj_to_obj(obj, tmp_obj);
-	}
-	else
-	{
-		log("SYSERR: Unknown attempt to subtract weight from an object.");
-	}
+  if (obj->get_in_room() != NOWHERE) {
+    obj->set_weight(MAX(1, GET_OBJ_WEIGHT(obj) + weight));
+  } else if ((tmp_ch = obj->get_carried_by())) {
+    obj_from_char(obj);
+    obj->set_weight(MAX(1, GET_OBJ_WEIGHT(obj) + weight));
+    obj_to_char(obj, tmp_ch);
+  } else if ((tmp_obj = obj->get_in_obj())) {
+    obj_from_obj(obj);
+    obj->set_weight(MAX(1, GET_OBJ_WEIGHT(obj) + weight));
+    obj_to_obj(obj, tmp_obj);
+  } else {
+    log("SYSERR: Unknown attempt to subtract weight from an object.");
+  }
 }
 
-void do_fry(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/)
-{
-	OBJ_DATA *meet;
-	one_argument(argument, arg);
-	if (!*arg)
-	{
-		send_to_char("Что вы собрались поджарить?\r\n", ch);
-		return;
-	}
-	if (ch->get_fighting())
-	{
-		send_to_char("Не стоит отвлекаться в бою.\r\n", ch);
-		return;
-	}
-	if (!(meet = get_obj_in_list_vis(ch, arg, ch->carrying)))
-	{
-		snprintf(buf, MAX_STRING_LENGTH, "У вас нет '%s'.\r\n", arg);
-		send_to_char(buf, ch);
-		return;
-	}
-	if (!world[ch->in_room]->fires)
-	{
-	        send_to_char(ch, "На чем вы собрались жарить, огня то нет!\r\n");
-		return;
-	}
-	if (world[ch->in_room]->fires > 2)
-	{
-	        send_to_char(ch, "Костер слишком силен, сгорит!\r\n");
-		return;
-	}
+void do_fry(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/) {
+  OBJ_DATA *meet;
+  one_argument(argument, arg);
+  if (!*arg) {
+    send_to_char("Что вы собрались поджарить?\r\n", ch);
+    return;
+  }
+  if (ch->get_fighting()) {
+    send_to_char("Не стоит отвлекаться в бою.\r\n", ch);
+    return;
+  }
+  if (!(meet = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+    snprintf(buf, MAX_STRING_LENGTH, "У вас нет '%s'.\r\n", arg);
+    send_to_char(buf, ch);
+    return;
+  }
+  if (!world[ch->in_room]->fires) {
+    send_to_char(ch, "На чем вы собрались жарить, огня то нет!\r\n");
+    return;
+  }
+  if (world[ch->in_room]->fires > 2) {
+    send_to_char(ch, "Костер слишком силен, сгорит!\r\n");
+    return;
+  }
 
-	const auto meet_vnum = GET_OBJ_VNUM(meet);
-	if (!meat_mapping.has(meet_vnum)) // не нашлось в массиве
-	{
-		send_to_char(ch, "%s не подходит для жарки.\r\n", GET_OBJ_PNAME(meet,0).c_str());
-		return;
-	}
+  const auto meet_vnum = GET_OBJ_VNUM(meet);
+  if (!meat_mapping.has(meet_vnum)) // не нашлось в массиве
+  {
+    send_to_char(ch, "%s не подходит для жарки.\r\n", GET_OBJ_PNAME(meet, 0).c_str());
+    return;
+  }
 
-	act("Вы нанизали на веточку и поджарили $o3.", FALSE, ch, meet, 0, TO_CHAR);
-	act("$n нанизал$g на веточку и поджарил$g $o3.", TRUE, ch, meet, 0, TO_ROOM | TO_ARENA_LISTEN);
-	const auto tobj = world_objects.create_from_prototype_by_vnum(meat_mapping.get(meet_vnum));
-	if (tobj)
-	{
-		can_carry_obj(ch, tobj.get());
-		extract_obj(meet);
-		WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
-	}
-	else
-	{
-		mudlog("Не возможно загрузить жаренное мясо в act.item.cpp::do_fry!", NRM, LVL_GRGOD, ERRLOG, TRUE);
-	}
+  act("Вы нанизали на веточку и поджарили $o3.", FALSE, ch, meet, 0, TO_CHAR);
+  act("$n нанизал$g на веточку и поджарил$g $o3.", TRUE, ch, meet, 0, TO_ROOM | TO_ARENA_LISTEN);
+  const auto tobj = world_objects.create_from_prototype_by_vnum(meat_mapping.get(meet_vnum));
+  if (tobj) {
+    can_carry_obj(ch, tobj.get());
+    extract_obj(meet);
+    WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
+  } else {
+    mudlog("Не возможно загрузить жаренное мясо в act.item.cpp::do_fry!", NRM, LVL_GRGOD, ERRLOG, TRUE);
+  }
 }
 
-void do_eat(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
-{
-	OBJ_DATA *food;
-	int amount;
+void do_eat(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  OBJ_DATA *food;
+  int amount;
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
+  if (subcmd == SCMD_DEVOUR) {
+    if (MOB_FLAGGED(ch, MOB_RESURRECTED)
+        && can_use_feat(ch->get_master(), ZOMBIE_DROVER_FEAT)) {
+      feed_charmice(ch, arg);
+      return;
+    }
+  }
+  if (!IS_NPC(ch)
+      && subcmd == SCMD_DEVOUR) {
+    send_to_char("Вы же не зверь какой, пожирать трупы!\r\n", ch);
+    return;
+  }
 
-	if (subcmd == SCMD_DEVOUR)
-	{
-		if (MOB_FLAGGED(ch, MOB_RESURRECTED)
-			&& can_use_feat(ch->get_master(), ZOMBIE_DROVER_FEAT))
-		{
-			feed_charmice(ch, arg);
-			return;
-		}
-	}
-	if (!IS_NPC(ch)
-		&& subcmd == SCMD_DEVOUR)
-	{
-		send_to_char("Вы же не зверь какой, пожирать трупы!\r\n", ch);
-		return;
-	}
+  if (IS_NPC(ch))        // Cannot use GET_COND() on mobs.
+    return;
 
-	if (IS_NPC(ch))		// Cannot use GET_COND() on mobs.
-		return;
+  if (!*arg) {
+    send_to_char("Чем вы собрались закусить?\r\n", ch);
+    return;
+  }
+  if (ch->get_fighting()) {
+    send_to_char("Не стоит отвлекаться в бою.\r\n", ch);
+    return;
+  }
 
-	if (!*arg)
-	{
-		send_to_char("Чем вы собрались закусить?\r\n", ch);
-		return;
-	}
-	if (ch->get_fighting())
-	{
-		send_to_char("Не стоит отвлекаться в бою.\r\n", ch);
-		return;
-	}
+  if (!(food = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+    snprintf(buf, MAX_INPUT_LENGTH, "У вас нет '%s'.\r\n", arg);
+    send_to_char(buf, ch);
+    return;
+  }
+  if (subcmd == SCMD_TASTE
+      && ((GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_DRINKCON)
+          || (GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_FOUNTAIN))) {
+    do_drink(ch, argument, 0, SCMD_SIP);
+    return;
+  }
 
-	if (!(food = get_obj_in_list_vis(ch, arg, ch->carrying)))
-	{
-		snprintf(buf, MAX_INPUT_LENGTH, "У вас нет '%s'.\r\n", arg);
-		send_to_char(buf, ch);
-		return;
-	}
-	if (subcmd == SCMD_TASTE
-		&& ((GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_DRINKCON)
-			|| (GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_FOUNTAIN)))
-	{
-		do_drink(ch, argument, 0, SCMD_SIP);
-		return;
-	}
+  if (!IS_GOD(ch)) {
+    if (GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_MING) //Сообщение на случай попытки проглотить ингры
+    {
+      send_to_char("Не можешь приготовить - покупай готовое!\r\n", ch);
+      return;
+    }
+    if (GET_OBJ_TYPE(food) != OBJ_DATA::ITEM_FOOD
+        && GET_OBJ_TYPE(food) != OBJ_DATA::ITEM_NOTE) {
+      send_to_char("Это несъедобно!\r\n", ch);
+      return;
+    }
+  }
+  if (GET_COND(ch, FULL) == 0
+      && GET_OBJ_TYPE(food) != OBJ_DATA::ITEM_NOTE)    // Stomach full
+  {
+    send_to_char("Вы слишком сыты для этого!\r\n", ch);
+    return;
+  }
+  if (subcmd == SCMD_EAT
+      || (subcmd == SCMD_TASTE
+          && GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_NOTE)) {
+    act("Вы съели $o3.", FALSE, ch, food, 0, TO_CHAR);
+    act("$n съел$g $o3.", TRUE, ch, food, 0, TO_ROOM | TO_ARENA_LISTEN);
+  } else {
+    act("Вы откусили маленький кусочек от $o1.", FALSE, ch, food, 0, TO_CHAR);
+    act("$n попробовал$g $o3 на вкус.", TRUE, ch, food, 0, TO_ROOM | TO_ARENA_LISTEN);
+  }
 
-	if (!IS_GOD(ch))
-	{
-		if (GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_MING) //Сообщение на случай попытки проглотить ингры
-		{
-			send_to_char("Не можешь приготовить - покупай готовое!\r\n", ch);
-			return;
-		}
-		if (GET_OBJ_TYPE(food) != OBJ_DATA::ITEM_FOOD
-			&& GET_OBJ_TYPE(food) != OBJ_DATA::ITEM_NOTE)
-		{
-			send_to_char("Это несъедобно!\r\n", ch);
-			return;
-		}
-	}
-	if (GET_COND(ch, FULL) == 0
-		&& GET_OBJ_TYPE(food) != OBJ_DATA::ITEM_NOTE)  	// Stomach full
-	{
-		send_to_char("Вы слишком сыты для этого!\r\n", ch);
-		return;
-	}
-	if (subcmd == SCMD_EAT
-		|| (subcmd == SCMD_TASTE
-			&& GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_NOTE))
-	{
-		act("Вы съели $o3.", FALSE, ch, food, 0, TO_CHAR);
-		act("$n съел$g $o3.", TRUE, ch, food, 0, TO_ROOM | TO_ARENA_LISTEN);
-	}
-	else
-	{
-		act("Вы откусили маленький кусочек от $o1.", FALSE, ch, food, 0, TO_CHAR);
-		act("$n попробовал$g $o3 на вкус.", TRUE, ch, food, 0, TO_ROOM | TO_ARENA_LISTEN);
-	}
+  amount = ((subcmd == SCMD_EAT && GET_OBJ_TYPE(food) != OBJ_DATA::ITEM_NOTE)
+            ? GET_OBJ_VAL(food, 0)
+            : 1);
 
-	amount = ((subcmd == SCMD_EAT && GET_OBJ_TYPE(food) != OBJ_DATA::ITEM_NOTE)
-		? GET_OBJ_VAL(food, 0)
-		: 1);
+  gain_condition(ch, FULL, -2 * amount);
 
-	gain_condition(ch, FULL, -2*amount);
+  if (GET_COND(ch, FULL) == 0) {
+    send_to_char("Вы наелись.\r\n", ch);
+  }
 
-	if (GET_COND(ch, FULL)==0)
-	{
-		send_to_char("Вы наелись.\r\n", ch);
-	}
-
-	for (int i = 0; i < MAX_OBJ_AFFECT; i++)
-	{
-		if (food->get_affected(i).modifier)
-		{
-			AFFECT_DATA<EApplyLocation> af;
-			af.location = food->get_affected(i).location;
-			af.modifier = food->get_affected(i).modifier;
-			af.bitvector = 0;
-			af.type = SPELL_FULL;
+  for (int i = 0; i < MAX_OBJ_AFFECT; i++) {
+    if (food->get_affected(i).modifier) {
+      AFFECT_DATA<EApplyLocation> af;
+      af.location = food->get_affected(i).location;
+      af.modifier = food->get_affected(i).modifier;
+      af.bitvector = 0;
+      af.type = SPELL_FULL;
 //			af.battleflag = 0;
-			af.duration = pc_duration(ch, 10 * 2, 0, 0, 0, 0);
-			affect_join_fspell(ch, af);
-		}
+      af.duration = pc_duration(ch, 10 * 2, 0, 0, 0, 0);
+      affect_join_fspell(ch, af);
+    }
 
-	}
+  }
 
-	if ((GET_OBJ_VAL(food, 3) == 1) && !IS_IMMORTAL(ch))  	// The shit was poisoned !
-	{
-		send_to_char("Однако, какой странный вкус!\r\n", ch);
-		act("$n закашлял$u и начал$g отплевываться.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  if ((GET_OBJ_VAL(food, 3) == 1) && !IS_IMMORTAL(ch))    // The shit was poisoned !
+  {
+    send_to_char("Однако, какой странный вкус!\r\n", ch);
+    act("$n закашлял$u и начал$g отплевываться.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
 
-		AFFECT_DATA<EApplyLocation> af;
-		af.type = SPELL_POISON;
-		af.duration = pc_duration(ch, amount == 1 ? amount : amount * 2, 0, 0, 0, 0);
-		af.modifier = 0;
-		af.location = APPLY_STR;
-		af.bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af.battleflag = AF_SAME_TIME;
-		affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-		af.type = SPELL_POISON;
-		af.duration = pc_duration(ch, amount == 1 ? amount : amount * 2, 0, 0, 0, 0);
-		af.modifier = amount * 3;
-		af.location = APPLY_POISON;
-		af.bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af.battleflag = AF_SAME_TIME;
-		affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-		ch->Poisoner = 0;
-	}
-	if (subcmd == SCMD_EAT
-		|| (subcmd == SCMD_TASTE
-			&& GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_NOTE))
-	{
-		extract_obj(food);
-	}
-	else
-	{
-		food->set_val(0, food->get_val(0) - 1);
-		if (!food->get_val(0))
-		{
-			send_to_char("Вы доели все!\r\n", ch);
-			extract_obj(food);
-		}
-	}
+    AFFECT_DATA<EApplyLocation> af;
+    af.type = SPELL_POISON;
+    af.duration = pc_duration(ch, amount == 1 ? amount : amount * 2, 0, 0, 0, 0);
+    af.modifier = 0;
+    af.location = APPLY_STR;
+    af.bitvector = to_underlying(EAffectFlag::AFF_POISON);
+    af.battleflag = AF_SAME_TIME;
+    affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+    af.type = SPELL_POISON;
+    af.duration = pc_duration(ch, amount == 1 ? amount : amount * 2, 0, 0, 0, 0);
+    af.modifier = amount * 3;
+    af.location = APPLY_POISON;
+    af.bitvector = to_underlying(EAffectFlag::AFF_POISON);
+    af.battleflag = AF_SAME_TIME;
+    affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+    ch->Poisoner = 0;
+  }
+  if (subcmd == SCMD_EAT
+      || (subcmd == SCMD_TASTE
+          && GET_OBJ_TYPE(food) == OBJ_DATA::ITEM_NOTE)) {
+    extract_obj(food);
+  } else {
+    food->set_val(0, food->get_val(0) - 1);
+    if (!food->get_val(0)) {
+      send_to_char("Вы доели все!\r\n", ch);
+      extract_obj(food);
+    }
+  }
 }
 
-void perform_wear(CHAR_DATA * ch, OBJ_DATA * obj, int where)
-{
-	/*
+void perform_wear(CHAR_DATA *ch, OBJ_DATA *obj, int where) {
+  /*
 	 * ITEM_WEAR_TAKE is used for objects that do not require special bits
 	 * to be put into that position (e.g. you can hold any object, not just
 	 * an object with a HOLD bit.)
 	 */
 
-	const EWearFlag wear_bitvectors[] =
-	{
-		EWearFlag::ITEM_WEAR_TAKE,
-		EWearFlag::ITEM_WEAR_FINGER,
-		EWearFlag::ITEM_WEAR_FINGER,
-		EWearFlag::ITEM_WEAR_NECK,
-		EWearFlag::ITEM_WEAR_NECK,
-		EWearFlag::ITEM_WEAR_BODY,
-		EWearFlag::ITEM_WEAR_HEAD,
-		EWearFlag::ITEM_WEAR_LEGS,
-		EWearFlag::ITEM_WEAR_FEET,
-		EWearFlag::ITEM_WEAR_HANDS,
-		EWearFlag::ITEM_WEAR_ARMS,
-		EWearFlag::ITEM_WEAR_SHIELD,
-		EWearFlag::ITEM_WEAR_ABOUT,
-		EWearFlag::ITEM_WEAR_WAIST,
-		EWearFlag::ITEM_WEAR_WRIST,
-		EWearFlag::ITEM_WEAR_WRIST,
-		EWearFlag::ITEM_WEAR_WIELD,
-		EWearFlag::ITEM_WEAR_TAKE,
-		EWearFlag::ITEM_WEAR_BOTHS,
-		EWearFlag::ITEM_WEAR_QUIVER
-	};
+  const EWearFlag wear_bitvectors[] =
+      {
+          EWearFlag::ITEM_WEAR_TAKE,
+          EWearFlag::ITEM_WEAR_FINGER,
+          EWearFlag::ITEM_WEAR_FINGER,
+          EWearFlag::ITEM_WEAR_NECK,
+          EWearFlag::ITEM_WEAR_NECK,
+          EWearFlag::ITEM_WEAR_BODY,
+          EWearFlag::ITEM_WEAR_HEAD,
+          EWearFlag::ITEM_WEAR_LEGS,
+          EWearFlag::ITEM_WEAR_FEET,
+          EWearFlag::ITEM_WEAR_HANDS,
+          EWearFlag::ITEM_WEAR_ARMS,
+          EWearFlag::ITEM_WEAR_SHIELD,
+          EWearFlag::ITEM_WEAR_ABOUT,
+          EWearFlag::ITEM_WEAR_WAIST,
+          EWearFlag::ITEM_WEAR_WRIST,
+          EWearFlag::ITEM_WEAR_WRIST,
+          EWearFlag::ITEM_WEAR_WIELD,
+          EWearFlag::ITEM_WEAR_TAKE,
+          EWearFlag::ITEM_WEAR_BOTHS,
+          EWearFlag::ITEM_WEAR_QUIVER
+      };
 
-	const std::array<const char *, sizeof(wear_bitvectors)> already_wearing =
-	{
-		"Вы уже используете свет.\r\n",
-		"YOU SHOULD NEVER SEE THIS MESSAGE.  PLEASE REPORT.\r\n",
-		"У вас уже что-то надето на пальцах.\r\n",
-		"YOU SHOULD NEVER SEE THIS MESSAGE.  PLEASE REPORT.\r\n",
-		"У вас уже что-то надето на шею.\r\n",
-		"У вас уже что-то надето на туловище.\r\n",
-		"У вас уже что-то надето на голову.\r\n",
-		"У вас уже что-то надето на ноги.\r\n",
-		"У вас уже что-то надето на ступни.\r\n",
-		"У вас уже что-то надето на кисти.\r\n",
-		"У вас уже что-то надето на руки.\r\n",
-		"Вы уже используете щит.\r\n",
-		"Вы уже облачены во что-то.\r\n",
-		"У вас уже что-то надето на пояс.\r\n",
-		"YOU SHOULD NEVER SEE THIS MESSAGE.  PLEASE REPORT.\r\n",
-		"У вас уже что-то надето на запястья.\r\n",
-		"Вы уже что-то держите в правой руке.\r\n",
-		"Вы уже что-то держите в левой руке.\r\n",
-		"Вы уже держите оружие в обеих руках.\r\n"
-		"Вы уже используете колчан.\r\n"
-	};
+  const std::array<const char *, sizeof(wear_bitvectors)> already_wearing =
+      {
+          "Вы уже используете свет.\r\n",
+          "YOU SHOULD NEVER SEE THIS MESSAGE.  PLEASE REPORT.\r\n",
+          "У вас уже что-то надето на пальцах.\r\n",
+          "YOU SHOULD NEVER SEE THIS MESSAGE.  PLEASE REPORT.\r\n",
+          "У вас уже что-то надето на шею.\r\n",
+          "У вас уже что-то надето на туловище.\r\n",
+          "У вас уже что-то надето на голову.\r\n",
+          "У вас уже что-то надето на ноги.\r\n",
+          "У вас уже что-то надето на ступни.\r\n",
+          "У вас уже что-то надето на кисти.\r\n",
+          "У вас уже что-то надето на руки.\r\n",
+          "Вы уже используете щит.\r\n",
+          "Вы уже облачены во что-то.\r\n",
+          "У вас уже что-то надето на пояс.\r\n",
+          "YOU SHOULD NEVER SEE THIS MESSAGE.  PLEASE REPORT.\r\n",
+          "У вас уже что-то надето на запястья.\r\n",
+          "Вы уже что-то держите в правой руке.\r\n",
+          "Вы уже что-то держите в левой руке.\r\n",
+          "Вы уже держите оружие в обеих руках.\r\n"
+          "Вы уже используете колчан.\r\n"
+      };
 
-	// first, make sure that the wear position is valid.
-	if (!CAN_WEAR(obj, wear_bitvectors[where])) {
-		act("Вы не можете надеть $o3 на эту часть тела.", FALSE, ch, obj, 0, TO_CHAR);
-		return;
-	}
-	if (unique_stuff(ch, obj) && OBJ_FLAGGED(obj, EExtraFlag::ITEM_UNIQUE)) {
-		send_to_char("Вы не можете использовать более одной такой вещи.\r\n", ch);
-		return;
-	}
-	if (ch->haveCooldown(SKILL_GLOBAL_COOLDOWN)) {
-		if (ch->get_fighting() && (where == WEAR_SHIELD || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)) {
-			send_to_char("Вм нужно набраться сил.\r\n", ch);
-			return;
-		}
-	};
+  // first, make sure that the wear position is valid.
+  if (!CAN_WEAR(obj, wear_bitvectors[where])) {
+    act("Вы не можете надеть $o3 на эту часть тела.", FALSE, ch, obj, 0, TO_CHAR);
+    return;
+  }
+  if (unique_stuff(ch, obj) && OBJ_FLAGGED(obj, EExtraFlag::ITEM_UNIQUE)) {
+    send_to_char("Вы не можете использовать более одной такой вещи.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_GLOBAL_COOLDOWN)) {
+    if (ch->get_fighting() && (where == WEAR_SHIELD || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)) {
+      send_to_char("Вм нужно набраться сил.\r\n", ch);
+      return;
+    }
+  };
 
-	// for neck, finger, and wrist, try pos 2 if pos 1 is already full
-	if (   // не может держать если есть свет или двуручник
-		(where == WEAR_HOLD && (GET_EQ(ch, WEAR_BOTHS) || GET_EQ(ch, WEAR_LIGHT)
-								|| GET_EQ(ch, WEAR_SHIELD))) ||
-		// не может вооружиться если есть двуручник
-		(where == WEAR_WIELD && GET_EQ(ch, WEAR_BOTHS)) ||
-		// не может держать щит если что-то держит или двуручник
-		(where == WEAR_SHIELD && (GET_EQ(ch, WEAR_HOLD) || GET_EQ(ch, WEAR_BOTHS))) ||
-		// не может двуручник если есть щит, свет, вооружен или держит
-		(where == WEAR_BOTHS && (GET_EQ(ch, WEAR_HOLD) || GET_EQ(ch, WEAR_LIGHT)
-								 || GET_EQ(ch, WEAR_SHIELD) || GET_EQ(ch, WEAR_WIELD))) ||
-		// не может держать свет если двуручник или держит
-		(where == WEAR_LIGHT && (GET_EQ(ch, WEAR_HOLD) || GET_EQ(ch, WEAR_BOTHS))))
-	{
-		send_to_char("У вас заняты руки.\r\n", ch);
-		return;
-	}
-	if (   // не может одеть колчан если одет не лук
-		(where == WEAR_QUIVER &&
-                !(GET_EQ(ch, WEAR_BOTHS) &&
-                (((GET_OBJ_TYPE(GET_EQ(ch, WEAR_BOTHS))) == OBJ_DATA::ITEM_WEAPON)
-                    && (GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS)) == SKILL_BOWS )))))
-        {
-		send_to_char("А стрелять чем будете?\r\n", ch);
-		return;
+  // for neck, finger, and wrist, try pos 2 if pos 1 is already full
+  if (   // не может держать если есть свет или двуручник
+      (where == WEAR_HOLD && (GET_EQ(ch, WEAR_BOTHS) || GET_EQ(ch, WEAR_LIGHT)
+          || GET_EQ(ch, WEAR_SHIELD))) ||
+          // не может вооружиться если есть двуручник
+          (where == WEAR_WIELD && GET_EQ(ch, WEAR_BOTHS)) ||
+          // не может держать щит если что-то держит или двуручник
+          (where == WEAR_SHIELD && (GET_EQ(ch, WEAR_HOLD) || GET_EQ(ch, WEAR_BOTHS))) ||
+          // не может двуручник если есть щит, свет, вооружен или держит
+          (where == WEAR_BOTHS && (GET_EQ(ch, WEAR_HOLD) || GET_EQ(ch, WEAR_LIGHT)
+              || GET_EQ(ch, WEAR_SHIELD) || GET_EQ(ch, WEAR_WIELD))) ||
+          // не может держать свет если двуручник или держит
+          (where == WEAR_LIGHT && (GET_EQ(ch, WEAR_HOLD) || GET_EQ(ch, WEAR_BOTHS)))) {
+    send_to_char("У вас заняты руки.\r\n", ch);
+    return;
+  }
+  if (   // не может одеть колчан если одет не лук
+      (where == WEAR_QUIVER &&
+          !(GET_EQ(ch, WEAR_BOTHS) &&
+              (((GET_OBJ_TYPE(GET_EQ(ch, WEAR_BOTHS))) == OBJ_DATA::ITEM_WEAPON)
+                  && (GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS)) == SKILL_BOWS))))) {
+    send_to_char("А стрелять чем будете?\r\n", ch);
+    return;
+  }
+  // нельзя надеть щит, если недостаточно силы
+  if (!IS_IMMORTAL(ch) && (where == WEAR_SHIELD) && !OK_SHIELD(ch, obj)) {
+  }
+
+  if ((where == WEAR_FINGER_R) || (where == WEAR_NECK_1) || (where == WEAR_WRIST_R))
+    if (GET_EQ(ch, where))
+      where++;
+
+  if (GET_EQ(ch, where)) {
+    send_to_char(already_wearing[where], ch);
+    return;
+  }
+  if (!wear_otrigger(obj, ch, where))
+    return;
+
+  //obj_from_char(obj);
+  equip_char(ch, obj, where | 0x100);
+}
+
+int find_eq_pos(CHAR_DATA *ch, OBJ_DATA *obj, char *arg) {
+  int where = -1;
+
+  // \r to prevent explicit wearing. Don't use \n, it's end-of-array marker.
+  const char *keywords[] =
+      {
+          "\r!RESERVED!",
+          "палецправый",
+          "палецлевый",
+          "шея",
+          "грудь",
+          "тело",
+          "голова",
+          "ноги",
+          "ступни",
+          "кисти",
+          "руки",
+          "щит",
+          "плечи",
+          "пояс",
+          "запястья",
+          "\r!RESERVED!",
+          "\r!RESERVED!",
+          "\r!RESERVED!",
+          "\n"
+      };
+
+  if (!arg || !*arg) {
+    int tmp_where = -1;
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FINGER)) {
+      if (!GET_EQ(ch, WEAR_FINGER_R)) {
+        where = WEAR_FINGER_R;
+      } else if (!GET_EQ(ch, WEAR_FINGER_L)) {
+        where = WEAR_FINGER_L;
+      } else {
+        tmp_where = WEAR_FINGER_R;
+      }
+    }
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_NECK)) {
+      if (!GET_EQ(ch, WEAR_NECK_1)) {
+        where = WEAR_NECK_1;
+      } else if (!GET_EQ(ch, WEAR_NECK_2)) {
+        where = WEAR_NECK_2;
+      } else {
+        tmp_where = WEAR_NECK_1;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY)) {
+      if (!GET_EQ(ch, WEAR_BODY)) {
+        where = WEAR_BODY;
+      } else {
+        tmp_where = WEAR_BODY;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD)) {
+      if (!GET_EQ(ch, WEAR_HEAD)) {
+        where = WEAR_HEAD;
+      } else {
+        tmp_where = WEAR_HEAD;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS)) {
+      if (!GET_EQ(ch, WEAR_LEGS)) {
+        where = WEAR_LEGS;
+      } else {
+        tmp_where = WEAR_LEGS;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET)) {
+      if (!GET_EQ(ch, WEAR_FEET)) {
+        where = WEAR_FEET;
+      } else {
+        tmp_where = WEAR_FEET;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS)) {
+      if (!GET_EQ(ch, WEAR_HANDS)) {
+        where = WEAR_HANDS;
+      } else {
+        tmp_where = WEAR_HANDS;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS)) {
+      if (!GET_EQ(ch, WEAR_ARMS)) {
+        where = WEAR_ARMS;
+      } else {
+        tmp_where = WEAR_ARMS;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_SHIELD)) {
+      if (!GET_EQ(ch, WEAR_SHIELD)) {
+        where = WEAR_SHIELD;
+      } else {
+        tmp_where = WEAR_SHIELD;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT)) {
+      if (!GET_EQ(ch, WEAR_ABOUT)) {
+        where = WEAR_ABOUT;
+      } else {
+        tmp_where = WEAR_ABOUT;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WAIST)) {
+      if (!GET_EQ(ch, WEAR_WAIST)) {
+        where = WEAR_WAIST;
+      } else {
+        tmp_where = WEAR_WAIST;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_QUIVER)) {
+      if (!GET_EQ(ch, WEAR_QUIVER)) {
+        where = WEAR_QUIVER;
+      } else {
+        tmp_where = WEAR_QUIVER;
+      }
+    }
+
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WRIST)) {
+      if (!GET_EQ(ch, WEAR_WRIST_R)) {
+        where = WEAR_WRIST_R;
+      } else if (!GET_EQ(ch, WEAR_WRIST_L)) {
+        where = WEAR_WRIST_L;
+      } else {
+        tmp_where = WEAR_WRIST_R;
+      }
+    }
+
+    if (where == -1) {
+      where = tmp_where;
+    }
+  } else {
+    where = search_block(arg, keywords, FALSE);
+    if (where < 0
+        || *arg == '!') {
+      sprintf(buf, "'%s'? Странная анатомия у этих русских!\r\n", arg);
+      send_to_char(buf, ch);
+      return -1;
+    }
+  }
+
+  return where;
+}
+
+void do_wear(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  char arg1[MAX_INPUT_LENGTH];
+  char arg2[MAX_INPUT_LENGTH];
+  OBJ_DATA *obj, *next_obj;
+  int where, dotmode, items_worn = 0;
+
+  two_arguments(argument, arg1, arg2);
+
+  if (IS_NPC(ch)
+      && AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+      && (!NPC_FLAGGED(ch, NPC_ARMORING)
+          || MOB_FLAGGED(ch, MOB_RESURRECTED))) {
+    return;
+  }
+
+  if (!*arg1) {
+    send_to_char("Что вы собрались надеть?\r\n", ch);
+    return;
+  }
+  dotmode = find_all_dots(arg1);
+
+  if (*arg2 && (dotmode != FIND_INDIV)) {
+    send_to_char("И на какую часть тела вы желаете это надеть?!\r\n", ch);
+    return;
+  }
+  if (dotmode == FIND_ALL) {
+    for (obj = ch->carrying; obj && !GET_MOB_HOLD(ch) && GET_POS(ch) > POS_SLEEPING; obj = next_obj) {
+      next_obj = obj->get_next_content();
+      if (CAN_SEE_OBJ(ch, obj)
+          && (where = find_eq_pos(ch, obj, 0)) >= 0) {
+        items_worn++;
+        perform_wear(ch, obj, where);
+      }
+    }
+    if (!items_worn) {
+      send_to_char("Увы, но надеть вам нечего.\r\n", ch);
+    }
+  } else if (dotmode == FIND_ALLDOT) {
+    if (!*arg1) {
+      send_to_char("Надеть \"все\" чего?\r\n", ch);
+      return;
+    }
+    if (!(obj = get_obj_in_list_vis(ch, arg1, ch->carrying))) {
+      sprintf(buf, "У вас нет ничего похожего на '%s'.\r\n", arg1);
+      send_to_char(buf, ch);
+    } else
+      while (obj && !GET_MOB_HOLD(ch) && GET_POS(ch) > POS_SLEEPING) {
+        next_obj = get_obj_in_list_vis(ch, arg1, obj->get_next_content());
+        if ((where = find_eq_pos(ch, obj, 0)) >= 0) {
+          perform_wear(ch, obj, where);
+        } else {
+          act("Вы не можете надеть $o3.", FALSE, ch, obj, 0, TO_CHAR);
         }
-	// нельзя надеть щит, если недостаточно силы
-	if (!IS_IMMORTAL(ch) && (where == WEAR_SHIELD) && !OK_SHIELD(ch, obj))
-	{
-	}
-
-	if ((where == WEAR_FINGER_R) || (where == WEAR_NECK_1) || (where == WEAR_WRIST_R))
-		if (GET_EQ(ch, where))
-			where++;
-
-	if (GET_EQ(ch, where))
-	{
-		send_to_char(already_wearing[where], ch);
-		return;
-	}
-	if (!wear_otrigger(obj, ch, where))
-		return;
-
-	//obj_from_char(obj);
-	equip_char(ch, obj, where | 0x100);
-}
-
-int find_eq_pos(CHAR_DATA * ch, OBJ_DATA * obj, char *arg)
-{
-	int where = -1;
-
-	// \r to prevent explicit wearing. Don't use \n, it's end-of-array marker.
-	const char *keywords[] =
-	{
-		"\r!RESERVED!",
-		"палецправый",
-		"палецлевый",
-		"шея",
-		"грудь",
-		"тело",
-		"голова",
-		"ноги",
-		"ступни",
-		"кисти",
-		"руки",
-		"щит",
-		"плечи",
-		"пояс",
-		"запястья",
-		"\r!RESERVED!",
-		"\r!RESERVED!",
-		"\r!RESERVED!",
-		"\n"
-	};
-
-	if (!arg || !*arg)
-	{
-		int tmp_where = -1;
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FINGER))
-		{
-			if (!GET_EQ(ch, WEAR_FINGER_R))
-			{
-				where = WEAR_FINGER_R;
-			}
-			else if (!GET_EQ(ch, WEAR_FINGER_L))
-			{
-				where = WEAR_FINGER_L;
-			}
-			else
-			{
-				tmp_where = WEAR_FINGER_R;
-			}
-		}
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_NECK))
-		{
-			if (!GET_EQ(ch, WEAR_NECK_1))
-			{
-				where = WEAR_NECK_1;
-			}
-			else if (!GET_EQ(ch, WEAR_NECK_2))
-			{
-				where = WEAR_NECK_2;
-			}
-			else
-			{
-				tmp_where = WEAR_NECK_1;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY))
-		{
-			if (!GET_EQ(ch, WEAR_BODY))
-			{
-				where = WEAR_BODY;
-			}
-			else
-			{
-				tmp_where = WEAR_BODY;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD))
-		{
-			if (!GET_EQ(ch, WEAR_HEAD))
-			{
-				where = WEAR_HEAD;
-			}
-			else
-			{
-				tmp_where = WEAR_HEAD;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS))
-		{
-			if (!GET_EQ(ch, WEAR_LEGS))
-			{
-				where = WEAR_LEGS;
-			}
-			else
-			{
-				tmp_where = WEAR_LEGS;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET))
-		{
-			if (!GET_EQ(ch, WEAR_FEET))
-			{
-				where = WEAR_FEET;
-			}
-			else
-			{
-				tmp_where = WEAR_FEET;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS))
-		{
-			if (!GET_EQ(ch, WEAR_HANDS))
-			{
-				where = WEAR_HANDS;
-			}
-			else
-			{
-				tmp_where = WEAR_HANDS;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS))
-		{
-			if (!GET_EQ(ch, WEAR_ARMS))
-			{
-				where = WEAR_ARMS;
-			}
-			else
-			{
-				tmp_where = WEAR_ARMS;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_SHIELD))
-		{
-			if (!GET_EQ(ch, WEAR_SHIELD))
-			{
-				where = WEAR_SHIELD;
-			}
-			else
-			{
-				tmp_where = WEAR_SHIELD;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT))
-		{
-			if (!GET_EQ(ch, WEAR_ABOUT))
-			{
-				where = WEAR_ABOUT;
-			}
-			else
-			{
-				tmp_where = WEAR_ABOUT;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WAIST))
-		{
-			if (!GET_EQ(ch, WEAR_WAIST))
-			{
-				where = WEAR_WAIST;
-			}
-			else
-			{
-				tmp_where = WEAR_WAIST;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_QUIVER))
-		{
-			if (!GET_EQ(ch, WEAR_QUIVER))
-			{
-				where = WEAR_QUIVER;
-			}
-			else
-			{
-				tmp_where = WEAR_QUIVER;
-			}
-		}
-
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WRIST))
-		{
-			if (!GET_EQ(ch, WEAR_WRIST_R))
-			{
-				where = WEAR_WRIST_R;
-			}
-			else if (!GET_EQ(ch, WEAR_WRIST_L))
-			{
-				where = WEAR_WRIST_L;
-			}
-			else
-			{
-				tmp_where = WEAR_WRIST_R;
-			}
-		}
-
-		if (where == -1)
-		{
-			where = tmp_where;
-		}
-	}
-	else
-	{
-		where = search_block(arg, keywords, FALSE);
-		if (where < 0
-			|| *arg == '!')
-		{
-			sprintf(buf, "'%s'? Странная анатомия у этих русских!\r\n", arg);
-			send_to_char(buf, ch);
-			return -1;
-		}
-	}
-
-	return where;
-}
-
-void do_wear(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	char arg1[MAX_INPUT_LENGTH];
-	char arg2[MAX_INPUT_LENGTH];
-	OBJ_DATA *obj, *next_obj;
-	int where, dotmode, items_worn = 0;
-
-	two_arguments(argument, arg1, arg2);
-
-	if (IS_NPC(ch)
-		&& AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-		&& (!NPC_FLAGGED(ch, NPC_ARMORING)
-			|| MOB_FLAGGED(ch, MOB_RESURRECTED)))
-	{
-		return;
-	}
-
-	if (!*arg1)
-	{
-		send_to_char("Что вы собрались надеть?\r\n", ch);
-		return;
-	}
-	dotmode = find_all_dots(arg1);
-
-	if (*arg2 && (dotmode != FIND_INDIV))
-	{
-		send_to_char("И на какую часть тела вы желаете это надеть?!\r\n", ch);
-		return;
-	}
-	if (dotmode == FIND_ALL)
-	{
-		for (obj = ch->carrying; obj && !GET_MOB_HOLD(ch) && GET_POS(ch) > POS_SLEEPING; obj = next_obj)
-		{
-			next_obj = obj->get_next_content();
-			if (CAN_SEE_OBJ(ch, obj)
-					&& (where = find_eq_pos(ch, obj, 0)) >= 0)
-			{
-				items_worn++;
-				perform_wear(ch, obj, where);
-			}
-		}
-		if (!items_worn)
-		{
-			send_to_char("Увы, но надеть вам нечего.\r\n", ch);
-		}
-	}
-	else if (dotmode == FIND_ALLDOT)
-	{
-		if (!*arg1)
-		{
-			send_to_char("Надеть \"все\" чего?\r\n", ch);
-			return;
-		}
-		if (!(obj = get_obj_in_list_vis(ch, arg1, ch->carrying)))
-		{
-			sprintf(buf, "У вас нет ничего похожего на '%s'.\r\n", arg1);
-			send_to_char(buf, ch);
-		}
-		else
-			while (obj && !GET_MOB_HOLD(ch) && GET_POS(ch) > POS_SLEEPING)
-			{
-				next_obj = get_obj_in_list_vis(ch, arg1, obj->get_next_content());
-				if ((where = find_eq_pos(ch, obj, 0)) >= 0)
-				{
-					perform_wear(ch, obj, where);
-				}
-				else
-				{
-					act("Вы не можете надеть $o3.", FALSE, ch, obj, 0, TO_CHAR);
-				}
-				obj = next_obj;
-			}
-	}
-	else
-	{
-		if (!(obj = get_obj_in_list_vis(ch, arg1, ch->carrying)))
-		{
-			sprintf(buf, "У вас нет ничего похожего на '%s'.\r\n", arg1);
-			send_to_char(buf, ch);
-		}
-		else
-		{
-			if ((where = find_eq_pos(ch, obj, arg2)) >= 0)
-				perform_wear(ch, obj, where);
-			else if (!*arg2)
-				act("Вы не можете надеть $o3.", FALSE, ch, obj, 0, TO_CHAR);
-		}
-	}
+        obj = next_obj;
+      }
+  } else {
+    if (!(obj = get_obj_in_list_vis(ch, arg1, ch->carrying))) {
+      sprintf(buf, "У вас нет ничего похожего на '%s'.\r\n", arg1);
+      send_to_char(buf, ch);
+    } else {
+      if ((where = find_eq_pos(ch, obj, arg2)) >= 0)
+        perform_wear(ch, obj, where);
+      else if (!*arg2)
+        act("Вы не можете надеть $o3.", FALSE, ch, obj, 0, TO_CHAR);
+    }
+  }
 }
 
 void do_wield(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-	OBJ_DATA *obj;
-	int wear;
+  OBJ_DATA *obj;
+  int wear;
 
-	if (IS_NPC(ch) && (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)&&(!NPC_FLAGGED(ch, NPC_WIELDING) || MOB_FLAGGED(ch, MOB_RESURRECTED))))
-		return;
+  if (IS_NPC(ch) && (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+      && (!NPC_FLAGGED(ch, NPC_WIELDING) || MOB_FLAGGED(ch, MOB_RESURRECTED))))
+    return;
 
-	if (ch->is_morphed()) {
-		send_to_char("Лапами неудобно держать оружие.\r\n", ch);
-		return;
-	}
-	argument = one_argument(argument, arg);
+  if (ch->is_morphed()) {
+    send_to_char("Лапами неудобно держать оружие.\r\n", ch);
+    return;
+  }
+  argument = one_argument(argument, arg);
 
-	if (!*arg)
-		send_to_char("Вооружиться чем?\r\n", ch);
-	else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-	{
-		snprintf(buf,  MAX_INPUT_LENGTH,"Вы не видите ничего похожего на \'%s\'.\r\n", arg);
-		send_to_char(buf, ch);
-	}
-	else
-	{
-		if (!CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD)
-			&& !CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS))
-		{
-			send_to_char("Вы не можете вооружиться этим.\r\n", ch);
-		}
-		else if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON)
-		{
-			send_to_char("Это не оружие.\r\n", ch);
-		}
-		else if (IS_NPC(ch)
-			&& AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-			&& MOB_FLAGGED(ch, MOB_CORPSE))
-		{
-			send_to_char("Ожившие трупы не могут вооружаться.\r\n", ch);
-		}
-		else
-		{
-			one_argument(argument, arg);
-			if (!str_cmp(arg, "обе")
-				&& CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS))
-			{
-				// иногда бывает надо
-				if (!IS_IMMORTAL(ch) && !OK_BOTH(ch, obj))
-				{
-					act("Вам слишком тяжело держать $o3 двумя руками.", FALSE, ch, obj, 0, TO_CHAR);
-					message_str_need(ch, obj, STR_BOTH_W);
-					return;
-				};
-				perform_wear(ch, obj, WEAR_BOTHS);
-				return;
-			}
+  if (!*arg)
+    send_to_char("Вооружиться чем?\r\n", ch);
+  else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+    snprintf(buf, MAX_INPUT_LENGTH, "Вы не видите ничего похожего на \'%s\'.\r\n", arg);
+    send_to_char(buf, ch);
+  } else {
+    if (!CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD)
+        && !CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)) {
+      send_to_char("Вы не можете вооружиться этим.\r\n", ch);
+    } else if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON) {
+      send_to_char("Это не оружие.\r\n", ch);
+    } else if (IS_NPC(ch)
+        && AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+        && MOB_FLAGGED(ch, MOB_CORPSE)) {
+      send_to_char("Ожившие трупы не могут вооружаться.\r\n", ch);
+    } else {
+      one_argument(argument, arg);
+      if (!str_cmp(arg, "обе")
+          && CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)) {
+        // иногда бывает надо
+        if (!IS_IMMORTAL(ch) && !OK_BOTH(ch, obj)) {
+          act("Вам слишком тяжело держать $o3 двумя руками.", FALSE, ch, obj, 0, TO_CHAR);
+          message_str_need(ch, obj, STR_BOTH_W);
+          return;
+        };
+        perform_wear(ch, obj, WEAR_BOTHS);
+        return;
+      }
 
-			if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD))
-			{
-				wear = WEAR_WIELD;
-			}
-			else
-			{
-				wear = WEAR_BOTHS;
-			}
+      if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD)) {
+        wear = WEAR_WIELD;
+      } else {
+        wear = WEAR_BOTHS;
+      }
 
-			if (wear == WEAR_WIELD && !IS_IMMORTAL(ch) && !OK_WIELD(ch, obj))
-			{
-				act("Вам слишком тяжело держать $o3 в правой руке.", FALSE, ch, obj, 0, TO_CHAR);
-				message_str_need(ch, obj, STR_WIELD_W);
+      if (wear == WEAR_WIELD && !IS_IMMORTAL(ch) && !OK_WIELD(ch, obj)) {
+        act("Вам слишком тяжело держать $o3 в правой руке.", FALSE, ch, obj, 0, TO_CHAR);
+        message_str_need(ch, obj, STR_WIELD_W);
 
-				if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS))
-				{
-					wear = WEAR_BOTHS;
-				}
-				else
-				{
-					return;
-				}
-			}
+        if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)) {
+          wear = WEAR_BOTHS;
+        } else {
+          return;
+        }
+      }
 
-			if (wear == WEAR_BOTHS && !IS_IMMORTAL(ch) && !OK_BOTH(ch, obj))
-			{
-				act("Вам слишком тяжело держать $o3 двумя руками.", FALSE, ch, obj, 0, TO_CHAR);
-				message_str_need(ch, obj, STR_BOTH_W);
-				return;
-			};
-			perform_wear(ch, obj, wear);
-		}
-	}
+      if (wear == WEAR_BOTHS && !IS_IMMORTAL(ch) && !OK_BOTH(ch, obj)) {
+        act("Вам слишком тяжело держать $o3 двумя руками.", FALSE, ch, obj, 0, TO_CHAR);
+        message_str_need(ch, obj, STR_BOTH_W);
+        return;
+      };
+      perform_wear(ch, obj, wear);
+    }
+  }
 }
 
-std::string readFile1(const std::string& fileName) {
-	std::ifstream f(fileName);
-	f.seekg(0, std::ios::end);
-	size_t size = f.tellg();
-	std::string s(size, ' ');
-	f.seekg(0);
-	f.read(&s[0], size); // по стандарту можно в C++11, по факту работает и на старых компиляторах
-	return s;
+std::string readFile1(const std::string &fileName) {
+  std::ifstream f(fileName);
+  f.seekg(0, std::ios::end);
+  size_t size = f.tellg();
+  std::string s(size, ' ');
+  f.seekg(0);
+  f.read(&s[0], size); // по стандарту можно в C++11, по факту работает и на старых компиляторах
+  return s;
 }
 
-void do_grab(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	int where = WEAR_HOLD;
-	OBJ_DATA *obj;
-	one_argument(argument, arg);
+void do_grab(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  int where = WEAR_HOLD;
+  OBJ_DATA *obj;
+  one_argument(argument, arg);
 
-	if (IS_NPC(ch) && !NPC_FLAGGED(ch, NPC_WIELDING))
-		return;
+  if (IS_NPC(ch) && !NPC_FLAGGED(ch, NPC_WIELDING))
+    return;
 
-	if (ch->is_morphed())
-	{
-		send_to_char("Лапами неудобно это держать.\r\n", ch);
-		return;
-	}
+  if (ch->is_morphed()) {
+    send_to_char("Лапами неудобно это держать.\r\n", ch);
+    return;
+  }
 
-	if (!*arg)
-		send_to_char("Вы заорали : 'Держи его!!! Хватай его!!!'\r\n", ch);
-	else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-	{
-		snprintf(buf, MAX_INPUT_LENGTH, "У вас нет ничего похожего на '%s'.\r\n", arg);
-		send_to_char(buf, ch);
-	}
-	else
-	{
-		if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_LIGHT)
-		{
-			perform_wear(ch, obj, WEAR_LIGHT);
-		}
-		else
-		{
-			if (!CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD)
-				&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WAND
-				&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_STAFF
-				&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_SCROLL
-				&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_POTION)
-			{
-				send_to_char("Вы не можете это держать.\r\n", ch);
-				return;
-			}
+  if (!*arg)
+    send_to_char("Вы заорали : 'Держи его!!! Хватай его!!!'\r\n", ch);
+  else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+    snprintf(buf, MAX_INPUT_LENGTH, "У вас нет ничего похожего на '%s'.\r\n", arg);
+    send_to_char(buf, ch);
+  } else {
+    if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_LIGHT) {
+      perform_wear(ch, obj, WEAR_LIGHT);
+    } else {
+      if (!CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD)
+          && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WAND
+          && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_STAFF
+          && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_SCROLL
+          && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_POTION) {
+        send_to_char("Вы не можете это держать.\r\n", ch);
+        return;
+      }
 
-			if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)
-			{
-				if (GET_OBJ_SKILL(obj) == SKILL_BOTHHANDS
-					|| GET_OBJ_SKILL(obj) == SKILL_BOWS)
-				{
-					send_to_char("Данный тип оружия держать невозможно.", ch);
-					return;
-				}
-			}
+      if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON) {
+        if (GET_OBJ_SKILL(obj) == SKILL_BOTHHANDS
+            || GET_OBJ_SKILL(obj) == SKILL_BOWS) {
+          send_to_char("Данный тип оружия держать невозможно.", ch);
+          return;
+        }
+      }
 
-			if (IS_NPC(ch)
-				&& AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-				&& MOB_FLAGGED(ch, MOB_CORPSE))
-			{
-				send_to_char("Ожившие трупы не могут вооружаться.\r\n", ch);
-				return;
-			}
-			if (!IS_IMMORTAL(ch)
-				&& !OK_HELD(ch, obj))
-			{
-				act("Вам слишком тяжело держать $o3 в левой руке.", FALSE, ch, obj, 0, TO_CHAR);
-				message_str_need(ch, obj, STR_HOLD_W);
+      if (IS_NPC(ch)
+          && AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+          && MOB_FLAGGED(ch, MOB_CORPSE)) {
+        send_to_char("Ожившие трупы не могут вооружаться.\r\n", ch);
+        return;
+      }
+      if (!IS_IMMORTAL(ch)
+          && !OK_HELD(ch, obj)) {
+        act("Вам слишком тяжело держать $o3 в левой руке.", FALSE, ch, obj, 0, TO_CHAR);
+        message_str_need(ch, obj, STR_HOLD_W);
 
-				if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS))
-				{
-					if (!OK_BOTH(ch, obj))
-					{
-						act("Вам слишком тяжело держать $o3 двумя руками.", FALSE, ch, obj, 0, TO_CHAR);
-						message_str_need(ch, obj, STR_BOTH_W);
-						return;
-					}
-					else
-					{
-						where = WEAR_BOTHS;
-					}
-				}
-				else
-				{
-					return;
-				}
-			}
-			perform_wear(ch, obj, where);
-		}
-	}
+        if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)) {
+          if (!OK_BOTH(ch, obj)) {
+            act("Вам слишком тяжело держать $o3 двумя руками.", FALSE, ch, obj, 0, TO_CHAR);
+            message_str_need(ch, obj, STR_BOTH_W);
+            return;
+          } else {
+            where = WEAR_BOTHS;
+          }
+        } else {
+          return;
+        }
+      }
+      perform_wear(ch, obj, where);
+    }
+  }
 }
 
+void perform_remove(CHAR_DATA *ch, int pos) {
+  OBJ_DATA *obj;
 
-
-void perform_remove(CHAR_DATA * ch, int pos) {
-	OBJ_DATA *obj;
-
-	if (!(obj = GET_EQ(ch, pos))) {
-		log("SYSERR: perform_remove: bad pos %d passed.", pos);
-	} else {
-		/*
+  if (!(obj = GET_EQ(ch, pos))) {
+    log("SYSERR: perform_remove: bad pos %d passed.", pos);
+  } else {
+    /*
 		   if (IS_OBJ_STAT(obj, ITEM_NODROP))
 		   act("Вы не можете снять $o3!", FALSE, ch, obj, 0, TO_CHAR);
 		   else
 		 */
-		if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch)) {
-			act("$p: Вы не можете нести столько вещей!", FALSE, ch, obj, 0, TO_CHAR);
-		} else {
-			if (!remove_otrigger(obj, ch)) {
-				return;
-			}
-			if (ch->get_fighting() && (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON || pos == WEAR_SHIELD)) {
-				ch->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, 2);
-			}
-			act("Вы прекратили использовать $o3.", FALSE, ch, obj, 0, TO_CHAR);
-			act("$n прекратил$g использовать $o3.", TRUE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-			obj_to_char(unequip_char(ch, pos | 0x40), ch);
-		}
-	}
+    if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch)) {
+      act("$p: Вы не можете нести столько вещей!", FALSE, ch, obj, 0, TO_CHAR);
+    } else {
+      if (!remove_otrigger(obj, ch)) {
+        return;
+      }
+      if (ch->get_fighting() && (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON || pos == WEAR_SHIELD)) {
+        ch->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, 2);
+      }
+      act("Вы прекратили использовать $o3.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n прекратил$g использовать $o3.", TRUE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      obj_to_char(unequip_char(ch, pos | 0x40), ch);
+    }
+  }
 }
 
-void do_remove(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	int i, dotmode, found;
-	OBJ_DATA *obj;
+void do_remove(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  int i, dotmode, found;
+  OBJ_DATA *obj;
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
-	if (!*arg)
-	{
-		send_to_char("Снять что?\r\n", ch);
-		return;
-	}
-	dotmode = find_all_dots(arg);
+  if (!*arg) {
+    send_to_char("Снять что?\r\n", ch);
+    return;
+  }
+  dotmode = find_all_dots(arg);
 
-	if (dotmode == FIND_ALL)
-	{
-		found = 0;
-		for (i = 0; i < NUM_WEARS; i++)
-		{
-			if (GET_EQ(ch, i))
-			{
-				perform_remove(ch, i);
-				found = 1;
-			}
-		}
-		if (!found)
-		{
-			send_to_char("На вас не надето предметов этого типа.\r\n", ch);
-        		return;
-		}
-	}
-	else if (dotmode == FIND_ALLDOT)
-	{
-		if (!*arg)
-		{
-			send_to_char("Снять все вещи какого типа?\r\n", ch);
-        		return;
-		}
-		else
-		{
-			found = 0;
-			for (i = 0; i < NUM_WEARS; i++)
-			{
-				if (GET_EQ(ch, i)
-					&& CAN_SEE_OBJ(ch, GET_EQ(ch, i))
-					&& (isname(arg, GET_EQ(ch, i)->get_aliases())
-						|| CHECK_CUSTOM_LABEL(arg, GET_EQ(ch, i), ch)))
-				{
-					perform_remove(ch, i);
-					found = 1;
-				}
-			}
-			if (!found)
-			{
-				snprintf(buf, MAX_STRING_LENGTH, "Вы не используете ни одного '%s'.\r\n", arg);
-				send_to_char(buf, ch);
-                                return;
-			}
-		}
-	}
-	else  		// Returns object pointer but we don't need it, just true/false.
-	{
-		if (!get_object_in_equip_vis(ch, arg, ch->equipment, &i))
-		{
-			// если предмет не найден, то возможно игрок ввел "левая" или "правая"
-			if (!str_cmp("правая", arg))
-			{
-				if (!GET_EQ(ch, WEAR_WIELD))
-				{
-					send_to_char("В правой руке ничего нет.\r\n", ch);
-				}
-				else
-				{
-					perform_remove(ch, WEAR_WIELD);
-				}
-			}
-			else if (!str_cmp("левая", arg))
-			{
-				if (!GET_EQ(ch, WEAR_HOLD))
-					send_to_char("В левой руке ничего нет.\r\n", ch);
-				else
-					perform_remove(ch, WEAR_HOLD);
-			}
-			else
-			{
-				snprintf(buf, MAX_INPUT_LENGTH, "Вы не используете '%s'.\r\n", arg);
-				send_to_char(buf, ch);
-                                return;
-			}
-		}
-		else {
-			perform_remove(ch, i);
-		}
-	}
-        //мы что-то да снимали. значит проверю я доп слот
-        if ((obj = GET_EQ(ch, WEAR_QUIVER)) && !GET_EQ(ch, WEAR_BOTHS))
-                {
-                    send_to_char("Нету лука, нет и стрел.\r\n", ch);
-                    act("$n прекратил$g использовать $o3.", FALSE, ch, obj, 0, TO_ROOM);
-                    obj_to_char(unequip_char(ch, WEAR_QUIVER), ch);
-                    return;
-                }
+  if (dotmode == FIND_ALL) {
+    found = 0;
+    for (i = 0; i < NUM_WEARS; i++) {
+      if (GET_EQ(ch, i)) {
+        perform_remove(ch, i);
+        found = 1;
+      }
+    }
+    if (!found) {
+      send_to_char("На вас не надето предметов этого типа.\r\n", ch);
+      return;
+    }
+  } else if (dotmode == FIND_ALLDOT) {
+    if (!*arg) {
+      send_to_char("Снять все вещи какого типа?\r\n", ch);
+      return;
+    } else {
+      found = 0;
+      for (i = 0; i < NUM_WEARS; i++) {
+        if (GET_EQ(ch, i)
+            && CAN_SEE_OBJ(ch, GET_EQ(ch, i))
+            && (isname(arg, GET_EQ(ch, i)->get_aliases())
+                || CHECK_CUSTOM_LABEL(arg, GET_EQ(ch, i), ch))) {
+          perform_remove(ch, i);
+          found = 1;
+        }
+      }
+      if (!found) {
+        snprintf(buf, MAX_STRING_LENGTH, "Вы не используете ни одного '%s'.\r\n", arg);
+        send_to_char(buf, ch);
+        return;
+      }
+    }
+  } else        // Returns object pointer but we don't need it, just true/false.
+  {
+    if (!get_object_in_equip_vis(ch, arg, ch->equipment, &i)) {
+      // если предмет не найден, то возможно игрок ввел "левая" или "правая"
+      if (!str_cmp("правая", arg)) {
+        if (!GET_EQ(ch, WEAR_WIELD)) {
+          send_to_char("В правой руке ничего нет.\r\n", ch);
+        } else {
+          perform_remove(ch, WEAR_WIELD);
+        }
+      } else if (!str_cmp("левая", arg)) {
+        if (!GET_EQ(ch, WEAR_HOLD))
+          send_to_char("В левой руке ничего нет.\r\n", ch);
+        else
+          perform_remove(ch, WEAR_HOLD);
+      } else {
+        snprintf(buf, MAX_INPUT_LENGTH, "Вы не используете '%s'.\r\n", arg);
+        send_to_char(buf, ch);
+        return;
+      }
+    } else {
+      perform_remove(ch, i);
+    }
+  }
+  //мы что-то да снимали. значит проверю я доп слот
+  if ((obj = GET_EQ(ch, WEAR_QUIVER)) && !GET_EQ(ch, WEAR_BOTHS)) {
+    send_to_char("Нету лука, нет и стрел.\r\n", ch);
+    act("$n прекратил$g использовать $o3.", FALSE, ch, obj, 0, TO_ROOM);
+    obj_to_char(unequip_char(ch, WEAR_QUIVER), ch);
+    return;
+  }
 }
 
-void do_upgrade(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	OBJ_DATA *obj;
-	int weight, add_hr, add_dr, prob, percent, min_mod, max_mod, i;
-	bool oldstate;
-	if (!ch->get_skill(SKILL_UPGRADE))
-	{
-		send_to_char("Вы не умеете этого.", ch);
-		return;
-	}
+void do_upgrade(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  OBJ_DATA *obj;
+  int weight, add_hr, add_dr, prob, percent, min_mod, max_mod, i;
+  bool oldstate;
+  if (!ch->get_skill(SKILL_UPGRADE)) {
+    send_to_char("Вы не умеете этого.", ch);
+    return;
+  }
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
-	if (!*arg)
-	{
-		send_to_char("Что вы хотите заточить?\r\n", ch);
-	}
+  if (!*arg) {
+    send_to_char("Что вы хотите заточить?\r\n", ch);
+  }
 
-	if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-	{
-		snprintf(buf, MAX_INPUT_LENGTH, "У вас нет \'%s\'.\r\n", arg);
-		send_to_char(buf, ch);
-		return;
-	};
+  if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+    snprintf(buf, MAX_INPUT_LENGTH, "У вас нет \'%s\'.\r\n", arg);
+    send_to_char(buf, ch);
+    return;
+  };
 
-	if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON)
-	{
-		send_to_char("Вы можете заточить только оружие.\r\n", ch);
-		return;
-	}
+  if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON) {
+    send_to_char("Вы можете заточить только оружие.\r\n", ch);
+    return;
+  }
 
-	if (GET_OBJ_SKILL(obj) == SKILL_BOWS)
-	{
-		send_to_char("Невозможно заточить этот тип оружия.\r\n", ch);
-		return;
-	}
+  if (GET_OBJ_SKILL(obj) == SKILL_BOWS) {
+    send_to_char("Невозможно заточить этот тип оружия.\r\n", ch);
+    return;
+  }
 
-	if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_MAGIC))
-	{
-		send_to_char("Вы не можете заточить заколдованный предмет.\r\n", ch);
-		return;
-	}
+  if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_MAGIC)) {
+    send_to_char("Вы не можете заточить заколдованный предмет.\r\n", ch);
+    return;
+  }
 
-	// Make sure no other (than hitroll & damroll) affections.
-	for (i = 0; i < MAX_OBJ_AFFECT; i++)
-	{
-		if ((obj->get_affected(i).location != APPLY_NONE)
-			&& (obj->get_affected(i).location != APPLY_HITROLL)
-			&& (obj->get_affected(i).location != APPLY_DAMROLL))
-		{
-			send_to_char("Этот предмет не может быть заточен.\r\n", ch);
-			return;
-		}
-	}
+  // Make sure no other (than hitroll & damroll) affections.
+  for (i = 0; i < MAX_OBJ_AFFECT; i++) {
+    if ((obj->get_affected(i).location != APPLY_NONE)
+        && (obj->get_affected(i).location != APPLY_HITROLL)
+        && (obj->get_affected(i).location != APPLY_DAMROLL)) {
+      send_to_char("Этот предмет не может быть заточен.\r\n", ch);
+      return;
+    }
+  }
 
-	switch (obj->get_material())
-	{
-	case OBJ_DATA::MAT_BRONZE:
-	case OBJ_DATA::MAT_BULAT:
-	case OBJ_DATA::MAT_IRON:
-	case OBJ_DATA::MAT_STEEL:
-	case OBJ_DATA::MAT_SWORDSSTEEL:
-	case OBJ_DATA::MAT_COLOR:
-	case OBJ_DATA::MAT_BONE:
-		act("Вы взялись точить $o3.", FALSE, ch, obj, 0, TO_CHAR);
-		act("$n взял$u точить $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-		weight = -1;
-		break;
+  switch (obj->get_material()) {
+    case OBJ_DATA::MAT_BRONZE:
+    case OBJ_DATA::MAT_BULAT:
+    case OBJ_DATA::MAT_IRON:
+    case OBJ_DATA::MAT_STEEL:
+    case OBJ_DATA::MAT_SWORDSSTEEL:
+    case OBJ_DATA::MAT_COLOR:
+    case OBJ_DATA::MAT_BONE: act("Вы взялись точить $o3.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n взял$u точить $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      weight = -1;
+      break;
 
-	case OBJ_DATA::MAT_WOOD:
-	case OBJ_DATA::MAT_SUPERWOOD:
-		act("Вы взялись стругать $o3.", FALSE, ch, obj, 0, TO_CHAR);
-		act("$n взял$u стругать $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-		weight = -1;
-		break;
+    case OBJ_DATA::MAT_WOOD:
+    case OBJ_DATA::MAT_SUPERWOOD: act("Вы взялись стругать $o3.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n взял$u стругать $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      weight = -1;
+      break;
 
-	case OBJ_DATA::MAT_SKIN:
-		act("Вы взялись проклепывать $o3.", FALSE, ch, obj, 0, TO_CHAR);
-		act("$n взял$u проклепывать $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-		weight = + 1;
-		break;
+    case OBJ_DATA::MAT_SKIN: act("Вы взялись проклепывать $o3.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n взял$u проклепывать $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      weight = +1;
+      break;
 
-	default:
-		sprintf(buf, "К сожалению, %s сделан из неподходящего материала.\r\n", OBJN(obj, ch, 0));
-		send_to_char(buf, ch);
-		return;
-	}
-	bool change_weight = 1;
-	//Заточить повторно можно, но это уменьшает таймер шмотки на 16%
-	if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_SHARPEN))
-	{
-		int timer = obj->get_timer() - MAX(1000, obj->get_timer() / 6); // абуз, таймер меньше 6 вычитается 0 бесконечная прокачка умелки
-		obj->set_timer(timer);
-		change_weight = 0;
-	}
-	else
-	{
-		obj->set_extra_flag(EExtraFlag::ITEM_SHARPEN);
-		obj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED); // установили флажок трансформации кодом
-	}
+    default: sprintf(buf, "К сожалению, %s сделан из неподходящего материала.\r\n", OBJN(obj, ch, 0));
+      send_to_char(buf, ch);
+      return;
+  }
+  bool change_weight = 1;
+  //Заточить повторно можно, но это уменьшает таймер шмотки на 16%
+  if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_SHARPEN)) {
+    int timer = obj->get_timer()
+        - MAX(1000, obj->get_timer() / 6); // абуз, таймер меньше 6 вычитается 0 бесконечная прокачка умелки
+    obj->set_timer(timer);
+    change_weight = 0;
+  } else {
+    obj->set_extra_flag(EExtraFlag::ITEM_SHARPEN);
+    obj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED); // установили флажок трансформации кодом
+  }
 
-	percent = number(1, skill_info[SKILL_UPGRADE].max_percent);
-	prob = train_skill(ch, SKILL_UPGRADE, skill_info[SKILL_UPGRADE].max_percent, 0);
-	if (obj->get_timer() == 0) // не ждем рассыпания на тике
-	{
-		act("$o не выдержал$G издевательств и рассыпал$U в мелкую пыль...", FALSE, ch, obj, 0, TO_CHAR);
-		extract_obj(obj);
-		return;
-	}
-	//При 200% заточки шмотка будет точиться на 4-5 хитролов и 4-5 дамролов
-	min_mod = ch->get_trained_skill(SKILL_UPGRADE) / 50;
-	//С мортами все меньший уровень требуется для макс. заточки
-	max_mod = MAX(1,MIN(5,(GET_LEVEL(ch) + 5 + GET_REMORT(ch) / 4) / 6));
-	oldstate = check_unlimited_timer(obj); // запомним какая шмотка была до заточки
-	if (IS_IMMORTAL(ch))
-	{
-		add_dr = add_hr = 10;
-	}
-	else
-	{
-		add_dr = add_hr = (max_mod <= min_mod) ? min_mod : number(min_mod, max_mod);
-	}
-	if (percent > prob || GET_GOD_FLAG(ch, GF_GODSCURSE))
-	{
-		act("Но только загубили $S.", FALSE, ch, obj, 0, TO_CHAR);
-		add_hr = -add_hr;
-		add_dr = -add_dr;
-	}
-	else
-	{
-		act("И вроде бы неплохо в итоге получилось.", FALSE, ch, obj, 0, TO_CHAR);
-	}
+  percent = number(1, skill_info[SKILL_UPGRADE].max_percent);
+  prob = calculate_skill(ch, SKILL_UPGRADE, nullptr);
+  train_skill(ch, SKILL_UPGRADE, percent <= prob, nullptr);
+  if (obj->get_timer() == 0) // не ждем рассыпания на тике
+  {
+    act("$o не выдержал$G издевательств и рассыпал$U в мелкую пыль...", FALSE, ch, obj, 0, TO_CHAR);
+    extract_obj(obj);
+    return;
+  }
+  //При 200% заточки шмотка будет точиться на 4-5 хитролов и 4-5 дамролов
+  min_mod = ch->get_trained_skill(SKILL_UPGRADE) / 50;
+  //С мортами все меньший уровень требуется для макс. заточки
+  max_mod = MAX(1, MIN(5, (GET_LEVEL(ch) + 5 + GET_REMORT(ch) / 4) / 6));
+  oldstate = check_unlimited_timer(obj); // запомним какая шмотка была до заточки
+  if (IS_IMMORTAL(ch)) {
+    add_dr = add_hr = 10;
+  } else {
+    add_dr = add_hr = (max_mod <= min_mod) ? min_mod : number(min_mod, max_mod);
+  }
+  if (percent > prob || GET_GOD_FLAG(ch, GF_GODSCURSE)) {
+    act("Но только загубили $S.", FALSE, ch, obj, 0, TO_CHAR);
+    add_hr = -add_hr;
+    add_dr = -add_dr;
+  } else {
+    act("И вроде бы неплохо в итоге получилось.", FALSE, ch, obj, 0, TO_CHAR);
+  }
 
-	obj->set_affected(0, APPLY_HITROLL, add_hr);
-	obj->set_affected(1, APPLY_DAMROLL, add_dr);
+  obj->set_affected(0, APPLY_HITROLL, add_hr);
+  obj->set_affected(1, APPLY_DAMROLL, add_dr);
 
-	// если шмотка перестала быть нерушимой ставим таймер из прототипа
-	if (oldstate && !check_unlimited_timer(obj))
-	{
-		obj->set_timer(obj_proto.at(GET_OBJ_RNUM(obj))->get_timer());
-	}
-	//Вес меняется только если шмотка еще не была заточена
-	//Также вес НЕ меняется если он уже нулевой и должен снизиться
-	const auto curent_weight = obj->get_weight();
-	if (change_weight && !(curent_weight == 0 && weight < 0))
-	{
-		obj->set_weight(curent_weight + weight);
-		IS_CARRYING_W(ch) += weight;
-	}
+  // если шмотка перестала быть нерушимой ставим таймер из прототипа
+  if (oldstate && !check_unlimited_timer(obj)) {
+    obj->set_timer(obj_proto.at(GET_OBJ_RNUM(obj))->get_timer());
+  }
+  //Вес меняется только если шмотка еще не была заточена
+  //Также вес НЕ меняется если он уже нулевой и должен снизиться
+  const auto curent_weight = obj->get_weight();
+  if (change_weight && !(curent_weight == 0 && weight < 0)) {
+    obj->set_weight(curent_weight + weight);
+    IS_CARRYING_W(ch) += weight;
+  }
 }
 
-//const char *armoredaffect[] = {"поглощение", "здоровье", "живучесть", "стойкость (сопротивление)", "огня (сопротивление)", "воздуха (сопротивление)", "воды (сопротивление)", "земли (сопротивление)"};
-void do_armored(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	OBJ_DATA *obj;
-	char arg2[MAX_INPUT_LENGTH];
-	int add_ac, prob, percent, i, armorvalue;
-	const auto& strengthening = GlobalObjects::strengthening();
+void do_armored(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  OBJ_DATA *obj;
+  char arg2[MAX_INPUT_LENGTH];
+  int add_ac, prob, percent, i, armorvalue;
+  const auto &strengthening = GlobalObjects::strengthening();
 
-	if (!ch->get_skill(SKILL_ARMORED))
-	{
-		send_to_char("Вы не умеете этого.", ch);
-		return;
-	}
+  if (!ch->get_skill(SKILL_ARMORED)) {
+    send_to_char("Вы не умеете этого.", ch);
+    return;
+  }
 
-	two_arguments(argument, arg, arg2);
+  two_arguments(argument, arg, arg2);
 
-	if (!*arg)
-		send_to_char("Что вы хотите укрепить?\r\n", ch);
+  if (!*arg)
+    send_to_char("Что вы хотите укрепить?\r\n", ch);
 
-	if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-	{
-		snprintf(buf, MAX_INPUT_LENGTH, "У вас нет \'%s\'.\r\n", arg);
-		send_to_char(buf, ch);
-		return;
-	}
+  if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+    snprintf(buf, MAX_INPUT_LENGTH, "У вас нет \'%s\'.\r\n", arg);
+    send_to_char(buf, ch);
+    return;
+  }
 
+  if (!ObjSystem::is_armor_type(obj)) {
+    send_to_char("Вы можете укрепить только доспех.\r\n", ch);
+    return;
+  }
 
-	if (!ObjSystem::is_armor_type(obj))
-	{
-		send_to_char("Вы можете укрепить только доспех.\r\n", ch);
-		return;
-	}
+  if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_MAGIC)
+      || OBJ_FLAGGED(obj, EExtraFlag::ITEM_ARMORED)) {
+    send_to_char("Вы не можете укрепить этот предмет.\r\n", ch);
+    return;
+  }
 
-	if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_MAGIC)
-		|| OBJ_FLAGGED(obj, EExtraFlag::ITEM_ARMORED))
-	{
-		send_to_char("Вы не можете укрепить этот предмет.\r\n", ch);
-		return;
-	}
+  // Make sure no other affections.
+  for (i = 0; i < MAX_OBJ_AFFECT; i++)
+    if (obj->get_affected(i).location != APPLY_NONE) {
+      send_to_char("Этот предмет не может быть укреплен.\r\n", ch);
+      return;
+    }
 
-	// Make sure no other affections.
-	for (i = 0; i < MAX_OBJ_AFFECT; i++)
-		if (obj->get_affected(i).location != APPLY_NONE)
-		{
-			send_to_char("Этот предмет не может быть укреплен.\r\n", ch);
-			return;
-		}
+  if (!OBJWEAR_FLAGGED(obj, (to_underlying(EWearFlag::ITEM_WEAR_BODY)
+      | to_underlying(EWearFlag::ITEM_WEAR_ABOUT)
+      | to_underlying(EWearFlag::ITEM_WEAR_HEAD)
+      | to_underlying(EWearFlag::ITEM_WEAR_ARMS)
+      | to_underlying(EWearFlag::ITEM_WEAR_LEGS)
+      | to_underlying(EWearFlag::ITEM_WEAR_FEET)))) {
+    act("$o3 невозможно укрепить.", FALSE, ch, obj, 0, TO_CHAR);
+    return;
+  }
+  if (obj->get_owner() != GET_UNIQUE(ch)) {
+    send_to_char(ch, "Укрепить можно только лично сделанный предмет.\r\n");
+    return;
+  }
+  if (!*arg2 && (GET_SKILL(ch, SKILL_ARMORED) >= 100)) {
+    send_to_char(ch,
+                 "Укажите параметр для улучшения: поглощение, здоровье, живучесть (сопротивление), стойкость (сопротивление), огня (сопротивление), воздуха (сопротивление), воды (сопротивление), земли (сопротивление)\r\n");
+    return;
+  }
+  switch (obj->get_material()) {
+    case OBJ_DATA::MAT_IRON:
+    case OBJ_DATA::MAT_STEEL:
+    case OBJ_DATA::MAT_BULAT: act("Вы принялись закалять $o3.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n принял$u закалять $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      break;
 
-	if (!OBJWEAR_FLAGGED(obj, (to_underlying(EWearFlag::ITEM_WEAR_BODY)
-		| to_underlying(EWearFlag::ITEM_WEAR_ABOUT)
-		| to_underlying(EWearFlag::ITEM_WEAR_HEAD)
-		| to_underlying(EWearFlag::ITEM_WEAR_ARMS)
-		| to_underlying(EWearFlag::ITEM_WEAR_LEGS)
-		| to_underlying(EWearFlag::ITEM_WEAR_FEET))))
-	{
-		act("$o3 невозможно укрепить.", FALSE, ch, obj, 0, TO_CHAR);
-		return;
-	}
-	if (obj->get_owner() != GET_UNIQUE(ch))
-	{
-		send_to_char(ch, "Укрепить можно только лично сделанный предмет.\r\n");
-		return;
-	}
-	if (!*arg2 && (GET_SKILL(ch, SKILL_ARMORED) >= 100))
-	{
-		send_to_char(ch, "Укажите параметр для улучшения: поглощение, здоровье, живучесть (сопротивление), стойкость (сопротивление), огня (сопротивление), воздуха (сопротивление), воды (сопротивление), земли (сопротивление)\r\n");
-		return;
-	}
-	switch (obj->get_material())
-	{
-	case OBJ_DATA::MAT_IRON:
-	case OBJ_DATA::MAT_STEEL:
-	case OBJ_DATA::MAT_BULAT:
-		act("Вы принялись закалять $o3.", FALSE, ch, obj, 0, TO_CHAR);
-		act("$n принял$u закалять $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-		break;
+    case OBJ_DATA::MAT_WOOD:
+    case OBJ_DATA::MAT_SUPERWOOD: act("Вы принялись обшивать $o3 железом.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n принял$u обшивать $o3 железом.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      break;
 
-	case OBJ_DATA::MAT_WOOD:
-	case OBJ_DATA::MAT_SUPERWOOD:
-		act("Вы принялись обшивать $o3 железом.", FALSE, ch, obj, 0, TO_CHAR);
-		act("$n принял$u обшивать $o3 железом.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-		break;
+    case OBJ_DATA::MAT_SKIN: act("Вы принялись проклепывать $o3.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n принял$u проклепывать $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      break;
 
-	case OBJ_DATA::MAT_SKIN:
-		act("Вы принялись проклепывать $o3.", FALSE, ch, obj, 0, TO_CHAR);
-		act("$n принял$u проклепывать $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-		break;
+    default: sprintf(buf, "К сожалению, %s сделан из неподходящего материала.\r\n", OBJN(obj, ch, 0));
+      send_to_char(buf, ch);
+      return;
+  }
 
-	default:
-		sprintf(buf, "К сожалению, %s сделан из неподходящего материала.\r\n", OBJN(obj, ch, 0));
-		send_to_char(buf, ch);
-		return;
-	}
-
-
-	percent = number(1, skill_info[SKILL_ARMORED].max_percent);
-	prob = train_skill(ch, SKILL_ARMORED, skill_info[SKILL_ARMORED].max_percent, 0);
-	add_ac = IS_IMMORTAL(ch) ? -20 : -number(1, (GET_LEVEL(ch) + 4) / 5);
-	if (percent > prob
-		|| GET_GOD_FLAG(ch, GF_GODSCURSE))
-	{
-		act("Но только испортили $S.", FALSE, ch, obj, 0, TO_CHAR);
-		add_ac = -add_ac;
-	}
-	else if (GET_SKILL(ch, SKILL_ARMORED) >= 100)
-	{
-		if (CompareParam(arg2, "поглощение"))
-		{
-			armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::ABSORBTION);
-			armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
+  percent = number(1, skill_info[SKILL_ARMORED].max_percent);
+  prob = calculate_skill(ch, SKILL_ARMORED, nullptr);
+  train_skill(ch, SKILL_ARMORED, percent <= prob, nullptr);
+  add_ac = IS_IMMORTAL(ch) ? -20 : -number(1, (GET_LEVEL(ch) + 4) / 5);
+  if (percent > prob
+      || GET_GOD_FLAG(ch, GF_GODSCURSE)) {
+    act("Но только испортили $S.", FALSE, ch, obj, 0, TO_CHAR);
+    add_ac = -add_ac;
+  } else if (GET_SKILL(ch, SKILL_ARMORED) >= 100) {
+    if (CompareParam(arg2, "поглощение")) {
+      armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::ABSORBTION);
+      armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
 //			send_to_char(ch, "увеличиваю поглот на %d\r\n", armorvalue);
-			obj->set_affected(1, APPLY_ABSORBE, armorvalue);
-		}
-		else if (CompareParam(arg2, "здоровье"))
-		{
-			armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::HEALTH);
-			armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
-			armorvalue *= -1;
+      obj->set_affected(1, APPLY_ABSORBE, armorvalue);
+    } else if (CompareParam(arg2, "здоровье")) {
+      armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::HEALTH);
+      armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
+      armorvalue *= -1;
 //			send_to_char(ch, "увеличиваю здоровье на %d\r\n", armorvalue);
-			obj->set_affected(1, APPLY_SAVING_CRITICAL, armorvalue);
-		}
-		else if (CompareParam(arg2, "живучесть"))// резисты в - лучше
-		{
-			armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::VITALITY);
-			armorvalue = - MAX(0, number(armorvalue, armorvalue - 2));
-			armorvalue *= -1;
+      obj->set_affected(1, APPLY_SAVING_CRITICAL, armorvalue);
+    } else if (CompareParam(arg2, "живучесть"))// резисты в - лучше
+    {
+      armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::VITALITY);
+      armorvalue = -MAX(0, number(armorvalue, armorvalue - 2));
+      armorvalue *= -1;
 //			send_to_char(ch, "увеличиваю живучесть на %d\r\n", armorvalue);
-			obj->set_affected(1, APPLY_RESIST_VITALITY, armorvalue);
-		}
-		else if (CompareParam(arg2, "стойкость"))
-		{
-			armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::STAMINA);
-			armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
-			armorvalue *= -1;
+      obj->set_affected(1, APPLY_RESIST_VITALITY, armorvalue);
+    } else if (CompareParam(arg2, "стойкость")) {
+      armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::STAMINA);
+      armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
+      armorvalue *= -1;
 //			send_to_char(ch, "увеличиваю стойкость на %d\r\n", armorvalue);
-			obj->set_affected(1, APPLY_SAVING_STABILITY, armorvalue);
-		}
-		else if (CompareParam(arg2, "воздуха"))
-		{
-			armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::AIR_PROTECTION);
-			armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
+      obj->set_affected(1, APPLY_SAVING_STABILITY, armorvalue);
+    } else if (CompareParam(arg2, "воздуха")) {
+      armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::AIR_PROTECTION);
+      armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
 //			send_to_char(ch, "увеличиваю сопр воздуха на %d\r\n", armorvalue);
-			obj->set_affected(1, APPLY_RESIST_AIR, armorvalue);
-		}
-		else if (CompareParam(arg2, "воды"))
-		{
-			armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::WATER_PROTECTION);
-			armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
+      obj->set_affected(1, APPLY_RESIST_AIR, armorvalue);
+    } else if (CompareParam(arg2, "воды")) {
+      armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::WATER_PROTECTION);
+      armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
 //			send_to_char(ch, "увеличиваю сопр воды на %d\r\n", armorvalue);
-			obj->set_affected(1, APPLY_RESIST_WATER, armorvalue);
-		}
-		else if (CompareParam(arg2, "огня"))
-		{
-			armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::FIRE_PROTECTION);
-			armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
+      obj->set_affected(1, APPLY_RESIST_WATER, armorvalue);
+    } else if (CompareParam(arg2, "огня")) {
+      armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::FIRE_PROTECTION);
+      armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
 //			send_to_char(ch, "увеличиваю сопр огню на %d\r\n", armorvalue);
-			obj->set_affected(1, APPLY_RESIST_FIRE, armorvalue);
-		}
-		else if (CompareParam(arg2, "земли"))
-		{
-			armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::EARTH_PROTECTION);
-			armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
+      obj->set_affected(1, APPLY_RESIST_FIRE, armorvalue);
+    } else if (CompareParam(arg2, "земли")) {
+      armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::EARTH_PROTECTION);
+      armorvalue = MAX(0, number(armorvalue, armorvalue - 2));
 //			send_to_char(ch, "увеличиваю сопр земли на %d\r\n", armorvalue);
-			obj->set_affected(1, APPLY_RESIST_EARTH, armorvalue);
-		}
-		else
-		{
-			send_to_char(ch, "Но не поняли что улучшать.\r\n");
-			return;
-		}
-		armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::TIMER);
-		int timer =  obj->get_timer() * strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::TIMER) / 100;
-		obj->set_timer(timer);
+      obj->set_affected(1, APPLY_RESIST_EARTH, armorvalue);
+    } else {
+      send_to_char(ch, "Но не поняли что улучшать.\r\n");
+      return;
+    }
+    armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::TIMER);
+    int timer = obj->get_timer() * strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::TIMER) / 100;
+    obj->set_timer(timer);
 //		send_to_char(ch, "увеличиваю таймер на %d%, устанавливаю таймер %d\r\n", armorvalue, timer);
-		armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::ARMOR);
+    armorvalue = strengthening((GET_SKILL(ch, SKILL_ARMORED) / 10 * 10), Strengthening::ARMOR);
 //		send_to_char(ch, "увеличиваю армор на %d скилл равен %d  значение берем %d\r\n", armorvalue, GET_SKILL(ch, SKILL_ARMORED), (GET_SKILL(ch, SKILL_ARMORED) / 10 * 10) );
-		obj->set_affected(2, APPLY_ARMOUR, armorvalue);
-		obj->set_extra_flag(EExtraFlag::ITEM_ARMORED);
-		obj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED); // установили флажок трансформации кодом
-	}
-	obj->set_affected(0, APPLY_AC, add_ac);
+    obj->set_affected(2, APPLY_ARMOUR, armorvalue);
+    obj->set_extra_flag(EExtraFlag::ITEM_ARMORED);
+    obj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED); // установили флажок трансформации кодом
+  }
+  obj->set_affected(0, APPLY_AC, add_ac);
 }
 
-void do_fire(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	int percent, prob;
-	if (!ch->get_skill(SKILL_FIRE))
-	{
-		send_to_char("Но вы не знаете как.\r\n", ch);
-		return;
-	}
+void do_fire(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  int percent, prob;
+  if (!ch->get_skill(SKILL_FIRE)) {
+    send_to_char("Но вы не знаете как.\r\n", ch);
+    return;
+  }
 
-	if (ch->ahorse())
-	{
-		send_to_char("Верхом это будет затруднительно.\r\n", ch);
-		return;
-	}
+  if (ch->ahorse()) {
+    send_to_char("Верхом это будет затруднительно.\r\n", ch);
+    return;
+  }
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-	{
-		send_to_char("Вы ничего не видите!\r\n", ch);
-		return;
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    send_to_char("Вы ничего не видите!\r\n", ch);
+    return;
+  }
 
+  if (world[ch->in_room]->fires) {
+    send_to_char("Здесь уже горит огонь.\r\n", ch);
+    return;
+  }
 
-	if (world[ch->in_room]->fires)
-	{
-		send_to_char("Здесь уже горит огонь.\r\n", ch);
-		return;
-	}
+  if (SECT(ch->in_room) == SECT_INSIDE ||
+      SECT(ch->in_room) == SECT_CITY ||
+      SECT(ch->in_room) == SECT_WATER_SWIM ||
+      SECT(ch->in_room) == SECT_WATER_NOSWIM ||
+      SECT(ch->in_room) == SECT_FLYING ||
+      SECT(ch->in_room) == SECT_UNDERWATER || SECT(ch->in_room) == SECT_SECRET) {
+    send_to_char("В этой комнате нельзя разжечь костер.\r\n", ch);
+    return;
+  }
 
-	if (SECT(ch->in_room) == SECT_INSIDE ||
-			SECT(ch->in_room) == SECT_CITY ||
-			SECT(ch->in_room) == SECT_WATER_SWIM ||
-			SECT(ch->in_room) == SECT_WATER_NOSWIM ||
-			SECT(ch->in_room) == SECT_FLYING ||
-			SECT(ch->in_room) == SECT_UNDERWATER || SECT(ch->in_room) == SECT_SECRET)
-	{
-		send_to_char("В этой комнате нельзя разжечь костер.\r\n", ch);
-		return;
-	}
+  if (!check_moves(ch, FIRE_MOVES))
+    return;
 
-	if (!check_moves(ch, FIRE_MOVES))
-		return;
-
-	percent = number(1, skill_info[SKILL_FIRE].max_percent);
-	prob = calculate_skill(ch, SKILL_FIRE, 0);
-	if (percent > prob)
-	{
-		send_to_char("Вы попытались разжечь костер, но у вас ничего не вышло.\r\n", ch);
-		return;
-	}
-	else
-	{
-		world[ch->in_room]->fires = MAX(0, (prob - percent) / 5) + 1;
-		send_to_char("Вы набрали хворосту и разожгли огонь.\n\r", ch);
-		act("$n развел$g огонь.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		improve_skill(ch, SKILL_FIRE, TRUE, 0);
-	}
+  percent = number(1, skill_info[SKILL_FIRE].max_percent);
+  prob = calculate_skill(ch, SKILL_FIRE, 0);
+  if (percent > prob) {
+    send_to_char("Вы попытались разжечь костер, но у вас ничего не вышло.\r\n", ch);
+    return;
+  } else {
+    world[ch->in_room]->fires = MAX(0, (prob - percent) / 5) + 1;
+    send_to_char("Вы набрали хворосту и разожгли огонь.\n\r", ch);
+    act("$n развел$g огонь.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+    improve_skill(ch, SKILL_FIRE, TRUE, 0);
+  }
 }
 
 #include "magic.rooms.hpp"
-void do_extinguish(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	CHAR_DATA *caster;
-	int tp, lag = 0;
-	const char *targets[] =
-	{
-		"костер",
-		"пламя",
-		"огонь",
-		"fire",
-		"метку",
-		"надпись",
-		"руны",
-		"label",
-		"\n"
-	};
+void do_extinguish(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *caster;
+  int tp, lag = 0;
+  const char *targets[] =
+      {
+          "костер",
+          "пламя",
+          "огонь",
+          "fire",
+          "метку",
+          "надпись",
+          "руны",
+          "label",
+          "\n"
+      };
 
-	if (IS_NPC(ch))
-	{
-		return;
-	}
+  if (IS_NPC(ch)) {
+    return;
+  }
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
-	if ((!*arg) || ((tp = search_block(arg, targets, FALSE)) == -1))
-	{
-		send_to_char("Что вы хотите затоптать?\r\n", ch);
-		return;
-	}
-	tp >>= 2;
+  if ((!*arg) || ((tp = search_block(arg, targets, FALSE)) == -1)) {
+    send_to_char("Что вы хотите затоптать?\r\n", ch);
+    return;
+  }
+  tp >>= 2;
 
-	switch (tp)
-	{
-	case 0:
-		if (world[ch->in_room]->fires)
-		{
-			if (world[ch->in_room]->fires < 5)
-				--world[ch->in_room]->fires;
-			else
-				world[ch->in_room]->fires = 4;
-			send_to_char("Вы затоптали костер.\r\n", ch);
-			act("$n затоптал$g костер.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-			if (world[ch->in_room]->fires == 0)
-			{
-				send_to_char("Костер потух.\r\n", ch);
-				act("Костер потух.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-			}
-			lag = 1;
-		}
-		else
-		{
-			send_to_char("А тут топтать и нечего :)\r\n", ch);
-		}
-		break;
+  switch (tp) {
+    case 0:
+      if (world[ch->in_room]->fires) {
+        if (world[ch->in_room]->fires < 5)
+          --world[ch->in_room]->fires;
+        else
+          world[ch->in_room]->fires = 4;
+        send_to_char("Вы затоптали костер.\r\n", ch);
+        act("$n затоптал$g костер.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        if (world[ch->in_room]->fires == 0) {
+          send_to_char("Костер потух.\r\n", ch);
+          act("Костер потух.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        }
+        lag = 1;
+      } else {
+        send_to_char("А тут топтать и нечего :)\r\n", ch);
+      }
+      break;
 
-	case 1:
-		const auto& room = world[ch->in_room];
-		auto aff_i = room->affected.end();
-		auto aff_first = room->affected.end();
+    case 1: const auto &room = world[ch->in_room];
+      auto aff_i = room->affected.end();
+      auto aff_first = room->affected.end();
 
-		//Find own rune label or first run label in room
-		for (auto affect_it = room->affected.begin(); affect_it != room->affected.end(); ++affect_it)
-		{
-			if (affect_it->get()->type == SPELL_RUNE_LABEL)
-			{
-				if (affect_it->get()->caster_id == GET_ID(ch))
-				{
-					aff_i = affect_it;
-					break;
-				}
+      //Find own rune label or first run label in room
+      for (auto affect_it = room->affected.begin(); affect_it != room->affected.end(); ++affect_it) {
+        if (affect_it->get()->type == SPELL_RUNE_LABEL) {
+          if (affect_it->get()->caster_id == GET_ID(ch)) {
+            aff_i = affect_it;
+            break;
+          }
 
-				if (aff_first == room->affected.end())
-				{
-					aff_first = affect_it;
-				}
-			}
-		}
+          if (aff_first == room->affected.end()) {
+            aff_first = affect_it;
+          }
+        }
+      }
 
-		if (aff_i == room->affected.end())
-		{
-			//Own rune label not found. Use first in room
-			aff_i = aff_first;
-		}
+      if (aff_i == room->affected.end()) {
+        //Own rune label not found. Use first in room
+        aff_i = aff_first;
+      }
 
-		if (aff_i != room->affected.end()
-			&& (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
-				|| IS_IMMORTAL(ch)
-				|| PRF_FLAGGED(ch, PRF_CODERINFO)))
-		{
-			send_to_char("Шаркнув несколько раз по земле, вы стерли светящуюся надпись.\r\n", ch);
-			act("$n шаркнул$g несколько раз по светящимся рунам, полностью их уничтожив.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      if (aff_i != room->affected.end()
+          && (AFF_FLAGGED(ch, EAffectFlag::AFF_DETECT_MAGIC)
+              || IS_IMMORTAL(ch)
+              || PRF_FLAGGED(ch, PRF_CODERINFO))) {
+        send_to_char("Шаркнув несколько раз по земле, вы стерли светящуюся надпись.\r\n", ch);
+        act("$n шаркнул$g несколько раз по светящимся рунам, полностью их уничтожив.",
+            FALSE,
+            ch,
+            0,
+            0,
+            TO_ROOM | TO_ARENA_LISTEN);
 
-			const auto& aff = *aff_i;
-			if (GET_ID(ch) != aff->caster_id) //чел стирает не свою метку - вай, нехорошо
-			{
-				//Ищем кастера по миру
-				caster = find_char(aff->caster_id);
-				//Если кастер онлайн - выдаем деятелю БД как за воровство
-				if (caster)
-				{
-					pk_thiefs_action(ch, caster);
-					sprintf(buf, "Послышался далекий звук лопнувшей струны, и перед вами промельнул призрачный облик %s.\r\n", GET_PAD(ch, 1));
-					send_to_char(buf, caster);
-				}
-			}
-			RoomSpells::removeAffectFromRoom(world[ch->in_room], aff_i);
-			lag = 3;
-		}
-		else
-		{
-			send_to_char("А тут топтать и нечего :)\r\n", ch);
-		}
-		break;
-	}
+        const auto &aff = *aff_i;
+        if (GET_ID(ch) != aff->caster_id) //чел стирает не свою метку - вай, нехорошо
+        {
+          //Ищем кастера по миру
+          caster = find_char(aff->caster_id);
+          //Если кастер онлайн - выдаем деятелю БД как за воровство
+          if (caster) {
+            pk_thiefs_action(ch, caster);
+            sprintf(buf,
+                    "Послышался далекий звук лопнувшей струны, и перед вами промельнул призрачный облик %s.\r\n",
+                    GET_PAD(ch, 1));
+            send_to_char(buf, caster);
+          }
+        }
+        RoomSpells::removeAffectFromRoom(world[ch->in_room], aff_i);
+        lag = 3;
+      } else {
+        send_to_char("А тут топтать и нечего :)\r\n", ch);
+      }
+      break;
+  }
 
-	//Выдадим-ка лаг за эти дела.
-	if (!WAITLESS(ch))
-	{
-		WAIT_STATE(ch, lag * PULSE_VIOLENCE);
-	}
+  //Выдадим-ка лаг за эти дела.
+  if (!WAITLESS(ch)) {
+    WAIT_STATE(ch, lag * PULSE_VIOLENCE);
+  }
 }
 
 #define MAX_REMOVE  13
-const int RemoveSpell[MAX_REMOVE] = { SPELL_SLEEP, SPELL_POISON, SPELL_WEAKNESS, SPELL_CURSE, SPELL_PLAQUE,
-			SPELL_SILENCE, SPELL_BLINDNESS, SPELL_HAEMORRAGIA, SPELL_HOLD, SPELL_PEACEFUL, SPELL_CONE_OF_COLD,
-			SPELL_DEAFNESS, SPELL_BATTLE };
+const int RemoveSpell[MAX_REMOVE] = {SPELL_SLEEP, SPELL_POISON, SPELL_WEAKNESS, SPELL_CURSE, SPELL_PLAQUE,
+                                     SPELL_SILENCE, SPELL_BLINDNESS, SPELL_HAEMORRAGIA, SPELL_HOLD, SPELL_PEACEFUL,
+                                     SPELL_CONE_OF_COLD,
+                                     SPELL_DEAFNESS, SPELL_BATTLE};
 
-void do_firstaid(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	int success = FALSE, need = FALSE, spellnum = 0;
-	struct timed_type timed;
+void do_firstaid(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  int success = FALSE, need = FALSE, spellnum = 0;
+  struct timed_type timed;
 
-	if (!ch->get_skill(SKILL_AID))
-	{
-		send_to_char("Вам следует этому научиться.\r\n", ch);
-		return;
-	}
-	if (!IS_GOD(ch) && timed_by_skill(ch, SKILL_AID))
-	{
-		send_to_char("Так много лечить нельзя - больных не останется.\r\n", ch);
-		return;
-	}
+  if (!ch->get_skill(SKILL_AID)) {
+    send_to_char("Вам следует этому научиться.\r\n", ch);
+    return;
+  }
+  if (!IS_GOD(ch) && timed_by_skill(ch, SKILL_AID)) {
+    send_to_char("Так много лечить нельзя - больных не останется.\r\n", ch);
+    return;
+  }
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
-	CHAR_DATA *vict;
-	if (!*arg)
-	{
-		vict = ch;
-	}
-	else
-	{
-		vict = get_char_vis(ch, arg, FIND_CHAR_ROOM);
-		if (!vict)
-		{
-			send_to_char("Кого вы хотите подлечить?\r\n", ch);
-			return;
-		}
-	}
+  CHAR_DATA *vict;
+  if (!*arg) {
+    vict = ch;
+  } else {
+    vict = get_char_vis(ch, arg, FIND_CHAR_ROOM);
+    if (!vict) {
+      send_to_char("Кого вы хотите подлечить?\r\n", ch);
+      return;
+    }
+  }
 
-	if (vict->get_fighting())
-	{
-		act("$N сражается, $M не до ваших телячьих нежностей.", FALSE, ch, 0, vict, TO_CHAR);
-		return;
-	}
+  if (vict->get_fighting()) {
+    act("$N сражается, $M не до ваших телячьих нежностей.", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
 
-	int percent = number(1, skill_info[SKILL_AID].max_percent);
-	int prob = calculate_skill(ch, SKILL_AID, vict);
+  int percent = number(1, skill_info[SKILL_AID].max_percent);
+  int prob = calculate_skill(ch, SKILL_AID, vict);
 
-	if (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE) || GET_GOD_FLAG(vict, GF_GODSLIKE))
-	{
-		percent = prob;
-	}
-	if (GET_GOD_FLAG(ch, GF_GODSCURSE) || GET_GOD_FLAG(vict, GF_GODSCURSE))
-	{
-		prob = 0;
-	}
-	success = (prob >= percent);
-	need = FALSE;
+  if (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE) || GET_GOD_FLAG(vict, GF_GODSLIKE)) {
+    percent = prob;
+  }
+  if (GET_GOD_FLAG(ch, GF_GODSCURSE) || GET_GOD_FLAG(vict, GF_GODSCURSE)) {
+    prob = 0;
+  }
+  success = (prob >= percent);
+  need = FALSE;
 
-	if ((GET_REAL_MAX_HIT(vict) > 0
-		&& (GET_HIT(vict) * 100 / GET_REAL_MAX_HIT(vict)) < 31)
-		|| (GET_REAL_MAX_HIT(vict) <= 0
-			&& GET_HIT(vict) < GET_REAL_MAX_HIT(vict))
-		|| (GET_HIT(vict) < GET_REAL_MAX_HIT(vict)
-			&& can_use_feat(ch, HEALER_FEAT)))
-	{
-		need = TRUE;
-		if (success)
-		{
-			if (!PRF_FLAGGED(ch, PRF_TESTER))
-			{
-				int dif = GET_REAL_MAX_HIT(vict) - GET_HIT(vict);
-				int add = MIN(dif, (dif * (prob - percent) / 100) + 1);
-				GET_HIT(vict) += add;
-			}
-			else
-			{
-				percent = calculate_skill(ch, SKILL_AID, vict);
-				prob = GET_LEVEL(ch) * percent * 0.5;
-				send_to_char(ch, "&RУровень цели %d Отхилено %d хитов, скилл %d\r\n", GET_LEVEL(vict), prob, percent);
-				GET_HIT(vict) += prob;
-				GET_HIT(vict) = MIN(GET_HIT(vict), GET_REAL_MAX_HIT(vict));
-				update_pos(vict);
-			}
-		}
-	}
+  if ((GET_REAL_MAX_HIT(vict) > 0
+      && (GET_HIT(vict) * 100 / GET_REAL_MAX_HIT(vict)) < 31)
+      || (GET_REAL_MAX_HIT(vict) <= 0
+          && GET_HIT(vict) < GET_REAL_MAX_HIT(vict))
+      || (GET_HIT(vict) < GET_REAL_MAX_HIT(vict)
+          && can_use_feat(ch, HEALER_FEAT))) {
+    need = TRUE;
+    if (success) {
+      if (!PRF_FLAGGED(ch, PRF_TESTER)) {
+        int dif = GET_REAL_MAX_HIT(vict) - GET_HIT(vict);
+        int add = MIN(dif, (dif * (prob - percent) / 100) + 1);
+        GET_HIT(vict) += add;
+      } else {
+        percent = calculate_skill(ch, SKILL_AID, vict);
+        prob = GET_LEVEL(ch) * percent * 0.5;
+        send_to_char(ch, "&RУровень цели %d Отхилено %d хитов, скилл %d\r\n", GET_LEVEL(vict), prob, percent);
+        GET_HIT(vict) += prob;
+        GET_HIT(vict) = MIN(GET_HIT(vict), GET_REAL_MAX_HIT(vict));
+        update_pos(vict);
+      }
+    }
+  }
 
-	int count = 0;
-	if (PRF_FLAGGED(ch, PRF_TESTER))
-	{
-		count = (GET_SKILL(ch, SKILL_AID) - 20) / 30;
-		send_to_char(ch, "Снимаю %d аффектов\r\n", count);
+  int count = 0;
+  if (PRF_FLAGGED(ch, PRF_TESTER)) {
+    count = (GET_SKILL(ch, SKILL_AID) - 20) / 30;
+    send_to_char(ch, "Снимаю %d аффектов\r\n", count);
 
-		const auto remove_count = vict->remove_random_affects(count);
-		send_to_char(ch, "Снято %ld аффектов\r\n", remove_count);
+    const auto remove_count = vict->remove_random_affects(count);
+    send_to_char(ch, "Снято %ld аффектов\r\n", remove_count);
 
-		//
-		need = TRUE;
-		prob = TRUE;
-	}
-	else
-	{
-		count = MIN(MAX_REMOVE, MAX_REMOVE * prob / 100);
+    //
+    need = TRUE;
+    prob = TRUE;
+  } else {
+    count = MIN(MAX_REMOVE, MAX_REMOVE * prob / 100);
 
-		for (percent = 0, prob = need; !need && percent < MAX_REMOVE && RemoveSpell[percent]; percent++)
-		{
-			if (affected_by_spell(vict, RemoveSpell[percent]))
-			{
-				need = TRUE;
-				if (percent < count)
-				{
-					spellnum = RemoveSpell[percent];
-					prob = TRUE;
-				}
-			}
-		}
-	}
+    for (percent = 0, prob = need; !need && percent < MAX_REMOVE && RemoveSpell[percent]; percent++) {
+      if (affected_by_spell(vict, RemoveSpell[percent])) {
+        need = TRUE;
+        if (percent < count) {
+          spellnum = RemoveSpell[percent];
+          prob = TRUE;
+        }
+      }
+    }
+  }
 
-	if (!need)
-	{
-		act("$N в лечении не нуждается.", FALSE, ch, 0, vict, TO_CHAR);
-	}
-	else if (!prob)
-	{
-		act("У вас не хватит умения вылечить $N3.", FALSE, ch, 0, vict, TO_CHAR);
-	}
-	else
-	{
-		timed.skill = SKILL_AID;
-		timed.time = IS_IMMORTAL(ch) ? 2 : IS_PALADINE(ch) ? 4 : IS_CLERIC(ch) ? 2 : 6;
-		timed_to_char(ch, &timed);
-		if (vict != ch)
-		{
-			improve_skill(ch, SKILL_AID, success, 0);
-			if (success)
-			{
-				act("Вы оказали первую помощь $N2.", FALSE, ch, 0, vict, TO_CHAR);
-				act("$N оказал$G вам первую помощь.", FALSE, vict, 0, ch, TO_CHAR);
-				act("$n оказал$g первую помощь $N2.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-				if (spellnum)
-					affect_from_char(vict, spellnum);
-			}
-			else
-			{
-				act("Вы безрезультатно попытались оказать первую помощь $N2.",
-					FALSE, ch, 0, vict, TO_CHAR);
-				act("$N безрезультатно попытал$U оказать вам первую помощь.",
-					FALSE, vict, 0, ch, TO_CHAR);
-				act("$n безрезультатно попытал$u оказать первую помощь $N2.",
-					TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-			}
-		}
-		else
-		{
-			if (success)
-			{
-				act("Вы оказали себе первую помощь.", FALSE, ch, 0, 0, TO_CHAR);
-				act("$n оказал$g себе первую помощь.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-				if (spellnum)
-					affect_from_char(vict, spellnum);
-			}
-			else
-			{
-				act("Вы безрезультатно попытались оказать себе первую помощь.",
-					FALSE, ch, 0, vict, TO_CHAR);
-				act("$n безрезультатно попытал$u оказать себе первую помощь.",
-					FALSE, ch, 0, vict, TO_ROOM | TO_ARENA_LISTEN);
-			}
-		}
-	}
+  if (!need) {
+    act("$N в лечении не нуждается.", FALSE, ch, 0, vict, TO_CHAR);
+  } else if (!prob) {
+    act("У вас не хватит умения вылечить $N3.", FALSE, ch, 0, vict, TO_CHAR);
+  } else {
+    timed.skill = SKILL_AID;
+    timed.time = IS_IMMORTAL(ch) ? 2 : IS_PALADINE(ch) ? 4 : IS_CLERIC(ch) ? 2 : 6;
+    timed_to_char(ch, &timed);
+    if (vict != ch) {
+      improve_skill(ch, SKILL_AID, success, 0);
+      if (success) {
+        act("Вы оказали первую помощь $N2.", FALSE, ch, 0, vict, TO_CHAR);
+        act("$N оказал$G вам первую помощь.", FALSE, vict, 0, ch, TO_CHAR);
+        act("$n оказал$g первую помощь $N2.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+        if (spellnum)
+          affect_from_char(vict, spellnum);
+      } else {
+        act("Вы безрезультатно попытались оказать первую помощь $N2.",
+            FALSE, ch, 0, vict, TO_CHAR);
+        act("$N безрезультатно попытал$U оказать вам первую помощь.",
+            FALSE, vict, 0, ch, TO_CHAR);
+        act("$n безрезультатно попытал$u оказать первую помощь $N2.",
+            TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+      }
+    } else {
+      if (success) {
+        act("Вы оказали себе первую помощь.", FALSE, ch, 0, 0, TO_CHAR);
+        act("$n оказал$g себе первую помощь.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        if (spellnum)
+          affect_from_char(vict, spellnum);
+      } else {
+        act("Вы безрезультатно попытались оказать себе первую помощь.",
+            FALSE, ch, 0, vict, TO_CHAR);
+        act("$n безрезультатно попытал$u оказать себе первую помощь.",
+            FALSE, ch, 0, vict, TO_ROOM | TO_ARENA_LISTEN);
+      }
+    }
+  }
 }
 
-void do_poisoned(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	if (!ch->get_skill(SKILL_POISONED))
-	{
-		send_to_char("Вы не умеете этого.", ch);
-		return;
-	}
+void do_poisoned(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  if (!ch->get_skill(SKILL_POISONED)) {
+    send_to_char("Вы не умеете этого.", ch);
+    return;
+  }
 
-	argument = one_argument(argument, arg);
-	skip_spaces(&argument);
+  argument = one_argument(argument, arg);
+  skip_spaces(&argument);
 
-	if (!*arg)
-	{
-		send_to_char("Что вы хотите отравить?\r\n", ch);
-		return;
-	}
-	else if (!*argument)
-	{
-		send_to_char("Из чего вы собираете взять яд?\r\n", ch);
-		return;
-	}
+  if (!*arg) {
+    send_to_char("Что вы хотите отравить?\r\n", ch);
+    return;
+  } else if (!*argument) {
+    send_to_char("Из чего вы собираете взять яд?\r\n", ch);
+    return;
+  }
 
-	OBJ_DATA *weapon = 0;
-	CHAR_DATA *dummy = 0;
-	int result = generic_find(arg, FIND_OBJ_INV | FIND_OBJ_EQUIP, ch, &dummy, &weapon);
+  OBJ_DATA *weapon = 0;
+  CHAR_DATA *dummy = 0;
+  int result = generic_find(arg, FIND_OBJ_INV | FIND_OBJ_EQUIP, ch, &dummy, &weapon);
 
-	if (!weapon || !result)
-	{
-		send_to_char(ch, "У вас нет \'%s\'.\r\n", arg);
-		return;
-	}
-	else if (GET_OBJ_TYPE(weapon) != OBJ_DATA::ITEM_WEAPON)
-	{
-		send_to_char("Вы можете нанести яд только на оружие.\r\n", ch);
-		return;
-	}
+  if (!weapon || !result) {
+    send_to_char(ch, "У вас нет \'%s\'.\r\n", arg);
+    return;
+  } else if (GET_OBJ_TYPE(weapon) != OBJ_DATA::ITEM_WEAPON) {
+    send_to_char("Вы можете нанести яд только на оружие.\r\n", ch);
+    return;
+  }
 
-	OBJ_DATA *cont = get_obj_in_list_vis(ch, argument, ch->carrying);
-	if (!cont)
-	{
-		send_to_char(ch, "У вас нет \'%s\'.\r\n", argument);
-		return;
-	}
-	else if (GET_OBJ_TYPE(cont) != OBJ_DATA::ITEM_DRINKCON)
-	{
-		send_to_char(ch, "%s не является емкостью.\r\n", cont->get_PName(0).c_str());
-		return;
-	}
-	else if (GET_OBJ_VAL(cont, 1) <= 0)
-	{
-		send_to_char(ch, "В %s нет никакой жидкости.\r\n", cont->get_PName(5).c_str());
-		return;
-	}
-	else if (!poison_in_vessel(GET_OBJ_VAL(cont, 2)))
-	{
-		send_to_char(ch, "В %s нет подходящего яда.\r\n", cont->get_PName(5).c_str());
-		return;
-	}
+  OBJ_DATA *cont = get_obj_in_list_vis(ch, argument, ch->carrying);
+  if (!cont) {
+    send_to_char(ch, "У вас нет \'%s\'.\r\n", argument);
+    return;
+  } else if (GET_OBJ_TYPE(cont) != OBJ_DATA::ITEM_DRINKCON) {
+    send_to_char(ch, "%s не является емкостью.\r\n", cont->get_PName(0).c_str());
+    return;
+  } else if (GET_OBJ_VAL(cont, 1) <= 0) {
+    send_to_char(ch, "В %s нет никакой жидкости.\r\n", cont->get_PName(5).c_str());
+    return;
+  } else if (!poison_in_vessel(GET_OBJ_VAL(cont, 2))) {
+    send_to_char(ch, "В %s нет подходящего яда.\r\n", cont->get_PName(5).c_str());
+    return;
+  }
 
-	int cost = MIN(GET_OBJ_VAL(cont, 1), GET_LEVEL(ch) <= 10 ? 1 : GET_LEVEL(ch) <= 20 ? 2 : 3);
-	cont->set_val(1, cont->get_val(1) - cost);
-	weight_change_object(cont, -cost);
-	if (!GET_OBJ_VAL(cont, 1))
-	{
-		name_from_drinkcon(cont);
-	}
+  int cost = MIN(GET_OBJ_VAL(cont, 1), GET_LEVEL(ch) <= 10 ? 1 : GET_LEVEL(ch) <= 20 ? 2 : 3);
+  cont->set_val(1, cont->get_val(1) - cost);
+  weight_change_object(cont, -cost);
+  if (!GET_OBJ_VAL(cont, 1)) {
+    name_from_drinkcon(cont);
+  }
 
-	set_weap_poison(weapon, cont->get_val(2));
+  set_weap_poison(weapon, cont->get_val(2));
 
-	snprintf(buf, sizeof(buf), "Вы осторожно нанесли немного %s на $o3.", drinks[cont->get_val(2)]);
-	act(buf, FALSE, ch, weapon, 0, TO_CHAR);
-	act("$n осторожно нанес$q яд на $o3.", FALSE, ch, weapon, 0, TO_ROOM | TO_ARENA_LISTEN);
+  snprintf(buf, sizeof(buf), "Вы осторожно нанесли немного %s на $o3.", drinks[cont->get_val(2)]);
+  act(buf, FALSE, ch, weapon, 0, TO_CHAR);
+  act("$n осторожно нанес$q яд на $o3.", FALSE, ch, weapon, 0, TO_ROOM | TO_ARENA_LISTEN);
 }
 
-void do_repair(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	OBJ_DATA *obj;
-	int prob, percent = 0, decay;
-	struct timed_type timed;
+void do_repair(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  OBJ_DATA *obj;
+  int prob, percent = 0, decay;
+  struct timed_type timed;
 
+  if (!ch->get_skill(SKILL_REPAIR)) {
+    send_to_char("Вы не умеете этого.\r\n", ch);
+    return;
+  }
+  if (timed_by_skill(ch, SKILL_REPAIR)) {
+    send_to_char("У вас недостаточно сил для ремонта.\r\n", ch);
+    return;
+  }
 
-	if (!ch->get_skill(SKILL_REPAIR))
-	{
-		send_to_char("Вы не умеете этого.\r\n", ch);
-		return;
-	}
-	if (timed_by_skill(ch, SKILL_REPAIR))
-	{
-	    send_to_char("У вас недостаточно сил для ремонта.\r\n", ch);
-	    return;
-	}
+  one_argument(argument, arg);
 
-	one_argument(argument, arg);
+  if (ch->get_fighting()) {
+    send_to_char("Вы не можете сделать это в бою!\r\n", ch);
+    return;
+  }
 
-	if (ch->get_fighting())
-	{
-		send_to_char("Вы не можете сделать это в бою!\r\n", ch);
-		return;
-	}
+  if (!*arg) {
+    send_to_char("Что вы хотите ремонтировать?\r\n", ch);
+    return;
+  }
 
-	if (!*arg)
-	{
-		send_to_char("Что вы хотите ремонтировать?\r\n", ch);
-		return;
-	}
+  if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+    snprintf(buf, MAX_INPUT_LENGTH, "У вас нет \'%s\'.\r\n", arg);
+    send_to_char(buf, ch);
+    return;
+  };
 
-	if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-	{
-		snprintf(buf, MAX_INPUT_LENGTH, "У вас нет \'%s\'.\r\n", arg);
-		send_to_char(buf, ch);
-		return;
-	};
+  if (GET_OBJ_MAX(obj) <= GET_OBJ_CUR(obj)) {
+    act("$o в ремонте не нуждается.", FALSE, ch, obj, 0, TO_CHAR);
+    return;
+  }
+  if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON
+      && !ObjSystem::is_armor_type(obj)) {
+    send_to_char("Вы можете отремонтировать только оружие или броню.\r\n", ch);
+    return;
+  }
 
-	if (GET_OBJ_MAX(obj) <= GET_OBJ_CUR(obj))
-	{
-		act("$o в ремонте не нуждается.", FALSE, ch, obj, 0, TO_CHAR);
-		return;
-	}
-	if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON
-		&& !ObjSystem::is_armor_type(obj))
-	{
-		send_to_char("Вы можете отремонтировать только оружие или броню.\r\n", ch);
-		return;
-	}
-
-	prob = number(1, skill_info[SKILL_REPAIR].max_percent);
-	percent = train_skill(ch, SKILL_REPAIR, skill_info[SKILL_REPAIR].max_percent, 0);
-	if (prob > percent)
-	{
+  prob = number(1, skill_info[SKILL_REPAIR].max_percent);
+  percent = calculate_skill(ch, SKILL_REPAIR, nullptr);
+  train_skill(ch, SKILL_REPAIR, prob <= percent, nullptr);
+  if (prob > percent) {
 //Polos.repair_bug
 //Потому что 0 уничтожает шмотку полностью даже при скиле 100+ и
 //состоянии шмотки <очень хорошо>
-		if (!percent)
-		{
-			percent = ch->get_skill(SKILL_REPAIR) / 10;
-		}
+    if (!percent) {
+      percent = ch->get_skill(SKILL_REPAIR) / 10;
+    }
 //-Polos.repair_bug
-		obj->set_current_durability(MAX(0, obj->get_current_durability() * percent / prob));
-		if (obj->get_current_durability())
-		{
-			act("Вы попытались починить $o3, но сломали $S еще больше.", FALSE, ch, obj, 0, TO_CHAR);
-			act("$n попытал$u починить $o3, но сломал$g $S еще больше.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-			decay = (GET_OBJ_MAX(obj) - GET_OBJ_CUR(obj)) / 10;
-			decay = MAX(1, MIN(decay, GET_OBJ_MAX(obj) / 20));
-			if (GET_OBJ_MAX(obj) > decay)
-			{
-				obj->set_maximum_durability(obj->get_maximum_durability() - decay);
-			}
-			else
-			{
-				obj->set_maximum_durability(1);
-			}
-		}
-		else
-		{
-			act("Вы окончательно доломали $o3.", FALSE, ch, obj, 0, TO_CHAR);
-			act("$n окончательно доломал$g $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-			extract_obj(obj);
-		}
-	}
-	else
-	{
-		timed.skill = SKILL_REPAIR;
-		// timed.time - это unsigned char, поэтому при уходе в минус будет вынос на 255 и ниже
-		int modif = ch->get_skill(SKILL_REPAIR) / 7 + number(1, 5);
-		timed.time = MAX(1, 25 - modif);
-		timed_to_char(ch, &timed);
-		obj->set_current_durability(MIN(GET_OBJ_MAX(obj), GET_OBJ_CUR(obj) * percent / prob + 1));
-		send_to_char(ch, "Теперь %s выгляд%s лучше.\r\n", obj->get_PName(0).c_str(), GET_OBJ_POLY_1(ch, obj));
-		act("$n умело починил$g $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-	}
+    obj->set_current_durability(MAX(0, obj->get_current_durability() * percent / prob));
+    if (obj->get_current_durability()) {
+      act("Вы попытались починить $o3, но сломали $S еще больше.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n попытал$u починить $o3, но сломал$g $S еще больше.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      decay = (GET_OBJ_MAX(obj) - GET_OBJ_CUR(obj)) / 10;
+      decay = MAX(1, MIN(decay, GET_OBJ_MAX(obj) / 20));
+      if (GET_OBJ_MAX(obj) > decay) {
+        obj->set_maximum_durability(obj->get_maximum_durability() - decay);
+      } else {
+        obj->set_maximum_durability(1);
+      }
+    } else {
+      act("Вы окончательно доломали $o3.", FALSE, ch, obj, 0, TO_CHAR);
+      act("$n окончательно доломал$g $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      extract_obj(obj);
+    }
+  } else {
+    timed.skill = SKILL_REPAIR;
+    // timed.time - это unsigned char, поэтому при уходе в минус будет вынос на 255 и ниже
+    int modif = ch->get_skill(SKILL_REPAIR) / 7 + number(1, 5);
+    timed.time = MAX(1, 25 - modif);
+    timed_to_char(ch, &timed);
+    obj->set_current_durability(MIN(GET_OBJ_MAX(obj), GET_OBJ_CUR(obj) * percent / prob + 1));
+    send_to_char(ch, "Теперь %s выгляд%s лучше.\r\n", obj->get_PName(0).c_str(), GET_OBJ_POLY_1(ch, obj));
+    act("$n умело починил$g $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+  }
 }
 
-bool skill_to_skin(CHAR_DATA *mob, CHAR_DATA *ch)
-{
-	int num;
-	switch (GET_LEVEL(mob) / 11)
-	{
-	case 0:
-		num = 15 * animals_levels[0] / 2201; // приводим пропорцией к количеству зверья на 15.11.2015 в мире
-		if (number(1, 100) <= num)
-			return true;
-		break;
-	case 1:
-		if (ch->get_skill(SKILL_MAKEFOOD) >= 40)
-		{
-			num = 20 * animals_levels[1] / 701;
-			if (number(1, 100) <= num)
-				return true;
-		}
-		else
-		{
-			sprintf(buf, "Ваше умение слишком низкое, чтобы содрать шкуру %s.\r\n", GET_PAD(mob, 1));
-			send_to_char(buf, ch);
-			return false;
-		}
+bool skill_to_skin(CHAR_DATA *mob, CHAR_DATA *ch) {
+  int num;
+  switch (GET_LEVEL(mob) / 11) {
+    case 0: num = 15 * animals_levels[0] / 2201; // приводим пропорцией к количеству зверья на 15.11.2015 в мире
+      if (number(1, 100) <= num)
+        return true;
+      break;
+    case 1:
+      if (ch->get_skill(SKILL_MAKEFOOD) >= 40) {
+        num = 20 * animals_levels[1] / 701;
+        if (number(1, 100) <= num)
+          return true;
+      } else {
+        sprintf(buf, "Ваше умение слишком низкое, чтобы содрать шкуру %s.\r\n", GET_PAD(mob, 1));
+        send_to_char(buf, ch);
+        return false;
+      }
 
-		break;
-	case 2:
-		if (ch->get_skill(SKILL_MAKEFOOD) >= 80)
-		{
-			num = 10 * animals_levels[2] / 594;
-			if (number(1, 100) <= num)
-				return true;
-		}
-		else
-		{
-			sprintf(buf, "Ваше умение слишком низкое, чтобы содрать шкуру %s.\r\n", GET_PAD(mob, 1));
-			send_to_char(buf, ch);
-			return false;
-		}
-		break;
+      break;
+    case 2:
+      if (ch->get_skill(SKILL_MAKEFOOD) >= 80) {
+        num = 10 * animals_levels[2] / 594;
+        if (number(1, 100) <= num)
+          return true;
+      } else {
+        sprintf(buf, "Ваше умение слишком низкое, чтобы содрать шкуру %s.\r\n", GET_PAD(mob, 1));
+        send_to_char(buf, ch);
+        return false;
+      }
+      break;
 
-	case 3:
-		if (ch->get_skill(SKILL_MAKEFOOD) >= 120)
-		{
-			num = 8 * animals_levels[3] / 209;
-			if (number(1, 100) <= num)
-				return true;
-		}
-		else
-		{
-			sprintf(buf, "Ваше умение слишком низкое, чтобы содрать шкуру %s.\r\n", GET_PAD(mob, 1));
-			send_to_char(buf, ch);
-			return false;
-		}
-		break;
+    case 3:
+      if (ch->get_skill(SKILL_MAKEFOOD) >= 120) {
+        num = 8 * animals_levels[3] / 209;
+        if (number(1, 100) <= num)
+          return true;
+      } else {
+        sprintf(buf, "Ваше умение слишком низкое, чтобы содрать шкуру %s.\r\n", GET_PAD(mob, 1));
+        send_to_char(buf, ch);
+        return false;
+      }
+      break;
 
-	case 4:
-		if (ch->get_skill(SKILL_MAKEFOOD) >= 160)
-		{
-			num = 25 * animals_levels[4] / 20;
-			if (number(1, 100) <= num)
-				return true;
-		}
-		else
-		{
-			sprintf(buf, "Ваше умение слишком низкое, чтобы содрать шкуру %s.\r\n", GET_PAD(mob, 1));
-			send_to_char(buf, ch);
-			return false;
-		}
-		break;
-	//TODO: Добавить для мобов выше 54 уровня
-	case 5:
-	case 6:
-	case 7:
-	case 8:
-	case 9:
-	case 10:
-	default:
-		return false;
-	}
-	return false;
+    case 4:
+      if (ch->get_skill(SKILL_MAKEFOOD) >= 160) {
+        num = 25 * animals_levels[4] / 20;
+        if (number(1, 100) <= num)
+          return true;
+      } else {
+        sprintf(buf, "Ваше умение слишком низкое, чтобы содрать шкуру %s.\r\n", GET_PAD(mob, 1));
+        send_to_char(buf, ch);
+        return false;
+      }
+      break;
+      //TODO: Добавить для мобов выше 54 уровня
+    case 5:
+    case 6:
+    case 7:
+    case 8:
+    case 9:
+    case 10:
+    default: return false;
+  }
+  return false;
 }
 
-void do_makefood(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	if (!ch->get_skill(SKILL_MAKEFOOD))
-	{
-		send_to_char("Вы не умеете этого.\r\n", ch);
-		return;
-	}
+void do_makefood(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  if (!ch->get_skill(SKILL_MAKEFOOD)) {
+    send_to_char("Вы не умеете этого.\r\n", ch);
+    return;
+  }
 
-	one_argument(argument, arg);
-	if (!*arg)
-	{
-		send_to_char("Что вы хотите освежевать?\r\n", ch);
-		return;
-	}
+  one_argument(argument, arg);
+  if (!*arg) {
+    send_to_char("Что вы хотите освежевать?\r\n", ch);
+    return;
+  }
 
-	auto obj = get_obj_in_list_vis(ch, arg, ch->carrying);
-	if (!obj)
-	{
-		obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents);
-		if (!obj)
-		{
-			snprintf(buf, MAX_INPUT_LENGTH, "Вы не видите здесь '%s'.\r\n", arg);
-			send_to_char(buf, ch);
-			return;
-		}
-	}
+  auto obj = get_obj_in_list_vis(ch, arg, ch->carrying);
+  if (!obj) {
+    obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents);
+    if (!obj) {
+      snprintf(buf, MAX_INPUT_LENGTH, "Вы не видите здесь '%s'.\r\n", arg);
+      send_to_char(buf, ch);
+      return;
+    }
+  }
 
-	const auto mobn = GET_OBJ_VAL(obj, 2);
-	if (!IS_CORPSE(obj) || mobn < 0)
-	{
-		act("Вы не сможете освежевать $o3.", FALSE, ch, obj, 0, TO_CHAR);
-		return;
-	}
+  const auto mobn = GET_OBJ_VAL(obj, 2);
+  if (!IS_CORPSE(obj) || mobn < 0) {
+    act("Вы не сможете освежевать $o3.", FALSE, ch, obj, 0, TO_CHAR);
+    return;
+  }
 
-	const auto mob = (mob_proto + real_mobile(mobn));
-	mob->set_normal_morph();
+  const auto mob = (mob_proto + real_mobile(mobn));
+  mob->set_normal_morph();
 
-	if (!IS_IMMORTAL(ch)
-		&& GET_RACE(mob) != NPC_RACE_ANIMAL
-		&& GET_RACE(mob) != NPC_RACE_REPTILE
-		&& GET_RACE(mob) != NPC_RACE_FISH
-		&& GET_RACE(mob) != NPC_RACE_BIRD
-		&& GET_RACE(mob) != NPC_RACE_HUMAN_ANIMAL)
-	{
-		send_to_char("Этот труп невозможно освежевать.\r\n", ch);
-		return;
-	}
+  if (!IS_IMMORTAL(ch)
+      && GET_RACE(mob) != NPC_RACE_ANIMAL
+      && GET_RACE(mob) != NPC_RACE_REPTILE
+      && GET_RACE(mob) != NPC_RACE_FISH
+      && GET_RACE(mob) != NPC_RACE_BIRD
+      && GET_RACE(mob) != NPC_RACE_HUMAN_ANIMAL) {
+    send_to_char("Этот труп невозможно освежевать.\r\n", ch);
+    return;
+  }
 
-	if (GET_WEIGHT(mob) < 11)
-	{
-		send_to_char("Этот труп слишком маленький, ничего не получится.\r\n", ch);
-		return;
-	}
+  if (GET_WEIGHT(mob) < 11) {
+    send_to_char("Этот труп слишком маленький, ничего не получится.\r\n", ch);
+    return;
+  }
 
-	const auto prob = number(1, skill_info[SKILL_MAKEFOOD].max_percent);
-	const auto percent = train_skill(ch, SKILL_MAKEFOOD, skill_info[SKILL_MAKEFOOD].max_percent, mob)
-		+ number(1, GET_REAL_DEX(ch)) + number(1, GET_REAL_STR(ch));
+  const auto prob = number(1, skill_info[SKILL_MAKEFOOD].max_percent);
+  const auto percent = calculate_skill(ch, SKILL_MAKEFOOD, mob)
+      + number(1, GET_REAL_DEX(ch)) + number(1, GET_REAL_STR(ch));
+  train_skill(ch, SKILL_MAKEFOOD, percent <= prob, mob);
 
-	OBJ_DATA::shared_ptr tobj;
-	if (GET_SKILL(ch, SKILL_MAKEFOOD) > 150 && number(1, 200) == 1) // артефакт
-	{
-		tobj = world_objects.create_from_prototype_by_vnum(meat_mapping.get_artefact_key());
-	}
-	else
-	{
-		tobj = world_objects.create_from_prototype_by_vnum(meat_mapping.random_key());
-	}
+  OBJ_DATA::shared_ptr tobj;
+  if (GET_SKILL(ch, SKILL_MAKEFOOD) > 150 && number(1, 200) == 1) // артефакт
+  {
+    tobj = world_objects.create_from_prototype_by_vnum(meat_mapping.get_artefact_key());
+  } else {
+    tobj = world_objects.create_from_prototype_by_vnum(meat_mapping.random_key());
+  }
 
-	if (prob > percent || !tobj)
-	{
-		act("Вы не сумели освежевать $o3.", FALSE, ch, obj, 0, TO_CHAR);
-		act("$n попытал$u освежевать $o3, но неудачно.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-	}
-	else
-	{
-		act("$n умело освежевал$g $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
-		act("Вы умело освежевали $o3.", FALSE, ch, obj, 0, TO_CHAR);
+  if (prob > percent || !tobj) {
+    act("Вы не сумели освежевать $o3.", FALSE, ch, obj, 0, TO_CHAR);
+    act("$n попытал$u освежевать $o3, но неудачно.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+  } else {
+    act("$n умело освежевал$g $o3.", FALSE, ch, obj, 0, TO_ROOM | TO_ARENA_LISTEN);
+    act("Вы умело освежевали $o3.", FALSE, ch, obj, 0, TO_CHAR);
 
-		dl_load_obj(obj, mob, ch, DL_SKIN);
+    dl_load_obj(obj, mob, ch, DL_SKIN);
 
-		std::vector<OBJ_DATA*> entrails;
-		entrails.push_back(tobj.get());
+    std::vector<OBJ_DATA *> entrails;
+    entrails.push_back(tobj.get());
 
-		if (GET_RACE(mob) == NPC_RACE_ANIMAL) // шкуры только с животных
-		{
-			if (WAITLESS(ch) || skill_to_skin(mob, ch))
-			{
-				entrails.push_back(create_skin(mob, ch));
-			}
-		}
+    if (GET_RACE(mob) == NPC_RACE_ANIMAL) // шкуры только с животных
+    {
+      if (WAITLESS(ch) || skill_to_skin(mob, ch)) {
+        entrails.push_back(create_skin(mob, ch));
+      }
+    }
 
-		entrails.push_back(try_make_ingr(mob, 1000 - ch->get_skill(SKILL_MAKEFOOD) * 2, 100));  // ингры со всех
+    entrails.push_back(try_make_ingr(mob, 1000 - ch->get_skill(SKILL_MAKEFOOD) * 2, 100));  // ингры со всех
 
-		for (const auto& it : entrails)
-		{
-			if (it)
-			{
-				if (obj->get_carried_by() == ch)
-				{
-					can_carry_obj(ch, it);
-				}
-				else
-				{
-					obj_to_room(it, ch->in_room);
-				}
-			}
-		}
-	}
+    for (const auto &it : entrails) {
+      if (it) {
+        if (obj->get_carried_by() == ch) {
+          can_carry_obj(ch, it);
+        } else {
+          obj_to_room(it, ch->in_room);
+        }
+      }
+    }
+  }
 
-	extract_obj(obj);
+  extract_obj(obj);
 }
 
-void feed_charmice(CHAR_DATA * ch, char *arg)
-{
-	OBJ_DATA *obj;
-	int max_charm_duration = 1;
-	int chance_to_eat = 0;
-	struct follow_type *k;
-	int reformed_hp_summ = 0;
+void feed_charmice(CHAR_DATA *ch, char *arg) {
+  OBJ_DATA *obj;
+  int max_charm_duration = 1;
+  int chance_to_eat = 0;
+  struct follow_type *k;
+  int reformed_hp_summ = 0;
 
-	obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents);
+  obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents);
 
-	if (!obj || !IS_CORPSE(obj) || !ch->has_master())
-	{
-		return;
-	}
+  if (!obj || !IS_CORPSE(obj) || !ch->has_master()) {
+    return;
+  }
 
-	for (k = ch->get_master()->followers; k; k = k->next)
-	{
-		if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_CHARM)
-			&& k->follower->get_master() == ch->get_master())
-		{
-			reformed_hp_summ += get_reformed_charmice_hp(ch->get_master(), k->follower, SPELL_ANIMATE_DEAD);
-		}
-	}
+  for (k = ch->get_master()->followers; k; k = k->next) {
+    if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_CHARM)
+        && k->follower->get_master() == ch->get_master()) {
+      reformed_hp_summ += get_reformed_charmice_hp(ch->get_master(), k->follower, SPELL_ANIMATE_DEAD);
+    }
+  }
 
-	if (reformed_hp_summ >= get_player_charms(ch->get_master(), SPELL_ANIMATE_DEAD))
-	{
-		send_to_char("Вы не можете управлять столькими последователями.\r\n", ch->get_master());
-		extract_char(ch, FALSE);
-		return;
-	}
+  if (reformed_hp_summ >= get_player_charms(ch->get_master(), SPELL_ANIMATE_DEAD)) {
+    send_to_char("Вы не можете управлять столькими последователями.\r\n", ch->get_master());
+    extract_char(ch, FALSE);
+    return;
+  }
 
-	int mob_level = 1;
-	// труп не игрока
-	if (GET_OBJ_VAL(obj, 2) != -1)
-	{
-		mob_level = GET_LEVEL(mob_proto + real_mobile(GET_OBJ_VAL(obj, 2)));
-	}
-	const int max_heal_hp = 3 * mob_level;
-	chance_to_eat = (100 - 2 * mob_level) / 2;
-	//Added by Ann
-	if (affected_by_spell(ch->get_master(), SPELL_FASCINATION))
-	{
-		chance_to_eat -= 30;
-	}
-	//end Ann
-	if (number(1, 100) < chance_to_eat)
-	{
-		act("$N подавил$U и начал$G сильно кашлять.", TRUE, ch, NULL, ch, TO_ROOM | TO_ARENA_LISTEN);
-		GET_HIT(ch) -= 3 * mob_level;
-		update_pos(ch);
-		// Подавился насмерть.
-		if (GET_POS(ch) == POS_DEAD)
-		{
-			die(ch, NULL);
-		}
-		extract_obj(obj);
-		return;
-	}
-	if (weather_info.moon_day < 14)
-	{
-		max_charm_duration = pc_duration(ch, GET_REAL_WIS(ch->get_master()) - 6 + number(0, weather_info.moon_day % 14), 0, 0, 0, 0);
-	}
-	else
-	{
-		max_charm_duration = pc_duration(ch, GET_REAL_WIS(ch->get_master()) - 6 + number(0, 14 - weather_info.moon_day % 14), 0, 0, 0, 0);
-	}
+  int mob_level = 1;
+  // труп не игрока
+  if (GET_OBJ_VAL(obj, 2) != -1) {
+    mob_level = GET_LEVEL(mob_proto + real_mobile(GET_OBJ_VAL(obj, 2)));
+  }
+  const int max_heal_hp = 3 * mob_level;
+  chance_to_eat = (100 - 2 * mob_level) / 2;
+  //Added by Ann
+  if (affected_by_spell(ch->get_master(), SPELL_FASCINATION)) {
+    chance_to_eat -= 30;
+  }
+  //end Ann
+  if (number(1, 100) < chance_to_eat) {
+    act("$N подавил$U и начал$G сильно кашлять.", TRUE, ch, NULL, ch, TO_ROOM | TO_ARENA_LISTEN);
+    GET_HIT(ch) -= 3 * mob_level;
+    update_pos(ch);
+    // Подавился насмерть.
+    if (GET_POS(ch) == POS_DEAD) {
+      die(ch, NULL);
+    }
+    extract_obj(obj);
+    return;
+  }
+  if (weather_info.moon_day < 14) {
+    max_charm_duration =
+        pc_duration(ch, GET_REAL_WIS(ch->get_master()) - 6 + number(0, weather_info.moon_day % 14), 0, 0, 0, 0);
+  } else {
+    max_charm_duration =
+        pc_duration(ch, GET_REAL_WIS(ch->get_master()) - 6 + number(0, 14 - weather_info.moon_day % 14), 0, 0, 0, 0);
+  }
 
-	AFFECT_DATA<EApplyLocation> af;
-	af.type = SPELL_CHARM;
-	af.duration = MIN(max_charm_duration, (int)(mob_level * max_charm_duration / 30));
-	af.modifier = 0;
-	af.location = EApplyLocation::APPLY_NONE;
-	af.bitvector = to_underlying(EAffectFlag::AFF_CHARM);
-	af.battleflag = 0;
+  AFFECT_DATA<EApplyLocation> af;
+  af.type = SPELL_CHARM;
+  af.duration = MIN(max_charm_duration, (int) (mob_level * max_charm_duration / 30));
+  af.modifier = 0;
+  af.location = EApplyLocation::APPLY_NONE;
+  af.bitvector = to_underlying(EAffectFlag::AFF_CHARM);
+  af.battleflag = 0;
 
-	affect_join_fspell(ch, af);
+  affect_join_fspell(ch, af);
 
-	act("Громко чавкая, $N сожрал$G труп.", TRUE, ch, obj, ch, TO_ROOM | TO_ARENA_LISTEN);
-	act("Похоже, лакомство пришлось по вкусу.", TRUE, ch, NULL, ch->get_master(), TO_VICT);
-	act("От омерзительного зрелища вас едва не вывернуло.", TRUE, ch, NULL, ch->get_master(), TO_NOTVICT | TO_ARENA_LISTEN);
+  act("Громко чавкая, $N сожрал$G труп.", TRUE, ch, obj, ch, TO_ROOM | TO_ARENA_LISTEN);
+  act("Похоже, лакомство пришлось по вкусу.", TRUE, ch, NULL, ch->get_master(), TO_VICT);
+  act("От омерзительного зрелища вас едва не вывернуло.",
+      TRUE,
+      ch,
+      NULL,
+      ch->get_master(),
+      TO_NOTVICT | TO_ARENA_LISTEN);
 
-	if (GET_HIT(ch) < GET_MAX_HIT(ch))
-	{
-		GET_HIT(ch) = MIN(GET_HIT(ch) + MIN(max_heal_hp, GET_MAX_HIT(ch)), GET_MAX_HIT(ch));
-	}
+  if (GET_HIT(ch) < GET_MAX_HIT(ch)) {
+    GET_HIT(ch) = MIN(GET_HIT(ch) + MIN(max_heal_hp, GET_MAX_HIT(ch)), GET_MAX_HIT(ch));
+  }
 
-	if (GET_HIT(ch) >= GET_MAX_HIT(ch))
-	{
-		act("$n сыто рыгнул$g и благодарно посмотрел$g на вас.", TRUE, ch, NULL, ch->get_master(), TO_VICT);
-		act("$n сыто рыгнул$g и благодарно посмотрел$g на $N3.", TRUE, ch, NULL, ch->get_master(), TO_NOTVICT | TO_ARENA_LISTEN);
-	}
+  if (GET_HIT(ch) >= GET_MAX_HIT(ch)) {
+    act("$n сыто рыгнул$g и благодарно посмотрел$g на вас.", TRUE, ch, NULL, ch->get_master(), TO_VICT);
+    act("$n сыто рыгнул$g и благодарно посмотрел$g на $N3.",
+        TRUE,
+        ch,
+        NULL,
+        ch->get_master(),
+        TO_NOTVICT | TO_ARENA_LISTEN);
+  }
 
-	extract_obj(obj);
+  extract_obj(obj);
 }
 
 // чтоб не абузили длину. персональные пофиг, а клановые не надо.
 #define MAX_LABEL_LENGTH 32
-void do_custom_label(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	char arg1[MAX_INPUT_LENGTH];
-	char arg2[MAX_INPUT_LENGTH];
+void do_custom_label(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  char arg1[MAX_INPUT_LENGTH];
+  char arg2[MAX_INPUT_LENGTH];
 
-	char arg3[MAX_INPUT_LENGTH];
-	char arg4[MAX_INPUT_LENGTH];
+  char arg3[MAX_INPUT_LENGTH];
+  char arg4[MAX_INPUT_LENGTH];
 
-	OBJ_DATA *target = NULL;
-	int erase_only = 0; // 0 -- наносим новую метку, 1 -- удаляем старую
-	int clan = 0; // клан режим, если единица. персональный, если не
-	int no_target = 0; // красиво сделать не выйдет, будем через флаги
+  OBJ_DATA *target = NULL;
+  int erase_only = 0; // 0 -- наносим новую метку, 1 -- удаляем старую
+  int clan = 0; // клан режим, если единица. персональный, если не
+  int no_target = 0; // красиво сделать не выйдет, будем через флаги
 
-	char *objname = NULL;
-	char *labels = NULL;
+  char *objname = NULL;
+  char *labels = NULL;
 
-	if (IS_NPC(ch))
-		return;
+  if (IS_NPC(ch))
+    return;
 
-	half_chop(argument, arg1, arg2);
+  half_chop(argument, arg1, arg2);
 
-	if (!strlen(arg1))
-		no_target = 1;
-	else
-	{
-		if (!strcmp(arg1, "клан")) { // если в arg1 "клан", то в arg2 ищем название объекта и метки
-			clan = 1;
-			if (strlen(arg2)) {
-				half_chop(arg2, arg3, arg4); // в arg3 получаем название объекта
-				objname = str_dup(arg3);
-				if (strlen(arg4))
-					labels = str_dup(arg4);
-				else
-					erase_only = 1;
-			}
-			else {
-				no_target = 1;
-			}
-		}
-		else { // слова "клан" не нашли, значит, ожидаем в arg1 сразу имя объекта и метки в arg2
-			if (strlen(arg1)) {
-				objname = str_dup(arg1);
-				if (strlen(arg2))
-					labels = str_dup(arg2);
-				else
-					erase_only = 1;
-			}
-			else {
-				no_target = 1;
-			}
-		}
-	}
+  if (!strlen(arg1))
+    no_target = 1;
+  else {
+    if (!strcmp(arg1, "клан")) { // если в arg1 "клан", то в arg2 ищем название объекта и метки
+      clan = 1;
+      if (strlen(arg2)) {
+        half_chop(arg2, arg3, arg4); // в arg3 получаем название объекта
+        objname = str_dup(arg3);
+        if (strlen(arg4))
+          labels = str_dup(arg4);
+        else
+          erase_only = 1;
+      } else {
+        no_target = 1;
+      }
+    } else { // слова "клан" не нашли, значит, ожидаем в arg1 сразу имя объекта и метки в arg2
+      if (strlen(arg1)) {
+        objname = str_dup(arg1);
+        if (strlen(arg2))
+          labels = str_dup(arg2);
+        else
+          erase_only = 1;
+      } else {
+        no_target = 1;
+      }
+    }
+  }
 
-	if (no_target)
-	{
-		send_to_char("На чем царапаем?\r\n", ch);
-	}
-	else
-	{
-		if (!(target = get_obj_in_list_vis(ch, objname, ch->carrying)))
-		{
-			sprintf(buf, "У вас нет \'%s\'.\r\n", objname);
-			send_to_char(buf, ch);
-		}
-		else
-		{
-			if (erase_only)
-			{
-				target->remove_custom_label();
-				act("Вы затерли надписи на $o5.", FALSE, ch, target, 0, TO_CHAR);
-			}
-			else if (labels)
-			{
-				if (strlen(labels) > MAX_LABEL_LENGTH)
-					labels[MAX_LABEL_LENGTH] = '\0';
+  if (no_target) {
+    send_to_char("На чем царапаем?\r\n", ch);
+  } else {
+    if (!(target = get_obj_in_list_vis(ch, objname, ch->carrying))) {
+      sprintf(buf, "У вас нет \'%s\'.\r\n", objname);
+      send_to_char(buf, ch);
+    } else {
+      if (erase_only) {
+        target->remove_custom_label();
+        act("Вы затерли надписи на $o5.", FALSE, ch, target, 0, TO_CHAR);
+      } else if (labels) {
+        if (strlen(labels) > MAX_LABEL_LENGTH)
+          labels[MAX_LABEL_LENGTH] = '\0';
 
-				// убираем тильды
-				for (int i = 0; labels[i] != '\0'; i++)
-					if (labels[i] == '~')
-						labels[i] = '-';
+        // убираем тильды
+        for (int i = 0; labels[i] != '\0'; i++)
+          if (labels[i] == '~')
+            labels[i] = '-';
 
-				std::shared_ptr<custom_label> label(new custom_label());
-				label->label_text = str_dup(labels);
-				label->author = ch->get_idnum();
-				label->author_mail = str_dup(GET_EMAIL(ch));
+        std::shared_ptr<custom_label> label(new custom_label());
+        label->label_text = str_dup(labels);
+        label->author = ch->get_idnum();
+        label->author_mail = str_dup(GET_EMAIL(ch));
 
-				const char* msg = "Вы покрыли $o3 каракулями, которые никто кроме вас не разберет.";
-				if (clan && ch->player_specials->clan)
-				{
-					label->clan = str_dup(ch->player_specials->clan->GetAbbrev());
-					msg = "Вы покрыли $o3 каракулями, понятными разве что вашим соратникам.";
-				}
-				target->set_custom_label(label);
-				act(msg, FALSE, ch, target, 0, TO_CHAR);
-			}
-		}
-	}
+        const char *msg = "Вы покрыли $o3 каракулями, которые никто кроме вас не разберет.";
+        if (clan && ch->player_specials->clan) {
+          label->clan = str_dup(ch->player_specials->clan->GetAbbrev());
+          msg = "Вы покрыли $o3 каракулями, понятными разве что вашим соратникам.";
+        }
+        target->set_custom_label(label);
+        act(msg, FALSE, ch, target, 0, TO_CHAR);
+      }
+    }
+  }
 
-	if (objname)
-	{
-		free(objname);
-	}
+  if (objname) {
+    free(objname);
+  }
 
-	if (labels)
-	{
-		free(labels);
-	}
+  if (labels) {
+    free(labels);
+  }
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/act.item.cpp
+++ b/src/act.item.cpp
@@ -2292,9 +2292,9 @@ void do_upgrade(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
     obj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED); // установили флажок трансформации кодом
   }
 
-  percent = number(1, skill_info[SKILL_UPGRADE].max_percent);
-  prob = calculate_skill(ch, SKILL_UPGRADE, nullptr);
-  train_skill(ch, SKILL_UPGRADE, percent <= prob, nullptr);
+  percent = number(1, skill_info[SKILL_UPGRADE].fail_percent);
+  prob = CalcCurrentSkill(ch, SKILL_UPGRADE, nullptr);
+  TrainSkill(ch, SKILL_UPGRADE, percent <= prob, nullptr);
   if (obj->get_timer() == 0) // не ждем рассыпания на тике
   {
     act("$o не выдержал$G издевательств и рассыпал$U в мелкую пыль...", FALSE, ch, obj, 0, TO_CHAR);
@@ -2414,9 +2414,9 @@ void do_armored(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
       return;
   }
 
-  percent = number(1, skill_info[SKILL_ARMORED].max_percent);
-  prob = calculate_skill(ch, SKILL_ARMORED, nullptr);
-  train_skill(ch, SKILL_ARMORED, percent <= prob, nullptr);
+  percent = number(1, skill_info[SKILL_ARMORED].fail_percent);
+  prob = CalcCurrentSkill(ch, SKILL_ARMORED, nullptr);
+  TrainSkill(ch, SKILL_ARMORED, percent <= prob, nullptr);
   add_ac = IS_IMMORTAL(ch) ? -20 : -number(1, (GET_LEVEL(ch) + 4) / 5);
   if (percent > prob
       || GET_GOD_FLAG(ch, GF_GODSCURSE)) {
@@ -2519,8 +2519,8 @@ void do_fire(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
   if (!check_moves(ch, FIRE_MOVES))
     return;
 
-  percent = number(1, skill_info[SKILL_FIRE].max_percent);
-  prob = calculate_skill(ch, SKILL_FIRE, 0);
+  percent = number(1, skill_info[SKILL_FIRE].fail_percent);
+  prob = CalcCurrentSkill(ch, SKILL_FIRE, 0);
   if (percent > prob) {
     send_to_char("Вы попытались разжечь костер, но у вас ничего не вышло.\r\n", ch);
     return;
@@ -2528,7 +2528,7 @@ void do_fire(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
     world[ch->in_room]->fires = MAX(0, (prob - percent) / 5) + 1;
     send_to_char("Вы набрали хворосту и разожгли огонь.\n\r", ch);
     act("$n развел$g огонь.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-    improve_skill(ch, SKILL_FIRE, TRUE, 0);
+    ImproveSkill(ch, SKILL_FIRE, TRUE, 0);
   }
 }
 
@@ -2680,8 +2680,8 @@ void do_firstaid(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
     return;
   }
 
-  int percent = number(1, skill_info[SKILL_AID].max_percent);
-  int prob = calculate_skill(ch, SKILL_AID, vict);
+  int percent = number(1, skill_info[SKILL_AID].fail_percent);
+  int prob = CalcCurrentSkill(ch, SKILL_AID, vict);
 
   if (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE) || GET_GOD_FLAG(vict, GF_GODSLIKE)) {
     percent = prob;
@@ -2705,7 +2705,7 @@ void do_firstaid(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
         int add = MIN(dif, (dif * (prob - percent) / 100) + 1);
         GET_HIT(vict) += add;
       } else {
-        percent = calculate_skill(ch, SKILL_AID, vict);
+        percent = CalcCurrentSkill(ch, SKILL_AID, vict);
         prob = GET_LEVEL(ch) * percent * 0.5;
         send_to_char(ch, "&RУровень цели %d Отхилено %d хитов, скилл %d\r\n", GET_LEVEL(vict), prob, percent);
         GET_HIT(vict) += prob;
@@ -2749,7 +2749,7 @@ void do_firstaid(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
     timed.time = IS_IMMORTAL(ch) ? 2 : IS_PALADINE(ch) ? 4 : IS_CLERIC(ch) ? 2 : 6;
     timed_to_char(ch, &timed);
     if (vict != ch) {
-      improve_skill(ch, SKILL_AID, success, 0);
+      ImproveSkill(ch, SKILL_AID, success, 0);
       if (success) {
         act("Вы оказали первую помощь $N2.", FALSE, ch, 0, vict, TO_CHAR);
         act("$N оказал$G вам первую помощь.", FALSE, vict, 0, ch, TO_CHAR);
@@ -2880,9 +2880,9 @@ void do_repair(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
     return;
   }
 
-  prob = number(1, skill_info[SKILL_REPAIR].max_percent);
-  percent = calculate_skill(ch, SKILL_REPAIR, nullptr);
-  train_skill(ch, SKILL_REPAIR, prob <= percent, nullptr);
+  prob = number(1, skill_info[SKILL_REPAIR].fail_percent);
+  percent = CalcCurrentSkill(ch, SKILL_REPAIR, nullptr);
+  TrainSkill(ch, SKILL_REPAIR, prob <= percent, nullptr);
   if (prob > percent) {
 //Polos.repair_bug
 //Потому что 0 уничтожает шмотку полностью даже при скиле 100+ и
@@ -3031,10 +3031,10 @@ void do_makefood(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
     return;
   }
 
-  const auto prob = number(1, skill_info[SKILL_MAKEFOOD].max_percent);
-  const auto percent = calculate_skill(ch, SKILL_MAKEFOOD, mob)
+  const auto prob = number(1, skill_info[SKILL_MAKEFOOD].fail_percent);
+  const auto percent = CalcCurrentSkill(ch, SKILL_MAKEFOOD, mob)
       + number(1, GET_REAL_DEX(ch)) + number(1, GET_REAL_STR(ch));
-  train_skill(ch, SKILL_MAKEFOOD, percent <= prob, mob);
+  TrainSkill(ch, SKILL_MAKEFOOD, percent <= prob, mob);
 
   OBJ_DATA::shared_ptr tobj;
   if (GET_SKILL(ch, SKILL_MAKEFOOD) > 150 && number(1, 200) == 1) // артефакт

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -45,279 +45,235 @@
 #include <cmath>
 
 // external functs
-void set_wait(CHAR_DATA * ch, int waittime, int victim_in_room);
-int find_eq_pos(CHAR_DATA * ch, OBJ_DATA * obj, char *arg);
+void set_wait(CHAR_DATA *ch, int waittime, int victim_in_room);
+int find_eq_pos(CHAR_DATA *ch, OBJ_DATA *obj, char *arg);
 // local functions
 void check_ice(int room);
 
 extern int get_pick_chance(int skill_pick, int lock_complexity);
 
-
-const int Reverse[NUM_OF_DIRS] = { 2, 3, 0, 1, 5, 4 };
+const int Reverse[NUM_OF_DIRS] = {2, 3, 0, 1, 5, 4};
 const char *DirIs[] =
-{
-	"север",
-	"восток",
-	"юг",
-	"запад",
-	"вверх",
-	"вниз",
-	"\n"
-};
+    {
+        "север",
+        "восток",
+        "юг",
+        "запад",
+        "вверх",
+        "вниз",
+        "\n"
+    };
 
 // check ice in room
-int check_death_ice(int room, CHAR_DATA* /*ch*/)
-{
-	int sector, mass = 0, result = FALSE;
+int check_death_ice(int room, CHAR_DATA * /*ch*/) {
+  int sector, mass = 0, result = FALSE;
 
-	if (room == NOWHERE)
-		return (FALSE);
-	sector = SECT(room);
-	if (sector != SECT_WATER_SWIM && sector != SECT_WATER_NOSWIM)
-		return (FALSE);
-	if ((sector = real_sector(room)) != SECT_THIN_ICE && sector != SECT_NORMAL_ICE)
-		return (FALSE);
+  if (room == NOWHERE)
+    return (FALSE);
+  sector = SECT(room);
+  if (sector != SECT_WATER_SWIM && sector != SECT_WATER_NOSWIM)
+    return (FALSE);
+  if ((sector = real_sector(room)) != SECT_THIN_ICE && sector != SECT_NORMAL_ICE)
+    return (FALSE);
 
-	for (const auto vict : world[room]->people)
-	{
-		if (!IS_NPC(vict)
-			&& !AFF_FLAGGED(vict, EAffectFlag::AFF_FLY))
-		{
-			mass += GET_WEIGHT(vict) + IS_CARRYING_W(vict);
-		}
-	}
+  for (const auto vict : world[room]->people) {
+    if (!IS_NPC(vict)
+        && !AFF_FLAGGED(vict, EAffectFlag::AFF_FLY)) {
+      mass += GET_WEIGHT(vict) + IS_CARRYING_W(vict);
+    }
+  }
 
-	if (!mass)
-	{
-		return (FALSE);
-	}
+  if (!mass) {
+    return (FALSE);
+  }
 
-	if ((sector == SECT_THIN_ICE && mass > 500) || (sector == SECT_NORMAL_ICE && mass > 1500))
-	{
-		const auto first_in_room = world[room]->first_character();
+  if ((sector == SECT_THIN_ICE && mass > 500) || (sector == SECT_NORMAL_ICE && mass > 1500)) {
+    const auto first_in_room = world[room]->first_character();
 
-		act("Лед проломился под вашей тяжестью.", FALSE, first_in_room, 0, 0, TO_ROOM);
-		act("Лед проломился под вашей тяжестью.", FALSE, first_in_room, 0, 0, TO_CHAR);
+    act("Лед проломился под вашей тяжестью.", FALSE, first_in_room, 0, 0, TO_ROOM);
+    act("Лед проломился под вашей тяжестью.", FALSE, first_in_room, 0, 0, TO_CHAR);
 
-		world[room]->weather.icelevel = 0;
-		world[room]->ices = 2;
-		GET_ROOM(room)->set_flag(ROOM_ICEDEATH);
-		DeathTrap::add(world[room]);
-	}
-	else
-	{
-		return (FALSE);
-	}
+    world[room]->weather.icelevel = 0;
+    world[room]->ices = 2;
+    GET_ROOM(room)->set_flag(ROOM_ICEDEATH);
+    DeathTrap::add(world[room]);
+  } else {
+    return (FALSE);
+  }
 
-	return (result);
+  return (result);
 }
 
 // simple function to determine if char can walk on water
-int has_boat(CHAR_DATA * ch)
-{
-	OBJ_DATA *obj;
-	int i;
+int has_boat(CHAR_DATA *ch) {
+  OBJ_DATA *obj;
+  int i;
 
-	//if (ROOM_IDENTITY(ch->in_room) == DEAD_SEA)
-	//	return (1);
+  //if (ROOM_IDENTITY(ch->in_room) == DEAD_SEA)
+  //	return (1);
 
-	if (IS_IMMORTAL(ch))
-		return (TRUE);
+  if (IS_IMMORTAL(ch))
+    return (TRUE);
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_WATERWALK))
-		return (TRUE);
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_WATERWALK))
+    return (TRUE);
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_WATERBREATH))
-		return (TRUE);
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_WATERBREATH))
+    return (TRUE);
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_FLY))
-		return (TRUE);
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_FLY))
+    return (TRUE);
 
-	// non-wearable boats in inventory will do it
-	for (obj = ch->carrying; obj; obj = obj->get_next_content())
-	{
-		if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_BOAT
-			&& (find_eq_pos(ch, obj, NULL) < 0))
-		{
-			return TRUE;
-		}
-	}
+  // non-wearable boats in inventory will do it
+  for (obj = ch->carrying; obj; obj = obj->get_next_content()) {
+    if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_BOAT
+        && (find_eq_pos(ch, obj, NULL) < 0)) {
+      return TRUE;
+    }
+  }
 
-	// and any boat you're wearing will do it too
-	for (i = 0; i < NUM_WEARS; i++)
-	{
-		if (GET_EQ(ch, i)
-			&& GET_OBJ_TYPE(GET_EQ(ch, i)) == OBJ_DATA::ITEM_BOAT)
-		{
-			return TRUE;
-		}
-	}
+  // and any boat you're wearing will do it too
+  for (i = 0; i < NUM_WEARS; i++) {
+    if (GET_EQ(ch, i)
+        && GET_OBJ_TYPE(GET_EQ(ch, i)) == OBJ_DATA::ITEM_BOAT) {
+      return TRUE;
+    }
+  }
 
-	return FALSE;
+  return FALSE;
 }
 
-void make_visible(CHAR_DATA * ch, const EAffectFlag affect)
-{
-	char to_room[MAX_STRING_LENGTH], to_char[MAX_STRING_LENGTH];
+void make_visible(CHAR_DATA *ch, const EAffectFlag affect) {
+  char to_room[MAX_STRING_LENGTH], to_char[MAX_STRING_LENGTH];
 
-	*to_room = *to_char = 0;
+  *to_room = *to_char = 0;
 
-	switch (affect)
-	{
-	case EAffectFlag::AFF_HIDE:
-		strcpy(to_char, "Вы прекратили прятаться.\r\n");
-		strcpy(to_room, "$n прекратил$g прятаться.\r\n");
-		break;
+  switch (affect) {
+    case EAffectFlag::AFF_HIDE: strcpy(to_char, "Вы прекратили прятаться.\r\n");
+      strcpy(to_room, "$n прекратил$g прятаться.\r\n");
+      break;
 
-	case EAffectFlag::AFF_CAMOUFLAGE:
-		strcpy(to_char, "Вы прекратили маскироваться.\r\n");
-		strcpy(to_room, "$n прекратил$g маскироваться.\r\n");
-		break;
+    case EAffectFlag::AFF_CAMOUFLAGE: strcpy(to_char, "Вы прекратили маскироваться.\r\n");
+      strcpy(to_room, "$n прекратил$g маскироваться.\r\n");
+      break;
 
-	default:
-		break;
-	}
-	AFF_FLAGS(ch).unset(affect);
-	CHECK_AGRO(ch) = TRUE;
-	if (*to_char)
-		send_to_char(to_char, ch);
-	if (*to_room)
-		act(to_room, FALSE, ch, 0, 0, TO_ROOM);
+    default: break;
+  }
+  AFF_FLAGS(ch).unset(affect);
+  CHECK_AGRO(ch) = TRUE;
+  if (*to_char)
+    send_to_char(to_char, ch);
+  if (*to_room)
+    act(to_room, FALSE, ch, 0, 0, TO_ROOM);
 }
 
+int skip_hiding(CHAR_DATA *ch, CHAR_DATA *vict) {
+  int percent, prob;
 
-int skip_hiding(CHAR_DATA * ch, CHAR_DATA * vict)
-{
-	int percent, prob;
-
-	if (MAY_SEE(ch, vict, ch) && (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE) || affected_by_spell(ch, SPELL_HIDE)))
-	{
-		if (awake_hide(ch))  	//if (affected_by_spell(ch, SPELL_HIDE))
-		{
-			send_to_char("Вы попытались спрятаться, но ваша экипировка выдала вас.\r\n", ch);
-			affect_from_char(ch, SPELL_HIDE);
-			make_visible(ch, EAffectFlag::AFF_HIDE);
-			EXTRA_FLAGS(ch).set(EXTRA_FAILHIDE);
-		}
-		else if (affected_by_spell(ch, SPELL_HIDE))
-		{
-			percent = number(1, 82 + GET_REAL_INT(vict));
-			prob = calculate_skill(ch, SKILL_HIDE, vict);
-			if (percent > prob)
-			{
-				affect_from_char(ch, SPELL_HIDE);
-				if (!AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE))
-				{
-					improve_skill(ch, SKILL_HIDE, FALSE, vict);
-					act("Вы не сумели остаться незаметным.", FALSE, ch, 0, vict, TO_CHAR);
-				}
-			}
-			else
-			{
-				improve_skill(ch, SKILL_HIDE, TRUE, vict);
-				act("Вам удалось остаться незаметным.\r\n", FALSE, ch, 0, vict, TO_CHAR);
-				return (TRUE);
-			}
-		}
-	}
-	return (FALSE);
+  if (MAY_SEE(ch, vict, ch) && (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE) || affected_by_spell(ch, SPELL_HIDE))) {
+    if (awake_hide(ch))    //if (affected_by_spell(ch, SPELL_HIDE))
+    {
+      send_to_char("Вы попытались спрятаться, но ваша экипировка выдала вас.\r\n", ch);
+      affect_from_char(ch, SPELL_HIDE);
+      make_visible(ch, EAffectFlag::AFF_HIDE);
+      EXTRA_FLAGS(ch).set(EXTRA_FAILHIDE);
+    } else if (affected_by_spell(ch, SPELL_HIDE)) {
+      percent = number(1, 82 + GET_REAL_INT(vict));
+      prob = calculate_skill(ch, SKILL_HIDE, vict);
+      if (percent > prob) {
+        affect_from_char(ch, SPELL_HIDE);
+        if (!AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE)) {
+          improve_skill(ch, SKILL_HIDE, FALSE, vict);
+          act("Вы не сумели остаться незаметным.", FALSE, ch, 0, vict, TO_CHAR);
+        }
+      } else {
+        improve_skill(ch, SKILL_HIDE, TRUE, vict);
+        act("Вам удалось остаться незаметным.\r\n", FALSE, ch, 0, vict, TO_CHAR);
+        return (TRUE);
+      }
+    }
+  }
+  return (FALSE);
 }
 
-int skip_camouflage(CHAR_DATA * ch, CHAR_DATA * vict)
-{
-	int percent, prob;
+int skip_camouflage(CHAR_DATA *ch, CHAR_DATA *vict) {
+  int percent, prob;
 
-	if (MAY_SEE(ch, vict, ch)
-		&& (AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE)
-			|| affected_by_spell(ch, SPELL_CAMOUFLAGE)))
-	{
-		if (awake_camouflage(ch))  	//if (affected_by_spell(ch,SPELL_CAMOUFLAGE))
-		{
-			send_to_char("Вы попытались замаскироваться, но ваша экипировка выдала вас.\r\n", ch);
-			affect_from_char(ch, SPELL_CAMOUFLAGE);
-			make_visible(ch, EAffectFlag::AFF_CAMOUFLAGE);
-			EXTRA_FLAGS(ch).set(EXTRA_FAILCAMOUFLAGE);
-		}
-		else if (affected_by_spell(ch, SPELL_CAMOUFLAGE))
-		{
-			percent = number(1, 82 + GET_REAL_INT(vict));
-			prob = calculate_skill(ch, SKILL_CAMOUFLAGE, vict);
-			if (percent > prob)
-			{
-				affect_from_char(ch, SPELL_CAMOUFLAGE);
-				if (!AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE))
-				{
-					improve_skill(ch, SKILL_CAMOUFLAGE, FALSE, vict);
-					act("Вы не сумели правильно замаскироваться.", FALSE, ch, 0, vict, TO_CHAR);
-				}
-			}
-			else
-			{
-				improve_skill(ch, SKILL_CAMOUFLAGE, TRUE, vict);
-				act("Ваша маскировка оказалась на высоте.\r\n", FALSE, ch, 0, vict, TO_CHAR);
-				return (TRUE);
-			}
-		}
-	}
-	return (FALSE);
+  if (MAY_SEE(ch, vict, ch)
+      && (AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE)
+          || affected_by_spell(ch, SPELL_CAMOUFLAGE))) {
+    if (awake_camouflage(ch))    //if (affected_by_spell(ch,SPELL_CAMOUFLAGE))
+    {
+      send_to_char("Вы попытались замаскироваться, но ваша экипировка выдала вас.\r\n", ch);
+      affect_from_char(ch, SPELL_CAMOUFLAGE);
+      make_visible(ch, EAffectFlag::AFF_CAMOUFLAGE);
+      EXTRA_FLAGS(ch).set(EXTRA_FAILCAMOUFLAGE);
+    } else if (affected_by_spell(ch, SPELL_CAMOUFLAGE)) {
+      percent = number(1, 82 + GET_REAL_INT(vict));
+      prob = calculate_skill(ch, SKILL_CAMOUFLAGE, vict);
+      if (percent > prob) {
+        affect_from_char(ch, SPELL_CAMOUFLAGE);
+        if (!AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE)) {
+          improve_skill(ch, SKILL_CAMOUFLAGE, FALSE, vict);
+          act("Вы не сумели правильно замаскироваться.", FALSE, ch, 0, vict, TO_CHAR);
+        }
+      } else {
+        improve_skill(ch, SKILL_CAMOUFLAGE, TRUE, vict);
+        act("Ваша маскировка оказалась на высоте.\r\n", FALSE, ch, 0, vict, TO_CHAR);
+        return (TRUE);
+      }
+    }
+  }
+  return (FALSE);
 }
 
+int skip_sneaking(CHAR_DATA *ch, CHAR_DATA *vict) {
+  int percent, prob, absolute_fail;
+  bool try_fail;
 
-int skip_sneaking(CHAR_DATA * ch, CHAR_DATA * vict)
-{
-	int percent, prob, absolute_fail;
-	bool try_fail;
+  if (MAY_SEE(ch, vict, ch) && (AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK) || affected_by_spell(ch, SPELL_SNEAK))) {
+    if (awake_sneak(ch))    //if (affected_by_spell(ch,SPELL_SNEAK))
+    {
+      send_to_char("Вы попытались подкрасться, но ваша экипировка выдала вас.\r\n", ch);
+      affect_from_char(ch, SPELL_SNEAK);
+      if (affected_by_spell(ch, SPELL_HIDE))
+        affect_from_char(ch, SPELL_HIDE);
+      make_visible(ch, EAffectFlag::AFF_SNEAK);
+      EXTRA_FLAGS(ch).get(EXTRA_FAILSNEAK);
+    } else if (affected_by_spell(ch, SPELL_SNEAK)) {
+      //if (can_use_feat(ch, STEALTHY_FEAT)) //тать или наем
+      //percent = number(1, 140 + GET_REAL_INT(vict));
+      //else
+      percent = number(1,
+                       (can_use_feat(ch, STEALTHY_FEAT) ? 102 : 112)
+                           + (GET_REAL_INT(vict) * (vict->get_role(MOB_ROLE_BOSS) ? 3 : 1))
+                           + (GET_LEVEL(vict) > 30 ? GET_LEVEL(vict) : 0));
+      prob = calculate_skill(ch, SKILL_SNEAK, vict);
 
-	if (MAY_SEE(ch, vict, ch) && (AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK) || affected_by_spell(ch, SPELL_SNEAK)))
-	{
-		if (awake_sneak(ch))  	//if (affected_by_spell(ch,SPELL_SNEAK))
-		{
-			send_to_char("Вы попытались подкрасться, но ваша экипировка выдала вас.\r\n", ch);
-			affect_from_char(ch, SPELL_SNEAK);
-			if (affected_by_spell(ch, SPELL_HIDE))
-				affect_from_char(ch, SPELL_HIDE);
-			make_visible(ch, EAffectFlag::AFF_SNEAK);
-			EXTRA_FLAGS(ch).get(EXTRA_FAILSNEAK);
-		}
-		else if (affected_by_spell(ch, SPELL_SNEAK))
-		{
-			//if (can_use_feat(ch, STEALTHY_FEAT)) //тать или наем
-				//percent = number(1, 140 + GET_REAL_INT(vict));
-			//else
-			percent = number(1, (can_use_feat(ch, STEALTHY_FEAT) ? 102 : 112) + (GET_REAL_INT(vict) * (vict->get_role(MOB_ROLE_BOSS) ? 3 : 1)) + (GET_LEVEL(vict) > 30 ? GET_LEVEL(vict) : 0));
-			prob = calculate_skill(ch, SKILL_SNEAK, vict);
+      int catch_level = (GET_LEVEL(vict) - GET_LEVEL(ch));
+      if (catch_level > 5) {
+        //5% шанс фэйла при prob==200 всегда, при prob = 100 - 10%, если босс, шанс множим на 5
+        absolute_fail = ((200 - prob) / 20 + 5) * (vict->get_role(MOB_ROLE_BOSS) ? 5 : 1);
+        try_fail = number(1, 100) < absolute_fail;
+      } else
+        try_fail = false;
 
-			int catch_level = (GET_LEVEL(vict) - GET_LEVEL(ch));
-			if (catch_level > 5)
-			{
-			//5% шанс фэйла при prob==200 всегда, при prob = 100 - 10%, если босс, шанс множим на 5
-			absolute_fail = ((200 - prob) / 20 + 5)*(vict->get_role(MOB_ROLE_BOSS) ? 5 : 1 );
-			try_fail = number(1, 100) < absolute_fail;
-			}
-			else
-				try_fail = false;
-
-
-			if ((percent > prob) || try_fail)
-			{
-				affect_from_char(ch, SPELL_SNEAK);
-				if (affected_by_spell(ch, SPELL_HIDE))
-					affect_from_char(ch, SPELL_HIDE);
-				if (!AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK))
-				{
-					improve_skill(ch, SKILL_SNEAK, FALSE, vict);
-					act("Вы не сумели пробраться незаметно.", FALSE, ch, 0, vict, TO_CHAR);
-				}
-			}
-			else
-			{
-				improve_skill(ch, SKILL_SNEAK, TRUE, vict);
-				act("Вам удалось прокрасться незаметно.\r\n", FALSE, ch, 0, vict, TO_CHAR);
-				return (TRUE);
-			}
-		}
-	}
-	return (FALSE);
+      if ((percent > prob) || try_fail) {
+        affect_from_char(ch, SPELL_SNEAK);
+        if (affected_by_spell(ch, SPELL_HIDE))
+          affect_from_char(ch, SPELL_HIDE);
+        if (!AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK)) {
+          improve_skill(ch, SKILL_SNEAK, FALSE, vict);
+          act("Вы не сумели пробраться незаметно.", FALSE, ch, 0, vict, TO_CHAR);
+        }
+      } else {
+        improve_skill(ch, SKILL_SNEAK, TRUE, vict);
+        act("Вам удалось прокрасться незаметно.\r\n", FALSE, ch, 0, vict, TO_CHAR);
+        return (TRUE);
+      }
+    }
+  }
+  return (FALSE);
 }
 
 /* do_simple_move assumes
@@ -333,1732 +289,1504 @@ int skip_sneaking(CHAR_DATA * ch, CHAR_DATA * vict)
  * -- only check if following; this avoids 'double spec-proc' bug
  */
 
-int real_forest_paths_sect(int sect)
-{
-	switch (sect)
-	{
-	case SECT_FOREST:
-		return SECT_FIELD;
-		break;
-	case SECT_FOREST_SNOW:
-		return SECT_FIELD_SNOW;
-		break;
-	case SECT_FOREST_RAIN:
-		return SECT_FIELD_RAIN;
-		break;
-	}
-	return sect;
+int real_forest_paths_sect(int sect) {
+  switch (sect) {
+    case SECT_FOREST: return SECT_FIELD;
+      break;
+    case SECT_FOREST_SNOW: return SECT_FIELD_SNOW;
+      break;
+    case SECT_FOREST_RAIN: return SECT_FIELD_RAIN;
+      break;
+  }
+  return sect;
 }
 
-int real_mountains_paths_sect(int sect)
-{
-	switch (sect)
-	{
-	case SECT_HILLS:
-	case SECT_MOUNTAIN:
-		return SECT_FIELD;
-		break;
-	case SECT_HILLS_RAIN:
-		return SECT_FIELD_RAIN;
-		break;
-	case SECT_HILLS_SNOW:
-	case SECT_MOUNTAIN_SNOW:
-		return SECT_FIELD_SNOW;
-		break;
-	}
-	return sect;
+int real_mountains_paths_sect(int sect) {
+  switch (sect) {
+    case SECT_HILLS:
+    case SECT_MOUNTAIN: return SECT_FIELD;
+      break;
+    case SECT_HILLS_RAIN: return SECT_FIELD_RAIN;
+      break;
+    case SECT_HILLS_SNOW:
+    case SECT_MOUNTAIN_SNOW: return SECT_FIELD_SNOW;
+      break;
+  }
+  return sect;
 }
 
-int calculate_move_cost(CHAR_DATA* ch, int dir)
-{
-	// move points needed is avg. move loss for src and destination sect type
-	auto ch_inroom = real_sector(ch->in_room);
-	auto ch_toroom = real_sector(EXIT(ch, dir)->to_room());
+int calculate_move_cost(CHAR_DATA *ch, int dir) {
+  // move points needed is avg. move loss for src and destination sect type
+  auto ch_inroom = real_sector(ch->in_room);
+  auto ch_toroom = real_sector(EXIT(ch, dir)->to_room());
 
-	if (can_use_feat(ch, FOREST_PATHS_FEAT))
-	{
-		ch_inroom = real_forest_paths_sect(ch_inroom);
-		ch_toroom = real_forest_paths_sect(ch_toroom);
-	}
+  if (can_use_feat(ch, FOREST_PATHS_FEAT)) {
+    ch_inroom = real_forest_paths_sect(ch_inroom);
+    ch_toroom = real_forest_paths_sect(ch_toroom);
+  }
 
-	if (can_use_feat(ch, MOUNTAIN_PATHS_FEAT))
-	{
-		ch_inroom = real_mountains_paths_sect(ch_inroom);
-		ch_toroom = real_mountains_paths_sect(ch_toroom);
-	}
+  if (can_use_feat(ch, MOUNTAIN_PATHS_FEAT)) {
+    ch_inroom = real_mountains_paths_sect(ch_inroom);
+    ch_toroom = real_mountains_paths_sect(ch_toroom);
+  }
 
-	int need_movement = (IS_FLY(ch) || ch->ahorse()) ? 1 :
-		(movement_loss[ch_inroom] + movement_loss[ch_toroom]) / 2;
+  int need_movement = (IS_FLY(ch) || ch->ahorse()) ? 1 :
+                      (movement_loss[ch_inroom] + movement_loss[ch_toroom]) / 2;
 
-	if (IS_IMMORTAL(ch))
-		need_movement = 0;
-	else if (affected_by_spell(ch, SPELL_CAMOUFLAGE))
-		need_movement += CAMOUFLAGE_MOVES;
-	else if (affected_by_spell(ch, SPELL_SNEAK))
-		need_movement += SNEAK_MOVES;
+  if (IS_IMMORTAL(ch))
+    need_movement = 0;
+  else if (affected_by_spell(ch, SPELL_CAMOUFLAGE))
+    need_movement += CAMOUFLAGE_MOVES;
+  else if (affected_by_spell(ch, SPELL_SNEAK))
+    need_movement += SNEAK_MOVES;
 
-	return need_movement;
+  return need_movement;
 }
 
-int legal_dir(CHAR_DATA * ch, int dir, int need_specials_check, int show_msg)
-{
-	buf2[0] = '\0';
-	if (need_specials_check && special(ch, dir + 1, buf2, 1))
-		return (FALSE);
+int legal_dir(CHAR_DATA *ch, int dir, int need_specials_check, int show_msg) {
+  buf2[0] = '\0';
+  if (need_specials_check && special(ch, dir + 1, buf2, 1))
+    return (FALSE);
 
-	if (!CAN_GO(ch, dir))
-		return (FALSE);
+  if (!CAN_GO(ch, dir))
+    return (FALSE);
 
-	// не пускать в ванрумы после пк, если его там прибьет сразу
-	if (DeathTrap::check_tunnel_death(ch, EXIT(ch, dir)->to_room()))
-	{
-		if (show_msg)
-		{
-			send_to_char("В связи с боевыми действиями эвакуация временно прекращена.\r\n", ch);
-		}
-		return (FALSE);
-	}
+  // не пускать в ванрумы после пк, если его там прибьет сразу
+  if (DeathTrap::check_tunnel_death(ch, EXIT(ch, dir)->to_room())) {
+    if (show_msg) {
+      send_to_char("В связи с боевыми действиями эвакуация временно прекращена.\r\n", ch);
+    }
+    return (FALSE);
+  }
 
-	// charmed
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-		&& ch->has_master()
-		&& ch->in_room == ch->get_master()->in_room)
-	{
-		if (show_msg)
-		{
-			send_to_char("Вы не можете покинуть свой идеал.\r\n", ch);
-			act("$N попытал$U покинуть вас.", FALSE, ch->get_master(), 0, ch, TO_CHAR);
-		}
-		return (FALSE);
-	}
+  // charmed
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+      && ch->has_master()
+      && ch->in_room == ch->get_master()->in_room) {
+    if (show_msg) {
+      send_to_char("Вы не можете покинуть свой идеал.\r\n", ch);
+      act("$N попытал$U покинуть вас.", FALSE, ch->get_master(), 0, ch, TO_CHAR);
+    }
+    return (FALSE);
+  }
 
-	// check NPC's
-	if (IS_NPC(ch))
-	{
-		if (GET_DEST(ch) != NOWHERE)
-		{
-			return (TRUE);
-		}
+  // check NPC's
+  if (IS_NPC(ch)) {
+    if (GET_DEST(ch) != NOWHERE) {
+      return (TRUE);
+    }
 
-		//  if this room or the one we're going to needs a boat, check for one */
-		if (!MOB_FLAGGED(ch, MOB_SWIMMING)
-			&& !MOB_FLAGGED(ch, MOB_FLYING)
-			&& !AFF_FLAGGED(ch, EAffectFlag::AFF_FLY)
-			&& (real_sector(ch->in_room) == SECT_WATER_NOSWIM
-				|| real_sector(EXIT(ch, dir)->to_room()) == SECT_WATER_NOSWIM))
-		{
-			if (!has_boat(ch))
-			{
-				return (FALSE);
-			}
-		}
+    //  if this room or the one we're going to needs a boat, check for one */
+    if (!MOB_FLAGGED(ch, MOB_SWIMMING)
+        && !MOB_FLAGGED(ch, MOB_FLYING)
+        && !AFF_FLAGGED(ch, EAffectFlag::AFF_FLY)
+        && (real_sector(ch->in_room) == SECT_WATER_NOSWIM
+            || real_sector(EXIT(ch, dir)->to_room()) == SECT_WATER_NOSWIM)) {
+      if (!has_boat(ch)) {
+        return (FALSE);
+      }
+    }
 
-		// Добавляем проверку на то что моб может вскрыть дверь
-		if (EXIT_FLAGGED(EXIT(ch, dir), EX_CLOSED) &&
-				!MOB_FLAGGED(ch, MOB_OPENDOOR))
-			return (FALSE);
+    // Добавляем проверку на то что моб может вскрыть дверь
+    if (EXIT_FLAGGED(EXIT(ch, dir), EX_CLOSED) &&
+        !MOB_FLAGGED(ch, MOB_OPENDOOR))
+      return (FALSE);
 
-		if (!MOB_FLAGGED(ch, MOB_FLYING) &&
-				!AFF_FLAGGED(ch, EAffectFlag::AFF_FLY) && SECT(EXIT(ch, dir)->to_room()) == SECT_FLYING)
-			return (FALSE);
+    if (!MOB_FLAGGED(ch, MOB_FLYING) &&
+        !AFF_FLAGGED(ch, EAffectFlag::AFF_FLY) && SECT(EXIT(ch, dir)->to_room()) == SECT_FLYING)
+      return (FALSE);
 
-		if (MOB_FLAGGED(ch, MOB_ONLYSWIMMING) &&
-				!(real_sector(EXIT(ch, dir)->to_room()) == SECT_WATER_SWIM ||
-				  real_sector(EXIT(ch, dir)->to_room()) == SECT_WATER_NOSWIM ||
-				  real_sector(EXIT(ch, dir)->to_room()) == SECT_UNDERWATER))
-			return (FALSE);
+    if (MOB_FLAGGED(ch, MOB_ONLYSWIMMING) &&
+        !(real_sector(EXIT(ch, dir)->to_room()) == SECT_WATER_SWIM ||
+            real_sector(EXIT(ch, dir)->to_room()) == SECT_WATER_NOSWIM ||
+            real_sector(EXIT(ch, dir)->to_room()) == SECT_UNDERWATER))
+      return (FALSE);
 
-		if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_NOMOB) &&
-				!IS_HORSE(ch) &&
-				!AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) && !(MOB_FLAGGED(ch, MOB_ANGEL)||MOB_FLAGGED(ch, MOB_GHOST)) && !MOB_FLAGGED(ch, MOB_IGNORNOMOB))
-			return (FALSE);
+    if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_NOMOB) &&
+        !IS_HORSE(ch) &&
+        !AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) && !(MOB_FLAGGED(ch, MOB_ANGEL) || MOB_FLAGGED(ch, MOB_GHOST))
+        && !MOB_FLAGGED(ch, MOB_IGNORNOMOB))
+      return (FALSE);
 
-		if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_DEATH) && !IS_HORSE(ch))
-			return (FALSE);
+    if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_DEATH) && !IS_HORSE(ch))
+      return (FALSE);
 
-		if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_GODROOM))
-			return (FALSE);
+    if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_GODROOM))
+      return (FALSE);
 
-		if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_NOHORSE) && IS_HORSE(ch))
-			return (FALSE);
-	}
-	else
-	{
-		//Вход в замок
-		if (ROOM_FLAGGED(ch->in_room, ROOM_ATRIUM))
-		{
-			if (!Clan::MayEnter(ch, EXIT(ch, dir)->to_room(), HCE_ATRIUM))
-			{
-				if (show_msg)
-					send_to_char("Частная собственность! Вход воспрещен!\r\n", ch);
-				return (FALSE);
-			}
-		}
+    if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_NOHORSE) && IS_HORSE(ch))
+      return (FALSE);
+  } else {
+    //Вход в замок
+    if (ROOM_FLAGGED(ch->in_room, ROOM_ATRIUM)) {
+      if (!Clan::MayEnter(ch, EXIT(ch, dir)->to_room(), HCE_ATRIUM)) {
+        if (show_msg)
+          send_to_char("Частная собственность! Вход воспрещен!\r\n", ch);
+        return (FALSE);
+      }
+    }
 
-		if (real_sector(ch->in_room) == SECT_WATER_NOSWIM ||
-				real_sector(EXIT(ch, dir)->to_room()) == SECT_WATER_NOSWIM)
-		{
-			if (!has_boat(ch))
-			{
-				if (show_msg)
-					send_to_char("Вам нужна лодка, чтобы попасть туда.\r\n", ch);
-				return (FALSE);
-			}
-		}
-		if (real_sector(EXIT(ch, dir)->to_room()) == SECT_FLYING
-			&& !IS_GOD(ch)
-			&& !AFF_FLAGGED(ch, EAffectFlag::AFF_FLY))
-		{
-			if (show_msg)
-			{
-				send_to_char("Туда можно только влететь.\r\n", ch);
-			}
-			return (FALSE);
-		}
+    if (real_sector(ch->in_room) == SECT_WATER_NOSWIM ||
+        real_sector(EXIT(ch, dir)->to_room()) == SECT_WATER_NOSWIM) {
+      if (!has_boat(ch)) {
+        if (show_msg)
+          send_to_char("Вам нужна лодка, чтобы попасть туда.\r\n", ch);
+        return (FALSE);
+      }
+    }
+    if (real_sector(EXIT(ch, dir)->to_room()) == SECT_FLYING
+        && !IS_GOD(ch)
+        && !AFF_FLAGGED(ch, EAffectFlag::AFF_FLY)) {
+      if (show_msg) {
+        send_to_char("Туда можно только влететь.\r\n", ch);
+      }
+      return (FALSE);
+    }
 
-		// если там ДТ и чар верхом на пони
-		if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_DEATH) && ch->ahorse())
-		{
-		    if (show_msg)
-		    {
-			// я весьма костоязычен, исправьте кто-нибудь на нормальную
-			// мессагу, антуражненькую
-			send_to_char("Ваш скакун не хочет идти туда.\r\n", ch);
-		    }
-		    return (FALSE);
-		}
+    // если там ДТ и чар верхом на пони
+    if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_DEATH) && ch->ahorse()) {
+      if (show_msg) {
+        // я весьма костоязычен, исправьте кто-нибудь на нормальную
+        // мессагу, антуражненькую
+        send_to_char("Ваш скакун не хочет идти туда.\r\n", ch);
+      }
+      return (FALSE);
+    }
 
-		const auto need_movement = calculate_move_cost(ch, dir);
-		if (GET_MOVE(ch) < need_movement)
-		{
-			if (need_specials_check
-				&& ch->has_master())
-			{
-				if (show_msg)
-				{
-					send_to_char("Вы слишком устали, чтобы следовать туда.\r\n", ch);
-				}
-			}
-			else
-			{
-				if (show_msg)
-				{
-					send_to_char("Вы слишком устали.\r\n", ch);
-				}
-			}
-			return (FALSE);
-		}
-		//Вход в замок
-		if (ROOM_FLAGGED(ch->in_room, ROOM_ATRIUM))
-		{
-			if (!Clan::MayEnter(ch, EXIT(ch, dir)->to_room(), HCE_ATRIUM))
-			{
-				if (show_msg)
-					send_to_char("Частная собственность! Вход воспрещен!\r\n", ch);
-				return (FALSE);
-			}
-		}
+    const auto need_movement = calculate_move_cost(ch, dir);
+    if (GET_MOVE(ch) < need_movement) {
+      if (need_specials_check
+          && ch->has_master()) {
+        if (show_msg) {
+          send_to_char("Вы слишком устали, чтобы следовать туда.\r\n", ch);
+        }
+      } else {
+        if (show_msg) {
+          send_to_char("Вы слишком устали.\r\n", ch);
+        }
+      }
+      return (FALSE);
+    }
+    //Вход в замок
+    if (ROOM_FLAGGED(ch->in_room, ROOM_ATRIUM)) {
+      if (!Clan::MayEnter(ch, EXIT(ch, dir)->to_room(), HCE_ATRIUM)) {
+        if (show_msg)
+          send_to_char("Частная собственность! Вход воспрещен!\r\n", ch);
+        return (FALSE);
+      }
+    }
 
-		//чтобы конь не лез в комнату с флагом !лошадь
-		if (ch->ahorse() && !legal_dir(ch->get_horse(), dir, need_specials_check, FALSE))
-		{
-			if (show_msg)
-			{
-				act("$Z $N отказывается туда идти, и вам пришлось соскочить.",
-					FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-				ch->dismount();
-			}
-		}
-		//проверка на ванрум: скидываем игрока с коня, если там незанято
-		if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_TUNNEL) &&
-				(num_pc_in_room((world[EXIT(ch, dir)->to_room()])) > 0))
-		{
-			if (show_msg)
-				send_to_char("Слишком мало места.\r\n", ch);
-			return (FALSE);
-		}
+    //чтобы конь не лез в комнату с флагом !лошадь
+    if (ch->ahorse() && !legal_dir(ch->get_horse(), dir, need_specials_check, FALSE)) {
+      if (show_msg) {
+        act("$Z $N отказывается туда идти, и вам пришлось соскочить.",
+            FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+        ch->dismount();
+      }
+    }
+    //проверка на ванрум: скидываем игрока с коня, если там незанято
+    if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_TUNNEL) &&
+        (num_pc_in_room((world[EXIT(ch, dir)->to_room()])) > 0)) {
+      if (show_msg)
+        send_to_char("Слишком мало места.\r\n", ch);
+      return (FALSE);
+    }
 
-		if (ch->ahorse() && GET_HORSESTATE(ch->get_horse()) <= 0)
-		{
-			if (show_msg)
-				act("$Z $N загнан$G настолько, что не может нести вас на себе.",
-					FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-			return (FALSE);
-		}
+    if (ch->ahorse() && GET_HORSESTATE(ch->get_horse()) <= 0) {
+      if (show_msg)
+        act("$Z $N загнан$G настолько, что не может нести вас на себе.",
+            FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+      return (FALSE);
+    }
 
-		if (ch->ahorse()
-			&& (AFF_FLAGGED(ch->get_horse(), EAffectFlag::AFF_HOLD)
-				|| AFF_FLAGGED(ch->get_horse(), EAffectFlag::AFF_SLEEP)))
-		{
-			if (show_msg)
-				act("$Z $N не в состоянии нести вас на себе.\r\n", FALSE, ch, 0, ch->get_horse(),	TO_CHAR);
-			return (FALSE);
-		}
+    if (ch->ahorse()
+        && (AFF_FLAGGED(ch->get_horse(), EAffectFlag::AFF_HOLD)
+            || AFF_FLAGGED(ch->get_horse(), EAffectFlag::AFF_SLEEP))) {
+      if (show_msg)
+        act("$Z $N не в состоянии нести вас на себе.\r\n", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+      return (FALSE);
+    }
 
-		if(ch->ahorse()
-			&& (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_TUNNEL)
-				|| ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_NOHORSE)))
-		{
-			if (show_msg)
-				act("$Z $N не в состоянии пройти туда.\r\n", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-			return FALSE;
-		}
+    if (ch->ahorse()
+        && (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_TUNNEL)
+            || ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_NOHORSE))) {
+      if (show_msg)
+        act("$Z $N не в состоянии пройти туда.\r\n", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+      return FALSE;
+    }
 
-		if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_GODROOM) && !IS_GRGOD(ch))
-		{
-			if (show_msg)
-				send_to_char("Вы не столь Божественны, как вам кажется!\r\n", ch);
-			return (FALSE);
-		}
+    if (ROOM_FLAGGED(EXIT(ch, dir)->to_room(), ROOM_GODROOM) && !IS_GRGOD(ch)) {
+      if (show_msg)
+        send_to_char("Вы не столь Божественны, как вам кажется!\r\n", ch);
+      return (FALSE);
+    }
 
-		for (const auto tch : world[ch->in_room]->people)
-		{
-			if (!IS_NPC(tch))
-				continue;
-			if (NPC_FLAGGED(tch, 1 << dir)
-				&& AWAKE(tch)
-				&& GET_POS(tch) > POS_SLEEPING
-				&& CAN_SEE(tch, ch)
-				&& !AFF_FLAGGED(tch, EAffectFlag::AFF_CHARM)
-				&& !AFF_FLAGGED(tch, EAffectFlag::AFF_HOLD)
-				&& !IS_GRGOD(ch))
-			{
-				if (show_msg)
-				{
-					act("$N преградил$G вам путь.", FALSE, ch, 0, tch, TO_CHAR);
-				}
+    for (const auto tch : world[ch->in_room]->people) {
+      if (!IS_NPC(tch))
+        continue;
+      if (NPC_FLAGGED(tch, 1 << dir)
+          && AWAKE(tch)
+          && GET_POS(tch) > POS_SLEEPING
+          && CAN_SEE(tch, ch)
+          && !AFF_FLAGGED(tch, EAffectFlag::AFF_CHARM)
+          && !AFF_FLAGGED(tch, EAffectFlag::AFF_HOLD)
+          && !IS_GRGOD(ch)) {
+        if (show_msg) {
+          act("$N преградил$G вам путь.", FALSE, ch, 0, tch, TO_CHAR);
+        }
 
-				return FALSE;
-			}
-		}
-	}
+        return FALSE;
+      }
+    }
+  }
 
-	return TRUE;
+  return TRUE;
 }
 
 #define MOB_AGGR_TO_ALIGN (MOB_AGGR_EVIL | MOB_AGGR_NEUTRAL | MOB_AGGR_GOOD)
 #define MAX_DRUNK_SONG 6
 #define MAX_DRUNK_VOICE 5
 
-void performDunkSong(CHAR_DATA* ch){
-    const char *drunk_songs[MAX_DRUNK_SONG] = { "\"Шумел камыш, и-к-к..., деревья гнулися\"",
-                                                "\"Куда ты, тропинка, меня завела\"",
-                                                "\"Пабабам, пара пабабам\"",
-                                                "\"А мне любое море по колено\"",
-                                                "\"Не жди меня мама, хорошего сына\"",
-                                                "\"Бываааали дниии, весеееелыя\"",
-    };
-    const char *drunk_voice[MAX_DRUNK_VOICE] = { " - затянул$g $n",
-                                                 " - запел$g $n.",
-                                                 " - прохрипел$g $n.",
-                                                 " - зычно заревел$g $n.",
-                                                 " - разухабисто протянул$g $n.",
-    };
-    // орем песни
-    if (!ch->get_fighting() && number(10, 24) < GET_COND(ch, DRUNK))
-    {
-        sprintf(buf, "%s", drunk_songs[number(0, MAX_DRUNK_SONG - 1)]);
-        send_to_char(buf, ch);
-        send_to_char("\r\n", ch);
-        strcat(buf, drunk_voice[number(0, MAX_DRUNK_VOICE - 1)]);
-        act(buf, FALSE, ch, 0, 0, TO_ROOM | CHECK_DEAF);
-        affect_from_char(ch, SPELL_SNEAK);
-        affect_from_char(ch, SPELL_HIDE);
-        affect_from_char(ch, SPELL_CAMOUFLAGE);
-    }
+void performDunkSong(CHAR_DATA *ch) {
+  const char *drunk_songs[MAX_DRUNK_SONG] = {"\"Шумел камыш, и-к-к..., деревья гнулися\"",
+                                             "\"Куда ты, тропинка, меня завела\"",
+                                             "\"Пабабам, пара пабабам\"",
+                                             "\"А мне любое море по колено\"",
+                                             "\"Не жди меня мама, хорошего сына\"",
+                                             "\"Бываааали дниии, весеееелыя\"",
+  };
+  const char *drunk_voice[MAX_DRUNK_VOICE] = {" - затянул$g $n",
+                                              " - запел$g $n.",
+                                              " - прохрипел$g $n.",
+                                              " - зычно заревел$g $n.",
+                                              " - разухабисто протянул$g $n.",
+  };
+  // орем песни
+  if (!ch->get_fighting() && number(10, 24) < GET_COND(ch, DRUNK)) {
+    sprintf(buf, "%s", drunk_songs[number(0, MAX_DRUNK_SONG - 1)]);
+    send_to_char(buf, ch);
+    send_to_char("\r\n", ch);
+    strcat(buf, drunk_voice[number(0, MAX_DRUNK_VOICE - 1)]);
+    act(buf, FALSE, ch, 0, 0, TO_ROOM | CHECK_DEAF);
+    affect_from_char(ch, SPELL_SNEAK);
+    affect_from_char(ch, SPELL_HIDE);
+    affect_from_char(ch, SPELL_CAMOUFLAGE);
+  }
 }
 
-int calcDrunkDirection(CHAR_DATA* ch, int direction, bool need_specials_check) {
+int calcDrunkDirection(CHAR_DATA *ch, int direction, bool need_specials_check) {
 
-    int drunk_move = direction;
-    //пересчет направления, в зависимости от степени опьянения
-	if (!IS_NPC(ch)
-	    && GET_COND(ch, DRUNK) >= CHAR_MORTALLY_DRUNKED
-	    && !ch->ahorse()
-		&& GET_COND(ch, DRUNK) >= number(CHAR_DRUNKED, 50))
-	{
-		int possibleDirs[NUM_OF_DIRS];
-		int correct_dirs = 0;
+  int drunk_move = direction;
+  //пересчет направления, в зависимости от степени опьянения
+  if (!IS_NPC(ch)
+      && GET_COND(ch, DRUNK) >= CHAR_MORTALLY_DRUNKED
+      && !ch->ahorse()
+      && GET_COND(ch, DRUNK) >= number(CHAR_DRUNKED, 50)) {
+    int possibleDirs[NUM_OF_DIRS];
+    int correct_dirs = 0;
 
-		for (auto i = 0; i < NUM_OF_DIRS; ++i) {
-			if (legal_dir(ch, i, need_specials_check, TRUE)) {
-                possibleDirs[correct_dirs] = i;
-				++correct_dirs;
-			}
-		}
-
-		if (correct_dirs > 0
-			&& !bernoulli_trial(std::pow((1.0 - static_cast<double>(correct_dirs) / NUM_OF_DIRS), NUM_OF_DIRS)))
-		{
-            drunk_move = possibleDirs[number(0, correct_dirs - 1)];
-		}
-	}
-
-    if (direction != drunk_move) {
-        sprintf(buf, "Ваши ноги не хотят слушаться вас...\r\n");
-        send_to_char(buf, ch);
+    for (auto i = 0; i < NUM_OF_DIRS; ++i) {
+      if (legal_dir(ch, i, need_specials_check, TRUE)) {
+        possibleDirs[correct_dirs] = i;
+        ++correct_dirs;
+      }
     }
-	return drunk_move;
+
+    if (correct_dirs > 0
+        && !bernoulli_trial(std::pow((1.0 - static_cast<double>(correct_dirs) / NUM_OF_DIRS), NUM_OF_DIRS))) {
+      drunk_move = possibleDirs[number(0, correct_dirs - 1)];
+    }
+  }
+
+  if (direction != drunk_move) {
+    sprintf(buf, "Ваши ноги не хотят слушаться вас...\r\n");
+    send_to_char(buf, ch);
+  }
+  return drunk_move;
 }
 
-int do_simple_move(CHAR_DATA * ch, int dir, int need_specials_check, CHAR_DATA * leader, bool is_flee)
-{
-	struct track_data *track;
-	room_rnum was_in, go_to;
-	int i, invis = 0, use_horse = 0, is_horse = 0, direction = 0;
-	int mob_rnum = -1;
-	CHAR_DATA *horse = nullptr;
+int do_simple_move(CHAR_DATA *ch, int dir, int need_specials_check, CHAR_DATA *leader, bool is_flee) {
+  struct track_data *track;
+  room_rnum was_in, go_to;
+  int i, invis = 0, use_horse = 0, is_horse = 0, direction = 0;
+  int mob_rnum = -1;
+  CHAR_DATA *horse = nullptr;
 
-    if (ch->purged()) {
-        return FALSE;
+  if (ch->purged()) {
+    return FALSE;
+  }
+  // если не моб и не ведут за ручку - проверка на пьяные выкрутасы
+  if (!IS_NPC(ch) && !leader) {
+    dir = calcDrunkDirection(ch, dir, need_specials_check);
+  }
+  performDunkSong(ch);
+
+  if (!legal_dir(ch, dir, need_specials_check, TRUE))
+    return (FALSE);
+
+  if (!entry_mtrigger(ch))
+    return (FALSE);
+
+  if (!enter_wtrigger(world[EXIT(ch, dir)->to_room()], ch, dir))
+    return (FALSE);
+
+  // Now we know we're allow to go into the room.
+  if (!IS_IMMORTAL(ch) && !IS_NPC(ch))
+    GET_MOVE(ch) -= calculate_move_cost(ch, dir);
+
+  i = skill_info[SKILL_SNEAK].max_percent;
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK) && !is_flee) {
+    if (IS_NPC(ch))
+      invis = 1;
+    else if (awake_sneak(ch)) {
+      affect_from_char(ch, SPELL_SNEAK);
+    } else if (!affected_by_spell(ch, SPELL_SNEAK) || calculate_skill(ch, SKILL_SNEAK, 0) >= number(1, i))
+      invis = 1;
+  }
+
+  i = skill_info[SKILL_CAMOUFLAGE].max_percent;
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE) && !is_flee) {
+    if (IS_NPC(ch))
+      invis = 1;
+    else if (awake_camouflage(ch)) {
+      affect_from_char(ch, SPELL_CAMOUFLAGE);
+    } else if (!affected_by_spell(ch, SPELL_CAMOUFLAGE) ||
+        calculate_skill(ch, SKILL_CAMOUFLAGE, 0) >= number(1, i))
+      invis = 1;
+  }
+
+  if (!is_flee) {
+    sprintf(buf, "Вы поплелись %s%s.", leader ? "следом за $N4 " : "", DirsTo[dir]);
+    act(buf, FALSE, ch, 0, leader, TO_CHAR);
+  }
+
+  was_in = ch->in_room;
+  go_to = world[was_in]->dir_option[dir]->to_room();
+  direction = dir + 1;
+  use_horse = ch->ahorse() && ch->has_horse(false)
+      && (IN_ROOM(ch->get_horse()) == was_in || IN_ROOM(ch->get_horse()) == go_to);
+  is_horse = IS_HORSE(ch)
+      && ch->has_master()
+      && !AFF_FLAGGED(ch->get_master(), EAffectFlag::AFF_INVISIBLE)
+      && (IN_ROOM(ch->get_master()) == was_in
+          || IN_ROOM(ch->get_master()) == go_to);
+
+  if (!invis && !is_horse) {
+    if (is_flee)
+      strcpy(smallBuf, "сбежал$g");
+    else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVERUN))
+      strcpy(smallBuf, "убежал$g");
+    else if ((!use_horse && AFF_FLAGGED(ch, EAffectFlag::AFF_FLY))
+        || (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVEFLY))) {
+      strcpy(smallBuf, "улетел$g");
+    } else if (IS_NPC(ch)
+        && NPC_FLAGGED(ch, NPC_MOVESWIM)
+        && (real_sector(was_in) == SECT_WATER_SWIM
+            || real_sector(was_in) == SECT_WATER_NOSWIM
+            || real_sector(was_in) == SECT_UNDERWATER)) {
+      strcpy(smallBuf, "уплыл$g");
+    } else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVEJUMP))
+      strcpy(smallBuf, "ускакал$g");
+    else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVECREEP))
+      strcpy(smallBuf, "уполз$q");
+    else if (real_sector(was_in) == SECT_WATER_SWIM
+        || real_sector(was_in) == SECT_WATER_NOSWIM
+        || real_sector(was_in) == SECT_UNDERWATER) {
+      strcpy(smallBuf, "уплыл$g");
+    } else if (use_horse) {
+      horse = ch->get_horse();
+      if (horse && AFF_FLAGGED(horse, EAffectFlag::AFF_FLY))
+        strcpy(smallBuf, "улетел$g");
+      else
+        strcpy(smallBuf, "уехал$g");
+    } else
+      strcpy(smallBuf, "уш$y");
+
+    if (is_flee && !IS_NPC(ch) && can_use_feat(ch, WRIGGLER_FEAT))
+      sprintf(buf2, "$n %s.", smallBuf);
+    else
+      sprintf(buf2, "$n %s %s.", smallBuf, DirsTo[dir]);
+    act(buf2, TRUE, ch, 0, 0, TO_ROOM);
+  }
+
+  if (invis && !is_horse) {
+    act("Кто-то тихо удалился отсюда.", TRUE, ch, 0, 0, TO_ROOM_HIDE);
+  }
+
+  if (ch->ahorse())
+    horse = ch->get_horse();
+
+  // Если сбежали, и по противнику никто не бьет, то убираем с него аттаку
+  if (is_flee) {
+    stop_fighting(ch, TRUE);
+  }
+
+  if (!IS_NPC(ch) && IS_BITS(ch->track_dirs, dir)) {
+    send_to_char("Вы двинулись по следу.\r\n", ch);
+    improve_skill(ch, SKILL_TRACK, TRUE, 0);
+  }
+
+  char_from_room(ch);
+  //затычка для бегства. чтоьы не отрабатывал MSDP протокол
+  if (is_flee && !IS_NPC(ch) && !can_use_feat(ch, CALMNESS_FEAT))
+    char_flee_to_room(ch, go_to);
+  else
+    char_to_room(ch, go_to);
+  if (horse) {
+    GET_HORSESTATE(horse) -= 1;
+    char_from_room(horse);
+    char_to_room(horse, go_to);
+  }
+
+  if (PRF_FLAGGED(ch, PRF_BLIND)) {
+    for (int i = 0; i < NUM_OF_DIRS; i++) {
+      if (CAN_GO(ch, i)
+          || (EXIT(ch, i)
+              && EXIT(ch, i)->to_room() != NOWHERE)) {
+        const auto &rdata = EXIT(ch, i);
+        if (ROOM_FLAGGED(rdata->to_room(), ROOM_DEATH)) {
+          send_to_char("\007", ch);
+        }
+      }
     }
-    // если не моб и не ведут за ручку - проверка на пьяные выкрутасы
-    if (!IS_NPC(ch) && !leader) {
-        dir = calcDrunkDirection(ch, dir, need_specials_check);
+  }
+
+  if (!invis && !is_horse) {
+    if (is_flee
+        || (IS_NPC(ch)
+            && NPC_FLAGGED(ch, NPC_MOVERUN))) {
+      strcpy(smallBuf, "прибежал$g");
+    } else if ((!use_horse && AFF_FLAGGED(ch, EAffectFlag::AFF_FLY))
+        || (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVEFLY))) {
+      strcpy(smallBuf, "прилетел$g");
+    } else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVESWIM)
+        && (real_sector(go_to) == SECT_WATER_SWIM
+            || real_sector(go_to) == SECT_WATER_NOSWIM
+            || real_sector(go_to) == SECT_UNDERWATER)) {
+      strcpy(smallBuf, "приплыл$g");
+    } else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVEJUMP))
+      strcpy(smallBuf, "прискакал$g");
+    else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVECREEP))
+      strcpy(smallBuf, "приполз$q");
+    else if (real_sector(go_to) == SECT_WATER_SWIM
+        || real_sector(go_to) == SECT_WATER_NOSWIM
+        || real_sector(go_to) == SECT_UNDERWATER) {
+      strcpy(smallBuf, "приплыл$g");
+    } else if (use_horse) {
+      horse = ch->get_horse();
+      if (horse && AFF_FLAGGED(horse, EAffectFlag::AFF_FLY)) {
+        strcpy(smallBuf, "прилетел$g");
+      } else {
+        strcpy(smallBuf, "приехал$g");
+      }
+
+    } else
+      strcpy(smallBuf, "приш$y");
+
+    //log("%s-%d",GET_NAME(ch),ch->in_room);
+    sprintf(buf2, "$n %s %s.", smallBuf, DirsFrom[dir]);
+    //log(buf2);
+    act(buf2, TRUE, ch, 0, 0, TO_ROOM);
+    //log("ACT OK !");
+  };
+
+  if (invis && !is_horse) {
+    act("Кто-то тихо подкрался сюда.", TRUE, ch, 0, 0, TO_ROOM_HIDE);
+  }
+
+  if (ch->desc != NULL)
+    look_at_room(ch, 0);
+
+  if (!IS_NPC(ch))
+    room_affect_process_on_entry(ch, ch->in_room);
+
+  if (DeathTrap::check_death_trap(ch)) {
+    if (horse) {
+      extract_char(horse, FALSE);
     }
-    performDunkSong(ch);
+    return (FALSE);
+  }
 
-	if (!legal_dir(ch, dir, need_specials_check, TRUE))
-	    return (FALSE);
+  if (check_death_ice(go_to, ch)) {
+    return (FALSE);
+  }
 
-	if (!entry_mtrigger(ch))
-		return (FALSE);
+  if (DeathTrap::tunnel_damage(ch)) {
+    return (FALSE);
+  }
 
-	if (!enter_wtrigger(world[EXIT(ch, dir)->to_room()], ch, dir))
-		return (FALSE);
+  greet_mtrigger(ch, dir);
+  greet_otrigger(ch, dir);
 
-	// Now we know we're allow to go into the room.
-	if (!IS_IMMORTAL(ch) && !IS_NPC(ch))
-		GET_MOVE(ch) -= calculate_move_cost(ch, dir);
+  // add track info
+  if (!AFF_FLAGGED(ch, EAffectFlag::AFF_NOTRACK)
+      && (!IS_NPC(ch)
+          || (mob_rnum = GET_MOB_RNUM(ch)) >= 0)) {
+    for (track = world[go_to]->track; track; track = track->next) {
+      if ((IS_NPC(ch) && IS_SET(track->track_info, TRACK_NPC) && track->who == mob_rnum)
+          || (!IS_NPC(ch) && !IS_SET(track->track_info, TRACK_NPC) && track->who == GET_IDNUM(ch))) {
+        break;
+      }
+    }
 
-	i = skill_info[SKILL_SNEAK].max_percent;
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK) && !is_flee)
-	{
-		if (IS_NPC(ch))
-			invis = 1;
-		else if (awake_sneak(ch))
-		{
-			affect_from_char(ch, SPELL_SNEAK);
-		}
-		else
-			if (!affected_by_spell(ch, SPELL_SNEAK) || calculate_skill(ch, SKILL_SNEAK, 0) >= number(1, i))
-				invis = 1;
-	}
+    if (!track && !ROOM_FLAGGED(go_to, ROOM_NOTRACK)) {
+      CREATE(track, 1);
+      track->track_info = IS_NPC(ch) ? TRACK_NPC : 0;
+      track->who = IS_NPC(ch) ? mob_rnum : GET_IDNUM(ch);
+      track->next = world[go_to]->track;
+      world[go_to]->track = track;
+    }
 
-	i = skill_info[SKILL_CAMOUFLAGE].max_percent;
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE) && !is_flee)
-	{
-		if (IS_NPC(ch))
-			invis = 1;
-		else if (awake_camouflage(ch))
-		{
-			affect_from_char(ch, SPELL_CAMOUFLAGE);
-		}
-		else
-			if (!affected_by_spell(ch, SPELL_CAMOUFLAGE) ||
-					calculate_skill(ch, SKILL_CAMOUFLAGE, 0) >= number(1, i))
-				invis = 1;
-	}
+    if (track) {
+      SET_BIT(track->time_income[Reverse[dir]], 1);
+      if (affected_by_spell(ch, SPELL_LIGHT_WALK) && !ch->ahorse())
+        if (AFF_FLAGGED(ch, EAffectFlag::AFF_LIGHT_WALK))
+          track->time_income[Reverse[dir]] <<= number(15, 30);
+      REMOVE_BIT(track->track_info, TRACK_HIDE);
+    }
 
-	if (!is_flee)
-	{
-		sprintf(buf, "Вы поплелись %s%s.", leader ? "следом за $N4 " : "", DirsTo[dir]);
-		act(buf, FALSE, ch, 0, leader, TO_CHAR);
-	}
+    for (track = world[was_in]->track; track; track = track->next)
+      if ((IS_NPC(ch) && IS_SET(track->track_info, TRACK_NPC)
+          && track->who == mob_rnum) || (!IS_NPC(ch)
+          && !IS_SET(track->track_info, TRACK_NPC)
+          && track->who == GET_IDNUM(ch)))
+        break;
 
-	was_in = ch->in_room;
-	go_to = world[was_in]->dir_option[dir]->to_room();
-	direction = dir + 1;
-	use_horse = ch->ahorse() && ch->has_horse(false)
-	            && (IN_ROOM(ch->get_horse()) == was_in || IN_ROOM(ch->get_horse()) == go_to);
-	is_horse = IS_HORSE(ch)
-		&& ch->has_master()
-		&& !AFF_FLAGGED(ch->get_master(), EAffectFlag::AFF_INVISIBLE)
-		&& (IN_ROOM(ch->get_master()) == was_in
-			|| IN_ROOM(ch->get_master()) == go_to);
+    if (!track && !ROOM_FLAGGED(was_in, ROOM_NOTRACK)) {
+      CREATE(track, 1);
+      track->track_info = IS_NPC(ch) ? TRACK_NPC : 0;
+      track->who = IS_NPC(ch) ? mob_rnum : GET_IDNUM(ch);
+      track->next = world[was_in]->track;
+      world[was_in]->track = track;
+    }
+    if (track) {
+      SET_BIT(track->time_outgone[dir], 1);
+      if (affected_by_spell(ch, SPELL_LIGHT_WALK) && !ch->ahorse())
+        if (AFF_FLAGGED(ch, EAffectFlag::AFF_LIGHT_WALK))
+          track->time_outgone[dir] <<= number(15, 30);
+      REMOVE_BIT(track->track_info, TRACK_HIDE);
+    }
+  }
 
-	if (!invis && !is_horse)
-	{
-		if (is_flee)
-			strcpy(smallBuf, "сбежал$g");
-		else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVERUN))
-			strcpy(smallBuf, "убежал$g");
-		else if ((!use_horse && AFF_FLAGGED(ch, EAffectFlag::AFF_FLY))
-			|| (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVEFLY)))
-		{
-			strcpy(smallBuf, "улетел$g");
-		}
-		else if (IS_NPC(ch)
-			&& NPC_FLAGGED(ch, NPC_MOVESWIM)
-			&& (real_sector(was_in) == SECT_WATER_SWIM
-				|| real_sector(was_in) == SECT_WATER_NOSWIM
-				|| real_sector(was_in) == SECT_UNDERWATER))
-		{
-			strcpy(smallBuf, "уплыл$g");
-		}
-		else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVEJUMP))
-			strcpy(smallBuf, "ускакал$g");
-		else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVECREEP))
-			strcpy(smallBuf, "уполз$q");
-		else if (real_sector(was_in) == SECT_WATER_SWIM
-			|| real_sector(was_in) == SECT_WATER_NOSWIM
-			|| real_sector(was_in) == SECT_UNDERWATER)
-		{
-			strcpy(smallBuf, "уплыл$g");
-		}
-		else if (use_horse)
-		{
-			horse = ch->get_horse();
-			if (horse && AFF_FLAGGED(horse, EAffectFlag::AFF_FLY))
-				strcpy(smallBuf, "улетел$g");
-			else
-				strcpy(smallBuf, "уехал$g");
-		}
-		else
-			strcpy(smallBuf, "уш$y");
+  // hide improovment
+  if (IS_NPC(ch)) {
+    for (const auto vict : world[ch->in_room]->people) {
+      if (!IS_NPC(vict)) {
+        skip_hiding(vict, ch);
+      }
+    }
+  }
 
-		if (is_flee && !IS_NPC(ch) && can_use_feat(ch, WRIGGLER_FEAT))
-			sprintf(buf2, "$n %s.", smallBuf);
-		else
-			sprintf(buf2, "$n %s %s.", smallBuf, DirsTo[dir]);
-		act(buf2, TRUE, ch, 0, 0, TO_ROOM);
-	}
+  income_mtrigger(ch, direction - 1);
 
-	if (invis && !is_horse)
-	{
-		act("Кто-то тихо удалился отсюда.", TRUE, ch, 0, 0, TO_ROOM_HIDE);
-	}
+  if (ch->purged())
+    return FALSE;
 
-	if (ch->ahorse())
-		horse = ch->get_horse();
+  // char income, go mobs action
+  if (!IS_NPC(ch)) {
+    for (const auto vict : world[ch->in_room]->people) {
+      if (!IS_NPC(vict)) {
+        continue;
+      }
 
-	// Если сбежали, и по противнику никто не бьет, то убираем с него аттаку
-	if (is_flee)
-	{
-		stop_fighting(ch, TRUE);
-	}
+      if (!CAN_SEE(vict, ch)
+          || AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK)
+          || AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE)
+          || vict->get_fighting()
+          || GET_POS(vict) < POS_RESTING) {
+        continue;
+      }
 
-	if (!IS_NPC(ch) && IS_BITS(ch->track_dirs, dir))
-	{
-		send_to_char("Вы двинулись по следу.\r\n", ch);
-		improve_skill(ch, SKILL_TRACK, TRUE, 0);
-	}
+      // AWARE mobs
+      if (MOB_FLAGGED(vict, MOB_AWARE)
+          && GET_POS(vict) < POS_FIGHTING
+          && !AFF_FLAGGED(vict, EAffectFlag::AFF_HOLD)
+          && GET_POS(vict) > POS_SLEEPING) {
+        act("$n поднял$u.", FALSE, vict, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        GET_POS(vict) = POS_STANDING;
+      }
+    }
+  }
 
-	char_from_room(ch);
-	//затычка для бегства. чтоьы не отрабатывал MSDP протокол
-	if (is_flee && !IS_NPC(ch) && !can_use_feat(ch, CALMNESS_FEAT))
-		char_flee_to_room(ch, go_to);
-	else
-		char_to_room(ch, go_to);
-	if (horse)
-	{
-		GET_HORSESTATE(horse) -= 1;
-		char_from_room(horse);
-		char_to_room(horse, go_to);
-	}
+  // If flee - go agressive mobs
+  if (!IS_NPC(ch)
+      && is_flee) {
+    do_aggressive_room(ch, FALSE);
+  }
 
-	if (PRF_FLAGGED(ch, PRF_BLIND))
-	{
-		for (int i = 0; i < NUM_OF_DIRS; i++)
-		{
-			if (CAN_GO(ch, i)
-				|| (EXIT(ch, i)
-					&& EXIT(ch, i)->to_room() != NOWHERE))
-			{
-				const auto& rdata = EXIT(ch, i);
-				if (ROOM_FLAGGED(rdata->to_room(), ROOM_DEATH))
-				{
-					send_to_char("\007", ch);
-				}
-			}
-	    }
-	}
-
-	if (!invis && !is_horse)
-	{
-		if (is_flee
-			|| (IS_NPC(ch)
-				&& NPC_FLAGGED(ch, NPC_MOVERUN)))
-		{
-			strcpy(smallBuf, "прибежал$g");
-		}
-		else if ((!use_horse && AFF_FLAGGED(ch, EAffectFlag::AFF_FLY))
-			|| (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVEFLY)))
-		{
-			strcpy(smallBuf, "прилетел$g");
-		}
-		else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVESWIM)
-			&& (real_sector(go_to) == SECT_WATER_SWIM
-				|| real_sector(go_to) == SECT_WATER_NOSWIM
-				|| real_sector(go_to) == SECT_UNDERWATER))
-		{
-			strcpy(smallBuf, "приплыл$g");
-		}
-		else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVEJUMP))
-			strcpy(smallBuf, "прискакал$g");
-		else if (IS_NPC(ch) && NPC_FLAGGED(ch, NPC_MOVECREEP))
-			strcpy(smallBuf, "приполз$q");
-		else if (real_sector(go_to) == SECT_WATER_SWIM
-			|| real_sector(go_to) == SECT_WATER_NOSWIM
-			|| real_sector(go_to) == SECT_UNDERWATER)
-		{
-			strcpy(smallBuf, "приплыл$g");
-		}
-		else if (use_horse)
-		{
-			horse = ch->get_horse();
-			if (horse && AFF_FLAGGED(horse, EAffectFlag::AFF_FLY))
-			{
-				strcpy(smallBuf, "прилетел$g");
-			}
-			else
-			{
-				strcpy(smallBuf, "приехал$g");
-			}
-
-		}
-		else
-			strcpy(smallBuf, "приш$y");
-
-		//log("%s-%d",GET_NAME(ch),ch->in_room);
-		sprintf(buf2, "$n %s %s.", smallBuf, DirsFrom[dir]);
-		//log(buf2);
-		act(buf2, TRUE, ch, 0, 0, TO_ROOM);
-		//log("ACT OK !");
-	};
-
-	if (invis && !is_horse)
-	{
-		act("Кто-то тихо подкрался сюда.", TRUE, ch, 0, 0, TO_ROOM_HIDE);
-	}
-
-	if (ch->desc != NULL)
-		look_at_room(ch, 0);
-
-	if (!IS_NPC(ch))
-		room_affect_process_on_entry(ch, ch->in_room);
-
-	if (DeathTrap::check_death_trap(ch))
-	{
-		if (horse)
-		{
-			extract_char(horse, FALSE);
-		}
-		return (FALSE);
-	}
-
-	if (check_death_ice(go_to, ch))
-	{
-		return (FALSE);
-	}
-
-	if (DeathTrap::tunnel_damage(ch))
-	{
-		return (FALSE);
-	}
-
-	greet_mtrigger(ch, dir);
-	greet_otrigger(ch, dir);
-
-	// add track info
-	if (!AFF_FLAGGED(ch, EAffectFlag::AFF_NOTRACK)
-		&& (!IS_NPC(ch)
-			|| (mob_rnum = GET_MOB_RNUM(ch)) >= 0))
-	{
-		for (track = world[go_to]->track; track; track = track->next)
-		{
-			if ((IS_NPC(ch) && IS_SET(track->track_info, TRACK_NPC) && track->who == mob_rnum)
-				|| (!IS_NPC(ch) && !IS_SET(track->track_info, TRACK_NPC) && track->who == GET_IDNUM(ch)))
-			{
-				break;
-			}
-		}
-
-		if (!track && !ROOM_FLAGGED(go_to, ROOM_NOTRACK))
-		{
-			CREATE(track, 1);
-			track->track_info = IS_NPC(ch) ? TRACK_NPC : 0;
-			track->who = IS_NPC(ch) ? mob_rnum : GET_IDNUM(ch);
-			track->next = world[go_to]->track;
-			world[go_to]->track = track;
-		}
-
-		if (track)
-		{
-			SET_BIT(track->time_income[Reverse[dir]], 1);
-			if (affected_by_spell(ch, SPELL_LIGHT_WALK) && !ch->ahorse())
-				if (AFF_FLAGGED(ch, EAffectFlag::AFF_LIGHT_WALK))
-					track->time_income[Reverse[dir]] <<= number(15, 30);
-			REMOVE_BIT(track->track_info, TRACK_HIDE);
-		}
-
-		for (track = world[was_in]->track; track; track = track->next)
-			if ((IS_NPC(ch) && IS_SET(track->track_info, TRACK_NPC)
-					&& track->who == mob_rnum) || (!IS_NPC(ch)
-													&& !IS_SET(track->track_info, TRACK_NPC)
-													&& track->who == GET_IDNUM(ch)))
-				break;
-
-		if (!track && !ROOM_FLAGGED(was_in, ROOM_NOTRACK))
-		{
-			CREATE(track, 1);
-			track->track_info = IS_NPC(ch) ? TRACK_NPC : 0;
-			track->who = IS_NPC(ch) ? mob_rnum : GET_IDNUM(ch);
-			track->next = world[was_in]->track;
-			world[was_in]->track = track;
-		}
-		if (track)
-		{
-			SET_BIT(track->time_outgone[dir], 1);
-			if (affected_by_spell(ch, SPELL_LIGHT_WALK) && !ch->ahorse())
-				if (AFF_FLAGGED(ch, EAffectFlag::AFF_LIGHT_WALK))
-					track->time_outgone[dir] <<= number(15, 30);
-			REMOVE_BIT(track->track_info, TRACK_HIDE);
-		}
-	}
-
-	// hide improovment
-	if (IS_NPC(ch))
-	{
-		for (const auto vict : world[ch->in_room]->people)
-		{
-			if (!IS_NPC(vict))
-			{
-				skip_hiding(vict, ch);
-			}
-		}
-	}
-
-	income_mtrigger(ch, direction - 1);
-
-	if (ch->purged())
-		return FALSE;
-
-	// char income, go mobs action
-	if (!IS_NPC(ch))
-	{
-		for (const auto vict : world[ch->in_room]->people)
-		{
-			if (!IS_NPC(vict))
-			{
-				continue;
-			}
-
-			if (!CAN_SEE(vict, ch)
-				|| AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK)
-				|| AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE)
-				|| vict->get_fighting()
-				|| GET_POS(vict) < POS_RESTING)
-			{
-				continue;
-			}
-
-			// AWARE mobs
-			if (MOB_FLAGGED(vict, MOB_AWARE)
-				&& GET_POS(vict) < POS_FIGHTING
-				&& !AFF_FLAGGED(vict, EAffectFlag::AFF_HOLD)
-				&& GET_POS(vict) > POS_SLEEPING)
-			{
-				act("$n поднял$u.", FALSE, vict, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-				GET_POS(vict) = POS_STANDING;
-			}
-		}
-	}
-
-	// If flee - go agressive mobs
-	if (!IS_NPC(ch)
-		&& is_flee)
-	{
-		do_aggressive_room(ch, FALSE);
-	}
-
-	return direction;
+  return direction;
 }
 
-int perform_move(CHAR_DATA *ch, int dir, int need_specials_check, int checkmob, CHAR_DATA *master)
-{
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_BANDAGE))
-	{
-		send_to_char("Перевязка была прервана!\r\n", ch);
-		affect_from_char(ch, SPELL_BANDAGE);
-	}
-	ch->set_motion(true);
+int perform_move(CHAR_DATA *ch, int dir, int need_specials_check, int checkmob, CHAR_DATA *master) {
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BANDAGE)) {
+    send_to_char("Перевязка была прервана!\r\n", ch);
+    affect_from_char(ch, SPELL_BANDAGE);
+  }
+  ch->set_motion(true);
 
-	room_rnum was_in;
-	struct follow_type *k, *next;
+  room_rnum was_in;
+  struct follow_type *k, *next;
 
-	if (ch == nullptr || dir < 0 || dir >= NUM_OF_DIRS || ch->get_fighting())
-		return FALSE;
-	else if (!EXIT(ch, dir) || EXIT(ch, dir)->to_room() == NOWHERE)
-		send_to_char("Вы не сможете туда пройти...\r\n", ch);
-	else if (EXIT_FLAGGED(EXIT(ch, dir), EX_CLOSED))
-	{
-		if (EXIT(ch, dir)->keyword)
-		{
-			sprintf(buf2, "Закрыто (%s).\r\n", EXIT(ch, dir)->keyword);
-			send_to_char(buf2, ch);
-		}
-		else
-			send_to_char("Закрыто.\r\n", ch);
-	}
-	else
-	{
-		if (!ch->followers)
-		{
-			if (!do_simple_move(ch, dir, need_specials_check, master, false))
-				return (FALSE);
-		}
-		else
-		{
-			was_in = ch->in_room;
-			// When leader mortally drunked - he change direction
-			// So returned value set to FALSE or DIR + 1
-			if (!(dir = do_simple_move(ch, dir, need_specials_check, master, false)))
-				return (FALSE);
+  if (ch == nullptr || dir < 0 || dir >= NUM_OF_DIRS || ch->get_fighting())
+    return FALSE;
+  else if (!EXIT(ch, dir) || EXIT(ch, dir)->to_room() == NOWHERE)
+    send_to_char("Вы не сможете туда пройти...\r\n", ch);
+  else if (EXIT_FLAGGED(EXIT(ch, dir), EX_CLOSED)) {
+    if (EXIT(ch, dir)->keyword) {
+      sprintf(buf2, "Закрыто (%s).\r\n", EXIT(ch, dir)->keyword);
+      send_to_char(buf2, ch);
+    } else
+      send_to_char("Закрыто.\r\n", ch);
+  } else {
+    if (!ch->followers) {
+      if (!do_simple_move(ch, dir, need_specials_check, master, false))
+        return (FALSE);
+    } else {
+      was_in = ch->in_room;
+      // When leader mortally drunked - he change direction
+      // So returned value set to FALSE or DIR + 1
+      if (!(dir = do_simple_move(ch, dir, need_specials_check, master, false)))
+        return (FALSE);
 
-			--dir;
-			for (k = ch->followers; k && k->follower->get_master(); k = next)
-			{
-				next = k->next;
-				if (k->follower->in_room == was_in
-					&& !k->follower->get_fighting()
-					&& HERE(k->follower)
-					&& !GET_MOB_HOLD(k->follower)
-					&& AWAKE(k->follower)
-					&& (IS_NPC(k->follower)
-						|| (!PLR_FLAGGED(k->follower, PLR_MAILING)
-							&& !PLR_FLAGGED(k->follower, PLR_WRITING)))
-					&& (!IS_HORSE(k->follower)
-						|| !AFF_FLAGGED(k->follower, EAffectFlag::AFF_TETHERED)))
-				{
-					if (GET_POS(k->follower) < POS_STANDING)
-					{
-						if (IS_NPC(k->follower)
-							&& IS_NPC(k->follower->get_master())
-							&& GET_POS(k->follower) > POS_SLEEPING
-							&& !GET_WAIT(k->follower))
-						{
-							act("$n поднял$u.", FALSE, k->follower, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-							GET_POS(k->follower) = POS_STANDING;
-						}
-						else
-						{
-							continue;
-						}
-					}
+      --dir;
+      for (k = ch->followers; k && k->follower->get_master(); k = next) {
+        next = k->next;
+        if (k->follower->in_room == was_in
+            && !k->follower->get_fighting()
+            && HERE(k->follower)
+            && !GET_MOB_HOLD(k->follower)
+            && AWAKE(k->follower)
+            && (IS_NPC(k->follower)
+                || (!PLR_FLAGGED(k->follower, PLR_MAILING)
+                    && !PLR_FLAGGED(k->follower, PLR_WRITING)))
+            && (!IS_HORSE(k->follower)
+                || !AFF_FLAGGED(k->follower, EAffectFlag::AFF_TETHERED))) {
+          if (GET_POS(k->follower) < POS_STANDING) {
+            if (IS_NPC(k->follower)
+                && IS_NPC(k->follower->get_master())
+                && GET_POS(k->follower) > POS_SLEEPING
+                && !GET_WAIT(k->follower)) {
+              act("$n поднял$u.", FALSE, k->follower, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+              GET_POS(k->follower) = POS_STANDING;
+            } else {
+              continue;
+            }
+          }
 //                   act("Вы поплелись следом за $N4.",FALSE,k->follower,0,ch,TO_CHAR);
-					perform_move(k->follower, dir, 1, FALSE, ch);
-				}
-			}
-		}
-		if (checkmob)
-		{
-			do_aggressive_room(ch, TRUE);
-		}
-		return (TRUE);
-	}
-	return (FALSE);
+          perform_move(k->follower, dir, 1, FALSE, ch);
+        }
+      }
+    }
+    if (checkmob) {
+      do_aggressive_room(ch, TRUE);
+    }
+    return (TRUE);
+  }
+  return (FALSE);
 }
 
-void do_move(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int subcmd)
-{
-	/*
-	 * This is basically a mapping of cmd numbers to perform_move indices.
-	 * It cannot be done in perform_move because perform_move is called
-	 * by other functions which do not require the remapping.
-	 */
-	perform_move(ch, subcmd - 1, 0, TRUE, 0);
+void do_move(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int subcmd) {
+  /*
+   * This is basically a mapping of cmd numbers to perform_move indices.
+   * It cannot be done in perform_move because perform_move is called
+   * by other functions which do not require the remapping.
+   */
+  perform_move(ch, subcmd - 1, 0, TRUE, 0);
 }
 
-void do_hidemove(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	int dir = 0, sneaking = affected_by_spell(ch, SPELL_SNEAK);
+void do_hidemove(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  int dir = 0, sneaking = affected_by_spell(ch, SPELL_SNEAK);
 
-	skip_spaces(&argument);
-	if (!ch->get_skill(SKILL_SNEAK))
-	{
-		send_to_char("Вы не умеете этого.\r\n", ch);
-		return;
-	}
+  skip_spaces(&argument);
+  if (!ch->get_skill(SKILL_SNEAK)) {
+    send_to_char("Вы не умеете этого.\r\n", ch);
+    return;
+  }
 
-	if (!*argument)
-	{
-		send_to_char("И куда это вы направляетесь?\r\n", ch);
-		return;
-	}
+  if (!*argument) {
+    send_to_char("И куда это вы направляетесь?\r\n", ch);
+    return;
+  }
 
-	if ((dir = search_block(argument, dirs, FALSE)) < 0 && (dir = search_block(argument, DirIs, FALSE)) < 0)
-	{
-		send_to_char("Неизвестное направление.\r\n", ch);
-		return;
-	}
-	if (ch->ahorse())
-	{
-		act("Вам мешает $N.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-		return;
-	}
-	if (!sneaking)
-	{
-		AFFECT_DATA<EApplyLocation> af;
-		af.type = SPELL_SNEAK;
-		af.location = EApplyLocation::APPLY_NONE;
-		af.modifier = 0;
-		af.duration = 1;
-		const int calculated_skill = calculate_skill(ch, SKILL_SNEAK, 0);
-		const int chance = number(1, skill_info[SKILL_SNEAK].max_percent);
-		af.bitvector = (chance < calculated_skill) ? to_underlying(EAffectFlag::AFF_SNEAK) : 0;
-		af.battleflag = 0;
-		affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-	}
-	perform_move(ch, dir, 0, TRUE, 0);
-	if (!sneaking || affected_by_spell(ch, SPELL_GLITTERDUST))
-	{
-		affect_from_char(ch, SPELL_SNEAK);
-	}
+  if ((dir = search_block(argument, dirs, FALSE)) < 0 && (dir = search_block(argument, DirIs, FALSE)) < 0) {
+    send_to_char("Неизвестное направление.\r\n", ch);
+    return;
+  }
+  if (ch->ahorse()) {
+    act("Вам мешает $N.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+    return;
+  }
+  if (!sneaking) {
+    AFFECT_DATA<EApplyLocation> af;
+    af.type = SPELL_SNEAK;
+    af.location = EApplyLocation::APPLY_NONE;
+    af.modifier = 0;
+    af.duration = 1;
+    const int calculated_skill = calculate_skill(ch, SKILL_SNEAK, 0);
+    const int chance = number(1, skill_info[SKILL_SNEAK].max_percent);
+    af.bitvector = (chance < calculated_skill) ? to_underlying(EAffectFlag::AFF_SNEAK) : 0;
+    af.battleflag = 0;
+    affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+  }
+  perform_move(ch, dir, 0, TRUE, 0);
+  if (!sneaking || affected_by_spell(ch, SPELL_GLITTERDUST)) {
+    affect_from_char(ch, SPELL_SNEAK);
+  }
 }
 
-#define DOOR_IS_OPENABLE(ch, obj, door)	((obj) ? \
-			((GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_CONTAINER) && \
-			OBJVAL_FLAGGED(obj, CONT_CLOSEABLE)) :\
-			(EXIT_FLAGGED(EXIT(ch, door), EX_ISDOOR)))
-#define DOOR_IS(ch, door)	((EXIT_FLAGGED(EXIT(ch, door), EX_ISDOOR)))
+#define DOOR_IS_OPENABLE(ch, obj, door)    ((obj) ? \
+            ((GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_CONTAINER) && \
+            OBJVAL_FLAGGED(obj, CONT_CLOSEABLE)) :\
+            (EXIT_FLAGGED(EXIT(ch, door), EX_ISDOOR)))
+#define DOOR_IS(ch, door)    ((EXIT_FLAGGED(EXIT(ch, door), EX_ISDOOR)))
 
-#define DOOR_IS_OPEN(ch, obj, door)	((obj) ? \
-			(!OBJVAL_FLAGGED(obj, CONT_CLOSED)) :\
-			(!EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED)))
-#define DOOR_IS_BROKEN(ch, obj, door)	((obj) ? \
-	(OBJVAL_FLAGGED(obj, CONT_BROKEN)) :\
-	(EXIT_FLAGGED(EXIT(ch, door), EX_BROKEN)))
-#define DOOR_IS_UNLOCKED(ch, obj, door)	((obj) ? \
-			(!OBJVAL_FLAGGED(obj, CONT_LOCKED)) :\
-			(!EXIT_FLAGGED(EXIT(ch, door), EX_LOCKED)))
+#define DOOR_IS_OPEN(ch, obj, door)    ((obj) ? \
+            (!OBJVAL_FLAGGED(obj, CONT_CLOSED)) :\
+            (!EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED)))
+#define DOOR_IS_BROKEN(ch, obj, door)    ((obj) ? \
+    (OBJVAL_FLAGGED(obj, CONT_BROKEN)) :\
+    (EXIT_FLAGGED(EXIT(ch, door), EX_BROKEN)))
+#define DOOR_IS_UNLOCKED(ch, obj, door)    ((obj) ? \
+            (!OBJVAL_FLAGGED(obj, CONT_LOCKED)) :\
+            (!EXIT_FLAGGED(EXIT(ch, door), EX_LOCKED)))
 #define DOOR_IS_PICKPROOF(ch, obj, door) ((obj) ? \
-	(OBJVAL_FLAGGED(obj, CONT_PICKPROOF) || OBJVAL_FLAGGED(obj, CONT_BROKEN)) : \
-	(EXIT_FLAGGED(EXIT(ch, door), EX_PICKPROOF) || EXIT_FLAGGED(EXIT(ch, door), EX_BROKEN)))
+    (OBJVAL_FLAGGED(obj, CONT_PICKPROOF) || OBJVAL_FLAGGED(obj, CONT_BROKEN)) : \
+    (EXIT_FLAGGED(EXIT(ch, door), EX_PICKPROOF) || EXIT_FLAGGED(EXIT(ch, door), EX_BROKEN)))
 
-#define DOOR_IS_CLOSED(ch, obj, door)	(!(DOOR_IS_OPEN(ch, obj, door)))
-#define DOOR_IS_LOCKED(ch, obj, door)	(!(DOOR_IS_UNLOCKED(ch, obj, door)))
-#define DOOR_KEY(ch, obj, door)		((obj) ? (GET_OBJ_VAL(obj, 2)) : \
-					(EXIT(ch, door)->key))
-#define DOOR_LOCK(ch, obj, door)	((obj) ? (GET_OBJ_VAL(obj, 1)) : \
-					(EXIT(ch, door)->exit_info))
+#define DOOR_IS_CLOSED(ch, obj, door)    (!(DOOR_IS_OPEN(ch, obj, door)))
+#define DOOR_IS_LOCKED(ch, obj, door)    (!(DOOR_IS_UNLOCKED(ch, obj, door)))
+#define DOOR_KEY(ch, obj, door)        ((obj) ? (GET_OBJ_VAL(obj, 2)) : \
+                    (EXIT(ch, door)->key))
+#define DOOR_LOCK(ch, obj, door)    ((obj) ? (GET_OBJ_VAL(obj, 1)) : \
+                    (EXIT(ch, door)->exit_info))
 #define DOOR_LOCK_COMPLEX(ch, obj, door) ((obj) ? \
-			(GET_OBJ_VAL(obj,3)) :\
-			(EXIT(ch, door)->lock_complexity))
+            (GET_OBJ_VAL(obj,3)) :\
+            (EXIT(ch, door)->lock_complexity))
 
-int find_door(CHAR_DATA* ch, const char *type, char *dir,  DOOR_SCMD scmd) {
-	int door;
-	bool found = false;
+int find_door(CHAR_DATA *ch, const char *type, char *dir, DOOR_SCMD scmd) {
+  int door;
+  bool found = false;
 
-	if (*dir)  //Указано направление (второй аргумент)
-	{
-		//Проверяем соответствует ли аргумент английским или русским направлениям
-		if ((door = search_block(dir, dirs, FALSE)) == -1 && (door = search_block(dir, DirIs, FALSE)) == -1)  	// Partial Match
-		{
-			//strcpy(doorbuf,"Уточните направление.\r\n");
-			return (FD_WRONG_DIR); //НЕВЕРНОЕ НАПРАВЛЕНИЕ
-		}
-		if (EXIT(ch, door)) { //Проверяем есть ли такая дверь в указанном направлении
-			if (EXIT(ch, door)->keyword && EXIT(ch, door)->vkeyword) {//Дверь как-то по-особенному называется?
-				if (isname(type, EXIT(ch, door)->keyword) || isname(type, EXIT(ch, door)->vkeyword))
-					//Первый аргумент соответствует именительному или винительному алиасу двери
-					return (door);
-				else
-					return (FD_WRONG_DOOR_NAME); //НЕ ПРАВИЛЬНО НАЗВАЛИ ДВЕРЬ В ЭТОМ НАПРАВЛЕНИИ
-			}
-			else if (is_abbrev(type, "дверь") || is_abbrev(type, "door")) {
-				//Аргумент соответствует "дверь" или "door" и есть в указанном направлении
-				return (door);
-			}
-			else
-				//Дверь с названием "дверь" есть, но аргумент не соответствует
-				return (FD_DOORNAME_WRONG);
-		}
-		else
-		{
-			return (FD_NO_DOOR_GIVEN_DIR); //В ЭТОМ НАПРАВЛЕНИИ НЕТ ДВЕРЕЙ
-		}
-	}
-	else //Направления не указано, ищем дверь по названию
-	{
-		if (!*type) { //Названия не указано
-			return (FD_DOORNAME_EMPTY); //НЕ УКАЗАНО АРГУМЕНТОВ
-		}
-		for (door = 0; door < NUM_OF_DIRS; door++) {//Проверяем все направления, не найдется ли двери?
-			found = false;
-			if (EXIT(ch, door)) {//Есть выход в этом направлении
-				if (EXIT(ch, door)->keyword && EXIT(ch, door)->vkeyword) { //Дверь как-то по-особенному называется?
-					if (isname(type, EXIT(ch, door)->keyword) || isname(type, EXIT(ch, door)->vkeyword))
-						//Аргумент соответствует имени этой двери
-						found = true;
-				}
-				else if (DOOR_IS(ch, door) && (is_abbrev(type, "дверь") || is_abbrev(type, "door")))
-					//Дверь не имеет особых алиасов, аргумент соответствует двери
-					found = true;
-			}
-			// дверь найдена проверяем ейный статус.
-			// скипуем попытку закрыть закрытую и открыть открытую.
-			// остальные статусы двери автоматом не проверяются.
-			if (found) {
-				if ((scmd == SCMD_OPEN && DOOR_IS_OPEN(ch, nullptr, door)) ||
-					(scmd == SCMD_CLOSE && DOOR_IS_CLOSED(ch, nullptr, door) ))
-					continue;
-				else
-					return door;
-			}
-		}
-		return (FD_DOORNAME_WRONG); //НЕПРАВИЛЬНО НАЗВАЛИ ДВЕРЬ БЕЗ УКАЗАНИЯ НАПРАВЛЕНИЯ
-	}
+  if (*dir)  //Указано направление (второй аргумент)
+  {
+    //Проверяем соответствует ли аргумент английским или русским направлениям
+    if ((door = search_block(dir, dirs, FALSE)) == -1
+        && (door = search_block(dir, DirIs, FALSE)) == -1)    // Partial Match
+    {
+      //strcpy(doorbuf,"Уточните направление.\r\n");
+      return (FD_WRONG_DIR); //НЕВЕРНОЕ НАПРАВЛЕНИЕ
+    }
+    if (EXIT(ch, door)) { //Проверяем есть ли такая дверь в указанном направлении
+      if (EXIT(ch, door)->keyword && EXIT(ch, door)->vkeyword) {//Дверь как-то по-особенному называется?
+        if (isname(type, EXIT(ch, door)->keyword) || isname(type, EXIT(ch, door)->vkeyword))
+          //Первый аргумент соответствует именительному или винительному алиасу двери
+          return (door);
+        else
+          return (FD_WRONG_DOOR_NAME); //НЕ ПРАВИЛЬНО НАЗВАЛИ ДВЕРЬ В ЭТОМ НАПРАВЛЕНИИ
+      } else if (is_abbrev(type, "дверь") || is_abbrev(type, "door")) {
+        //Аргумент соответствует "дверь" или "door" и есть в указанном направлении
+        return (door);
+      } else
+        //Дверь с названием "дверь" есть, но аргумент не соответствует
+        return (FD_DOORNAME_WRONG);
+    } else {
+      return (FD_NO_DOOR_GIVEN_DIR); //В ЭТОМ НАПРАВЛЕНИИ НЕТ ДВЕРЕЙ
+    }
+  } else //Направления не указано, ищем дверь по названию
+  {
+    if (!*type) { //Названия не указано
+      return (FD_DOORNAME_EMPTY); //НЕ УКАЗАНО АРГУМЕНТОВ
+    }
+    for (door = 0; door < NUM_OF_DIRS; door++) {//Проверяем все направления, не найдется ли двери?
+      found = false;
+      if (EXIT(ch, door)) {//Есть выход в этом направлении
+        if (EXIT(ch, door)->keyword && EXIT(ch, door)->vkeyword) { //Дверь как-то по-особенному называется?
+          if (isname(type, EXIT(ch, door)->keyword) || isname(type, EXIT(ch, door)->vkeyword))
+            //Аргумент соответствует имени этой двери
+            found = true;
+        } else if (DOOR_IS(ch, door) && (is_abbrev(type, "дверь") || is_abbrev(type, "door")))
+          //Дверь не имеет особых алиасов, аргумент соответствует двери
+          found = true;
+      }
+      // дверь найдена проверяем ейный статус.
+      // скипуем попытку закрыть закрытую и открыть открытую.
+      // остальные статусы двери автоматом не проверяются.
+      if (found) {
+        if ((scmd == SCMD_OPEN && DOOR_IS_OPEN(ch, nullptr, door)) ||
+            (scmd == SCMD_CLOSE && DOOR_IS_CLOSED(ch, nullptr, door)))
+          continue;
+        else
+          return door;
+      }
+    }
+    return (FD_DOORNAME_WRONG); //НЕПРАВИЛЬНО НАЗВАЛИ ДВЕРЬ БЕЗ УКАЗАНИЯ НАПРАВЛЕНИЯ
+  }
 
 }
 
-int has_key(CHAR_DATA * ch, obj_vnum key)
-{
-	for (auto o = ch->carrying; o; o = o->get_next_content())
-	{
-		if (GET_OBJ_VNUM(o) == key && key != -1)
-		{
-			return (TRUE);
-		}
-	}
+int has_key(CHAR_DATA *ch, obj_vnum key) {
+  for (auto o = ch->carrying; o; o = o->get_next_content()) {
+    if (GET_OBJ_VNUM(o) == key && key != -1) {
+      return (TRUE);
+    }
+  }
 
-	if (GET_EQ(ch, WEAR_HOLD))
-	{
-		if (GET_OBJ_VNUM(GET_EQ(ch, WEAR_HOLD)) == key && key != -1)
-		{
-			return (TRUE);
-		}
-	}
+  if (GET_EQ(ch, WEAR_HOLD)) {
+    if (GET_OBJ_VNUM(GET_EQ(ch, WEAR_HOLD)) == key && key != -1) {
+      return (TRUE);
+    }
+  }
 
-	return (FALSE);
+  return (FALSE);
 }
 
-
-
-#define NEED_OPEN	(1 << 0)
-#define NEED_CLOSED	(1 << 1)
-#define NEED_UNLOCKED	(1 << 2)
-#define NEED_LOCKED	(1 << 3)
+#define NEED_OPEN    (1 << 0)
+#define NEED_CLOSED    (1 << 1)
+#define NEED_UNLOCKED    (1 << 2)
+#define NEED_LOCKED    (1 << 3)
 
 const char *cmd_door[] =
-{
-	"открыл$g",
-	"закрыл$g",
-	"отпер$q",
-	"запер$q",
-	"взломал$g"
-};
+    {
+        "открыл$g",
+        "закрыл$g",
+        "отпер$q",
+        "запер$q",
+        "взломал$g"
+    };
 
 const char *a_cmd_door[] =
-{
-	"открыть",
-	"закрыть",
-	"отпереть",
-	"запереть",
-	"взломать"
-};
+    {
+        "открыть",
+        "закрыть",
+        "отпереть",
+        "запереть",
+        "взломать"
+    };
 
 const int flags_door[] =
-{
-	NEED_CLOSED | NEED_UNLOCKED,
-	NEED_OPEN,
-	NEED_CLOSED | NEED_LOCKED,
-	NEED_CLOSED | NEED_UNLOCKED,
-	NEED_CLOSED | NEED_LOCKED
-};
+    {
+        NEED_CLOSED | NEED_UNLOCKED,
+        NEED_OPEN,
+        NEED_CLOSED | NEED_LOCKED,
+        NEED_CLOSED | NEED_UNLOCKED,
+        NEED_CLOSED | NEED_LOCKED
+    };
 
+#define EXITN(room, door)        (world[room]->dir_option[door])
 
-#define EXITN(room, door)		(world[room]->dir_option[door])
-
-inline void OPEN_DOOR(const room_rnum room, OBJ_DATA* obj, const int door)
-{
-	if (obj) {
-		auto v = obj->get_val(1);
-		TOGGLE_BIT(v, CONT_CLOSED);
-		obj->set_val(1, v);
-	}
-	else {
-		TOGGLE_BIT(EXITN(room, door)->exit_info, EX_CLOSED);
-	}
+inline void OPEN_DOOR(const room_rnum room, OBJ_DATA *obj, const int door) {
+  if (obj) {
+    auto v = obj->get_val(1);
+    TOGGLE_BIT(v, CONT_CLOSED);
+    obj->set_val(1, v);
+  } else {
+    TOGGLE_BIT(EXITN(room, door)->exit_info, EX_CLOSED);
+  }
 }
 
-inline void LOCK_DOOR(const room_rnum room, OBJ_DATA* obj, const int door)
-{
-	if (obj) {
-		auto v = obj->get_val(1);
-		TOGGLE_BIT(v, CONT_LOCKED);
-		obj->set_val(1, v);
-	}
-	else {
-		TOGGLE_BIT(EXITN(room, door)->exit_info, EX_LOCKED);
-	}
+inline void LOCK_DOOR(const room_rnum room, OBJ_DATA *obj, const int door) {
+  if (obj) {
+    auto v = obj->get_val(1);
+    TOGGLE_BIT(v, CONT_LOCKED);
+    obj->set_val(1, v);
+  } else {
+    TOGGLE_BIT(EXITN(room, door)->exit_info, EX_LOCKED);
+  }
 }
 
 // для кейсов
 extern std::vector<_case> cases;;
-void do_doorcmd(CHAR_DATA * ch, OBJ_DATA * obj, int door, DOOR_SCMD scmd)
-{
-	bool deaf = false;
-	int other_room = 0;
-	int r_num, vnum;
-	int rev_dir[] = { SOUTH, WEST, NORTH, EAST, DOWN, UP };
-	char local_buf[MAX_STRING_LENGTH]; // строка, в которую накапливается совершенное действо
-	// пишем начало строки - кто чё сделал
-	sprintf(local_buf, "$n %s ", cmd_door[scmd]);
+void do_doorcmd(CHAR_DATA *ch, OBJ_DATA *obj, int door, DOOR_SCMD scmd) {
+  bool deaf = false;
+  int other_room = 0;
+  int r_num, vnum;
+  int rev_dir[] = {SOUTH, WEST, NORTH, EAST, DOWN, UP};
+  char local_buf[MAX_STRING_LENGTH]; // строка, в которую накапливается совершенное действо
+  // пишем начало строки - кто чё сделал
+  sprintf(local_buf, "$n %s ", cmd_door[scmd]);
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
-		deaf = true;
-	// ищем парную дверь в другой клетке
-	ROOM_DATA::exit_data_ptr back;
-	if (!obj && ((other_room = EXIT(ch, door)->to_room()) != NOWHERE)) {
-		back = world[other_room]->dir_option[rev_dir[door]];
-		if (back) {
-			if ((back->to_room() != ch->in_room)
-				|| ((EXITDATA(ch->in_room, door)->exit_info
-					^ EXITDATA(other_room, rev_dir[door])->exit_info)
-					& (EX_ISDOOR | EX_CLOSED | EX_LOCKED))) {
-				back.reset();
-			}
-		}
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
+    deaf = true;
+  // ищем парную дверь в другой клетке
+  ROOM_DATA::exit_data_ptr back;
+  if (!obj && ((other_room = EXIT(ch, door)->to_room()) != NOWHERE)) {
+    back = world[other_room]->dir_option[rev_dir[door]];
+    if (back) {
+      if ((back->to_room() != ch->in_room)
+          || ((EXITDATA(ch->in_room, door)->exit_info
+              ^ EXITDATA(other_room, rev_dir[door])->exit_info)
+              & (EX_ISDOOR | EX_CLOSED | EX_LOCKED))) {
+        back.reset();
+      }
+    }
+  }
 
-	switch (scmd)
-	{
-	case SCMD_OPEN:
-	case SCMD_CLOSE:
-		if (scmd == SCMD_OPEN && obj && !open_otrigger(obj, ch, FALSE))
-			return;
-		if (scmd == SCMD_OPEN && !obj && !open_wtrigger(world[ch->in_room], ch, door, FALSE))
-			return;
-		if (scmd == SCMD_OPEN && !obj && back && !open_wtrigger(world[other_room], ch, rev_dir[door], FALSE))
-			return;
-		if (scmd == SCMD_CLOSE && obj && !close_otrigger(obj, ch, FALSE))
-			return;
-		if (scmd == SCMD_CLOSE && !obj && !close_wtrigger(world[ch->in_room], ch, door, FALSE))
-			return;
-		if (scmd == SCMD_CLOSE && !obj && back && !close_wtrigger(world[other_room], ch, rev_dir[door], FALSE))
-			return;
-		OPEN_DOOR(ch->in_room, obj, door);
-		if (back)
-		{
-			OPEN_DOOR(other_room, obj, rev_dir[door]);
-		}
-		// вываливание и пурж кошелька
-		if (obj && system_obj::is_purse(obj)) {
-			sprintf(buf, "<%s> {%d} открыл трупный кошелек %s.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), get_name_by_unique(GET_OBJ_VAL(obj, 3)));
-			mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-			system_obj::process_open_purse(ch, obj);
-			return;
-		}
-		else {
-			send_to_char(OK, ch);
-		}
-		break;
+  switch (scmd) {
+    case SCMD_OPEN:
+    case SCMD_CLOSE:
+      if (scmd == SCMD_OPEN && obj && !open_otrigger(obj, ch, FALSE))
+        return;
+      if (scmd == SCMD_OPEN && !obj && !open_wtrigger(world[ch->in_room], ch, door, FALSE))
+        return;
+      if (scmd == SCMD_OPEN && !obj && back && !open_wtrigger(world[other_room], ch, rev_dir[door], FALSE))
+        return;
+      if (scmd == SCMD_CLOSE && obj && !close_otrigger(obj, ch, FALSE))
+        return;
+      if (scmd == SCMD_CLOSE && !obj && !close_wtrigger(world[ch->in_room], ch, door, FALSE))
+        return;
+      if (scmd == SCMD_CLOSE && !obj && back && !close_wtrigger(world[other_room], ch, rev_dir[door], FALSE))
+        return;
+      OPEN_DOOR(ch->in_room, obj, door);
+      if (back) {
+        OPEN_DOOR(other_room, obj, rev_dir[door]);
+      }
+      // вываливание и пурж кошелька
+      if (obj && system_obj::is_purse(obj)) {
+        sprintf(buf,
+                "<%s> {%d} открыл трупный кошелек %s.",
+                ch->get_name().c_str(),
+                GET_ROOM_VNUM(ch->in_room),
+                get_name_by_unique(GET_OBJ_VAL(obj, 3)));
+        mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+        system_obj::process_open_purse(ch, obj);
+        return;
+      } else {
+        send_to_char(OK, ch);
+      }
+      break;
 
-	case SCMD_UNLOCK:
-	case SCMD_LOCK:
-		if (scmd == SCMD_UNLOCK && obj && !open_otrigger(obj, ch, TRUE))
-			return;
-		if (scmd == SCMD_LOCK && obj && !close_otrigger(obj, ch, TRUE))
-			return;
-		if (scmd == SCMD_UNLOCK && !obj && !open_wtrigger(world[ch->in_room], ch, door, TRUE))
-			return;
-		if (scmd == SCMD_LOCK && !obj && !close_wtrigger(world[ch->in_room], ch, door, TRUE))
-			return;
-		if (scmd == SCMD_UNLOCK && !obj && back && !open_wtrigger(world[other_room], ch, rev_dir[door], TRUE))
-			return;
-		if (scmd == SCMD_LOCK && !obj && back && !close_wtrigger(world[other_room], ch, rev_dir[door], TRUE))
-			return;
-		LOCK_DOOR(ch->in_room, obj, door);
-		if (back)
-			LOCK_DOOR(other_room, obj, rev_dir[door]);
-		if (!deaf)
-			send_to_char("*Щелк*\r\n", ch);
-		if (obj)
-		{
-			for (unsigned long i = 0; i < cases.size(); i++)
-			{
-				if (GET_OBJ_VNUM(obj) == cases[i].vnum)
-				{
-					if (!deaf)
-						send_to_char("&GГде-то далеко наверху раздалась звонкая музыка.&n\r\n", ch);
-					// chance = cases[i].chance;
-					// chance пока что не учитывается, просто падает одна рандомная стафина из всего этого
-					const int maximal_chance = static_cast<int>(cases[i].vnum_objs.size() - 1);
-					const int random_number = number(0, maximal_chance);
-					vnum = cases[i].vnum_objs[random_number];
-					if ((r_num = real_object(vnum)) < 0)
-					{
-						act("$o исчез$Y с яркой вспышкой. Случилось неладное, поняли вы..", FALSE, ch, obj, 0, TO_ROOM);
-						sprintf(local_buf, "[ERROR] do_doorcmd: ошибка при открытии контейнера %d, неизвестное содержимое!",obj->get_vnum());
-						mudlog(local_buf, LogMode::CMP, LVL_GRGOD, MONEY_LOG, TRUE);
-						return;
-					}
-					// сначала удалим ключ из инвентаря
-					int vnum_key = GET_OBJ_VAL(obj, 2);
-					// первый предмет в инвентаре
-					OBJ_DATA *obj_inv = ch->carrying;
-					OBJ_DATA *i;
-					for (i = obj_inv; i; i = i->get_next_content()) {
-						if (GET_OBJ_VNUM(i) == vnum_key) {
-							extract_obj(i);
-							break;
-						}
-					}
-					extract_obj(obj);
-					obj = world_objects.create_from_prototype_by_rnum(r_num).get();
-					obj->set_crafter_uid(GET_UNIQUE(ch));
-					obj_to_char(obj, ch);
-					act("$n завизжал$g от радости.", FALSE, ch, 0, 0, TO_ROOM);
-					load_otrigger(obj);
-					obj_decay(obj);
-					olc_log("%s load obj %s #%d", GET_NAME(ch), obj->get_short_description().c_str(), vnum);
-					return;
-				}
-			}
-		}
-		break;
+    case SCMD_UNLOCK:
+    case SCMD_LOCK:
+      if (scmd == SCMD_UNLOCK && obj && !open_otrigger(obj, ch, TRUE))
+        return;
+      if (scmd == SCMD_LOCK && obj && !close_otrigger(obj, ch, TRUE))
+        return;
+      if (scmd == SCMD_UNLOCK && !obj && !open_wtrigger(world[ch->in_room], ch, door, TRUE))
+        return;
+      if (scmd == SCMD_LOCK && !obj && !close_wtrigger(world[ch->in_room], ch, door, TRUE))
+        return;
+      if (scmd == SCMD_UNLOCK && !obj && back && !open_wtrigger(world[other_room], ch, rev_dir[door], TRUE))
+        return;
+      if (scmd == SCMD_LOCK && !obj && back && !close_wtrigger(world[other_room], ch, rev_dir[door], TRUE))
+        return;
+      LOCK_DOOR(ch->in_room, obj, door);
+      if (back)
+        LOCK_DOOR(other_room, obj, rev_dir[door]);
+      if (!deaf)
+        send_to_char("*Щелк*\r\n", ch);
+      if (obj) {
+        for (unsigned long i = 0; i < cases.size(); i++) {
+          if (GET_OBJ_VNUM(obj) == cases[i].vnum) {
+            if (!deaf)
+              send_to_char("&GГде-то далеко наверху раздалась звонкая музыка.&n\r\n", ch);
+            // chance = cases[i].chance;
+            // chance пока что не учитывается, просто падает одна рандомная стафина из всего этого
+            const int maximal_chance = static_cast<int>(cases[i].vnum_objs.size() - 1);
+            const int random_number = number(0, maximal_chance);
+            vnum = cases[i].vnum_objs[random_number];
+            if ((r_num = real_object(vnum)) < 0) {
+              act("$o исчез$Y с яркой вспышкой. Случилось неладное, поняли вы..", FALSE, ch, obj, 0, TO_ROOM);
+              sprintf(local_buf,
+                      "[ERROR] do_doorcmd: ошибка при открытии контейнера %d, неизвестное содержимое!",
+                      obj->get_vnum());
+              mudlog(local_buf, LogMode::CMP, LVL_GRGOD, MONEY_LOG, TRUE);
+              return;
+            }
+            // сначала удалим ключ из инвентаря
+            int vnum_key = GET_OBJ_VAL(obj, 2);
+            // первый предмет в инвентаре
+            OBJ_DATA *obj_inv = ch->carrying;
+            OBJ_DATA *i;
+            for (i = obj_inv; i; i = i->get_next_content()) {
+              if (GET_OBJ_VNUM(i) == vnum_key) {
+                extract_obj(i);
+                break;
+              }
+            }
+            extract_obj(obj);
+            obj = world_objects.create_from_prototype_by_rnum(r_num).get();
+            obj->set_crafter_uid(GET_UNIQUE(ch));
+            obj_to_char(obj, ch);
+            act("$n завизжал$g от радости.", FALSE, ch, 0, 0, TO_ROOM);
+            load_otrigger(obj);
+            obj_decay(obj);
+            olc_log("%s load obj %s #%d", GET_NAME(ch), obj->get_short_description().c_str(), vnum);
+            return;
+          }
+        }
+      }
+      break;
 
-	case SCMD_PICK:
-		if (obj && !pick_otrigger(obj, ch))
-			return;
-		if (!obj && !pick_wtrigger(world[ch->in_room], ch, door))
-			return;
-		if (!obj && back && !pick_wtrigger(world[other_room], ch, rev_dir[door]))
-			return;
-		LOCK_DOOR(ch->in_room, obj, door);
-		if (back)
-			LOCK_DOOR(other_room, obj, rev_dir[door]);
-		send_to_char("Замок очень скоро поддался под вашим натиском.\r\n", ch);
-		strcpy(local_buf, "$n умело взломал$g ");
-		break;
-	}
+    case SCMD_PICK:
+      if (obj && !pick_otrigger(obj, ch))
+        return;
+      if (!obj && !pick_wtrigger(world[ch->in_room], ch, door))
+        return;
+      if (!obj && back && !pick_wtrigger(world[other_room], ch, rev_dir[door]))
+        return;
+      LOCK_DOOR(ch->in_room, obj, door);
+      if (back)
+        LOCK_DOOR(other_room, obj, rev_dir[door]);
+      send_to_char("Замок очень скоро поддался под вашим натиском.\r\n", ch);
+      strcpy(local_buf, "$n умело взломал$g ");
+      break;
+  }
 
-	// Notify the room
-	sprintf(local_buf + strlen(local_buf), "%s.", (obj) ? "$o3" : (EXIT(ch, door)->vkeyword ? "$F" : "дверь"));
-	if (!obj || (obj->get_in_room() != NOWHERE)) {
-		act(local_buf, FALSE, ch, obj, obj ? 0 : EXIT(ch, door)->vkeyword, TO_ROOM);
-	}
+  // Notify the room
+  sprintf(local_buf + strlen(local_buf), "%s.", (obj) ? "$o3" : (EXIT(ch, door)->vkeyword ? "$F" : "дверь"));
+  if (!obj || (obj->get_in_room() != NOWHERE)) {
+    act(local_buf, FALSE, ch, obj, obj ? 0 : EXIT(ch, door)->vkeyword, TO_ROOM);
+  }
 
-	// Notify the other room
-	if ((scmd == SCMD_OPEN || scmd == SCMD_CLOSE) && back) {
-		const auto& people = world[EXIT(ch, door)->to_room()]->people;
-		if (!people.empty()) {
-			sprintf(local_buf + strlen(local_buf) - 1, " с той стороны.");
-			int allowed_items_remained = 1000;
-			for (const auto to : people) {
-				if (0 == allowed_items_remained) {
-					break;
-				}
-				perform_act(local_buf, ch, obj, obj ? 0 : EXIT(ch, door)->vkeyword, to);
-				--allowed_items_remained;
-			}
-		}
-	}
+  // Notify the other room
+  if ((scmd == SCMD_OPEN || scmd == SCMD_CLOSE) && back) {
+    const auto &people = world[EXIT(ch, door)->to_room()]->people;
+    if (!people.empty()) {
+      sprintf(local_buf + strlen(local_buf) - 1, " с той стороны.");
+      int allowed_items_remained = 1000;
+      for (const auto to : people) {
+        if (0 == allowed_items_remained) {
+          break;
+        }
+        perform_act(local_buf, ch, obj, obj ? 0 : EXIT(ch, door)->vkeyword, to);
+        --allowed_items_remained;
+      }
+    }
+  }
 }
 
-int ok_pick(CHAR_DATA* ch, obj_vnum /*keynum*/, OBJ_DATA* obj, int door, int scmd)
-{
-	int percent;
-	int pickproof = DOOR_IS_PICKPROOF(ch, obj, door);
-	percent = number(1, skill_info[SKILL_PICK_LOCK].max_percent);
+int ok_pick(CHAR_DATA *ch, obj_vnum /*keynum*/, OBJ_DATA *obj, int door, int scmd) {
+  int pickproof = DOOR_IS_PICKPROOF(ch, obj, door);
+  int prob = number(1, skill_info[SKILL_PICK_LOCK].max_percent);
 
-	if (scmd == SCMD_PICK)
-	{
-		if (pickproof)
-			send_to_char("Вы никогда не сможете взломать ЭТО.\r\n", ch);
-		else if (!check_moves(ch, PICKLOCK_MOVES));
-		else if (DOOR_LOCK_COMPLEX(ch, obj, door) - ch->get_skill(SKILL_PICK_LOCK) > 10)//Polud очередной magic number...
-		//если скилл меньше сложности на 10 и более - даже трениться на таком замке нельзя
-			send_to_char("С таким сложным замком даже и пытаться не следует...\r\n", ch);
-		else if ((ch->get_skill(SKILL_PICK_LOCK) - DOOR_LOCK_COMPLEX(ch, obj, door) <= 10)  && //если скилл больше сложности на 10 и более - даже трениться на таком замке нельзя
-			(percent > train_skill(ch, SKILL_PICK_LOCK, skill_info[SKILL_PICK_LOCK].max_percent, NULL)))
-			send_to_char("Взломщик из вас пока еще никудышний.\r\n", ch);
-		else if (get_pick_chance(ch->get_skill(SKILL_PICK_LOCK), DOOR_LOCK_COMPLEX(ch, obj, door)) < number(1,10))
-		{
-			send_to_char("Вы все-таки сломали этот замок...\r\n", ch);
-			if (obj)
-			{
-				auto v = obj->get_val(1);
-				SET_BIT(v, CONT_BROKEN);
-				obj->set_val(1, v);
-			}
-			if (door > -1)
-			{
-				SET_BIT(EXIT(ch, door)->exit_info, EX_BROKEN);
-			}
-		}
-		else
-			return (1);
-		return (0);
-	}
-	return (1);
+  if (scmd == SCMD_PICK) {
+    auto percent = calculate_skill(ch, SKILL_PICK_LOCK, nullptr);
+    if (pickproof)
+      send_to_char("Вы никогда не сможете взломать ЭТО.\r\n", ch);
+    else if (!check_moves(ch, PICKLOCK_MOVES));
+      //Polud очередной magic number...
+    else if (DOOR_LOCK_COMPLEX(ch, obj, door) - ch->get_skill(SKILL_PICK_LOCK) > 10)
+      //если скилл меньше сложности на 10 и более - даже трениться на таком замке нельзя
+      send_to_char("С таким сложным замком даже и пытаться не следует...\r\n", ch);
+      //если скилл больше сложности на 10 и более - даже трениться на таком замке нельзя
+    else if ((ch->get_skill(SKILL_PICK_LOCK) - DOOR_LOCK_COMPLEX(ch, obj, door) <= 10) && (prob > percent)) {
+      send_to_char("Взломщик из вас пока еще никудышний.\r\n", ch);
+      train_skill(ch, SKILL_PICK_LOCK, false, nullptr);
+    } else if (get_pick_chance(ch->get_skill(SKILL_PICK_LOCK), DOOR_LOCK_COMPLEX(ch, obj, door)) < number(1, 10)) {
+      send_to_char("Вы все-таки сломали этот замок...\r\n", ch);
+      if (obj) {
+        auto v = obj->get_val(1);
+        SET_BIT(v, CONT_BROKEN);
+        obj->set_val(1, v);
+      }
+      if (door > -1) {
+        SET_BIT(EXIT(ch, door)->exit_info, EX_BROKEN);
+      }
+    } else
+      return (1);
+    return (0);
+  }
+  return (1);
 }
 
-void do_gen_door(CHAR_DATA *ch, char *argument, int, int subcmd)
-{
-	int door = -1;
-	obj_vnum keynum;
-	char type[MAX_INPUT_LENGTH], dir[MAX_INPUT_LENGTH];
-	OBJ_DATA *obj = NULL;
-	CHAR_DATA *victim = NULL;
-	int where_bits = FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP;
+void do_gen_door(CHAR_DATA *ch, char *argument, int, int subcmd) {
+  int door = -1;
+  obj_vnum keynum;
+  char type[MAX_INPUT_LENGTH], dir[MAX_INPUT_LENGTH];
+  OBJ_DATA *obj = NULL;
+  CHAR_DATA *victim = NULL;
+  int where_bits = FIND_OBJ_INV | FIND_OBJ_ROOM | FIND_OBJ_EQUIP;
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
-		send_to_char("Очнитесь, вы же слепы!\r\n", ch);
-		return;
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    send_to_char("Очнитесь, вы же слепы!\r\n", ch);
+    return;
+  }
 
-	if (subcmd == SCMD_PICK && !ch->get_skill(SKILL_PICK_LOCK)) {
-		send_to_char("Это умение вам недоступно.\r\n", ch);
-		return;
-	}
-	skip_spaces(&argument);
-	if (!*argument) {
-		sprintf(buf, "%s что?\r\n", a_cmd_door[subcmd]);
-		send_to_char(CAP(buf), ch);
-		return;
-	}
-	two_arguments(argument, type, dir);
+  if (subcmd == SCMD_PICK && !ch->get_skill(SKILL_PICK_LOCK)) {
+    send_to_char("Это умение вам недоступно.\r\n", ch);
+    return;
+  }
+  skip_spaces(&argument);
+  if (!*argument) {
+    sprintf(buf, "%s что?\r\n", a_cmd_door[subcmd]);
+    send_to_char(CAP(buf), ch);
+    return;
+  }
+  two_arguments(argument, type, dir);
 
-	if (isname(dir, "земля комната room ground"))
-		where_bits = FIND_OBJ_ROOM;
-	else if (isname(dir, "инвентарь inventory"))
-		where_bits = FIND_OBJ_INV;
-	else if (isname(dir, "экипировка equipment"))
-		where_bits = FIND_OBJ_EQUIP;
+  if (isname(dir, "земля комната room ground"))
+    where_bits = FIND_OBJ_ROOM;
+  else if (isname(dir, "инвентарь inventory"))
+    where_bits = FIND_OBJ_INV;
+  else if (isname(dir, "экипировка equipment"))
+    where_bits = FIND_OBJ_EQUIP;
 
-	//Сначала ищем дверь, считая второй аргумент указанием на сторону света
-	door = find_door(ch, type, dir, (DOOR_SCMD)subcmd);
-	//Если двери не нашлось, проверяем объекты в экипировке, инвентаре, на земле
-	if (door < 0)
-		if (!generic_find(type, where_bits, ch, &victim, &obj))
-		{
-			//Если и объектов не нашлось, выдаем одно из сообщений об ошибке
-			switch (door)
-			{
-			case -1: //НЕВЕРНОЕ НАПРАВЛЕНИЕ
-				send_to_char("Уточните направление.\r\n",ch);
-				break;
-			case -2: //НЕ ПРАВИЛЬНО НАЗВАЛИ ДВЕРЬ В ЭТОМ НАПРАВЛЕНИИ
-				sprintf(buf, "Вы не видите '%s' в этой комнате.\r\n", type);
-				send_to_char(buf, ch);
-				break;
-			case -3: //В ЭТОМ НАПРАВЛЕНИИ НЕТ ДВЕРЕЙ
-				sprintf(buf, "Вы не можете это '%s'.\r\n", a_cmd_door[subcmd]);
-				send_to_char(buf, ch);
-				break;
-			case -4: //НЕ УКАЗАНО АРГУМЕНТОВ
-				sprintf(buf, "Что вы хотите '%s'?\r\n", a_cmd_door[subcmd]);
-				send_to_char(buf, ch);
-				break;
-			case -5: //НЕПРАВИЛЬНО НАЗВАЛИ ДВЕРЬ БЕЗ УКАЗАНИЯ НАПРАВЛЕНИЯ
-				sprintf(buf, "Вы не видите здесь '%s'.\r\n", type);
-				send_to_char(buf, ch);
-				break;
-			}
-			return;
-		}
-	if ((obj) || (door >= 0))
-	{
-		if ((obj) && !IS_IMMORTAL(ch) && (OBJ_FLAGGED(obj, EExtraFlag::ITEM_NAMED)) && NamedStuff::check_named(ch, obj, true))//Именной предмет открывать(закрывать) может только владелец
-		{
-			if (!NamedStuff::wear_msg(ch, obj))
-				send_to_char("Просьба не трогать! Частная собственность!\r\n", ch);
-			return;
-		}
-		keynum = DOOR_KEY(ch, obj, door);
-		if ((subcmd == SCMD_CLOSE || subcmd == SCMD_LOCK) && !IS_NPC(ch) && RENTABLE(ch))
-			send_to_char("Ведите себя достойно во время боевых действий!\r\n", ch);
-		else if (!(DOOR_IS_OPENABLE(ch, obj, door)))
-			act("Вы никогда не сможете $F это!", FALSE, ch, 0, a_cmd_door[subcmd], TO_CHAR);
-		else if (!DOOR_IS_OPEN(ch, obj, door)
-				 && IS_SET(flags_door[subcmd], NEED_OPEN))
-			send_to_char("Вообще-то здесь закрыто!\r\n", ch);
-		else if (!DOOR_IS_CLOSED(ch, obj, door) && IS_SET(flags_door[subcmd], NEED_CLOSED))
-			send_to_char("Уже открыто!\r\n", ch);
-		else if (!(DOOR_IS_LOCKED(ch, obj, door)) && IS_SET(flags_door[subcmd], NEED_LOCKED))
-			send_to_char("Да отперли уже все...\r\n", ch);
-		else if (!(DOOR_IS_UNLOCKED(ch, obj, door)) && IS_SET(flags_door[subcmd], NEED_UNLOCKED))
-			send_to_char("Угу, заперто.\r\n", ch);
-		else if (!has_key(ch, keynum) && !Privilege::check_flag(ch, Privilege::USE_SKILLS) && ((subcmd == SCMD_LOCK) || (subcmd == SCMD_UNLOCK)))
-			send_to_char("У вас нет ключа.\r\n", ch);
-		else if (DOOR_IS_BROKEN(ch, obj, door) && !Privilege::check_flag(ch, Privilege::USE_SKILLS) && ((subcmd == SCMD_LOCK) || (subcmd == SCMD_UNLOCK)))
-			send_to_char("Замок сломан.\r\n", ch);
-		else if (ok_pick(ch, keynum, obj, door, subcmd))
-			do_doorcmd(ch, obj, door, (DOOR_SCMD)subcmd);
-	}
+  //Сначала ищем дверь, считая второй аргумент указанием на сторону света
+  door = find_door(ch, type, dir, (DOOR_SCMD) subcmd);
+  //Если двери не нашлось, проверяем объекты в экипировке, инвентаре, на земле
+  if (door < 0)
+    if (!generic_find(type, where_bits, ch, &victim, &obj)) {
+      //Если и объектов не нашлось, выдаем одно из сообщений об ошибке
+      switch (door) {
+        case -1: //НЕВЕРНОЕ НАПРАВЛЕНИЕ
+          send_to_char("Уточните направление.\r\n", ch);
+          break;
+        case -2: //НЕ ПРАВИЛЬНО НАЗВАЛИ ДВЕРЬ В ЭТОМ НАПРАВЛЕНИИ
+          sprintf(buf, "Вы не видите '%s' в этой комнате.\r\n", type);
+          send_to_char(buf, ch);
+          break;
+        case -3: //В ЭТОМ НАПРАВЛЕНИИ НЕТ ДВЕРЕЙ
+          sprintf(buf, "Вы не можете это '%s'.\r\n", a_cmd_door[subcmd]);
+          send_to_char(buf, ch);
+          break;
+        case -4: //НЕ УКАЗАНО АРГУМЕНТОВ
+          sprintf(buf, "Что вы хотите '%s'?\r\n", a_cmd_door[subcmd]);
+          send_to_char(buf, ch);
+          break;
+        case -5: //НЕПРАВИЛЬНО НАЗВАЛИ ДВЕРЬ БЕЗ УКАЗАНИЯ НАПРАВЛЕНИЯ
+          sprintf(buf, "Вы не видите здесь '%s'.\r\n", type);
+          send_to_char(buf, ch);
+          break;
+      }
+      return;
+    }
+  if ((obj) || (door >= 0)) {
+    if ((obj) && !IS_IMMORTAL(ch) && (OBJ_FLAGGED(obj, EExtraFlag::ITEM_NAMED))
+        && NamedStuff::check_named(ch, obj, true))//Именной предмет открывать(закрывать) может только владелец
+    {
+      if (!NamedStuff::wear_msg(ch, obj))
+        send_to_char("Просьба не трогать! Частная собственность!\r\n", ch);
+      return;
+    }
+    keynum = DOOR_KEY(ch, obj, door);
+    if ((subcmd == SCMD_CLOSE || subcmd == SCMD_LOCK) && !IS_NPC(ch) && RENTABLE(ch))
+      send_to_char("Ведите себя достойно во время боевых действий!\r\n", ch);
+    else if (!(DOOR_IS_OPENABLE(ch, obj, door)))
+      act("Вы никогда не сможете $F это!", FALSE, ch, 0, a_cmd_door[subcmd], TO_CHAR);
+    else if (!DOOR_IS_OPEN(ch, obj, door)
+        && IS_SET(flags_door[subcmd], NEED_OPEN))
+      send_to_char("Вообще-то здесь закрыто!\r\n", ch);
+    else if (!DOOR_IS_CLOSED(ch, obj, door) && IS_SET(flags_door[subcmd], NEED_CLOSED))
+      send_to_char("Уже открыто!\r\n", ch);
+    else if (!(DOOR_IS_LOCKED(ch, obj, door)) && IS_SET(flags_door[subcmd], NEED_LOCKED))
+      send_to_char("Да отперли уже все...\r\n", ch);
+    else if (!(DOOR_IS_UNLOCKED(ch, obj, door)) && IS_SET(flags_door[subcmd], NEED_UNLOCKED))
+      send_to_char("Угу, заперто.\r\n", ch);
+    else if (!has_key(ch, keynum) && !Privilege::check_flag(ch, Privilege::USE_SKILLS)
+        && ((subcmd == SCMD_LOCK) || (subcmd == SCMD_UNLOCK)))
+      send_to_char("У вас нет ключа.\r\n", ch);
+    else if (DOOR_IS_BROKEN(ch, obj, door) && !Privilege::check_flag(ch, Privilege::USE_SKILLS)
+        && ((subcmd == SCMD_LOCK) || (subcmd == SCMD_UNLOCK)))
+      send_to_char("Замок сломан.\r\n", ch);
+    else if (ok_pick(ch, keynum, obj, door, subcmd))
+      do_doorcmd(ch, obj, door, (DOOR_SCMD) subcmd);
+  }
 }
 
-void do_enter(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	int door, from_room;
-	const char *p_str = "пентаграмма";
-	struct follow_type *k, *k_next;
+void do_enter(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  int door, from_room;
+  const char *p_str = "пентаграмма";
+  struct follow_type *k, *k_next;
 
-	one_argument(argument, smallBuf);
+  one_argument(argument, smallBuf);
 
-	if (*smallBuf)
+  if (*smallBuf)
 //     {if (!str_cmp("пентаграмма",smallBuf))
-	{
-		if (isname(smallBuf, p_str))
-		{
-			if (!world[ch->in_room]->portal_time)
-				send_to_char("Вы не видите здесь пентаграмму.\r\n", ch);
-			else
-			{
-				from_room = ch->in_room;
-				door = world[ch->in_room]->portal_room;
-				// не пускать игрока на холженном коне
-				if (ch->ahorse() && GET_MOB_HOLD(ch->get_horse()))
-				{
-					act("$Z $N не в состоянии нести вас на себе.\r\n",
-						FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-					return;
-				}
-				// не пускать в ванрумы после пк, если его там прибьет сразу
-				if (DeathTrap::check_tunnel_death(ch, door))
-				{
-					send_to_char("В связи с боевыми действиями эвакуация временно прекращена.\r\n", ch);
-					return;
-				}
-				// Если чар под местью, и портал односторонний, то не пускать
-				if (RENTABLE(ch) && !IS_NPC(ch) && !world[door]->portal_time)
-				{
-					send_to_char("Грехи мешают вам воспользоваться вратами.\r\n", ch);
-					return;
-				}
-				//проверка на флаг нельзя_верхом
-				if (ROOM_FLAGGED(door, ROOM_NOHORSE) && ch->ahorse())
-				{
-					act("$Z $N отказывается туда идти, и вам пришлось соскочить.",
-						FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-					ch->dismount();
-				}
-				//проверка на ванрум и лошадь
-				if (ROOM_FLAGGED(door, ROOM_TUNNEL) &&
-						(num_pc_in_room(world[door]) > 0 || ch->ahorse()))
-				{
-					if (num_pc_in_room(world[door]) > 0)
-					{
-						send_to_char("Слишком мало места.\r\n", ch);
-						return;
-					}
-					else
-					{
-						act("$Z $N заупрямил$U, и вам пришлось соскочить.",
-							FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-						ch->dismount();
-					}
-				}
-				// Обработка флагов NOTELEPORTIN и NOTELEPORTOUT здесь же
-				if (!IS_IMMORTAL(ch)
-					&& ((!IS_NPC(ch) && (!Clan::MayEnter(ch, door, HCE_PORTAL) || (GET_LEVEL(ch) <= 10 && world[door]->portal_time)))
-						|| (ROOM_FLAGGED(from_room, ROOM_NOTELEPORTOUT)	|| ROOM_FLAGGED(door, ROOM_NOTELEPORTIN))
-						|| AFF_FLAGGED(ch, EAffectFlag::AFF_NOTELEPORT)
-						|| (world[door]->pkPenterUnique && (ROOM_FLAGGED(door, ROOM_ARENA) || ROOM_FLAGGED(door, ROOM_HOUSE)))))
-				{
-					sprintf(smallBuf, "%sПентаграмма ослепительно вспыхнула!%s\r\n",
-							CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
-					act(smallBuf, TRUE, ch, 0, 0, TO_CHAR);
-					act(smallBuf, TRUE, ch, 0, 0, TO_ROOM);
+  {
+    if (isname(smallBuf, p_str)) {
+      if (!world[ch->in_room]->portal_time)
+        send_to_char("Вы не видите здесь пентаграмму.\r\n", ch);
+      else {
+        from_room = ch->in_room;
+        door = world[ch->in_room]->portal_room;
+        // не пускать игрока на холженном коне
+        if (ch->ahorse() && GET_MOB_HOLD(ch->get_horse())) {
+          act("$Z $N не в состоянии нести вас на себе.\r\n",
+              FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+          return;
+        }
+        // не пускать в ванрумы после пк, если его там прибьет сразу
+        if (DeathTrap::check_tunnel_death(ch, door)) {
+          send_to_char("В связи с боевыми действиями эвакуация временно прекращена.\r\n", ch);
+          return;
+        }
+        // Если чар под местью, и портал односторонний, то не пускать
+        if (RENTABLE(ch) && !IS_NPC(ch) && !world[door]->portal_time) {
+          send_to_char("Грехи мешают вам воспользоваться вратами.\r\n", ch);
+          return;
+        }
+        //проверка на флаг нельзя_верхом
+        if (ROOM_FLAGGED(door, ROOM_NOHORSE) && ch->ahorse()) {
+          act("$Z $N отказывается туда идти, и вам пришлось соскочить.",
+              FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+          ch->dismount();
+        }
+        //проверка на ванрум и лошадь
+        if (ROOM_FLAGGED(door, ROOM_TUNNEL) &&
+            (num_pc_in_room(world[door]) > 0 || ch->ahorse())) {
+          if (num_pc_in_room(world[door]) > 0) {
+            send_to_char("Слишком мало места.\r\n", ch);
+            return;
+          } else {
+            act("$Z $N заупрямил$U, и вам пришлось соскочить.",
+                FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+            ch->dismount();
+          }
+        }
+        // Обработка флагов NOTELEPORTIN и NOTELEPORTOUT здесь же
+        if (!IS_IMMORTAL(ch)
+            && ((!IS_NPC(ch)
+                && (!Clan::MayEnter(ch, door, HCE_PORTAL) || (GET_LEVEL(ch) <= 10 && world[door]->portal_time)))
+                || (ROOM_FLAGGED(from_room, ROOM_NOTELEPORTOUT) || ROOM_FLAGGED(door, ROOM_NOTELEPORTIN))
+                || AFF_FLAGGED(ch, EAffectFlag::AFF_NOTELEPORT)
+                || (world[door]->pkPenterUnique
+                    && (ROOM_FLAGGED(door, ROOM_ARENA) || ROOM_FLAGGED(door, ROOM_HOUSE))))) {
+          sprintf(smallBuf, "%sПентаграмма ослепительно вспыхнула!%s\r\n",
+                  CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
+          act(smallBuf, TRUE, ch, 0, 0, TO_CHAR);
+          act(smallBuf, TRUE, ch, 0, 0, TO_ROOM);
 
-					send_to_char("Мощным ударом вас отшвырнуло от пентаграммы.\r\n", ch);
-					act("$n с визгом отлетел$g от пентаграммы.\r\n", TRUE, ch,
-						0, 0, TO_ROOM | CHECK_DEAF);
-					act("$n отлетел$g от пентаграммы.\r\n", TRUE, ch, 0, 0, TO_ROOM | CHECK_NODEAF);
-					WAIT_STATE(ch, PULSE_VIOLENCE);
-					return;
-				}
-				act("$n исчез$q в пентаграмме.", TRUE, ch, 0, 0, TO_ROOM);
-				if (world[from_room]->pkPenterUnique && world[from_room]->pkPenterUnique != GET_UNIQUE(ch) && !IS_IMMORTAL(ch))
-				{
-					send_to_char(ch, "%sВаш поступок был расценен как потенциально агрессивный.%s\r\n",
-						CCIRED(ch, C_NRM), CCINRM(ch, C_NRM));
-					pkPortal(ch);
-				}
-				char_from_room(ch);
-				char_to_room(ch, door);
-				set_wait(ch, 3, FALSE);
-				act("$n появил$u из пентаграммы.", TRUE, ch, 0, 0, TO_ROOM);
-				// ищем ангела и лошадь
-				for (k = ch->followers; k; k = k_next)
-				{
-					k_next = k->next;
-					if (IS_HORSE(k->follower) &&
-							!k->follower->get_fighting() &&
-							!GET_MOB_HOLD(k->follower) &&
-							IN_ROOM(k->follower) == from_room && AWAKE(k->follower))
-					{
-						if (!ROOM_FLAGGED(door, ROOM_NOHORSE))
-						{
-							char_from_room(k->follower);
-							char_to_room(k->follower, door);
-						}
-					}
-					if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_HELPER)
-						&& !GET_MOB_HOLD(k->follower)
-						&& (MOB_FLAGGED(k->follower, MOB_ANGEL)||MOB_FLAGGED(k->follower, MOB_GHOST))
-						&& !k->follower->get_fighting()
-						&& IN_ROOM(k->follower) == from_room
-						&& AWAKE(k->follower))
-					{
-						act("$n исчез$q в пентаграмме.", TRUE,
-							k->follower, 0, 0, TO_ROOM);
-						char_from_room(k->follower);
-						char_to_room(k->follower, door);
-						set_wait(k->follower, 3, FALSE);
-						act("$n появил$u из пентаграммы.", TRUE,
-							k->follower, 0, 0, TO_ROOM);
-					}
-					if (IS_CHARMICE(k->follower) &&
-							!GET_MOB_HOLD(k->follower) &&
-							GET_POS(k->follower) == POS_STANDING &&
-							IN_ROOM(k->follower) == from_room)
-					{
-						snprintf(buf2, MAX_STRING_LENGTH, "войти пентаграмма");
-						command_interpreter(k->follower, buf2);
-					}
-				}
-				if (ch->desc != nullptr)
-					look_at_room(ch, 0);
-			}
-		}
-		else
-		{	// an argument was supplied, search for door keyword
-			for (door = 0; door < NUM_OF_DIRS; door++)
-			{
-				if (EXIT(ch, door)
-					&& (isname(smallBuf, EXIT(ch, door)->keyword)
-						|| isname(smallBuf, EXIT(ch, door)->vkeyword)))
-				{
-					perform_move(ch, door, 1, TRUE, 0);
-					return;
-				}
-			}
-			sprintf(buf2, "Вы не нашли здесь '%s'.\r\n", smallBuf);
-			send_to_char(buf2, ch);
-		}
-	}
-	else if (ROOM_FLAGGED(ch->in_room, ROOM_INDOORS))
-		send_to_char("Вы уже внутри.\r\n", ch);
-	else  			// try to locate an entrance
-	{
-		for (door = 0; door < NUM_OF_DIRS; door++)
-			if (EXIT(ch, door))
-				if (EXIT(ch, door)->to_room() != NOWHERE)
-					if (!EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED) &&
-							ROOM_FLAGGED(EXIT(ch, door)->to_room(), ROOM_INDOORS))
-					{
-						perform_move(ch, door, 1, TRUE, 0);
-						return;
-					}
-		send_to_char("Вы не можете найти вход.\r\n", ch);
-	}
+          send_to_char("Мощным ударом вас отшвырнуло от пентаграммы.\r\n", ch);
+          act("$n с визгом отлетел$g от пентаграммы.\r\n", TRUE, ch,
+              0, 0, TO_ROOM | CHECK_DEAF);
+          act("$n отлетел$g от пентаграммы.\r\n", TRUE, ch, 0, 0, TO_ROOM | CHECK_NODEAF);
+          WAIT_STATE(ch, PULSE_VIOLENCE);
+          return;
+        }
+        act("$n исчез$q в пентаграмме.", TRUE, ch, 0, 0, TO_ROOM);
+        if (world[from_room]->pkPenterUnique && world[from_room]->pkPenterUnique != GET_UNIQUE(ch)
+            && !IS_IMMORTAL(ch)) {
+          send_to_char(ch, "%sВаш поступок был расценен как потенциально агрессивный.%s\r\n",
+                       CCIRED(ch, C_NRM), CCINRM(ch, C_NRM));
+          pkPortal(ch);
+        }
+        char_from_room(ch);
+        char_to_room(ch, door);
+        set_wait(ch, 3, FALSE);
+        act("$n появил$u из пентаграммы.", TRUE, ch, 0, 0, TO_ROOM);
+        // ищем ангела и лошадь
+        for (k = ch->followers; k; k = k_next) {
+          k_next = k->next;
+          if (IS_HORSE(k->follower) &&
+              !k->follower->get_fighting() &&
+              !GET_MOB_HOLD(k->follower) &&
+              IN_ROOM(k->follower) == from_room && AWAKE(k->follower)) {
+            if (!ROOM_FLAGGED(door, ROOM_NOHORSE)) {
+              char_from_room(k->follower);
+              char_to_room(k->follower, door);
+            }
+          }
+          if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_HELPER)
+              && !GET_MOB_HOLD(k->follower)
+              && (MOB_FLAGGED(k->follower, MOB_ANGEL) || MOB_FLAGGED(k->follower, MOB_GHOST))
+              && !k->follower->get_fighting()
+              && IN_ROOM(k->follower) == from_room
+              && AWAKE(k->follower)) {
+            act("$n исчез$q в пентаграмме.", TRUE,
+                k->follower, 0, 0, TO_ROOM);
+            char_from_room(k->follower);
+            char_to_room(k->follower, door);
+            set_wait(k->follower, 3, FALSE);
+            act("$n появил$u из пентаграммы.", TRUE,
+                k->follower, 0, 0, TO_ROOM);
+          }
+          if (IS_CHARMICE(k->follower) &&
+              !GET_MOB_HOLD(k->follower) &&
+              GET_POS(k->follower) == POS_STANDING &&
+              IN_ROOM(k->follower) == from_room) {
+            snprintf(buf2, MAX_STRING_LENGTH, "войти пентаграмма");
+            command_interpreter(k->follower, buf2);
+          }
+        }
+        if (ch->desc != nullptr)
+          look_at_room(ch, 0);
+      }
+    } else {    // an argument was supplied, search for door keyword
+      for (door = 0; door < NUM_OF_DIRS; door++) {
+        if (EXIT(ch, door)
+            && (isname(smallBuf, EXIT(ch, door)->keyword)
+                || isname(smallBuf, EXIT(ch, door)->vkeyword))) {
+          perform_move(ch, door, 1, TRUE, 0);
+          return;
+        }
+      }
+      sprintf(buf2, "Вы не нашли здесь '%s'.\r\n", smallBuf);
+      send_to_char(buf2, ch);
+    }
+  } else if (ROOM_FLAGGED(ch->in_room, ROOM_INDOORS))
+    send_to_char("Вы уже внутри.\r\n", ch);
+  else            // try to locate an entrance
+  {
+    for (door = 0; door < NUM_OF_DIRS; door++)
+      if (EXIT(ch, door))
+        if (EXIT(ch, door)->to_room() != NOWHERE)
+          if (!EXIT_FLAGGED(EXIT(ch, door), EX_CLOSED) &&
+              ROOM_FLAGGED(EXIT(ch, door)->to_room(), ROOM_INDOORS)) {
+            perform_move(ch, door, 1, TRUE, 0);
+            return;
+          }
+    send_to_char("Вы не можете найти вход.\r\n", ch);
+  }
 }
 
-void do_stand(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	if (GET_POS(ch) > POS_SLEEPING && AFF_FLAGGED(ch, EAffectFlag::AFF_SLEEP))
-	{
-		send_to_char("Вы сладко зевнули и решили еще немного подремать.\r\n", ch);
-		act("$n сладко зевнул$a и решил$a еще немного подремать.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_SLEEPING;
-	}
+void do_stand(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  if (GET_POS(ch) > POS_SLEEPING && AFF_FLAGGED(ch, EAffectFlag::AFF_SLEEP)) {
+    send_to_char("Вы сладко зевнули и решили еще немного подремать.\r\n", ch);
+    act("$n сладко зевнул$a и решил$a еще немного подремать.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+    GET_POS(ch) = POS_SLEEPING;
+  }
 
-	if (ch->ahorse())
-	{
-		act("Прежде всего, вам стоит слезть с $N1.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-		return;
-	}
-	switch (GET_POS(ch))
-	{
-	case POS_STANDING:
-		send_to_char("А вы уже стоите.\r\n", ch);
-		break;
-	case POS_SITTING:
-		send_to_char("Вы встали.\r\n", ch);
-		act("$n поднял$u.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		// Will be sitting after a successful bash and may still be fighting.
-		GET_POS(ch) = ch->get_fighting() ? POS_FIGHTING : POS_STANDING;
-		break;
-	case POS_RESTING:
-		send_to_char("Вы прекратили отдыхать и встали.\r\n", ch);
-		act("$n прекратил$g отдых и поднял$u.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = ch->get_fighting() ? POS_FIGHTING : POS_STANDING;
-		break;
-	case POS_SLEEPING:
-		send_to_char("Пожалуй, сначала стоит проснуться!\r\n", ch);
-		break;
-	case POS_FIGHTING:
-		send_to_char("Вы дрались лежа? Это что-то новенькое.\r\n", ch);
-		break;
-	default:
-		send_to_char("Вы прекратили летать и опустились на грешную землю.\r\n", ch);
-		act("$n опустил$u на землю.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_STANDING;
-		break;
-	}
+  if (ch->ahorse()) {
+    act("Прежде всего, вам стоит слезть с $N1.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+    return;
+  }
+  switch (GET_POS(ch)) {
+    case POS_STANDING: send_to_char("А вы уже стоите.\r\n", ch);
+      break;
+    case POS_SITTING: send_to_char("Вы встали.\r\n", ch);
+      act("$n поднял$u.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      // Will be sitting after a successful bash and may still be fighting.
+      GET_POS(ch) = ch->get_fighting() ? POS_FIGHTING : POS_STANDING;
+      break;
+    case POS_RESTING: send_to_char("Вы прекратили отдыхать и встали.\r\n", ch);
+      act("$n прекратил$g отдых и поднял$u.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = ch->get_fighting() ? POS_FIGHTING : POS_STANDING;
+      break;
+    case POS_SLEEPING: send_to_char("Пожалуй, сначала стоит проснуться!\r\n", ch);
+      break;
+    case POS_FIGHTING: send_to_char("Вы дрались лежа? Это что-то новенькое.\r\n", ch);
+      break;
+    default: send_to_char("Вы прекратили летать и опустились на грешную землю.\r\n", ch);
+      act("$n опустил$u на землю.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_STANDING;
+      break;
+  }
 }
 
-void do_sit(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	if (ch->ahorse())
-	{
-		act("Прежде всего, вам стоит слезть с $N1.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-		return;
-	}
-	switch (GET_POS(ch))
-	{
-	case POS_STANDING:
-		send_to_char("Вы сели.\r\n", ch);
-		act("$n сел$g.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_SITTING;
-		break;
-	case POS_SITTING:
-		send_to_char("А вы и так сидите.\r\n", ch);
-		break;
-	case POS_RESTING:
-		send_to_char("Вы прекратили отдыхать и сели.\r\n", ch);
-		act("$n прервал$g отдых и сел$g.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_SITTING;
-		break;
-	case POS_SLEEPING:
-		send_to_char("Вам стоит проснуться.\r\n", ch);
-		break;
-	case POS_FIGHTING:
-		send_to_char("Сесть? Во время боя? Вы явно не в себе.\r\n", ch);
-		break;
-	default:
-		send_to_char("Вы прекратили свой полет и сели.\r\n", ch);
-		act("$n прекратил$g свой полет и сел$g.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_SITTING;
-		break;
-	}
+void do_sit(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  if (ch->ahorse()) {
+    act("Прежде всего, вам стоит слезть с $N1.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+    return;
+  }
+  switch (GET_POS(ch)) {
+    case POS_STANDING: send_to_char("Вы сели.\r\n", ch);
+      act("$n сел$g.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_SITTING;
+      break;
+    case POS_SITTING: send_to_char("А вы и так сидите.\r\n", ch);
+      break;
+    case POS_RESTING: send_to_char("Вы прекратили отдыхать и сели.\r\n", ch);
+      act("$n прервал$g отдых и сел$g.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_SITTING;
+      break;
+    case POS_SLEEPING: send_to_char("Вам стоит проснуться.\r\n", ch);
+      break;
+    case POS_FIGHTING: send_to_char("Сесть? Во время боя? Вы явно не в себе.\r\n", ch);
+      break;
+    default: send_to_char("Вы прекратили свой полет и сели.\r\n", ch);
+      act("$n прекратил$g свой полет и сел$g.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_SITTING;
+      break;
+  }
 }
 
-void do_rest(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	if (ch->ahorse())
-	{
-		act("Прежде всего, вам стоит слезть с $N1.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-		return;
-	}
-	switch (GET_POS(ch))
-	{
-	case POS_STANDING:
-		send_to_char("Вы присели отдохнуть.\r\n", ch);
-		act("$n присел$g отдохнуть.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_RESTING;
-		break;
-	case POS_SITTING:
-		send_to_char("Вы пристроились поудобнее для отдыха.\r\n", ch);
-		act("$n пристроил$u поудобнее для отдыха.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_RESTING;
-		break;
-	case POS_RESTING:
-		send_to_char("Вы и так отдыхаете.\r\n", ch);
-		break;
-	case POS_SLEEPING:
-		send_to_char("Вам лучше сначала проснуться.\r\n", ch);
-		break;
-	case POS_FIGHTING:
-		send_to_char("Отдыха в бою вам не будет!\r\n", ch);
-		break;
-	default:
-		send_to_char("Вы прекратили полет и присели отдохнуть.\r\n", ch);
-		act("$n прекратил$g полет и пристроил$u поудобнее для отдыха.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_SITTING;
-		break;
-	}
+void do_rest(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  if (ch->ahorse()) {
+    act("Прежде всего, вам стоит слезть с $N1.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+    return;
+  }
+  switch (GET_POS(ch)) {
+    case POS_STANDING: send_to_char("Вы присели отдохнуть.\r\n", ch);
+      act("$n присел$g отдохнуть.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_RESTING;
+      break;
+    case POS_SITTING: send_to_char("Вы пристроились поудобнее для отдыха.\r\n", ch);
+      act("$n пристроил$u поудобнее для отдыха.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_RESTING;
+      break;
+    case POS_RESTING: send_to_char("Вы и так отдыхаете.\r\n", ch);
+      break;
+    case POS_SLEEPING: send_to_char("Вам лучше сначала проснуться.\r\n", ch);
+      break;
+    case POS_FIGHTING: send_to_char("Отдыха в бою вам не будет!\r\n", ch);
+      break;
+    default: send_to_char("Вы прекратили полет и присели отдохнуть.\r\n", ch);
+      act("$n прекратил$g полет и пристроил$u поудобнее для отдыха.", FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_SITTING;
+      break;
+  }
 }
 
-void do_sleep(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	if (GET_LEVEL(ch) >= LVL_IMMORT)
-	{
-		send_to_char("Не время вам спать, родина в опасности!\r\n", ch);
-		return;
-	}
-	if (ch->ahorse())
-	{
-		act("Прежде всего, вам стоит слезть с $N1.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
-		return;
-	}
-	switch (GET_POS(ch))
-	{
-	case POS_STANDING:
-	case POS_SITTING:
-	case POS_RESTING:
-		send_to_char("Вы заснули.\r\n", ch);
-		act("$n сладко зевнул$g и задал$g храпака.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_SLEEPING;
-		break;
-	case POS_SLEEPING:
-		send_to_char("А вы и так спите.\r\n", ch);
-		break;
-	case POS_FIGHTING:
-		send_to_char("Вам нужно сражаться! Отоспитесь после смерти.\r\n", ch);
-		break;
-	default:
-		send_to_char("Вы прекратили свой полет и отошли ко сну.\r\n", ch);
-		act("$n прекратил$g летать и нагло заснул$g.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_SLEEPING;
-		break;
-	}
+void do_sleep(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  if (GET_LEVEL(ch) >= LVL_IMMORT) {
+    send_to_char("Не время вам спать, родина в опасности!\r\n", ch);
+    return;
+  }
+  if (ch->ahorse()) {
+    act("Прежде всего, вам стоит слезть с $N1.", FALSE, ch, 0, ch->get_horse(), TO_CHAR);
+    return;
+  }
+  switch (GET_POS(ch)) {
+    case POS_STANDING:
+    case POS_SITTING:
+    case POS_RESTING: send_to_char("Вы заснули.\r\n", ch);
+      act("$n сладко зевнул$g и задал$g храпака.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_SLEEPING;
+      break;
+    case POS_SLEEPING: send_to_char("А вы и так спите.\r\n", ch);
+      break;
+    case POS_FIGHTING: send_to_char("Вам нужно сражаться! Отоспитесь после смерти.\r\n", ch);
+      break;
+    default: send_to_char("Вы прекратили свой полет и отошли ко сну.\r\n", ch);
+      act("$n прекратил$g летать и нагло заснул$g.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+      GET_POS(ch) = POS_SLEEPING;
+      break;
+  }
 }
 
-void do_wake(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
-{
-	CHAR_DATA *vict;
-	int self = 0;
+void do_wake(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  CHAR_DATA *vict;
+  int self = 0;
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
-	if (subcmd == SCMD_WAKEUP)
-	{
-		if (!(*arg))
-		{
-			send_to_char("Кого будить то будем???\r\n", ch);
-			return;
-		}
-	}
-	else
-	{
-		*arg = 0;
-	}
+  if (subcmd == SCMD_WAKEUP) {
+    if (!(*arg)) {
+      send_to_char("Кого будить то будем???\r\n", ch);
+      return;
+    }
+  } else {
+    *arg = 0;
+  }
 
-	if (*arg)
-	{
-		if (GET_POS(ch) == POS_SLEEPING)
-			send_to_char("Может быть вам лучше проснуться?\r\n", ch);
-		else if ((vict = get_char_vis(ch, arg, FIND_CHAR_ROOM)) == NULL)
-			send_to_char(NOPERSON, ch);
-		else if (vict == ch)
-			self = 1;
-		else if (AWAKE(vict))
-			act("$E и не спал$G.", FALSE, ch, 0, vict, TO_CHAR);
-		else if (GET_POS(vict) < POS_SLEEPING)
-			act("$M так плохо! Оставьте $S в покое!", FALSE, ch, 0, vict, TO_CHAR);
-		else
-		{
-			act("Вы $S разбудили.", FALSE, ch, 0, vict, TO_CHAR);
-			act("$n растолкал$g вас.", FALSE, ch, 0, vict, TO_VICT | TO_SLEEP);
-			GET_POS(vict) = POS_SITTING;
-		}
-		if (!self)
-			return;
-	}
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_SLEEP))
-		send_to_char("Вы не можете проснуться!\r\n", ch);
-	else if (GET_POS(ch) > POS_SLEEPING)
-		send_to_char("А вы и не спали...\r\n", ch);
-	else
-	{
-		send_to_char("Вы проснулись и сели.\r\n", ch);
-		act("$n проснул$u.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		GET_POS(ch) = POS_SITTING;
-	}
+  if (*arg) {
+    if (GET_POS(ch) == POS_SLEEPING)
+      send_to_char("Может быть вам лучше проснуться?\r\n", ch);
+    else if ((vict = get_char_vis(ch, arg, FIND_CHAR_ROOM)) == NULL)
+      send_to_char(NOPERSON, ch);
+    else if (vict == ch)
+      self = 1;
+    else if (AWAKE(vict))
+      act("$E и не спал$G.", FALSE, ch, 0, vict, TO_CHAR);
+    else if (GET_POS(vict) < POS_SLEEPING)
+      act("$M так плохо! Оставьте $S в покое!", FALSE, ch, 0, vict, TO_CHAR);
+    else {
+      act("Вы $S разбудили.", FALSE, ch, 0, vict, TO_CHAR);
+      act("$n растолкал$g вас.", FALSE, ch, 0, vict, TO_VICT | TO_SLEEP);
+      GET_POS(vict) = POS_SITTING;
+    }
+    if (!self)
+      return;
+  }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_SLEEP))
+    send_to_char("Вы не можете проснуться!\r\n", ch);
+  else if (GET_POS(ch) > POS_SLEEPING)
+    send_to_char("А вы и не спали...\r\n", ch);
+  else {
+    send_to_char("Вы проснулись и сели.\r\n", ch);
+    act("$n проснул$u.", TRUE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+    GET_POS(ch) = POS_SITTING;
+  }
 }
 
 

--- a/src/act.movement.cpp
+++ b/src/act.movement.cpp
@@ -179,15 +179,15 @@ int skip_hiding(CHAR_DATA *ch, CHAR_DATA *vict) {
       EXTRA_FLAGS(ch).set(EXTRA_FAILHIDE);
     } else if (affected_by_spell(ch, SPELL_HIDE)) {
       percent = number(1, 82 + GET_REAL_INT(vict));
-      prob = calculate_skill(ch, SKILL_HIDE, vict);
+      prob = CalcCurrentSkill(ch, SKILL_HIDE, vict);
       if (percent > prob) {
         affect_from_char(ch, SPELL_HIDE);
         if (!AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE)) {
-          improve_skill(ch, SKILL_HIDE, FALSE, vict);
+          ImproveSkill(ch, SKILL_HIDE, FALSE, vict);
           act("Вы не сумели остаться незаметным.", FALSE, ch, 0, vict, TO_CHAR);
         }
       } else {
-        improve_skill(ch, SKILL_HIDE, TRUE, vict);
+        ImproveSkill(ch, SKILL_HIDE, TRUE, vict);
         act("Вам удалось остаться незаметным.\r\n", FALSE, ch, 0, vict, TO_CHAR);
         return (TRUE);
       }
@@ -210,15 +210,15 @@ int skip_camouflage(CHAR_DATA *ch, CHAR_DATA *vict) {
       EXTRA_FLAGS(ch).set(EXTRA_FAILCAMOUFLAGE);
     } else if (affected_by_spell(ch, SPELL_CAMOUFLAGE)) {
       percent = number(1, 82 + GET_REAL_INT(vict));
-      prob = calculate_skill(ch, SKILL_CAMOUFLAGE, vict);
+      prob = CalcCurrentSkill(ch, SKILL_CAMOUFLAGE, vict);
       if (percent > prob) {
         affect_from_char(ch, SPELL_CAMOUFLAGE);
         if (!AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE)) {
-          improve_skill(ch, SKILL_CAMOUFLAGE, FALSE, vict);
+          ImproveSkill(ch, SKILL_CAMOUFLAGE, FALSE, vict);
           act("Вы не сумели правильно замаскироваться.", FALSE, ch, 0, vict, TO_CHAR);
         }
       } else {
-        improve_skill(ch, SKILL_CAMOUFLAGE, TRUE, vict);
+        ImproveSkill(ch, SKILL_CAMOUFLAGE, TRUE, vict);
         act("Ваша маскировка оказалась на высоте.\r\n", FALSE, ch, 0, vict, TO_CHAR);
         return (TRUE);
       }
@@ -248,7 +248,7 @@ int skip_sneaking(CHAR_DATA *ch, CHAR_DATA *vict) {
                        (can_use_feat(ch, STEALTHY_FEAT) ? 102 : 112)
                            + (GET_REAL_INT(vict) * (vict->get_role(MOB_ROLE_BOSS) ? 3 : 1))
                            + (GET_LEVEL(vict) > 30 ? GET_LEVEL(vict) : 0));
-      prob = calculate_skill(ch, SKILL_SNEAK, vict);
+      prob = CalcCurrentSkill(ch, SKILL_SNEAK, vict);
 
       int catch_level = (GET_LEVEL(vict) - GET_LEVEL(ch));
       if (catch_level > 5) {
@@ -263,11 +263,11 @@ int skip_sneaking(CHAR_DATA *ch, CHAR_DATA *vict) {
         if (affected_by_spell(ch, SPELL_HIDE))
           affect_from_char(ch, SPELL_HIDE);
         if (!AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK)) {
-          improve_skill(ch, SKILL_SNEAK, FALSE, vict);
+          ImproveSkill(ch, SKILL_SNEAK, FALSE, vict);
           act("Вы не сумели пробраться незаметно.", FALSE, ch, 0, vict, TO_CHAR);
         }
       } else {
-        improve_skill(ch, SKILL_SNEAK, TRUE, vict);
+        ImproveSkill(ch, SKILL_SNEAK, TRUE, vict);
         act("Вам удалось прокрасться незаметно.\r\n", FALSE, ch, 0, vict, TO_CHAR);
         return (TRUE);
       }
@@ -634,24 +634,24 @@ int do_simple_move(CHAR_DATA *ch, int dir, int need_specials_check, CHAR_DATA *l
   if (!IS_IMMORTAL(ch) && !IS_NPC(ch))
     GET_MOVE(ch) -= calculate_move_cost(ch, dir);
 
-  i = skill_info[SKILL_SNEAK].max_percent;
+  i = skill_info[SKILL_SNEAK].fail_percent;
   if (AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK) && !is_flee) {
     if (IS_NPC(ch))
       invis = 1;
     else if (awake_sneak(ch)) {
       affect_from_char(ch, SPELL_SNEAK);
-    } else if (!affected_by_spell(ch, SPELL_SNEAK) || calculate_skill(ch, SKILL_SNEAK, 0) >= number(1, i))
+    } else if (!affected_by_spell(ch, SPELL_SNEAK) || CalcCurrentSkill(ch, SKILL_SNEAK, 0) >= number(1, i))
       invis = 1;
   }
 
-  i = skill_info[SKILL_CAMOUFLAGE].max_percent;
+  i = skill_info[SKILL_CAMOUFLAGE].fail_percent;
   if (AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE) && !is_flee) {
     if (IS_NPC(ch))
       invis = 1;
     else if (awake_camouflage(ch)) {
       affect_from_char(ch, SPELL_CAMOUFLAGE);
     } else if (!affected_by_spell(ch, SPELL_CAMOUFLAGE) ||
-        calculate_skill(ch, SKILL_CAMOUFLAGE, 0) >= number(1, i))
+        CalcCurrentSkill(ch, SKILL_CAMOUFLAGE, 0) >= number(1, i))
       invis = 1;
   }
 
@@ -723,7 +723,7 @@ int do_simple_move(CHAR_DATA *ch, int dir, int need_specials_check, CHAR_DATA *l
 
   if (!IS_NPC(ch) && IS_BITS(ch->track_dirs, dir)) {
     send_to_char("Вы двинулись по следу.\r\n", ch);
-    improve_skill(ch, SKILL_TRACK, TRUE, 0);
+    ImproveSkill(ch, SKILL_TRACK, TRUE, 0);
   }
 
   char_from_room(ch);
@@ -1022,8 +1022,8 @@ void do_hidemove(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
     af.location = EApplyLocation::APPLY_NONE;
     af.modifier = 0;
     af.duration = 1;
-    const int calculated_skill = calculate_skill(ch, SKILL_SNEAK, 0);
-    const int chance = number(1, skill_info[SKILL_SNEAK].max_percent);
+    const int calculated_skill = CalcCurrentSkill(ch, SKILL_SNEAK, 0);
+    const int chance = number(1, skill_info[SKILL_SNEAK].fail_percent);
     af.bitvector = (chance < calculated_skill) ? to_underlying(EAffectFlag::AFF_SNEAK) : 0;
     af.battleflag = 0;
     affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
@@ -1357,10 +1357,10 @@ void do_doorcmd(CHAR_DATA *ch, OBJ_DATA *obj, int door, DOOR_SCMD scmd) {
 
 int ok_pick(CHAR_DATA *ch, obj_vnum /*keynum*/, OBJ_DATA *obj, int door, int scmd) {
   int pickproof = DOOR_IS_PICKPROOF(ch, obj, door);
-  int prob = number(1, skill_info[SKILL_PICK_LOCK].max_percent);
+  int prob = number(1, skill_info[SKILL_PICK_LOCK].fail_percent);
 
   if (scmd == SCMD_PICK) {
-    auto percent = calculate_skill(ch, SKILL_PICK_LOCK, nullptr);
+    auto percent = CalcCurrentSkill(ch, SKILL_PICK_LOCK, nullptr);
     if (pickproof)
       send_to_char("Вы никогда не сможете взломать ЭТО.\r\n", ch);
     else if (!check_moves(ch, PICKLOCK_MOVES));
@@ -1371,7 +1371,7 @@ int ok_pick(CHAR_DATA *ch, obj_vnum /*keynum*/, OBJ_DATA *obj, int door, int scm
       //если скилл больше сложности на 10 и более - даже трениться на таком замке нельзя
     else if ((ch->get_skill(SKILL_PICK_LOCK) - DOOR_LOCK_COMPLEX(ch, obj, door) <= 10) && (prob > percent)) {
       send_to_char("Взломщик из вас пока еще никудышний.\r\n", ch);
-      train_skill(ch, SKILL_PICK_LOCK, false, nullptr);
+      TrainSkill(ch, SKILL_PICK_LOCK, false, nullptr);
     } else if (get_pick_chance(ch->get_skill(SKILL_PICK_LOCK), DOOR_LOCK_COMPLEX(ch, obj, door)) < number(1, 10)) {
       send_to_char("Вы все-таки сломали этот замок...\r\n", ch);
       if (obj) {

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -384,8 +384,8 @@ void do_sneak(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
 
 	send_to_char("Хорошо, вы попытаетесь двигаться бесшумно.\r\n", ch);
 	EXTRA_FLAGS(ch).unset(EXTRA_FAILSNEAK);
-	percent = number(1, skill_info[SKILL_SNEAK].max_percent);
-	prob = calculate_skill(ch, SKILL_SNEAK, 0);
+	percent = number(1, skill_info[SKILL_SNEAK].fail_percent);
+	prob = CalcCurrentSkill(ch, SKILL_SNEAK, 0);
 
 	AFFECT_DATA<EApplyLocation> af;
 	af.type = SPELL_SNEAK;
@@ -448,8 +448,8 @@ void do_camouflage(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*
 
 	send_to_char("Вы начали усиленно маскироваться.\r\n", ch);
 	EXTRA_FLAGS(ch).unset(EXTRA_FAILCAMOUFLAGE);
-	percent = number(1, skill_info[SKILL_CAMOUFLAGE].max_percent);
-	prob = calculate_skill(ch, SKILL_CAMOUFLAGE, 0);
+	percent = number(1, skill_info[SKILL_CAMOUFLAGE].fail_percent);
+	prob = CalcCurrentSkill(ch, SKILL_CAMOUFLAGE, 0);
 
 	AFFECT_DATA<EApplyLocation> af;
 	af.type = SPELL_CAMOUFLAGE;
@@ -514,8 +514,8 @@ void do_hide(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
 
 	send_to_char("Хорошо, вы попытаетесь спрятаться.\r\n", ch);
 	EXTRA_FLAGS(ch).unset(EXTRA_FAILHIDE);
-	percent = number(1, skill_info[SKILL_HIDE].max_percent);
-	prob = calculate_skill(ch, SKILL_HIDE, 0);
+	percent = number(1, skill_info[SKILL_HIDE].fail_percent);
+	prob = CalcCurrentSkill(ch, SKILL_HIDE, 0);
 
 	AFFECT_DATA<EApplyLocation> af;
 	af.type = SPELL_HIDE;
@@ -557,7 +557,7 @@ void go_steal(CHAR_DATA * ch, CHAR_DATA * vict, char *obj_name)
 	}
 
 	// 101% is a complete failure
-	percent = number(1, skill_info[SKILL_STEAL].max_percent);
+	percent = number(1, skill_info[SKILL_STEAL].fail_percent);
 
 	if (WAITLESS(ch) || (GET_POS(vict) <= POS_SLEEPING && !AFF_FLAGGED(vict, EAffectFlag::AFF_SLEEP)))
 		success = 1;	// ALWAYS SUCCESS, unless heavy object.
@@ -633,7 +633,7 @@ void go_steal(CHAR_DATA * ch, CHAR_DATA * vict, char *obj_name)
 				return;
 			}
 			percent += GET_OBJ_WEIGHT(obj);	// Make heavy harder
-			prob = calculate_skill(ch, SKILL_STEAL, vict);
+			prob = CalcCurrentSkill(ch, SKILL_STEAL, vict);
 
 			if (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE))
 				prob += 5;
@@ -670,12 +670,12 @@ void go_steal(CHAR_DATA * ch, CHAR_DATA * vict, char *obj_name)
 				}
 			}
 			if (CAN_SEE(vict, ch) && AWAKE(vict))
-				improve_skill(ch, SKILL_STEAL, 0, vict);
+              ImproveSkill(ch, SKILL_STEAL, 0, vict);
 		}
 	}
 	else  		// Steal some coins
 	{
-		prob = calculate_skill(ch, SKILL_STEAL, vict);
+		prob = CalcCurrentSkill(ch, SKILL_STEAL, vict);
 		if (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE))
 			prob += 5;
 		if (!WAITLESS(ch) && AFF_FLAGGED(vict, EAffectFlag::AFF_SLEEP))
@@ -735,7 +735,7 @@ void go_steal(CHAR_DATA * ch, CHAR_DATA * vict, char *obj_name)
 			}
 		}
 		if (CAN_SEE(vict, ch) && AWAKE(vict))
-			improve_skill(ch, SKILL_STEAL, 0, vict);
+          ImproveSkill(ch, SKILL_STEAL, 0, vict);
 	}
 	if (!WAITLESS(ch) && ohoh)
 		WAIT_STATE(ch, 3 * PULSE_VIOLENCE);
@@ -881,7 +881,7 @@ void do_courage(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
 	timed.skill = SKILL_COURAGE;
 	timed.time = 6;
 	timed_to_char(ch, &timed);
-	prob = calculate_skill(ch, SKILL_COURAGE, 0) / 20;
+	prob = CalcCurrentSkill(ch, SKILL_COURAGE, 0) / 20;
 	AFFECT_DATA<EApplyLocation> af[4];
 	af[0].type = SPELL_COURAGE;
 	af[0].duration = pc_duration(ch, 3, 0, 0, 0, 0);
@@ -3223,13 +3223,13 @@ void do_dig(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
 		return;
 	}
 
-	percent = number(1, skill_info[SKILL_DIG].max_percent);
+	percent = number(1, skill_info[SKILL_DIG].fail_percent);
 	prob = ch->get_skill(SKILL_DIG);
 	old_int = ch->get_int();
 	old_wis = ch->get_wis();
 	ch->set_int(ch->get_int() + 14 - MAX(14, GET_REAL_INT(ch)));
 	ch->set_wis(ch->get_wis() + 14 - MAX(14, GET_REAL_WIS(ch)));
-	improve_skill(ch, SKILL_DIG, 0, 0);
+  ImproveSkill(ch, SKILL_DIG, 0, 0);
 	ch->set_int(old_int);
 	ch->set_wis(old_wis);
 
@@ -3432,7 +3432,7 @@ void do_insertgem(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/)
 		return;
 	}
 
-	percent = number(1, skill_info[SKILL_INSERTGEM].max_percent);
+	percent = number(1, skill_info[SKILL_INSERTGEM].fail_percent);
 	prob = ch->get_skill(SKILL_INSERTGEM);
 
 	WAIT_STATE(ch, PULSE_VIOLENCE);
@@ -3458,7 +3458,7 @@ void do_insertgem(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/)
 
 	if (!*arg3)
 	{
-		improve_skill(ch, SKILL_INSERTGEM, 0, 0);
+      ImproveSkill(ch, SKILL_INSERTGEM, 0, 0);
 
 		if (percent > prob / insgem_vars.prob_divide)
 		{
@@ -3505,7 +3505,7 @@ void do_insertgem(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/)
 			return;
 		}
 
-		improve_skill(ch, SKILL_INSERTGEM, 0, 0);
+      ImproveSkill(ch, SKILL_INSERTGEM, 0, 0);
 
 		//успех или фэйл? при 80% скила успех 30% при 100% скила 50% при 200% скила успех 75%
 		if (number(1, ch->get_skill(SKILL_INSERTGEM)) > (ch->get_skill(SKILL_INSERTGEM) - 50))

--- a/src/chars/char.hpp
+++ b/src/chars/char.hpp
@@ -984,15 +984,6 @@ inline auto GET_REAL_CHA(const CHAR_DATA* ch) {
 	return VPOSI_MOB(ch, 5, ch->get_cha() + ch->get_cha_add());
 };
 
-const short CAP_SKILLS = 200;
-const byte  MAX_EXP_PERCENT = 80;
-
-inline auto MAX_EXP_RMRT_PERCENT(const CHAR_DATA* ch) {
-	return MIN(CAP_SKILLS, MAX_EXP_PERCENT + ch->get_remort() * 5);
-}
-inline auto max_upgradable_skill(const CHAR_DATA *ch) {
-	return MIN(MAX_EXP_RMRT_PERCENT(ch), wis_bonus(GET_REAL_WIS(ch), WIS_MAX_LEARN_L20) * GET_LEVEL(ch) / 20.0);
-};
 void change_fighting(CHAR_DATA * ch, int need_stop);
 
 #endif // CHAR_HPP_INCLUDED

--- a/src/cmd/cast.cpp
+++ b/src/cmd/cast.cpp
@@ -161,7 +161,7 @@ void do_cast(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/)
 		//log("[DO_CAST->AFFECT_TOTAL] Start");
 		affect_total(ch);
 		//log("[DO_CAST->AFFECT_TOTAL] Stop");
-		if (!tch || !skill_message(0, ch, tch, spellnum))
+		if (!tch || !SendSkillMessages(0, ch, tch, spellnum))
 			send_to_char("Вы не смогли сосредоточиться!\r\n", ch);
 	}
 	else  		// cast spell returns 1 on success; subtract mana & set waitstate

--- a/src/cmd/learn.cpp
+++ b/src/cmd/learn.cpp
@@ -201,7 +201,7 @@ void do_learn(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/) {
 
 		// апгрейд скилла до макс.скилла плеера (без макса в книге)
 		if (GET_OBJ_VAL(obj, 3) <= 0
-			&& ch->get_trained_skill(static_cast<ESkill>(spellnum)) >= MAX_EXP_PERCENT + GET_REMORT(ch) * 5)
+			&& ch->get_trained_skill(static_cast<ESkill>(spellnum)) >= kSkillCapOnZeroRemort + GET_REMORT(ch) * 5)
 		{
 			book_upgrd_fail_message(ch, obj);
 			return;
@@ -277,7 +277,7 @@ void do_learn(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/) {
 				}
 				else
 				{
-					ch->set_skill(skill, MIN(left_skill_level, MAX_EXP_PERCENT + GET_REMORT(ch) * 5));
+					ch->set_skill(skill, MIN(left_skill_level, kSkillCapOnZeroRemort + GET_REMORT(ch) * 5));
 				}
 			}
 			break;

--- a/src/cmd/mixture.cpp
+++ b/src/cmd/mixture.cpp
@@ -119,7 +119,7 @@ void do_mixture(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
 		if (!spell_use_success(ch, tch, SAVING_NONE, spellnum))
 		{
 			WAIT_STATE(ch, PULSE_VIOLENCE);
-			if (!tch || !skill_message(0, ch, tch, spellnum))
+			if (!tch || !SendSkillMessages(0, ch, tch, spellnum))
 			{
 				if (subcmd == SCMD_ITEMS)
 					send_to_char("Вы неправильно смешали ингредиенты!\r\n", ch);

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -219,7 +219,7 @@ TIME_INFO_DATA *mud_time_passed(time_t t2, time_t t1);
 void free_alias(struct alias_data *a);
 void load_messages(void);
 void initSpells(void);
-void initSkills(void);
+void InitSkills(void);
 void sort_commands(void);
 void Read_Invalid_List(void);
 int find_name(const char *name);
@@ -2601,7 +2601,7 @@ void boot_db(void)
 
 	boot_profiler.next_step("Loading skill definitions");
 	log("Loading skill definitions.");
-	initSkills();
+  InitSkills();
 
 	boot_profiler.next_step("Loading feature definitions");
 	log("Loading feature definitions.");

--- a/src/dg_script/dg_handler.cpp
+++ b/src/dg_script/dg_handler.cpp
@@ -29,133 +29,115 @@
 #include "conf.h"
 
 // remove a single trigger from a mob/obj/room
-void extract_trigger(TRIG_DATA* trig)
-{
-	if (GET_TRIG_WAIT(trig))
-	{
-		// см. объяснения в вызове trig_data_free()
-		free(GET_TRIG_WAIT(trig)->info);
-		remove_event(GET_TRIG_WAIT(trig));
-		GET_TRIG_WAIT(trig) = NULL;
-	}
+void extract_trigger(TRIG_DATA *trig) {
+  if (GET_TRIG_WAIT(trig)) {
+    // см. объяснения в вызове trig_data_free()
+    free(GET_TRIG_WAIT(trig)->info);
+    remove_event(GET_TRIG_WAIT(trig));
+    GET_TRIG_WAIT(trig) = NULL;
+  }
 
-	trig_index[trig->get_rnum()]->number--;
+  trig_index[trig->get_rnum()]->number--;
 
-	// walk the trigger list and remove this one
-	trigger_list.remove(trig);
+  // walk the trigger list and remove this one
+  trigger_list.remove(trig);
 
-	trig->clear_var_list();
+  trig->clear_var_list();
 
-	delete trig;
+  delete trig;
 }
 
 // remove all triggers from a mob/obj/room
-void extract_script(SCRIPT_DATA * sc)
-{
-	sc->trig_list.clear();
+void extract_script(SCRIPT_DATA *sc) {
+  sc->trig_list.clear();
 }
 
 // erase the script memory of a mob
-void extract_script_mem(struct script_memory *sc)
-{
-	struct script_memory *next;
-	while (sc)
-	{
-		next = sc->next;
-		if (sc->cmd)
-			free(sc->cmd);
-		free(sc);
-		sc = next;
-	}
+void extract_script_mem(struct script_memory *sc) {
+  struct script_memory *next;
+  while (sc) {
+    next = sc->next;
+    if (sc->cmd)
+      free(sc->cmd);
+    free(sc);
+    sc = next;
+  }
 }
 
 // perhaps not the best place for this, but I didn't want a new file
-const char * skill_percent(TRIG_DATA* trig, CHAR_DATA * ch, char *skill)
-{
-	static char retval[256];
-	im_rskill *rs;
-	int rid;
+const char *skill_percent(TRIG_DATA *trig, CHAR_DATA *ch, char *skill) {
+  static char retval[256];
+  im_rskill *rs;
+  int rid;
 
-	const ESkill skillnum = fix_name_and_find_skill_num(skill);
-	if (skillnum > 0)
-	{
-		//edited by WorM 2011.05.23 триги должны возвращать реальный скилл без бонусов от стафа
-		sprintf(retval, "%d", ch->get_trained_skill(skillnum));
-		return retval;
-	}
-	rid = im_get_recipe_by_name(skill);
-	if (rid >= 0)
-	{
-		rs = im_get_char_rskill(ch, rid);
-		if (!rs)
-			return "0";
-		sprintf(retval, "%d", rs->perc);
-		return retval;
-	}
-	if ((skillnum == 0) && (rid < 0))
-	{
-		sprintf(buf2, "Wrong skill\recipe name: %s", skill);
-		trig_log(trig, buf2);
-	}
-	return ("0");
+  const ESkill skillnum = fix_name_and_find_skill_num(skill);
+  if (skillnum > 0) {
+    sprintf(retval, "%d", ch->get_trained_skill(skillnum));
+    return retval;
+  }
+  rid = im_get_recipe_by_name(skill);
+  if (rid >= 0) {
+    rs = im_get_char_rskill(ch, rid);
+    if (!rs)
+      return "0";
+    sprintf(retval, "%d", rs->perc);
+    return retval;
+  }
+  if ((skillnum == 0) && (rid < 0)) {
+    sprintf(buf2, "Wrong skill\recipe name: %s", skill);
+    trig_log(trig, buf2);
+  }
+  return ("0");
 }
 
-bool feat_owner(TRIG_DATA* trig, CHAR_DATA * ch, char *feat)
-{
-	int featnum;
+bool feat_owner(TRIG_DATA *trig, CHAR_DATA *ch, char *feat) {
+  int featnum;
 
-	featnum = find_feat_num(feat);
-	if (featnum > 0)
-	{
-		if (HAVE_FEAT(ch, featnum))
-			return 1;
-	}
-	else
-	{
-		sprintf(buf2, "Wrong feat name: %s", feat);
-		trig_log(trig, buf2);
-	}
-	return 0;
+  featnum = find_feat_num(feat);
+  if (featnum > 0) {
+    if (HAVE_FEAT(ch, featnum))
+      return 1;
+  } else {
+    sprintf(buf2, "Wrong feat name: %s", feat);
+    trig_log(trig, buf2);
+  }
+  return 0;
 }
 
-const char * spell_count(TRIG_DATA* trig, CHAR_DATA * ch, char *spell)
-{
-	static char retval[256];
-	int spellnum;
+const char *spell_count(TRIG_DATA *trig, CHAR_DATA *ch, char *spell) {
+  static char retval[256];
+  int spellnum;
 
-	spellnum = fix_name_and_find_spell_num(spell);
-	if (spellnum <= 0)
-	{
-		sprintf(buf2, "Wrong spell name: %s", spell);
-		trig_log(trig, buf2);
-		return ("0");
-	}
+  spellnum = fix_name_and_find_spell_num(spell);
+  if (spellnum <= 0) {
+    sprintf(buf2, "Wrong spell name: %s", spell);
+    trig_log(trig, buf2);
+    return ("0");
+  }
 
-	if (GET_SPELL_MEM(ch, spellnum))
-		sprintf(retval, "%d", GET_SPELL_MEM(ch, spellnum));
-	else
-		strcpy(retval, "0");
-	return retval;
+  if (GET_SPELL_MEM(ch, spellnum))
+    sprintf(retval, "%d", GET_SPELL_MEM(ch, spellnum));
+  else
+    strcpy(retval, "0");
+  return retval;
 }
 
-const char * spell_knowledge(TRIG_DATA* trig, CHAR_DATA * ch, char *spell)
-{
-	static char retval[256];
-	int spellnum;
+const char *spell_knowledge(TRIG_DATA *trig, CHAR_DATA *ch, char *spell) {
+  static char retval[256];
+  int spellnum;
 
-	spellnum = fix_name_and_find_spell_num(spell);
-	if (spellnum <= 0)
-	{
-		sprintf(buf2, "Wrong spell name: %s", spell);
-		trig_log(trig, buf2);
-		return ("0");
-	}
+  spellnum = fix_name_and_find_spell_num(spell);
+  if (spellnum <= 0) {
+    sprintf(buf2, "Wrong spell name: %s", spell);
+    trig_log(trig, buf2);
+    return ("0");
+  }
 
-	if (GET_SPELL_TYPE(ch, spellnum))
-		sprintf(retval, "%d", GET_SPELL_TYPE(ch, spellnum));
-	else
-		strcpy(retval, "0");
-	return retval;
+  if (GET_SPELL_TYPE(ch, spellnum))
+    sprintf(retval, "%d", GET_SPELL_TYPE(ch, spellnum));
+  else
+    strcpy(retval, "0");
+  return retval;
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/dg_script/dg_scripts.cpp
+++ b/src/dg_script/dg_scripts.cpp
@@ -2326,7 +2326,7 @@ void find_replacement(void *go,
     } else if (!str_cmp(field, "maxskill")) {
       const ESkill skillnum = fix_name_and_find_skill_num(subfield);
       if (skillnum > 0) {
-        sprintf(str, "%d", CalcSkillMinCap(c, skillnum));
+        sprintf(str, "%d", CalcSkillHardCap(c, skillnum));
       } else {
         strcpy(str, "0");
       }

--- a/src/dg_script/dg_scripts.cpp
+++ b/src/dg_script/dg_scripts.cpp
@@ -57,11 +57,11 @@
 #define IS_CHARMED(ch)          (IS_HORSE(ch)||AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM))
 
 // Вывод сообщений о неверных управляющих конструкциях DGScript
-#define	DG_CODE_ANALYZE
+#define    DG_CODE_ANALYZE
 
 // external vars from triggers.cpp
 extern const char *trig_types[], *otrig_types[], *wtrig_types[];
-const char *attach_name[] = { "mob", "obj", "room", "unknown!!!" };
+const char *attach_name[] = {"mob", "obj", "room", "unknown!!!"};
 
 int last_trig_vnum = 0;
 
@@ -78,23 +78,23 @@ extern INDEX_DATA *mob_index;
 extern TIME_INFO_DATA time_info;
 const char *spell_name(int num);
 
-extern int can_take_obj(CHAR_DATA * ch, OBJ_DATA * obj);
+extern int can_take_obj(CHAR_DATA *ch, OBJ_DATA *obj);
 extern void split_or_clan_tax(CHAR_DATA *ch, long amount);
 
 // external functions
-room_rnum find_target_room(CHAR_DATA * ch, char *rawroomstr, int trig);
+room_rnum find_target_room(CHAR_DATA *ch, char *rawroomstr, int trig);
 void free_varlist(struct trig_var_data *vd);
-int obj_room(OBJ_DATA * obj);
+int obj_room(OBJ_DATA *obj);
 bool is_empty(int zone_nr);
 TRIG_DATA *read_trigger(int nr);
-OBJ_DATA *get_object_in_equip(CHAR_DATA * ch, char *name);
-void extract_trigger(TRIG_DATA * trig);
-int eval_lhs_op_rhs(const char *expr, char *result, void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type);
-const char * skill_percent(TRIG_DATA* trig, CHAR_DATA * ch, char *skill);
-bool feat_owner(TRIG_DATA* trig, CHAR_DATA * ch, char *feat);
-const char * spell_count(TRIG_DATA* trig, CHAR_DATA * ch, char *spell);
-const char * spell_knowledge(TRIG_DATA* trig, CHAR_DATA * ch, char *spell);
-int find_eq_pos(CHAR_DATA * ch, OBJ_DATA * obj, char *arg);
+OBJ_DATA *get_object_in_equip(CHAR_DATA *ch, char *name);
+void extract_trigger(TRIG_DATA *trig);
+int eval_lhs_op_rhs(const char *expr, char *result, void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type);
+const char *skill_percent(TRIG_DATA *trig, CHAR_DATA *ch, char *skill);
+bool feat_owner(TRIG_DATA *trig, CHAR_DATA *ch, char *feat);
+const char *spell_count(TRIG_DATA *trig, CHAR_DATA *ch, char *spell);
+const char *spell_knowledge(TRIG_DATA *trig, CHAR_DATA *ch, char *spell);
+int find_eq_pos(CHAR_DATA *ch, OBJ_DATA *obj, char *arg);
 void reset_zone(int znum);
 
 void do_restore(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
@@ -102,8 +102,8 @@ void do_mpurge(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_mjunk(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_arena_restore(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 // function protos from this file
-void extract_value(SCRIPT_DATA * sc, TRIG_DATA * trig, char *cmd);
-int script_driver(void *go, TRIG_DATA * trig, int type, int mode);
+void extract_value(SCRIPT_DATA *sc, TRIG_DATA *trig, char *cmd);
+int script_driver(void *go, TRIG_DATA *trig, int type, int mode);
 int trgvar_in_room(int vnum);
 
 /*
@@ -113,56 +113,78 @@ bool CharacterLinkDrop = false;
 
 //table for replace UID_CHAR, UID_OBJ, UID_ROOM
 const char uid_replace_table[] = {
-	'\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\x08', '\x09', '\x0a', '\x0b', '\x0c', '\x0d', '\x0e', '\x0f',	//16
-	'\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17', '\x18', '\x19', '\x1a', '\x1b', '\x20', '\x20', '\x20', '\x1f',	//32
-	'\x20', '\x21', '\x22', '\x23', '\x24', '\x25', '\x26', '\x27', '\x28', '\x29', '\x2a', '\x2b', '\x2c', '\x2d', '\x2e', '\x2f',	//48
-	'\x30', '\x31', '\x32', '\x33', '\x34', '\x35', '\x36', '\x37', '\x38', '\x39', '\x3a', '\x3b', '\x3c', '\x3d', '\x3e', '\x3f',	//64
-	'\x40', '\x41', '\x42', '\x43', '\x44', '\x45', '\x46', '\x47', '\x48', '\x49', '\x4a', '\x4b', '\x4c', '\x4d', '\x4e', '\x4f',	//80
-	'\x50', '\x51', '\x52', '\x53', '\x54', '\x55', '\x56', '\x57', '\x58', '\x59', '\x5a', '\x5b', '\x5c', '\x5d', '\x5e', '\x5f',	//96
-	'\x60', '\x61', '\x62', '\x63', '\x64', '\x65', '\x66', '\x67', '\x68', '\x69', '\x6a', '\x6b', '\x6c', '\x6d', '\x6e', '\x6f',	//112
-	'\x70', '\x71', '\x72', '\x73', '\x74', '\x75', '\x76', '\x77', '\x78', '\x79', '\x7a', '\x7b', '\x7c', '\x7d', '\x7e', '\x7f',	//128
-	'\x80', '\x81', '\x82', '\x83', '\x84', '\x85', '\x86', '\x87', '\x88', '\x89', '\x8a', '\x8b', '\x8c', '\x8d', '\x8e', '\x8f',	//144
-	'\x90', '\x91', '\x92', '\x93', '\x94', '\x95', '\x96', '\x97', '\x98', '\x99', '\x9a', '\x9b', '\x9c', '\x9d', '\x9e', '\x9f',	//160
-	'\xa0', '\xa1', '\xa2', '\xa3', '\xa4', '\xa5', '\xa6', '\xa7', '\xa8', '\xa9', '\xaa', '\xab', '\xac', '\xad', '\xae', '\xaf',	//176
-	'\xb0', '\xb1', '\xb2', '\xb3', '\xb4', '\xb5', '\xb6', '\xb7', '\xb8', '\xb9', '\xba', '\xbb', '\xbc', '\xbd', '\xbe', '\xbf',	//192
-	'\xc0', '\xc1', '\xc2', '\xc3', '\xc4', '\xc5', '\xc6', '\xc7', '\xc8', '\xc9', '\xca', '\xcb', '\xcc', '\xcd', '\xce', '\xcf',	//208
-	'\xd0', '\xd1', '\xd2', '\xd3', '\xd4', '\xd5', '\xd6', '\xd7', '\xd8', '\xd9', '\xda', '\xdb', '\xdc', '\xdd', '\xde', '\xdf',	//224
-	'\xe0', '\xe1', '\xe2', '\xe3', '\xe4', '\xe5', '\xe6', '\xe7', '\xe8', '\xe9', '\xea', '\xeb', '\xec', '\xed', '\xee', '\xef',	//240
-	'\xf0', '\xf1', '\xf2', '\xf3', '\xf4', '\xf5', '\xf6', '\xf7', '\xf8', '\xf9', '\xfa', '\xfb', '\xfc', '\xfd', '\xfe', '\xff'	//256
+    '\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\x08', '\x09', '\x0a', '\x0b', '\x0c', '\x0d',
+    '\x0e', '\x0f',    //16
+    '\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17', '\x18', '\x19', '\x1a', '\x1b', '\x20', '\x20',
+    '\x20', '\x1f',    //32
+    '\x20', '\x21', '\x22', '\x23', '\x24', '\x25', '\x26', '\x27', '\x28', '\x29', '\x2a', '\x2b', '\x2c', '\x2d',
+    '\x2e', '\x2f',    //48
+    '\x30', '\x31', '\x32', '\x33', '\x34', '\x35', '\x36', '\x37', '\x38', '\x39', '\x3a', '\x3b', '\x3c', '\x3d',
+    '\x3e', '\x3f',    //64
+    '\x40', '\x41', '\x42', '\x43', '\x44', '\x45', '\x46', '\x47', '\x48', '\x49', '\x4a', '\x4b', '\x4c', '\x4d',
+    '\x4e', '\x4f',    //80
+    '\x50', '\x51', '\x52', '\x53', '\x54', '\x55', '\x56', '\x57', '\x58', '\x59', '\x5a', '\x5b', '\x5c', '\x5d',
+    '\x5e', '\x5f',    //96
+    '\x60', '\x61', '\x62', '\x63', '\x64', '\x65', '\x66', '\x67', '\x68', '\x69', '\x6a', '\x6b', '\x6c', '\x6d',
+    '\x6e', '\x6f',    //112
+    '\x70', '\x71', '\x72', '\x73', '\x74', '\x75', '\x76', '\x77', '\x78', '\x79', '\x7a', '\x7b', '\x7c', '\x7d',
+    '\x7e', '\x7f',    //128
+    '\x80', '\x81', '\x82', '\x83', '\x84', '\x85', '\x86', '\x87', '\x88', '\x89', '\x8a', '\x8b', '\x8c', '\x8d',
+    '\x8e', '\x8f',    //144
+    '\x90', '\x91', '\x92', '\x93', '\x94', '\x95', '\x96', '\x97', '\x98', '\x99', '\x9a', '\x9b', '\x9c', '\x9d',
+    '\x9e', '\x9f',    //160
+    '\xa0', '\xa1', '\xa2', '\xa3', '\xa4', '\xa5', '\xa6', '\xa7', '\xa8', '\xa9', '\xaa', '\xab', '\xac', '\xad',
+    '\xae', '\xaf',    //176
+    '\xb0', '\xb1', '\xb2', '\xb3', '\xb4', '\xb5', '\xb6', '\xb7', '\xb8', '\xb9', '\xba', '\xbb', '\xbc', '\xbd',
+    '\xbe', '\xbf',    //192
+    '\xc0', '\xc1', '\xc2', '\xc3', '\xc4', '\xc5', '\xc6', '\xc7', '\xc8', '\xc9', '\xca', '\xcb', '\xcc', '\xcd',
+    '\xce', '\xcf',    //208
+    '\xd0', '\xd1', '\xd2', '\xd3', '\xd4', '\xd5', '\xd6', '\xd7', '\xd8', '\xd9', '\xda', '\xdb', '\xdc', '\xdd',
+    '\xde', '\xdf',    //224
+    '\xe0', '\xe1', '\xe2', '\xe3', '\xe4', '\xe5', '\xe6', '\xe7', '\xe8', '\xe9', '\xea', '\xeb', '\xec', '\xed',
+    '\xee', '\xef',    //240
+    '\xf0', '\xf1', '\xf2', '\xf3', '\xf4', '\xf5', '\xf6', '\xf7', '\xf8', '\xf9', '\xfa', '\xfb', '\xfc', '\xfd',
+    '\xfe', '\xff'    //256
 };
 
-void script_log(const char *msg, LogMode type)
-{
-	char tmpbuf[MAX_STRING_LENGTH];
+void script_log(const char *msg, LogMode type) {
+  char tmpbuf[MAX_STRING_LENGTH];
 
-	snprintf(tmpbuf, MAX_STRING_LENGTH, "SCRIPT LOG %s", msg);
+  snprintf(tmpbuf, MAX_STRING_LENGTH, "SCRIPT LOG %s", msg);
 
-	char* pos = tmpbuf;
-	while (*pos != '\0')
-	{
-		*pos = uid_replace_table[static_cast<unsigned char>(*pos)];
-		++pos;
-	}
+  char *pos = tmpbuf;
+  while (*pos != '\0') {
+    *pos = uid_replace_table[static_cast<unsigned char>(*pos)];
+    ++pos;
+  }
 
-	log("%s", tmpbuf);
-	mudlog(tmpbuf, type ? type : NRM, LVL_BUILDER, ERRLOG, TRUE);
+  log("%s", tmpbuf);
+  mudlog(tmpbuf, type ? type : NRM, LVL_BUILDER, ERRLOG, TRUE);
 }
 
 /*
  *  Logs any errors caused by scripts to the system log.
  *  Will eventually allow on-line view of script errors.
  */
-void trig_log(TRIG_DATA * trig, const char *msg, LogMode type)
-{
-	char tmpbuf[MAX_STRING_LENGTH];
-	snprintf(tmpbuf, MAX_STRING_LENGTH, "(Trigger: %s, VNum: %d) : %s", GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), msg);
-	script_log(tmpbuf, type);
+void trig_log(TRIG_DATA *trig, const char *msg, LogMode type) {
+  char tmpbuf[MAX_STRING_LENGTH];
+  snprintf(tmpbuf, MAX_STRING_LENGTH, "(Trigger: %s, VNum: %d) : %s", GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), msg);
+  script_log(tmpbuf, type);
 }
 
-cmdlist_element::shared_ptr find_end(TRIG_DATA * trig, cmdlist_element::shared_ptr cl);
-cmdlist_element::shared_ptr find_done(TRIG_DATA * trig, cmdlist_element::shared_ptr cl);
-cmdlist_element::shared_ptr find_case(TRIG_DATA * trig, cmdlist_element::shared_ptr cl, void *go, SCRIPT_DATA * sc, int type, char *cond);
-cmdlist_element::shared_ptr find_else_end(TRIG_DATA * trig, cmdlist_element::shared_ptr cl, void *go, SCRIPT_DATA * sc, int type);
+cmdlist_element::shared_ptr find_end(TRIG_DATA *trig, cmdlist_element::shared_ptr cl);
+cmdlist_element::shared_ptr find_done(TRIG_DATA *trig, cmdlist_element::shared_ptr cl);
+cmdlist_element::shared_ptr find_case(TRIG_DATA *trig,
+                                      cmdlist_element::shared_ptr cl,
+                                      void *go,
+                                      SCRIPT_DATA *sc,
+                                      int type,
+                                      char *cond);
+cmdlist_element::shared_ptr find_else_end(TRIG_DATA *trig,
+                                          cmdlist_element::shared_ptr cl,
+                                          void *go,
+                                          SCRIPT_DATA *sc,
+                                          int type);
 
 struct trig_var_data *worlds_vars;
 
@@ -170,979 +192,788 @@ struct trig_var_data *worlds_vars;
 int reloc_target = -1;
 TRIG_DATA *cur_trig = NULL;
 
-GlobalTriggersStorage::~GlobalTriggersStorage()
-{
-	// notify all observers that of each trigger that they are going to be removed
-	for (const auto& i : m_observers)
-	{
-		for (const auto& observer : i.second)
-		{
-			observer->notify(i.first);
-		}
-	}
+GlobalTriggersStorage::~GlobalTriggersStorage() {
+  // notify all observers that of each trigger that they are going to be removed
+  for (const auto &i : m_observers) {
+    for (const auto &observer : i.second) {
+      observer->notify(i.first);
+    }
+  }
 }
 
-void GlobalTriggersStorage::add(TRIG_DATA* trigger)
-{
-	m_triggers.insert(trigger);
-	m_rnum2triggers_set[trigger->get_rnum()].insert(trigger);
+void GlobalTriggersStorage::add(TRIG_DATA *trigger) {
+  m_triggers.insert(trigger);
+  m_rnum2triggers_set[trigger->get_rnum()].insert(trigger);
 }
 
-void GlobalTriggersStorage::remove(TRIG_DATA* trigger)
-{
-	// notify all observers that this trigger is going to be removed.
-	const auto observers_list_i = m_observers.find(trigger);
-	if (observers_list_i != m_observers.end())
-	{
-		for (const auto& observer : m_observers[trigger])
-		{
-			observer->notify(trigger);
-		}
+void GlobalTriggersStorage::remove(TRIG_DATA *trigger) {
+  // notify all observers that this trigger is going to be removed.
+  const auto observers_list_i = m_observers.find(trigger);
+  if (observers_list_i != m_observers.end()) {
+    for (const auto &observer : m_observers[trigger]) {
+      observer->notify(trigger);
+    }
 
-		m_observers.erase(observers_list_i);
-	}
+    m_observers.erase(observers_list_i);
+  }
 
-	// then erase trigger
-	m_triggers.erase(trigger);
-	m_rnum2triggers_set[trigger->get_rnum()].erase(trigger);
+  // then erase trigger
+  m_triggers.erase(trigger);
+  m_rnum2triggers_set[trigger->get_rnum()].erase(trigger);
 }
 
-void GlobalTriggersStorage::shift_rnums_from(const rnum_t rnum)
-{
-	// TODO: Get rid of this function when index will not has to be sorted by rnums
-	//       Actually we need to get rid of rnums at all.
-	std::list<TRIG_DATA*> to_rebind;
-	for (const auto trigger : m_triggers)
-	{
-		if (trigger->get_rnum() > rnum)
-		{
-			to_rebind.push_back(trigger);
-		}
-	}
+void GlobalTriggersStorage::shift_rnums_from(const rnum_t rnum) {
+  // TODO: Get rid of this function when index will not has to be sorted by rnums
+  //       Actually we need to get rid of rnums at all.
+  std::list<TRIG_DATA *> to_rebind;
+  for (const auto trigger : m_triggers) {
+    if (trigger->get_rnum() > rnum) {
+      to_rebind.push_back(trigger);
+    }
+  }
 
-	for (const auto trigger : to_rebind)
-	{
-		remove(trigger);
-		trigger->set_rnum(1 + trigger->get_rnum());
-		add(trigger);
-	}
+  for (const auto trigger : to_rebind) {
+    remove(trigger);
+    trigger->set_rnum(1 + trigger->get_rnum());
+    add(trigger);
+  }
 }
 
-void GlobalTriggersStorage::register_remove_observer(TRIG_DATA* trigger, const TriggerEventObserver::shared_ptr& observer)
-{
-	const auto i = m_triggers.find(trigger);
-	if (i != m_triggers.end())
-	{
-		m_observers[trigger].insert(observer);
-	}
+void GlobalTriggersStorage::register_remove_observer(TRIG_DATA *trigger,
+                                                     const TriggerEventObserver::shared_ptr &observer) {
+  const auto i = m_triggers.find(trigger);
+  if (i != m_triggers.end()) {
+    m_observers[trigger].insert(observer);
+  }
 }
 
-void GlobalTriggersStorage::unregister_remove_observer(TRIG_DATA* trigger, const TriggerEventObserver::shared_ptr& observer)
-{
-	const auto i = m_observers.find(trigger);
-	if (i != m_observers.end())
-	{
-		i->second.erase(observer);
+void GlobalTriggersStorage::unregister_remove_observer(TRIG_DATA *trigger,
+                                                       const TriggerEventObserver::shared_ptr &observer) {
+  const auto i = m_observers.find(trigger);
+  if (i != m_observers.end()) {
+    i->second.erase(observer);
 
-		if (i->second.empty())
-		{
-			m_observers.erase(i);
-		}
-	}
+    if (i->second.empty()) {
+      m_observers.erase(i);
+    }
+  }
 }
 
-obj2triggers_t& obj2triggers = GlobalObjects::obj_triggers();
-GlobalTriggersStorage& trigger_list = GlobalObjects::trigger_list();	// all attached triggers
+obj2triggers_t &obj2triggers = GlobalObjects::obj_triggers();
+GlobalTriggersStorage &trigger_list = GlobalObjects::trigger_list();    // all attached triggers
 
-int trgvar_in_room(int vnum)
-{
-	const int rnum = real_room(vnum);
+int trgvar_in_room(int vnum) {
+  const int rnum = real_room(vnum);
 
-	if (NOWHERE == rnum)
-	{
-		script_log("people.vnum: world[rnum] does not exist");
-		return (-1);
-	}
+  if (NOWHERE == rnum) {
+    script_log("people.vnum: world[rnum] does not exist");
+    return (-1);
+  }
 
-	int count = 0;
-	for (const auto& ch : world[rnum]->people)
-	{
-		if (!GET_INVIS_LEV(ch))
-		{
-			++count;
-		}
-	}
+  int count = 0;
+  for (const auto &ch : world[rnum]->people) {
+    if (!GET_INVIS_LEV(ch)) {
+      ++count;
+    }
+  }
 
-	return count;
+  return count;
 };
 
-OBJ_DATA *get_obj_in_list(char *name, OBJ_DATA * list)
-{
-	OBJ_DATA *i;
-	long id;
+OBJ_DATA *get_obj_in_list(char *name, OBJ_DATA *list) {
+  OBJ_DATA *i;
+  long id;
 
-	if (*name == UID_OBJ)
-	{
-		id = atoi(name + 1);
+  if (*name == UID_OBJ) {
+    id = atoi(name + 1);
 
-		for (i = list; i; i = i->get_next_content())
-		{
-			if (id == i->get_id())
-			{
-				return i;
-			}
-		}
-	}
-	else
-	{
-		for (i = list; i; i = i->get_next_content())
-		{
-			if (isname(name, i->get_aliases()))
-			{
-				return i;
-			}
-		}
-	}
+    for (i = list; i; i = i->get_next_content()) {
+      if (id == i->get_id()) {
+        return i;
+      }
+    }
+  } else {
+    for (i = list; i; i = i->get_next_content()) {
+      if (isname(name, i->get_aliases())) {
+        return i;
+      }
+    }
+  }
 
-	return NULL;
+  return NULL;
 }
 
-OBJ_DATA *get_object_in_equip(CHAR_DATA * ch, char *name)
-{
-	int j, n = 0, number;
-	OBJ_DATA *obj;
-	char tmpname[MAX_INPUT_LENGTH];
-	char *tmp = tmpname;
-	long id;
+OBJ_DATA *get_object_in_equip(CHAR_DATA *ch, char *name) {
+  int j, n = 0, number;
+  OBJ_DATA *obj;
+  char tmpname[MAX_INPUT_LENGTH];
+  char *tmp = tmpname;
+  long id;
 
-	if (*name == UID_OBJ)
-	{
-		id = atoi(name + 1);
+  if (*name == UID_OBJ) {
+    id = atoi(name + 1);
 
-		for (j = 0; j < NUM_WEARS; j++)
-			if ((obj = GET_EQ(ch, j)))
-				if (id == obj->get_id())
-					return (obj);
-	}
-	else
-	{
-		strcpy(tmp, name);
-		if (!(number = get_number(&tmp)))
-			return NULL;
+    for (j = 0; j < NUM_WEARS; j++)
+      if ((obj = GET_EQ(ch, j)))
+        if (id == obj->get_id())
+          return (obj);
+  } else {
+    strcpy(tmp, name);
+    if (!(number = get_number(&tmp)))
+      return NULL;
 
-		for (j = 0; (j < NUM_WEARS) && (n <= number); j++)
-		{
-			obj = GET_EQ(ch, j);
-			if (!obj)
-			{
-				continue;
-			}
+    for (j = 0; (j < NUM_WEARS) && (n <= number); j++) {
+      obj = GET_EQ(ch, j);
+      if (!obj) {
+        continue;
+      }
 
-			if (isname(tmp, obj->get_aliases()))
-			{
-				++n;
-				if (n == number)
-				{
-					return (obj);
-				}
-			}
-		}
-	}
+      if (isname(tmp, obj->get_aliases())) {
+        ++n;
+        if (n == number) {
+          return (obj);
+        }
+      }
+    }
+  }
 
-	return NULL;
+  return NULL;
 }
 
 // * return number of object in world
-const char * get_objs_in_world(OBJ_DATA * obj)
-{
-	int i;
-	static char retval[16];
-	if (!obj)
-		return "";
-	if ((i = GET_OBJ_RNUM(obj)) < 0)
-	{
-		log("DG_SCRIPTS : attemp count unknown object");
-		return "";
-	}
-	sprintf(retval, "%d", obj_proto.actual_count(i));
-	return retval;
+const char *get_objs_in_world(OBJ_DATA *obj) {
+  int i;
+  static char retval[16];
+  if (!obj)
+    return "";
+  if ((i = GET_OBJ_RNUM(obj)) < 0) {
+    log("DG_SCRIPTS : attemp count unknown object");
+    return "";
+  }
+  sprintf(retval, "%d", obj_proto.actual_count(i));
+  return retval;
 }
 
 // * return number of obj|mob in world by vnum
-int gcount_char_vnum(long n)
-{
-	int count = 0;
+int gcount_char_vnum(long n) {
+  int count = 0;
 
-	for (const auto ch : character_list)
-	{
-		if (n == GET_MOB_VNUM(ch))
-		{
-			count++;
-		}
-	}
+  for (const auto ch : character_list) {
+    if (n == GET_MOB_VNUM(ch)) {
+      count++;
+    }
+  }
 
-	return (count);
+  return (count);
 }
 
-int count_char_vnum(long n)
-{
-	int i;
-	if ((i = real_mobile(n)) < 0)
-		return 0;
-	return (mob_index[i].number);
+int count_char_vnum(long n) {
+  int i;
+  if ((i = real_mobile(n)) < 0)
+    return 0;
+  return (mob_index[i].number);
 }
 
-inline auto gcount_obj_vnum(long n)
-{
-	const auto i = real_object(n);
+inline auto gcount_obj_vnum(long n) {
+  const auto i = real_object(n);
 
-	if (i < 0)
-	{
-		return 0;
-	}
+  if (i < 0) {
+    return 0;
+  }
 
-	return obj_proto.number(i);
+  return obj_proto.number(i);
 }
 
-inline auto count_obj_vnum(long n)
-{
-	const auto i = real_object(n);
+inline auto count_obj_vnum(long n) {
+  const auto i = real_object(n);
 
-	if (i < 0)
-	{
-		return 0;
-	}
+  if (i < 0) {
+    return 0;
+  }
 
-	// Чот косячит таймер, решили переделать тригги, хоть и дольше
-	//	if (check_unlimited_timer(obj_proto[i]))
-	//		return 0;
-	return obj_proto.actual_count(i);
+  // Чот косячит таймер, решили переделать тригги, хоть и дольше
+  //	if (check_unlimited_timer(obj_proto[i]))
+  //		return 0;
+  return obj_proto.actual_count(i);
 }
 
 /************************************************************
  * search by number routines
  ************************************************************/
 
- // return object with UID n
-OBJ_DATA *find_obj_by_id(const object_id_t id)
-{
-	const auto result = world_objects.find_first_by_id(id);
-	return result.get();
+// return object with UID n
+OBJ_DATA *find_obj_by_id(const object_id_t id) {
+  const auto result = world_objects.find_first_by_id(id);
+  return result.get();
 }
 
 // return room with UID n
-ROOM_DATA *find_room(long n)
-{
-	n = real_room(n - ROOM_ID_BASE);
+ROOM_DATA *find_room(long n) {
+  n = real_room(n - ROOM_ID_BASE);
 
-	if ((n >= FIRST_ROOM) && (n <= top_of_world))
-		return world[n];
+  if ((n >= FIRST_ROOM) && (n <= top_of_world))
+    return world[n];
 
-	return NULL;
+  return NULL;
 }
 
 /************************************************************
  * search by VNUM routines
  ************************************************************/
 
- /**
+/**
  * Возвращает id моба указанного внума.
  * \param num - если есть и больше 0 - возвращает id не первого моба, а указанного порядкового номера.
  */
-int find_char_vnum(long n, int num = 0)
-{
-	int count = 0;
-	for (const auto ch : character_list)
-	{
-		if (n == GET_MOB_VNUM(ch) && ch->in_room != NOWHERE)
-		{
-			if (num != count)
-			{
-				++count;
-				continue;
-			}
-			else
-			{
-				return (GET_ID(ch));
-			}
-		}
-	}
-	return -1;
+int find_char_vnum(long n, int num = 0) {
+  int count = 0;
+  for (const auto ch : character_list) {
+    if (n == GET_MOB_VNUM(ch) && ch->in_room != NOWHERE) {
+      if (num != count) {
+        ++count;
+        continue;
+      } else {
+        return (GET_ID(ch));
+      }
+    }
+  }
+  return -1;
 }
 
 // return room with VNUM n
 // Внимание! Для комнаты UID = ROOM_ID_BASE+VNUM, т.к.
 // RNUM может быть независимо изменен с помощью OLC
-int find_room_vnum(long n)
-{
-	//  return (real_room (n) != NOWHERE) ? ROOM_ID_BASE + n : -1;
-	return (real_room(n) != NOWHERE) ? n : -1;
+int find_room_vnum(long n) {
+  //  return (real_room (n) != NOWHERE) ? ROOM_ID_BASE + n : -1;
+  return (real_room(n) != NOWHERE) ? n : -1;
 }
 
-int find_room_uid(long n)
-{
-	return (real_room(n) != NOWHERE) ? ROOM_ID_BASE + n : -1;
-	//return (real_room (n) != NOWHERE) ? n : -1;
+int find_room_uid(long n) {
+  return (real_room(n) != NOWHERE) ? ROOM_ID_BASE + n : -1;
+  //return (real_room (n) != NOWHERE) ? n : -1;
 }
 
 /************************************************************
  * generic searches based only on name
  ************************************************************/
 
- // search the entire world for a char, and return a pointer
-CHAR_DATA *get_char(char *name, int/* vnum*/)
-{
-	CHAR_DATA *i;
+// search the entire world for a char, and return a pointer
+CHAR_DATA *get_char(char *name, int/* vnum*/) {
+  CHAR_DATA *i;
 
-	// Отсекаем поиск левых UID-ов.
-	if ((*name == UID_OBJ) || (*name == UID_ROOM))
-		return NULL;
+  // Отсекаем поиск левых UID-ов.
+  if ((*name == UID_OBJ) || (*name == UID_ROOM))
+    return NULL;
 
-	if (*name == UID_CHAR)
-	{
-		i = find_char(atoi(name + 1));
+  if (*name == UID_CHAR) {
+    i = find_char(atoi(name + 1));
 
-		if (i && (IS_NPC(i) || !GET_INVIS_LEV(i)))
-		{
-			return i;
-		}
-	}
-	else
-	{
-		for (const auto& character : character_list)
-		{
-			const auto i = character.get();
-			if (isname(name, i->get_pc_name())
-				&& (IS_NPC(i)
-					|| !GET_INVIS_LEV(i)))
-			{
-				return i;
-			}
-		}
-	}
+    if (i && (IS_NPC(i) || !GET_INVIS_LEV(i))) {
+      return i;
+    }
+  } else {
+    for (const auto &character : character_list) {
+      const auto i = character.get();
+      if (isname(name, i->get_pc_name())
+          && (IS_NPC(i)
+              || !GET_INVIS_LEV(i))) {
+        return i;
+      }
+    }
+  }
 
-	return NULL;
+  return NULL;
 }
 
 // returns the object in the world with name name, or NULL if not found
-OBJ_DATA *get_obj(char *name, int/* vnum*/)
-{
-	long id;
+OBJ_DATA *get_obj(char *name, int/* vnum*/) {
+  long id;
 
-	if ((*name == UID_CHAR) || (*name == UID_ROOM))
-		return NULL;
+  if ((*name == UID_CHAR) || (*name == UID_ROOM))
+    return NULL;
 
-	if (*name == UID_OBJ)
-	{
-		id = atoi(name + 1);
-		return find_obj_by_id(id);
-	}
-	else
-	{
-		const auto result = world_objects.find_by_name(name);
-		return result.get();
-	}
-	return NULL;
+  if (*name == UID_OBJ) {
+    id = atoi(name + 1);
+    return find_obj_by_id(id);
+  } else {
+    const auto result = world_objects.find_by_name(name);
+    return result.get();
+  }
+  return NULL;
 }
 
 // finds room by with name.  returns NULL if not found
-ROOM_DATA *get_room(char *name)
-{
-	int nr;
+ROOM_DATA *get_room(char *name) {
+  int nr;
 
-	if ((*name == UID_CHAR) || (*name == UID_OBJ))
-		return NULL;
+  if ((*name == UID_CHAR) || (*name == UID_OBJ))
+    return NULL;
 
-	if (*name == UID_ROOM)
-		return find_room(atoi(name + 1));
-	else if ((nr = real_room(atoi(name))) == NOWHERE)
-		return NULL;
-	else
-		return world[nr];
+  if (*name == UID_ROOM)
+    return find_room(atoi(name + 1));
+  else if ((nr = real_room(atoi(name))) == NOWHERE)
+    return NULL;
+  else
+    return world[nr];
 }
-
 
 /*
  * returns a pointer to the first character in world by name name,
  * or NULL if none found.  Starts searching with the person owing the object
  */
-CHAR_DATA *get_char_by_obj(OBJ_DATA * obj, char *name)
-{
-	CHAR_DATA *ch;
+CHAR_DATA *get_char_by_obj(OBJ_DATA *obj, char *name) {
+  CHAR_DATA *ch;
 
-	if ((*name == UID_ROOM) || (*name == UID_OBJ))
-		return NULL;
+  if ((*name == UID_ROOM) || (*name == UID_OBJ))
+    return NULL;
 
-	if (*name == UID_CHAR)
-	{
-		ch = find_char(atoi(name + 1));
+  if (*name == UID_CHAR) {
+    ch = find_char(atoi(name + 1));
 
-		if (ch && (IS_NPC(ch) || !GET_INVIS_LEV(ch)))
-			return ch;
-	}
-	else
-	{
-		if (obj->get_carried_by()
-			&& isname(name, obj->get_carried_by()->get_pc_name())
-			&& (IS_NPC(obj->get_carried_by())
-				|| !GET_INVIS_LEV(obj->get_carried_by())))
-		{
-			return obj->get_carried_by();
-		}
+    if (ch && (IS_NPC(ch) || !GET_INVIS_LEV(ch)))
+      return ch;
+  } else {
+    if (obj->get_carried_by()
+        && isname(name, obj->get_carried_by()->get_pc_name())
+        && (IS_NPC(obj->get_carried_by())
+            || !GET_INVIS_LEV(obj->get_carried_by()))) {
+      return obj->get_carried_by();
+    }
 
-		if (obj->get_worn_by()
-			&& isname(name, obj->get_worn_by()->get_pc_name())
-			&& (IS_NPC(obj->get_worn_by())
-				|| !GET_INVIS_LEV(obj->get_worn_by())))
-		{
-			return obj->get_worn_by();
-		}
+    if (obj->get_worn_by()
+        && isname(name, obj->get_worn_by()->get_pc_name())
+        && (IS_NPC(obj->get_worn_by())
+            || !GET_INVIS_LEV(obj->get_worn_by()))) {
+      return obj->get_worn_by();
+    }
 
-		for (const auto ch : character_list)
-		{
-			if (isname(name, ch->get_pc_name())
-				&& (IS_NPC(ch)
-					|| !GET_INVIS_LEV(ch)))
-			{
-				return ch.get();
-			}
-		}
-	}
+    for (const auto ch : character_list) {
+      if (isname(name, ch->get_pc_name())
+          && (IS_NPC(ch)
+              || !GET_INVIS_LEV(ch))) {
+        return ch.get();
+      }
+    }
+  }
 
-	return NULL;
+  return NULL;
 }
-
 
 /*
  * returns a pointer to the first character in world by name name,
  * or NULL if none found.  Starts searching in room room first
  */
-CHAR_DATA *get_char_by_room(ROOM_DATA * room, char *name)
-{
-	CHAR_DATA *ch;
+CHAR_DATA *get_char_by_room(ROOM_DATA *room, char *name) {
+  CHAR_DATA *ch;
 
-	if (*name == UID_ROOM
-		|| *name == UID_OBJ)
-	{
-		return NULL;
-	}
+  if (*name == UID_ROOM
+      || *name == UID_OBJ) {
+    return NULL;
+  }
 
-	if (*name == UID_CHAR)
-	{
-		ch = find_char(atoi(name + 1));
+  if (*name == UID_CHAR) {
+    ch = find_char(atoi(name + 1));
 
-		if (ch
-			&& (IS_NPC(ch)
-				|| !GET_INVIS_LEV(ch)))
-		{
-			return ch;
-		}
-	}
-	else
-	{
-		for (const auto ch : room->people)
-		{
-			if (isname(name, ch->get_pc_name())
-				&& (IS_NPC(ch)
-					|| !GET_INVIS_LEV(ch)))
-			{
-				return ch;
-			}
-		}
+    if (ch
+        && (IS_NPC(ch)
+            || !GET_INVIS_LEV(ch))) {
+      return ch;
+    }
+  } else {
+    for (const auto ch : room->people) {
+      if (isname(name, ch->get_pc_name())
+          && (IS_NPC(ch)
+              || !GET_INVIS_LEV(ch))) {
+        return ch;
+      }
+    }
 
-		for (const auto ch : character_list)
-		{
-			if (isname(name, ch->get_pc_name())
-				&& (IS_NPC(ch)
-					|| !GET_INVIS_LEV(ch)))
-			{
-				return ch.get();
-			}
-		}
-	}
+    for (const auto ch : character_list) {
+      if (isname(name, ch->get_pc_name())
+          && (IS_NPC(ch)
+              || !GET_INVIS_LEV(ch))) {
+        return ch.get();
+      }
+    }
+  }
 
-	return NULL;
+  return NULL;
 }
-
 
 /*
  * returns the object in the world with name name, or NULL if not found
  * search based on obj
  */
-OBJ_DATA *get_obj_by_obj(OBJ_DATA * obj, char *name)
-{
-	OBJ_DATA *i = NULL;
-	int rm;
-	long id;
+OBJ_DATA *get_obj_by_obj(OBJ_DATA *obj, char *name) {
+  OBJ_DATA *i = NULL;
+  int rm;
+  long id;
 
-	if ((*name == UID_ROOM) || (*name == UID_CHAR))
-		return NULL;
+  if ((*name == UID_ROOM) || (*name == UID_CHAR))
+    return NULL;
 
-	if (!str_cmp(name, "self") || !str_cmp(name, "me"))
-		return obj;
+  if (!str_cmp(name, "self") || !str_cmp(name, "me"))
+    return obj;
 
-	if (obj->get_contains() && (i = get_obj_in_list(name, obj->get_contains())))
-		return i;
+  if (obj->get_contains() && (i = get_obj_in_list(name, obj->get_contains())))
+    return i;
 
-	if (obj->get_in_obj())
-	{
-		if (*name == UID_OBJ)
-		{
-			id = atoi(name + 1);
+  if (obj->get_in_obj()) {
+    if (*name == UID_OBJ) {
+      id = atoi(name + 1);
 
-			if (id == obj->get_in_obj()->get_id())
-			{
-				return obj->get_in_obj();
-			}
-		}
-		else if (isname(name, obj->get_in_obj()->get_aliases()))
-		{
-			return obj->get_in_obj();
-		}
-	}
-	else if (obj->get_worn_by() && (i = get_object_in_equip(obj->get_worn_by(), name)))
-	{
-		return i;
-	}
-	else if (obj->get_carried_by() && (i = get_obj_in_list(name, obj->get_carried_by()->carrying)))
-	{
-		return i;
-	}
-	else if (((rm = obj_room(obj)) != NOWHERE) && (i = get_obj_in_list(name, world[rm]->contents)))
-	{
-		return i;
-	}
+      if (id == obj->get_in_obj()->get_id()) {
+        return obj->get_in_obj();
+      }
+    } else if (isname(name, obj->get_in_obj()->get_aliases())) {
+      return obj->get_in_obj();
+    }
+  } else if (obj->get_worn_by() && (i = get_object_in_equip(obj->get_worn_by(), name))) {
+    return i;
+  } else if (obj->get_carried_by() && (i = get_obj_in_list(name, obj->get_carried_by()->carrying))) {
+    return i;
+  } else if (((rm = obj_room(obj)) != NOWHERE) && (i = get_obj_in_list(name, world[rm]->contents))) {
+    return i;
+  }
 
-	if (*name == UID_OBJ)
-	{
-		id = atoi(name + 1);
+  if (*name == UID_OBJ) {
+    id = atoi(name + 1);
 
-		i = world_objects.find_first_by_id(id).get();
-	}
-	else
-	{
-		i = world_objects.find_by_name(name).get();
-	}
+    i = world_objects.find_first_by_id(id).get();
+  } else {
+    i = world_objects.find_by_name(name).get();
+  }
 
-	return i;
-}
-
-
-// returns obj with name
-OBJ_DATA *get_obj_by_room(ROOM_DATA * room, char *name)
-{
-	OBJ_DATA *obj;
-	long id;
-
-	if ((*name == UID_ROOM) || (*name == UID_CHAR))
-		return NULL;
-
-	if (*name == UID_OBJ)
-	{
-		id = atoi(name + 1);
-
-		for (obj = room->contents; obj; obj = obj->get_next_content())
-		{
-			if (id == obj->get_id())
-			{
-				return obj;
-			}
-		}
-
-		return world_objects.find_first_by_id(id).get();
-	}
-	else
-	{
-		for (obj = room->contents; obj; obj = obj->get_next_content())
-		{
-			if (isname(name, obj->get_aliases()))
-			{
-				return obj;
-			}
-		}
-
-		return world_objects.find_by_name(name).get();
-	}
-
-	return NULL;
+  return i;
 }
 
 // returns obj with name
-OBJ_DATA *get_obj_by_char(CHAR_DATA * ch, char *name)
-{
-	OBJ_DATA *obj;
-	long id;
+OBJ_DATA *get_obj_by_room(ROOM_DATA *room, char *name) {
+  OBJ_DATA *obj;
+  long id;
 
-	if ((*name == UID_ROOM) || (*name == UID_CHAR))
-		return NULL;
+  if ((*name == UID_ROOM) || (*name == UID_CHAR))
+    return NULL;
 
-	if (*name == UID_OBJ)
-	{
-		id = atoi(name + 1);
-		if (ch)
-		{
-			for (obj = ch->carrying; obj; obj = obj->get_next_content())
-			{
-				if (id == obj->get_id())
-				{
-					return obj;
-				}
-			}
-		}
+  if (*name == UID_OBJ) {
+    id = atoi(name + 1);
 
-		return world_objects.find_first_by_id(id).get();
-	}
-	else
-	{
-		if (ch)
-		{
-			for (obj = ch->carrying; obj; obj = obj->get_next_content())
-			{
-				if (isname(name, obj->get_aliases()))
-				{
-					return obj;
-				}
-			}
-		}
+    for (obj = room->contents; obj; obj = obj->get_next_content()) {
+      if (id == obj->get_id()) {
+        return obj;
+      }
+    }
 
-		return world_objects.find_by_name(name).get();
-	}
+    return world_objects.find_first_by_id(id).get();
+  } else {
+    for (obj = room->contents; obj; obj = obj->get_next_content()) {
+      if (isname(name, obj->get_aliases())) {
+        return obj;
+      }
+    }
 
-	return NULL;
+    return world_objects.find_by_name(name).get();
+  }
+
+  return NULL;
+}
+
+// returns obj with name
+OBJ_DATA *get_obj_by_char(CHAR_DATA *ch, char *name) {
+  OBJ_DATA *obj;
+  long id;
+
+  if ((*name == UID_ROOM) || (*name == UID_CHAR))
+    return NULL;
+
+  if (*name == UID_OBJ) {
+    id = atoi(name + 1);
+    if (ch) {
+      for (obj = ch->carrying; obj; obj = obj->get_next_content()) {
+        if (id == obj->get_id()) {
+          return obj;
+        }
+      }
+    }
+
+    return world_objects.find_first_by_id(id).get();
+  } else {
+    if (ch) {
+      for (obj = ch->carrying; obj; obj = obj->get_next_content()) {
+        if (isname(name, obj->get_aliases())) {
+          return obj;
+        }
+      }
+    }
+
+    return world_objects.find_by_name(name).get();
+  }
+
+  return NULL;
 }
 
 // checks every PLUSE_SCRIPT for random triggers
-void script_trigger_check()
-{
-	character_list.foreach_on_copy([](const CHAR_DATA::shared_ptr& ch)
-	{
-		if (SCRIPT(ch)->has_triggers())
-		{
-			auto sc = SCRIPT(ch).get();
+void script_trigger_check() {
+  character_list.foreach_on_copy([](const CHAR_DATA::shared_ptr &ch) {
+    if (SCRIPT(ch)->has_triggers()) {
+      auto sc = SCRIPT(ch).get();
 
-			if (IS_SET(SCRIPT_TYPES(sc), MTRIG_RANDOM)
-				&& (!is_empty(world[ch->in_room]->zone)
-					|| IS_SET(SCRIPT_TYPES(sc), MTRIG_GLOBAL)))
-			{
-				random_mtrigger(ch.get());
-			}
-		}
-	});
+      if (IS_SET(SCRIPT_TYPES(sc), MTRIG_RANDOM)
+          && (!is_empty(world[ch->in_room]->zone)
+              || IS_SET(SCRIPT_TYPES(sc), MTRIG_GLOBAL))) {
+        random_mtrigger(ch.get());
+      }
+    }
+  });
 
-	world_objects.foreach_on_copy([&](const OBJ_DATA::shared_ptr& obj)
-	{
-		if (OBJ_FLAGGED(obj.get(), EExtraFlag::ITEM_NAMED))
-		{
-			if (obj->get_worn_by() && number(1, 100) <= 5)
-			{
-				NamedStuff::wear_msg(obj->get_worn_by(), obj.get());
-			}
-		}
-		else if (obj->get_script()->has_triggers())
-		{
-			auto sc = obj->get_script().get();
-			if (IS_SET(SCRIPT_TYPES(sc), OTRIG_RANDOM))
-			{
-				random_otrigger(obj.get());
-			}
-		}
-	});
+  world_objects.foreach_on_copy([&](const OBJ_DATA::shared_ptr &obj) {
+    if (OBJ_FLAGGED(obj.get(), EExtraFlag::ITEM_NAMED)) {
+      if (obj->get_worn_by() && number(1, 100) <= 5) {
+        NamedStuff::wear_msg(obj->get_worn_by(), obj.get());
+      }
+    } else if (obj->get_script()->has_triggers()) {
+      auto sc = obj->get_script().get();
+      if (IS_SET(SCRIPT_TYPES(sc), OTRIG_RANDOM)) {
+        random_otrigger(obj.get());
+      }
+    }
+  });
 
-	for (std::size_t nr = FIRST_ROOM; nr <= static_cast<std::size_t>(top_of_world); nr++)
-	{
-		if (SCRIPT(world[nr])->has_triggers())
-		{
-			auto room = world[nr];
-			auto sc = SCRIPT(room).get();
+  for (std::size_t nr = FIRST_ROOM; nr <= static_cast<std::size_t>(top_of_world); nr++) {
+    if (SCRIPT(world[nr])->has_triggers()) {
+      auto room = world[nr];
+      auto sc = SCRIPT(room).get();
 
-			if (IS_SET(SCRIPT_TYPES(sc), WTRIG_RANDOM)
-				&& (!is_empty(room->zone)
-					|| IS_SET(SCRIPT_TYPES(sc), WTRIG_GLOBAL)))
-			{
-				// Если будет крэш (а он несомненно будет) можно будет посмотреть параметры в стеке
-				random_wtrigger(room, room->number, sc, sc->types, sc->trig_list);
-			}
-		}
-	}
+      if (IS_SET(SCRIPT_TYPES(sc), WTRIG_RANDOM)
+          && (!is_empty(room->zone)
+              || IS_SET(SCRIPT_TYPES(sc), WTRIG_GLOBAL))) {
+        // Если будет крэш (а он несомненно будет) можно будет посмотреть параметры в стеке
+        random_wtrigger(room, room->number, sc, sc->types, sc->trig_list);
+      }
+    }
+  }
 }
 
 // проверка каждый час на триги изменении времени
-void script_timechange_trigger_check(const int time)
-{
-	character_list.foreach_on_copy([&](const std::shared_ptr<CHAR_DATA>& ch)
-	{
-		if (SCRIPT(ch)->has_triggers())
-		{
-			auto sc = SCRIPT(ch).get();
+void script_timechange_trigger_check(const int time) {
+  character_list.foreach_on_copy([&](const std::shared_ptr<CHAR_DATA> &ch) {
+    if (SCRIPT(ch)->has_triggers()) {
+      auto sc = SCRIPT(ch).get();
 
-			if (IS_SET(SCRIPT_TYPES(sc), MTRIG_TIMECHANGE)
-				&& (!is_empty(world[ch->in_room]->zone)
-					|| IS_SET(SCRIPT_TYPES(sc), MTRIG_GLOBAL)))
-			{
-				timechange_mtrigger(ch.get(), time);
-			}
-		}
-	});
+      if (IS_SET(SCRIPT_TYPES(sc), MTRIG_TIMECHANGE)
+          && (!is_empty(world[ch->in_room]->zone)
+              || IS_SET(SCRIPT_TYPES(sc), MTRIG_GLOBAL))) {
+        timechange_mtrigger(ch.get(), time);
+      }
+    }
+  });
 
-	world_objects.foreach_on_copy([&](const OBJ_DATA::shared_ptr& obj)
-	{
-		if (obj->get_script()->has_triggers())
-		{
-			auto sc = obj->get_script().get();
-			if (IS_SET(SCRIPT_TYPES(sc), OTRIG_TIMECHANGE))
-			{
-				timechange_otrigger(obj.get(), time);
-			}
-		}
-	});
+  world_objects.foreach_on_copy([&](const OBJ_DATA::shared_ptr &obj) {
+    if (obj->get_script()->has_triggers()) {
+      auto sc = obj->get_script().get();
+      if (IS_SET(SCRIPT_TYPES(sc), OTRIG_TIMECHANGE)) {
+        timechange_otrigger(obj.get(), time);
+      }
+    }
+  });
 
-	for (std::size_t nr = FIRST_ROOM; nr <= static_cast<std::size_t>(top_of_world); nr++)
-	{
-		if (SCRIPT(world[nr])->has_triggers())
-		{
-			auto room = world[nr];
-			auto sc = SCRIPT(room).get();
+  for (std::size_t nr = FIRST_ROOM; nr <= static_cast<std::size_t>(top_of_world); nr++) {
+    if (SCRIPT(world[nr])->has_triggers()) {
+      auto room = world[nr];
+      auto sc = SCRIPT(room).get();
 
-			if (IS_SET(SCRIPT_TYPES(sc), WTRIG_TIMECHANGE)
-				&& (!is_empty(room->zone)
-					|| IS_SET(SCRIPT_TYPES(sc), WTRIG_GLOBAL)))
-			{
-				timechange_wtrigger(room, time);
-			}
-		}
-	}
+      if (IS_SET(SCRIPT_TYPES(sc), WTRIG_TIMECHANGE)
+          && (!is_empty(room->zone)
+              || IS_SET(SCRIPT_TYPES(sc), WTRIG_GLOBAL))) {
+        timechange_wtrigger(room, time);
+      }
+    }
+  }
 }
 
-EVENT(trig_wait_event)
-{
-	struct wait_event_data *wait_event_obj = (struct wait_event_data *) info;
-	TRIG_DATA *trig;
-	void *go;
-	int type;
+EVENT(trig_wait_event) {
+  struct wait_event_data *wait_event_obj = (struct wait_event_data *) info;
+  TRIG_DATA *trig;
+  void *go;
+  int type;
 
-	trig = wait_event_obj->trigger;
-	go = wait_event_obj->go;
-	type = wait_event_obj->type;
+  trig = wait_event_obj->trigger;
+  go = wait_event_obj->go;
+  type = wait_event_obj->type;
 
-	GET_TRIG_WAIT(trig) = NULL;
+  GET_TRIG_WAIT(trig) = NULL;
 
-	script_driver(go, trig, type, TRIG_RESTART);
-	free(wait_event_obj);
+  script_driver(go, trig, type, TRIG_RESTART);
+  free(wait_event_obj);
 }
 
+void do_stat_trigger(CHAR_DATA *ch, TRIG_DATA *trig) {
+  char sb[MAX_EXTEND_LENGTH];
 
-void do_stat_trigger(CHAR_DATA * ch, TRIG_DATA * trig)
-{
-	char sb[MAX_EXTEND_LENGTH];
+  if (!trig) {
+    log("SYSERR: NULL trigger passed to do_stat_trigger.");
+    return;
+  }
 
-	if (!trig)
-	{
-		log("SYSERR: NULL trigger passed to do_stat_trigger.");
-		return;
-	}
+  sprintf(sb, "Name: '%s%s%s',  VNum: [%s%5d%s], RNum: [%5d]\r\n",
+          CCYEL(ch, C_NRM), GET_TRIG_NAME(trig), CCNRM(ch, C_NRM),
+          CCGRN(ch, C_NRM), GET_TRIG_VNUM(trig), CCNRM(ch, C_NRM), GET_TRIG_RNUM(trig));
+  send_to_char(sb, ch);
 
-	sprintf(sb, "Name: '%s%s%s',  VNum: [%s%5d%s], RNum: [%5d]\r\n",
-		CCYEL(ch, C_NRM), GET_TRIG_NAME(trig), CCNRM(ch, C_NRM),
-		CCGRN(ch, C_NRM), GET_TRIG_VNUM(trig), CCNRM(ch, C_NRM), GET_TRIG_RNUM(trig));
-	send_to_char(sb, ch);
+  if (trig->get_attach_type() == MOB_TRIGGER) {
+    send_to_char("Trigger Intended Assignment: Mobiles\r\n", ch);
+    sprintbit(GET_TRIG_TYPE(trig), trig_types, buf);
+  } else if (trig->get_attach_type() == OBJ_TRIGGER) {
+    send_to_char("Trigger Intended Assignment: Objects\r\n", ch);
+    sprintbit(GET_TRIG_TYPE(trig), otrig_types, buf);
+  } else if (trig->get_attach_type() == WLD_TRIGGER) {
+    send_to_char("Trigger Intended Assignment: Rooms\r\n", ch);
+    sprintbit(GET_TRIG_TYPE(trig), wtrig_types, buf);
+  } else {
+    send_to_char(ch, "Trigger Intended Assignment: undefined (attach_type=%d)\r\n",
+                 static_cast<int>(trig->get_attach_type()));
+  }
 
-	if (trig->get_attach_type() == MOB_TRIGGER)
-	{
-		send_to_char("Trigger Intended Assignment: Mobiles\r\n", ch);
-		sprintbit(GET_TRIG_TYPE(trig), trig_types, buf);
-	}
-	else if (trig->get_attach_type() == OBJ_TRIGGER)
-	{
-		send_to_char("Trigger Intended Assignment: Objects\r\n", ch);
-		sprintbit(GET_TRIG_TYPE(trig), otrig_types, buf);
-	}
-	else if (trig->get_attach_type() == WLD_TRIGGER)
-	{
-		send_to_char("Trigger Intended Assignment: Rooms\r\n", ch);
-		sprintbit(GET_TRIG_TYPE(trig), wtrig_types, buf);
-	}
-	else
-	{
-		send_to_char(ch, "Trigger Intended Assignment: undefined (attach_type=%d)\r\n",
-			static_cast<int>(trig->get_attach_type()));
-	}
+  sprintf(sb, "Trigger Type: %s, Numeric Arg: %d, Arg list: %s\r\n",
+          buf, GET_TRIG_NARG(trig), !trig->arglist.empty() ? trig->arglist.c_str() : "None");
 
-	sprintf(sb, "Trigger Type: %s, Numeric Arg: %d, Arg list: %s\r\n",
-		buf, GET_TRIG_NARG(trig), !trig->arglist.empty() ? trig->arglist.c_str() : "None");
+  strcat(sb, "Commands:\r\n   ");
 
-	strcat(sb, "Commands:\r\n   ");
+  auto cmd_list = *trig->cmdlist;
+  while (cmd_list) {
+    if (!cmd_list->cmd.empty()) {
+      strcat(sb, cmd_list->cmd.c_str());
+      strcat(sb, "\r\n   ");
+    }
 
-	auto cmd_list = *trig->cmdlist;
-	while (cmd_list)
-	{
-		if (!cmd_list->cmd.empty())
-		{
-			strcat(sb, cmd_list->cmd.c_str());
-			strcat(sb, "\r\n   ");
-		}
+    cmd_list = cmd_list->next;
+  }
 
-		cmd_list = cmd_list->next;
-	}
-
-	page_string(ch->desc, sb, 1);
+  page_string(ch->desc, sb, 1);
 }
 
 // find the name of what the uid points to
-void find_uid_name(char *uid, char *name)
-{
-	CHAR_DATA *ch;
-	OBJ_DATA *obj;
+void find_uid_name(char *uid, char *name) {
+  CHAR_DATA *ch;
+  OBJ_DATA *obj;
 
-	if ((ch = get_char(uid)))
-	{
-		strcpy(name, ch->get_pc_name().c_str());
-	}
-	else if ((obj = get_obj(uid)))
-	{
-		strcpy(name, obj->get_aliases().c_str());
-	}
-	else
-	{
-		sprintf(name, "uid = %s, (not found)", uid + 1);
-	}
+  if ((ch = get_char(uid))) {
+    strcpy(name, ch->get_pc_name().c_str());
+  } else if ((obj = get_obj(uid))) {
+    strcpy(name, obj->get_aliases().c_str());
+  } else {
+    sprintf(name, "uid = %s, (not found)", uid + 1);
+  }
 }
-
 
 // general function to display stats on script sc
-void script_stat(CHAR_DATA * ch, SCRIPT_DATA * sc)
-{
-	struct trig_var_data *tv;
-	char name[MAX_INPUT_LENGTH];
-	char namebuf[512];
+void script_stat(CHAR_DATA *ch, SCRIPT_DATA *sc) {
+  struct trig_var_data *tv;
+  char name[MAX_INPUT_LENGTH];
+  char namebuf[512];
 
-	sprintf(buf, "Global Variables: %s\r\n", sc->global_vars ? "" : "None");
-	send_to_char(buf, ch);
-	sprintf(buf, "Global context: %ld\r\n", sc->context);
-	send_to_char(buf, ch);
+  sprintf(buf, "Global Variables: %s\r\n", sc->global_vars ? "" : "None");
+  send_to_char(buf, ch);
+  sprintf(buf, "Global context: %ld\r\n", sc->context);
+  send_to_char(buf, ch);
 
-	for (tv = sc->global_vars; tv; tv = tv->next)
-	{
-		sprintf(namebuf, "%s:%ld", tv->name, tv->context);
-		if (*(tv->value) == UID_CHAR || *(tv->value) == UID_ROOM || *(tv->value) == UID_OBJ)
-		{
-			find_uid_name(tv->value, name);
-			sprintf(buf, "    %15s:  %s\r\n", tv->context ? namebuf : tv->name, name);
-		}
-		else
-			sprintf(buf, "    %15s:  %s\r\n", tv->context ? namebuf : tv->name, tv->value);
-		send_to_char(buf, ch);
-	}
+  for (tv = sc->global_vars; tv; tv = tv->next) {
+    sprintf(namebuf, "%s:%ld", tv->name, tv->context);
+    if (*(tv->value) == UID_CHAR || *(tv->value) == UID_ROOM || *(tv->value) == UID_OBJ) {
+      find_uid_name(tv->value, name);
+      sprintf(buf, "    %15s:  %s\r\n", tv->context ? namebuf : tv->name, name);
+    } else
+      sprintf(buf, "    %15s:  %s\r\n", tv->context ? namebuf : tv->name, tv->value);
+    send_to_char(buf, ch);
+  }
 
-	for (auto t : sc->trig_list)
-	{
-		sprintf(buf, "\r\n  Trigger: %s%s%s, VNum: [%s%5d%s], RNum: [%5d]\r\n",
-			CCYEL(ch, C_NRM), GET_TRIG_NAME(t), CCNRM(ch, C_NRM),
-			CCGRN(ch, C_NRM), GET_TRIG_VNUM(t), CCNRM(ch, C_NRM), GET_TRIG_RNUM(t));
-		send_to_char(buf, ch);
+  for (auto t : sc->trig_list) {
+    sprintf(buf, "\r\n  Trigger: %s%s%s, VNum: [%s%5d%s], RNum: [%5d]\r\n",
+            CCYEL(ch, C_NRM), GET_TRIG_NAME(t), CCNRM(ch, C_NRM),
+            CCGRN(ch, C_NRM), GET_TRIG_VNUM(t), CCNRM(ch, C_NRM), GET_TRIG_RNUM(t));
+    send_to_char(buf, ch);
 
-		if (t->get_attach_type() == MOB_TRIGGER)
-		{
-			send_to_char("  Trigger Intended Assignment: Mobiles\r\n", ch);
-			sprintbit(GET_TRIG_TYPE(t), trig_types, buf1);
-		}
-		else if (t->get_attach_type() == OBJ_TRIGGER)
-		{
-			send_to_char("  Trigger Intended Assignment: Objects\r\n", ch);
-			sprintbit(GET_TRIG_TYPE(t), otrig_types, buf1);
-		}
-		else if (t->get_attach_type() == WLD_TRIGGER)
-		{
-			send_to_char("  Trigger Intended Assignment: Rooms\r\n", ch);
-			sprintbit(GET_TRIG_TYPE(t), wtrig_types, buf1);
-		}
-		else
-		{
-			send_to_char(ch, "Trigger Intended Assignment: undefined (attach_type=%d)\r\n",
-				static_cast<int>(t->get_attach_type()));
-		}
-		std::stringstream buffer;
-		buffer << "  Trigger Type: " << buf1 << ", Numeric Arg:" << GET_TRIG_NARG(t)
-			<< " , Arg list:"  << !t->arglist.empty() ? t->arglist.c_str() : "None";
+    if (t->get_attach_type() == MOB_TRIGGER) {
+      send_to_char("  Trigger Intended Assignment: Mobiles\r\n", ch);
+      sprintbit(GET_TRIG_TYPE(t), trig_types, buf1);
+    } else if (t->get_attach_type() == OBJ_TRIGGER) {
+      send_to_char("  Trigger Intended Assignment: Objects\r\n", ch);
+      sprintbit(GET_TRIG_TYPE(t), otrig_types, buf1);
+    } else if (t->get_attach_type() == WLD_TRIGGER) {
+      send_to_char("  Trigger Intended Assignment: Rooms\r\n", ch);
+      sprintbit(GET_TRIG_TYPE(t), wtrig_types, buf1);
+    } else {
+      send_to_char(ch, "Trigger Intended Assignment: undefined (attach_type=%d)\r\n",
+                   static_cast<int>(t->get_attach_type()));
+    }
+    std::stringstream buffer;
+    buffer << "  Trigger Type: " << buf1 << ", Numeric Arg:" << GET_TRIG_NARG(t)
+           << " , Arg list:" << !t->arglist.empty() ? t->arglist.c_str() : "None";
 //		sprintf(buf, "  Trigger Type: %s, Numeric Arg: %d, Arg list: %s\r\n",
 //			buf1, GET_TRIG_NARG(t), !t->arglist.empty() ? t->arglist.c_str() : "None");
-		send_to_char(buffer.str(), ch);
+    send_to_char(buffer.str(), ch);
 
-		if (GET_TRIG_WAIT(t))
-		{
-			if (t->curr_state != NULL)
-			{
-				sprintf(buf, "    Wait: %d, Current line: %s\r\n",
-					GET_TRIG_WAIT(t)->time_remaining, t->curr_state->cmd.c_str());
-				send_to_char(buf, ch);
-			}
-			else
-			{
-				sprintf(buf, "    Wait: %d\r\n", GET_TRIG_WAIT(t)->time_remaining);
-				send_to_char(buf, ch);
-			}
+    if (GET_TRIG_WAIT(t)) {
+      if (t->curr_state != NULL) {
+        sprintf(buf, "    Wait: %d, Current line: %s\r\n",
+                GET_TRIG_WAIT(t)->time_remaining, t->curr_state->cmd.c_str());
+        send_to_char(buf, ch);
+      } else {
+        sprintf(buf, "    Wait: %d\r\n", GET_TRIG_WAIT(t)->time_remaining);
+        send_to_char(buf, ch);
+      }
 
-			sprintf(buf, "  Variables: %s\r\n", GET_TRIG_VARS(t) ? "" : "None");
-			send_to_char(buf, ch);
+      sprintf(buf, "  Variables: %s\r\n", GET_TRIG_VARS(t) ? "" : "None");
+      send_to_char(buf, ch);
 
-			for (tv = GET_TRIG_VARS(t); tv; tv = tv->next)
-			{
-				if (*(tv->value) == UID_CHAR || *(tv->value) == UID_ROOM || *(tv->value) == UID_OBJ)
-				{
-					find_uid_name(tv->value, name);
-					sprintf(buf, "    %15s:  %s\r\n", tv->name, name);
-				}
-				else
-				{
-					sprintf(buf, "    %15s:  %s\r\n", tv->name, tv->value);
-				}
-				send_to_char(buf, ch);
-			}
-		}
-	}
+      for (tv = GET_TRIG_VARS(t); tv; tv = tv->next) {
+        if (*(tv->value) == UID_CHAR || *(tv->value) == UID_ROOM || *(tv->value) == UID_OBJ) {
+          find_uid_name(tv->value, name);
+          sprintf(buf, "    %15s:  %s\r\n", tv->name, name);
+        } else {
+          sprintf(buf, "    %15s:  %s\r\n", tv->name, tv->value);
+        }
+        send_to_char(buf, ch);
+      }
+    }
+  }
 }
 
-void do_sstat_room(CHAR_DATA * ch)
-{
-	ROOM_DATA *rm = world[ch->in_room];
+void do_sstat_room(CHAR_DATA *ch) {
+  ROOM_DATA *rm = world[ch->in_room];
 
-	do_sstat_room(rm, ch);
+  do_sstat_room(rm, ch);
 
 }
 
-void do_sstat_room(ROOM_DATA *rm, CHAR_DATA * ch)
-{
-	send_to_char("Script information:\r\n", ch);
-	if (!SCRIPT(rm)->has_triggers())
-	{
-		send_to_char("  None.\r\n", ch);
-		return;
-	}
+void do_sstat_room(ROOM_DATA *rm, CHAR_DATA *ch) {
+  send_to_char("Script information:\r\n", ch);
+  if (!SCRIPT(rm)->has_triggers()) {
+    send_to_char("  None.\r\n", ch);
+    return;
+  }
 
-	script_stat(ch, SCRIPT(rm).get());
+  script_stat(ch, SCRIPT(rm).get());
 }
 
-void do_sstat_object(CHAR_DATA * ch, OBJ_DATA * j)
-{
-	send_to_char("Script information:\r\n", ch);
-	if (!j->get_script()->has_triggers())
-	{
-		send_to_char("  None.\r\n", ch);
-		return;
-	}
+void do_sstat_object(CHAR_DATA *ch, OBJ_DATA *j) {
+  send_to_char("Script information:\r\n", ch);
+  if (!j->get_script()->has_triggers()) {
+    send_to_char("  None.\r\n", ch);
+    return;
+  }
 
-	script_stat(ch, j->get_script().get());
+  script_stat(ch, j->get_script().get());
 }
 
-void do_sstat_character(CHAR_DATA * ch, CHAR_DATA * k)
-{
-	send_to_char("Script information:\r\n", ch);
-	if (!SCRIPT(k)->has_triggers())
-	{
-		send_to_char("  None.\r\n", ch);
-		return;
-	}
+void do_sstat_character(CHAR_DATA *ch, CHAR_DATA *k) {
+  send_to_char("Script information:\r\n", ch);
+  if (!SCRIPT(k)->has_triggers()) {
+    send_to_char("  None.\r\n", ch);
+    return;
+  }
 
-	script_stat(ch, SCRIPT(k).get());
+  script_stat(ch, SCRIPT(k).get());
 }
 
 /*
@@ -1152,276 +983,212 @@ void do_sstat_character(CHAR_DATA * ch, CHAR_DATA * k)
  * Return true if trigger successfully added
  * Return false if trigger with same rnum already exists and can not be added
  */
-bool add_trigger(SCRIPT_DATA* sc, TRIG_DATA * t, int loc)
-{
-	if (!t || !sc)
-	{
-		return false;
-	}
+bool add_trigger(SCRIPT_DATA *sc, TRIG_DATA *t, int loc) {
+  if (!t || !sc) {
+    return false;
+  }
 
-	const bool added = sc->trig_list.add(t, 0 == loc);
-	if (added)
-	{
-		SCRIPT_TYPES(sc) |= GET_TRIG_TYPE(t);
-		trigger_list.add(t);
-	}
+  const bool added = sc->trig_list.add(t, 0 == loc);
+  if (added) {
+    SCRIPT_TYPES(sc) |= GET_TRIG_TYPE(t);
+    trigger_list.add(t);
+  }
 
-	return added;
+  return added;
 }
 
-void do_attach(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	CHAR_DATA *victim;
-	OBJ_DATA *object;
-	TRIG_DATA *trig;
-	char targ_name[MAX_INPUT_LENGTH], trig_name[MAX_INPUT_LENGTH];
-	char loc_name[MAX_INPUT_LENGTH];
-	int loc, room, tn, rn;
+void do_attach(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *victim;
+  OBJ_DATA *object;
+  TRIG_DATA *trig;
+  char targ_name[MAX_INPUT_LENGTH], trig_name[MAX_INPUT_LENGTH];
+  char loc_name[MAX_INPUT_LENGTH];
+  int loc, room, tn, rn;
 
-	argument = two_arguments(argument, arg, trig_name);
-	two_arguments(argument, targ_name, loc_name);
+  argument = two_arguments(argument, arg, trig_name);
+  two_arguments(argument, targ_name, loc_name);
 
-	if (!*arg || !*targ_name || !*trig_name)
-	{
-		send_to_char("Usage: attach { mtr | otr | wtr } { trigger } { name } [ location ]\r\n", ch);
-		return;
-	}
+  if (!*arg || !*targ_name || !*trig_name) {
+    send_to_char("Usage: attach { mtr | otr | wtr } { trigger } { name } [ location ]\r\n", ch);
+    return;
+  }
 
-	tn = atoi(trig_name);
-	loc = (*loc_name) ? atoi(loc_name) : -1;
+  tn = atoi(trig_name);
+  loc = (*loc_name) ? atoi(loc_name) : -1;
 
-	rn = real_trigger(tn);
-	if (rn >= 0
-		&& ((is_abbrev(arg, "mtr") && trig_index[rn]->proto->get_attach_type() != MOB_TRIGGER)
-			|| (is_abbrev(arg, "otr") && trig_index[rn]->proto->get_attach_type() != OBJ_TRIGGER)
-			|| (is_abbrev(arg, "wtr") && trig_index[rn]->proto->get_attach_type() != WLD_TRIGGER)))
-	{
-		tn = (is_abbrev(arg, "mtr") ? 0 : is_abbrev(arg, "otr") ? 1 : is_abbrev(arg, "wtr") ? 2 : 3);
-		sprintf(buf, "Trigger %d (%s) has wrong attach_type %s expected %s.\r\n",
-			tn, GET_TRIG_NAME(trig_index[rn]->proto), attach_name[(int)trig_index[rn]->proto->get_attach_type()], attach_name[tn]);
-		send_to_char(buf, ch);
-		return;
-	}
-	if (is_abbrev(arg, "mtr"))
-	{
-		if ((victim = get_char_vis(ch, targ_name, FIND_CHAR_WORLD)))
-		{
-			if (IS_NPC(victim))  	// have a valid mob, now get trigger
-			{
-				rn = real_trigger(tn);
-				if ((rn >= 0) && (trig = read_trigger(rn)))
-				{
-					sprintf(buf, "Trigger %d (%s) attached to %s.\r\n", tn, GET_TRIG_NAME(trig), GET_SHORT(victim));
-					send_to_char(buf, ch);
+  rn = real_trigger(tn);
+  if (rn >= 0
+      && ((is_abbrev(arg, "mtr") && trig_index[rn]->proto->get_attach_type() != MOB_TRIGGER)
+          || (is_abbrev(arg, "otr") && trig_index[rn]->proto->get_attach_type() != OBJ_TRIGGER)
+          || (is_abbrev(arg, "wtr") && trig_index[rn]->proto->get_attach_type() != WLD_TRIGGER))) {
+    tn = (is_abbrev(arg, "mtr") ? 0 : is_abbrev(arg, "otr") ? 1 : is_abbrev(arg, "wtr") ? 2 : 3);
+    sprintf(buf,
+            "Trigger %d (%s) has wrong attach_type %s expected %s.\r\n",
+            tn,
+            GET_TRIG_NAME(trig_index[rn]->proto),
+            attach_name[(int) trig_index[rn]->proto->get_attach_type()],
+            attach_name[tn]);
+    send_to_char(buf, ch);
+    return;
+  }
+  if (is_abbrev(arg, "mtr")) {
+    if ((victim = get_char_vis(ch, targ_name, FIND_CHAR_WORLD))) {
+      if (IS_NPC(victim))    // have a valid mob, now get trigger
+      {
+        rn = real_trigger(tn);
+        if ((rn >= 0) && (trig = read_trigger(rn))) {
+          sprintf(buf, "Trigger %d (%s) attached to %s.\r\n", tn, GET_TRIG_NAME(trig), GET_SHORT(victim));
+          send_to_char(buf, ch);
 
-					if (!add_trigger(SCRIPT(victim).get(), trig, loc))
-					{
-						extract_trigger(trig);
-					}
-				}
-				else
-				{
-					send_to_char("That trigger does not exist.\r\n", ch);
-				}
-			}
-			else
-				send_to_char("Players can't have scripts.\r\n", ch);
-		}
-		else
-		{
-			send_to_char("That mob does not exist.\r\n", ch);
-		}
-	}
-	else if (is_abbrev(arg, "otr"))
-	{
-		if ((object = get_obj_vis(ch, targ_name)))  	// have a valid obj, now get trigger
-		{
-			rn = real_trigger(tn);
-			if ((rn >= 0) && (trig = read_trigger(rn)))
-			{
-				sprintf(buf, "Trigger %d (%s) attached to %s.\r\n",
-					tn, GET_TRIG_NAME(trig),
-					(!object->get_short_description().empty() ? object->get_short_description().c_str() : object->get_aliases().c_str()));
-				send_to_char(buf, ch);
+          if (!add_trigger(SCRIPT(victim).get(), trig, loc)) {
+            extract_trigger(trig);
+          }
+        } else {
+          send_to_char("That trigger does not exist.\r\n", ch);
+        }
+      } else
+        send_to_char("Players can't have scripts.\r\n", ch);
+    } else {
+      send_to_char("That mob does not exist.\r\n", ch);
+    }
+  } else if (is_abbrev(arg, "otr")) {
+    if ((object = get_obj_vis(ch, targ_name)))    // have a valid obj, now get trigger
+    {
+      rn = real_trigger(tn);
+      if ((rn >= 0) && (trig = read_trigger(rn))) {
+        sprintf(buf, "Trigger %d (%s) attached to %s.\r\n",
+                tn, GET_TRIG_NAME(trig),
+                (!object->get_short_description().empty() ? object->get_short_description().c_str()
+                                                          : object->get_aliases().c_str()));
+        send_to_char(buf, ch);
 
-				if (!add_trigger(object->get_script().get(), trig, loc))
-				{
-					extract_trigger(trig);
-				}
-			}
-			else
-				send_to_char("That trigger does not exist.\r\n", ch);
-		}
-		else
-			send_to_char("That object does not exist.\r\n", ch);
-	}
-	else if (is_abbrev(arg, "wtr"))
-	{
-		if (a_isdigit(*targ_name) && !strchr(targ_name, '.'))
-		{
-			if ((room = find_target_room(ch, targ_name, 0)) != NOWHERE)  	// have a valid room, now get trigger
-			{
-				rn = real_trigger(tn);
-				if ((rn >= 0) && (trig = read_trigger(rn)))
-				{
-					sprintf(buf, "Trigger %d (%s) attached to room %d.\r\n",
-						tn, GET_TRIG_NAME(trig), world[room]->number);
-					send_to_char(buf, ch);
+        if (!add_trigger(object->get_script().get(), trig, loc)) {
+          extract_trigger(trig);
+        }
+      } else
+        send_to_char("That trigger does not exist.\r\n", ch);
+    } else
+      send_to_char("That object does not exist.\r\n", ch);
+  } else if (is_abbrev(arg, "wtr")) {
+    if (a_isdigit(*targ_name) && !strchr(targ_name, '.')) {
+      if ((room = find_target_room(ch, targ_name, 0)) != NOWHERE)    // have a valid room, now get trigger
+      {
+        rn = real_trigger(tn);
+        if ((rn >= 0) && (trig = read_trigger(rn))) {
+          sprintf(buf, "Trigger %d (%s) attached to room %d.\r\n",
+                  tn, GET_TRIG_NAME(trig), world[room]->number);
+          send_to_char(buf, ch);
 
-					if (!add_trigger(world[room]->script.get(), trig, loc))
-					{
-						extract_trigger(trig);
-					}
-				}
-				else
-				{
-					send_to_char("That trigger does not exist.\r\n", ch);
-				}
-			}
-		}
-		else
-		{
-			send_to_char("You need to supply a room number.\r\n", ch);
-		}
-	}
-	else
-	{
-		send_to_char("Please specify 'mtr', otr', or 'wtr'.\r\n", ch);
-	}
+          if (!add_trigger(world[room]->script.get(), trig, loc)) {
+            extract_trigger(trig);
+          }
+        } else {
+          send_to_char("That trigger does not exist.\r\n", ch);
+        }
+      }
+    } else {
+      send_to_char("You need to supply a room number.\r\n", ch);
+    }
+  } else {
+    send_to_char("Please specify 'mtr', otr', or 'wtr'.\r\n", ch);
+  }
 }
 
-void do_detach(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	CHAR_DATA *victim = NULL;
-	OBJ_DATA *object = NULL;
-	ROOM_DATA *room;
-	char arg1[MAX_INPUT_LENGTH], arg2[MAX_INPUT_LENGTH], arg3[MAX_INPUT_LENGTH];
-	char *trigger = 0;
-	int tmp;
+void do_detach(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *victim = NULL;
+  OBJ_DATA *object = NULL;
+  ROOM_DATA *room;
+  char arg1[MAX_INPUT_LENGTH], arg2[MAX_INPUT_LENGTH], arg3[MAX_INPUT_LENGTH];
+  char *trigger = 0;
+  int tmp;
 
-	argument = two_arguments(argument, arg1, arg2);
-	one_argument(argument, arg3);
+  argument = two_arguments(argument, arg1, arg2);
+  one_argument(argument, arg3);
 
-	if (!*arg1 || !*arg2)
-	{
-		send_to_char("Usage: detach [ mob | object | room ] { target } { trigger |" " 'all' }\r\n", ch);
-		return;
-	}
+  if (!*arg1 || !*arg2) {
+    send_to_char("Usage: detach [ mob | object | room ] { target } { trigger |" " 'all' }\r\n", ch);
+    return;
+  }
 
-	if (!str_cmp(arg1, "room"))
-	{
-		room = world[ch->in_room];
-		if (!SCRIPT(room)->has_triggers())
-		{
-			send_to_char("This room does not have any triggers.\r\n", ch);
-		}
-		else if (!str_cmp(arg2, "all") || !str_cmp(arg2, "все"))
-		{
-			room->cleanup_script();
+  if (!str_cmp(arg1, "room")) {
+    room = world[ch->in_room];
+    if (!SCRIPT(room)->has_triggers()) {
+      send_to_char("This room does not have any triggers.\r\n", ch);
+    } else if (!str_cmp(arg2, "all") || !str_cmp(arg2, "все")) {
+      room->cleanup_script();
 
-			send_to_char("All triggers removed from room.\r\n", ch);
-		}
-		else if (SCRIPT(room)->remove_trigger(arg2))
-		{
-			send_to_char("Trigger removed.\r\n", ch);
-		}
-		else
-		{
-			send_to_char("That trigger was not found.\r\n", ch);
-		}
-	}
-	else
-	{
-		if (is_abbrev(arg1, "mob"))
-		{
-			if (!(victim = get_char_vis(ch, arg2, FIND_CHAR_WORLD)))
-				send_to_char("No such mobile around.\r\n", ch);
-			else if (!*arg3)
-				send_to_char("You must specify a trigger to remove.\r\n", ch);
-			else
-				trigger = arg3;
-		}
-		else if (is_abbrev(arg1, "object"))
-		{
-			if (!(object = get_obj_vis(ch, arg2)))
-				send_to_char("No such object around.\r\n", ch);
-			else if (!*arg3)
-				send_to_char("You must specify a trigger to remove.\r\n", ch);
-			else
-				trigger = arg3;
-		}
-		else
-		{
-			if ((object = get_object_in_equip_vis(ch, arg1, ch->equipment, &tmp)));
-			else if ((object = get_obj_in_list_vis(ch, arg1, ch->carrying)));
-			else if ((victim = get_char_room_vis(ch, arg1)));
-			else if ((object = get_obj_in_list_vis(ch, arg1, world[ch->in_room]->contents)));
-			else if ((victim = get_char_vis(ch, arg1, FIND_CHAR_WORLD)));
-			else if ((object = get_obj_vis(ch, arg1)));
-			else
-				send_to_char("Nothing around by that name.\r\n", ch);
-			trigger = arg2;
-		}
+      send_to_char("All triggers removed from room.\r\n", ch);
+    } else if (SCRIPT(room)->remove_trigger(arg2)) {
+      send_to_char("Trigger removed.\r\n", ch);
+    } else {
+      send_to_char("That trigger was not found.\r\n", ch);
+    }
+  } else {
+    if (is_abbrev(arg1, "mob")) {
+      if (!(victim = get_char_vis(ch, arg2, FIND_CHAR_WORLD)))
+        send_to_char("No such mobile around.\r\n", ch);
+      else if (!*arg3)
+        send_to_char("You must specify a trigger to remove.\r\n", ch);
+      else
+        trigger = arg3;
+    } else if (is_abbrev(arg1, "object")) {
+      if (!(object = get_obj_vis(ch, arg2)))
+        send_to_char("No such object around.\r\n", ch);
+      else if (!*arg3)
+        send_to_char("You must specify a trigger to remove.\r\n", ch);
+      else
+        trigger = arg3;
+    } else {
+      if ((object = get_object_in_equip_vis(ch, arg1, ch->equipment, &tmp)));
+      else if ((object = get_obj_in_list_vis(ch, arg1, ch->carrying)));
+      else if ((victim = get_char_room_vis(ch, arg1)));
+      else if ((object = get_obj_in_list_vis(ch, arg1, world[ch->in_room]->contents)));
+      else if ((victim = get_char_vis(ch, arg1, FIND_CHAR_WORLD)));
+      else if ((object = get_obj_vis(ch, arg1)));
+      else
+        send_to_char("Nothing around by that name.\r\n", ch);
+      trigger = arg2;
+    }
 
-		if (victim)
-		{
-			if (!IS_NPC(victim))
-			{
-				send_to_char("Players don't have triggers.\r\n", ch);
-			}
-			else if (!SCRIPT(victim)->has_triggers())
-			{
-				send_to_char("That mob doesn't have any triggers.\r\n", ch);
-			}
-			else if (!str_cmp(arg2, "all") || !str_cmp(arg2, "все"))
-			{
-				victim->cleanup_script();
-				sprintf(buf, "All triggers removed from %s.\r\n", GET_SHORT(victim));
-				send_to_char(buf, ch);
-			}
-			else if (trigger
-				&& SCRIPT(victim)->remove_trigger(trigger))
-			{
-				send_to_char("Trigger removed.\r\n", ch);
-			}
-			else
-			{
-				send_to_char("That trigger was not found.\r\n", ch);
-			}
-		}
-		else if (object)
-		{
-			if (!object->get_script()->has_triggers())
-			{
-				send_to_char("That object doesn't have any triggers.\r\n", ch);
-			}
-			else if (!str_cmp(arg2, "all") || !str_cmp(arg2, "все"))
-			{
-				object->cleanup_script();
-				sprintf(buf, "All triggers removed from %s.\r\n",
-					!object->get_short_description().empty() ? object->get_short_description().c_str() : object->get_aliases().c_str());
-				send_to_char(buf, ch);
-			}
-			else if (object->get_script()->remove_trigger(trigger))
-			{
-				send_to_char("Trigger removed.\r\n", ch);
-			}
-			else
-			{
-				send_to_char("That trigger was not found.\r\n", ch);
-			}
-		}
-	}
+    if (victim) {
+      if (!IS_NPC(victim)) {
+        send_to_char("Players don't have triggers.\r\n", ch);
+      } else if (!SCRIPT(victim)->has_triggers()) {
+        send_to_char("That mob doesn't have any triggers.\r\n", ch);
+      } else if (!str_cmp(arg2, "all") || !str_cmp(arg2, "все")) {
+        victim->cleanup_script();
+        sprintf(buf, "All triggers removed from %s.\r\n", GET_SHORT(victim));
+        send_to_char(buf, ch);
+      } else if (trigger
+          && SCRIPT(victim)->remove_trigger(trigger)) {
+        send_to_char("Trigger removed.\r\n", ch);
+      } else {
+        send_to_char("That trigger was not found.\r\n", ch);
+      }
+    } else if (object) {
+      if (!object->get_script()->has_triggers()) {
+        send_to_char("That object doesn't have any triggers.\r\n", ch);
+      } else if (!str_cmp(arg2, "all") || !str_cmp(arg2, "все")) {
+        object->cleanup_script();
+        sprintf(buf, "All triggers removed from %s.\r\n",
+                !object->get_short_description().empty() ? object->get_short_description().c_str()
+                                                         : object->get_aliases().c_str());
+        send_to_char(buf, ch);
+      } else if (object->get_script()->remove_trigger(trigger)) {
+        send_to_char("Trigger removed.\r\n", ch);
+      } else {
+        send_to_char("That trigger was not found.\r\n", ch);
+      }
+    }
+  }
 }
 
 // frees memory associated with var
-void free_var_el(struct trig_var_data *var)
-{
-	free(var->name);
-	free(var->value);
-	free(var);
+void free_var_el(struct trig_var_data *var) {
+  free(var->name);
+  free(var->value);
+  free(var);
 }
-
 
 void add_var_cntx(struct trig_var_data **var_list, const char *name, const char *value, long id)
 /*++
@@ -1434,50 +1201,43 @@ void add_var_cntx(struct trig_var_data **var_list, const char *name, const char 
 	id			- контекст переменной
 --*/
 {
-	struct trig_var_data *vd, *vd_prev;
+  struct trig_var_data *vd, *vd_prev;
 
-	// Обращаю внимание, что при добавлении необходимо ТОЧНОЕ совпадение контекстов
-	for (vd_prev = NULL, vd = *var_list;
-		vd && ((vd->context != id) || str_cmp(vd->name, name)); vd_prev = vd, vd = vd->next);
+  // Обращаю внимание, что при добавлении необходимо ТОЧНОЕ совпадение контекстов
+  for (vd_prev = NULL, vd = *var_list;
+       vd && ((vd->context != id) || str_cmp(vd->name, name)); vd_prev = vd, vd = vd->next);
 
-	if (vd)
-	{
-		// Переменная существует, заменить значение
-		free(vd->value);
-	}
-	else
-	{
-		// Создать новую переменную
-		CREATE(vd, 1);
-		CREATE(vd->name, strlen(name) + 1);
-		strcpy(vd->name, name);
+  if (vd) {
+    // Переменная существует, заменить значение
+    free(vd->value);
+  } else {
+    // Создать новую переменную
+    CREATE(vd, 1);
+    CREATE(vd->name, strlen(name) + 1);
+    strcpy(vd->name, name);
 
-		vd->context = id;
+    vd->context = id;
 
-		// Добавление переменной в список
-		// Для нулевого контекста в конец списка, для ненулевого - в начало
-		if (id)
-		{
-			vd->next = *var_list;
-			*var_list = vd;
-		}
-		else
-		{
-			vd->next = NULL;
-			if (vd_prev)
-				vd_prev->next = vd;
-			else
-				*var_list = vd;
-		}
-	}
+    // Добавление переменной в список
+    // Для нулевого контекста в конец списка, для ненулевого - в начало
+    if (id) {
+      vd->next = *var_list;
+      *var_list = vd;
+    } else {
+      vd->next = NULL;
+      if (vd_prev)
+        vd_prev->next = vd;
+      else
+        *var_list = vd;
+    }
+  }
 
-	CREATE(vd->value, strlen(value) + 1);
-	strcpy(vd->value, value);
+  CREATE(vd->value, strlen(value) + 1);
+  strcpy(vd->value, value);
 }
 
-
 struct trig_var_data *find_var_cntx(struct trig_var_data **var_list, char *name, long id)
-	/*++
+/*++
 		Поиск переменной с учетом контекста (НЕСТРОГИЙ поиск).
 
 		Поиск осуществляется по паре ИМЯ:КОНТЕКСТ.
@@ -1491,13 +1251,12 @@ struct trig_var_data *find_var_cntx(struct trig_var_data **var_list, char *name,
 		id			- контекст переменной
 	--*/
 {
-	struct trig_var_data *vd;
+  struct trig_var_data *vd;
 
-	for (vd = *var_list; vd && ((vd->context && vd->context != id) || str_cmp(vd->name, name)); vd = vd->next);
+  for (vd = *var_list; vd && ((vd->context && vd->context != id) || str_cmp(vd->name, name)); vd = vd->next);
 
-	return vd;
+  return vd;
 }
-
 
 int remove_var_cntx(struct trig_var_data **var_list, char *name, long id)
 /*++
@@ -1515,2681 +1274,2026 @@ int remove_var_cntx(struct trig_var_data **var_list, char *name, long id)
 
 --*/
 {
-	struct trig_var_data *vd, *vd_prev;
+  struct trig_var_data *vd, *vd_prev;
 
-	for (vd_prev = NULL, vd = *var_list;
-		vd && ((vd->context != id) || str_cmp(vd->name, name)); vd_prev = vd, vd = vd->next);
+  for (vd_prev = NULL, vd = *var_list;
+       vd && ((vd->context != id) || str_cmp(vd->name, name)); vd_prev = vd, vd = vd->next);
 
-	if (!vd)
-		return 0;	// Не удалось найти
+  if (!vd)
+    return 0;    // Не удалось найти
 
-	if (vd_prev)
-		vd_prev->next = vd->next;
-	else
-		*var_list = vd->next;
+  if (vd_prev)
+    vd_prev->next = vd->next;
+  else
+    *var_list = vd->next;
 
-	free_var_el(vd);
+  free_var_el(vd);
 
-	return 1;
+  return 1;
 }
 
-bool SCRIPT_CHECK(const OBJ_DATA* go, const long type)
-{
-	return !go->get_script()->is_purged() && go->get_script()->has_triggers() && IS_SET(SCRIPT_TYPES(go->get_script()), type);
+bool SCRIPT_CHECK(const OBJ_DATA *go, const long type) {
+  return !go->get_script()->is_purged() && go->get_script()->has_triggers()
+      && IS_SET(SCRIPT_TYPES(go->get_script()), type);
 }
 
-bool SCRIPT_CHECK(const CHAR_DATA* go, const long type)
-{
-	return !SCRIPT(go)->is_purged() && SCRIPT(go)->has_triggers() && IS_SET(SCRIPT_TYPES(go->script), type);
+bool SCRIPT_CHECK(const CHAR_DATA *go, const long type) {
+  return !SCRIPT(go)->is_purged() && SCRIPT(go)->has_triggers() && IS_SET(SCRIPT_TYPES(go->script), type);
 }
 
-bool SCRIPT_CHECK(const ROOM_DATA* go, const long type)
-{
-	return !SCRIPT(go)->is_purged() && SCRIPT(go)->has_triggers() && IS_SET(SCRIPT_TYPES(go->script), type);
+bool SCRIPT_CHECK(const ROOM_DATA *go, const long type) {
+  return !SCRIPT(go)->is_purged() && SCRIPT(go)->has_triggers() && IS_SET(SCRIPT_TYPES(go->script), type);
 }
 
 // * Изменение указанной целочисленной константы
-long gm_char_field(CHAR_DATA * ch, char *field, char *subfield, long val)
-{
-	int tmpval;
-	if (*subfield)
-	{
-		sprintf(buf, "DG_Script: Set %s with <%s> for %s.", field, subfield, GET_NAME(ch));
-		log("%s", buf);
-		if (*subfield == '-')
-			return (val - atoi(subfield + 1));
-		else if (*subfield == '+')
-			return (val + atoi(subfield + 1));
-		else if ((tmpval = atoi(subfield)) > 0)
-			return tmpval;
-	}
-	return val;
+long gm_char_field(CHAR_DATA *ch, char *field, char *subfield, long val) {
+  int tmpval;
+  if (*subfield) {
+    sprintf(buf, "DG_Script: Set %s with <%s> for %s.", field, subfield, GET_NAME(ch));
+    log("%s", buf);
+    if (*subfield == '-')
+      return (val - atoi(subfield + 1));
+    else if (*subfield == '+')
+      return (val + atoi(subfield + 1));
+    else if ((tmpval = atoi(subfield)) > 0)
+      return tmpval;
+  }
+  return val;
 }
 
-int text_processed(char *field, char *subfield, struct trig_var_data *vd, char *str)
-{
-	char *p, *p2;
-	*str = '\0';
-	if (!vd || !vd->name || !vd->value)
-		return FALSE;
+int text_processed(char *field, char *subfield, struct trig_var_data *vd, char *str) {
+  char *p, *p2;
+  *str = '\0';
+  if (!vd || !vd->name || !vd->value)
+    return FALSE;
 
-	if (!str_cmp(field, "strlen"))  	// strlen
-	{
-		sprintf(str, "%lu", static_cast<unsigned long>(strlen(vd->value)));
-		return TRUE;
-	}
-	else if (!str_cmp(field, "trim"))  	// trim
-	{
-		// trim whitespace from ends
-		p = vd->value;
-		p2 = vd->value + strlen(vd->value) - 1;
-		while (*p && a_isspace(*p))
-			p++;
-		while ((p >= p2) && a_isspace(*p2))
-			p2--;
-		if (p > p2)  	// nothing left
-		{
-			*str = '\0';
-			return TRUE;
-		}
-		while (p <= p2)
-			*str++ = *p++;
-		*str = '\0';
-		return TRUE;
-	}
-	else if (!str_cmp(field, "contains"))  	// contains
-	{
-		if (str_str(vd->value, subfield))
-			sprintf(str, "1");
-		else
-			sprintf(str, "0");
-		return TRUE;
-	}
-	else if (!str_cmp(field, "car"))  	// car
-	{
-		char *car = vd->value;
-		while (*car && !a_isspace(*car))
-			*str++ = *car++;
-		*str = '\0';
-		return TRUE;
-	}
-	else if (!str_cmp(field, "cdr"))  	// cdr
-	{
-		char *cdr = vd->value;
-		while (*cdr && !a_isspace(*cdr))
-			cdr++;	// skip 1st field
-		while (*cdr && a_isspace(*cdr))
-			cdr++;	// skip to next
-		while (*cdr)
-			*str++ = *cdr++;
-		*str = '\0';
-		return TRUE;
-	}
-	else if (!str_cmp(field, "words"))
-	{
-		int n = 0;
-		// Подсчет количества слов или получение слова
-		char buf1[MAX_INPUT_LENGTH];
-		char buf2[MAX_INPUT_LENGTH];
-		buf1[0] = 0;
-		strcpy(buf2, vd->value);
-		if (*subfield)
-		{
-			for (n = atoi(subfield); n; --n)
-			{
-				half_chop(buf2, buf1, buf2);
-			}
-			strcpy(str, buf1);
-		}
-		else
-		{
-			while (buf2[0] != 0)
-			{
-				half_chop(buf2, buf1, buf2);
-				++n;
-			}
-			sprintf(str, "%d", n);
-		}
-		return TRUE;
-	}
-	else if (!str_cmp(field, "mudcommand"))  	// find the mud command returned from this text
-	{
-		// NOTE: you may need to replace "cmd_info" with "complete_cmd_info",
-		// depending on what patches you've got applied.
-		extern const struct command_info cmd_info[];
-		// on older source bases:    extern struct command_info *cmd_info;
-		int cmd = 0;
-		const size_t length = strlen(vd->value);
-		while (*cmd_info[cmd].command != '\n')
-		{
-			if (!strncmp(cmd_info[cmd].command, vd->value, length))
-			{
-				break;
-			}
-			cmd++;
-		}
+  if (!str_cmp(field, "strlen"))    // strlen
+  {
+    sprintf(str, "%lu", static_cast<unsigned long>(strlen(vd->value)));
+    return TRUE;
+  } else if (!str_cmp(field, "trim"))    // trim
+  {
+    // trim whitespace from ends
+    p = vd->value;
+    p2 = vd->value + strlen(vd->value) - 1;
+    while (*p && a_isspace(*p))
+      p++;
+    while ((p >= p2) && a_isspace(*p2))
+      p2--;
+    if (p > p2)    // nothing left
+    {
+      *str = '\0';
+      return TRUE;
+    }
+    while (p <= p2)
+      *str++ = *p++;
+    *str = '\0';
+    return TRUE;
+  } else if (!str_cmp(field, "contains"))    // contains
+  {
+    if (str_str(vd->value, subfield))
+      sprintf(str, "1");
+    else
+      sprintf(str, "0");
+    return TRUE;
+  } else if (!str_cmp(field, "car"))    // car
+  {
+    char *car = vd->value;
+    while (*car && !a_isspace(*car))
+      *str++ = *car++;
+    *str = '\0';
+    return TRUE;
+  } else if (!str_cmp(field, "cdr"))    // cdr
+  {
+    char *cdr = vd->value;
+    while (*cdr && !a_isspace(*cdr))
+      cdr++;    // skip 1st field
+    while (*cdr && a_isspace(*cdr))
+      cdr++;    // skip to next
+    while (*cdr)
+      *str++ = *cdr++;
+    *str = '\0';
+    return TRUE;
+  } else if (!str_cmp(field, "words")) {
+    int n = 0;
+    // Подсчет количества слов или получение слова
+    char buf1[MAX_INPUT_LENGTH];
+    char buf2[MAX_INPUT_LENGTH];
+    buf1[0] = 0;
+    strcpy(buf2, vd->value);
+    if (*subfield) {
+      for (n = atoi(subfield); n; --n) {
+        half_chop(buf2, buf1, buf2);
+      }
+      strcpy(str, buf1);
+    } else {
+      while (buf2[0] != 0) {
+        half_chop(buf2, buf1, buf2);
+        ++n;
+      }
+      sprintf(str, "%d", n);
+    }
+    return TRUE;
+  } else if (!str_cmp(field, "mudcommand"))    // find the mud command returned from this text
+  {
+    // NOTE: you may need to replace "cmd_info" with "complete_cmd_info",
+    // depending on what patches you've got applied.
+    extern const struct command_info cmd_info[];
+    // on older source bases:    extern struct command_info *cmd_info;
+    int cmd = 0;
+    const size_t length = strlen(vd->value);
+    while (*cmd_info[cmd].command != '\n') {
+      if (!strncmp(cmd_info[cmd].command, vd->value, length)) {
+        break;
+      }
+      cmd++;
+    }
 
-		if (*cmd_info[cmd].command == '\n')
-			strcpy(str, "");
-		else
-			strcpy(str, cmd_info[cmd].command);
-		return TRUE;
-	}
+    if (*cmd_info[cmd].command == '\n')
+      strcpy(str, "");
+    else
+      strcpy(str, cmd_info[cmd].command);
+    return TRUE;
+  }
 
-	return FALSE;
+  return FALSE;
 }
 
-void find_replacement(void* go, SCRIPT_DATA* sc, TRIG_DATA* trig, int type, char* var, char* field, char* subfield, char* str)
-{
-	struct trig_var_data *vd = NULL;
-	CHAR_DATA *ch, *c = NULL, *rndm;
-	OBJ_DATA *obj, *o = NULL;
-	ROOM_DATA *room, *r = NULL;
-	char *name;
-	int num = 0, count = 0, i;
-	char uid_type = '\0';
-	char tmp[MAX_INPUT_LENGTH] = {};
+void find_replacement(void *go,
+                      SCRIPT_DATA *sc,
+                      TRIG_DATA *trig,
+                      int type,
+                      char *var,
+                      char *field,
+                      char *subfield,
+                      char *str) {
+  struct trig_var_data *vd = NULL;
+  CHAR_DATA *ch, *c = NULL, *rndm;
+  OBJ_DATA *obj, *o = NULL;
+  ROOM_DATA *room, *r = NULL;
+  char *name;
+  int num = 0, count = 0, i;
+  char uid_type = '\0';
+  char tmp[MAX_INPUT_LENGTH] = {};
 
-	const char *send_cmd[] = { "msend", "osend", "wsend" };
-	const char *echo_cmd[] = { "mecho", "oecho", "wecho" };
-	const char *echoaround_cmd[] = { "mechoaround", "oechoaround", "wechoaround" };
-	const char *door[] = { "mdoor", "odoor", "wdoor" };
-	const char *force[] = { "mforce", "oforce", "wforce" };
-	const char *load[] = { "mload", "oload", "wload" };
-	const char *purge[] = { "mpurge", "opurge", "wpurge" };
-	const char *teleport[] = { "mteleport", "oteleport", "wteleport" };
-	const char *damage[] = { "mdamage", "odamage", "wdamage" };
-	const char *featturn[] = { "mfeatturn", "ofeatturn", "wfeatturn" };
-	const char *skillturn[] = { "mskillturn", "oskillturn", "wskillturn" };
-	const char *skilladd[] = { "mskilladd", "oskilladd", "wskilladd" };
-	const char *spellturn[] = { "mspellturn", "ospellturn", "wspellturn" };
-	const char *spelladd[] = { "mspelladd", "ospelladd", "wspelladd" };
-	const char *spellitem[] = { "mspellitem", "ospellitem", "wspellitem" };
-	const char *portal[] = { "mportal", "oportal", "wportal" };
+  const char *send_cmd[] = {"msend", "osend", "wsend"};
+  const char *echo_cmd[] = {"mecho", "oecho", "wecho"};
+  const char *echoaround_cmd[] = {"mechoaround", "oechoaround", "wechoaround"};
+  const char *door[] = {"mdoor", "odoor", "wdoor"};
+  const char *force[] = {"mforce", "oforce", "wforce"};
+  const char *load[] = {"mload", "oload", "wload"};
+  const char *purge[] = {"mpurge", "opurge", "wpurge"};
+  const char *teleport[] = {"mteleport", "oteleport", "wteleport"};
+  const char *damage[] = {"mdamage", "odamage", "wdamage"};
+  const char *featturn[] = {"mfeatturn", "ofeatturn", "wfeatturn"};
+  const char *skillturn[] = {"mskillturn", "oskillturn", "wskillturn"};
+  const char *skilladd[] = {"mskilladd", "oskilladd", "wskilladd"};
+  const char *spellturn[] = {"mspellturn", "ospellturn", "wspellturn"};
+  const char *spelladd[] = {"mspelladd", "ospelladd", "wspelladd"};
+  const char *spellitem[] = {"mspellitem", "ospellitem", "wspellitem"};
+  const char *portal[] = {"mportal", "oportal", "wportal"};
 
-	if (!subfield)
-	{
-		subfield = NULL;	// Чтобы проверок меньше было
-	}
+  if (!subfield) {
+    subfield = NULL;    // Чтобы проверок меньше было
+  }
 
-	// X.global() will have a NULL trig
-	if (trig)
-		vd = find_var_cntx(&GET_TRIG_VARS(trig), var, 0);
-	if (!vd)
-		vd = find_var_cntx(&(sc->global_vars), var, sc->context);
-	if (!vd)
-		vd = find_var_cntx(&worlds_vars, var, sc->context);
+  // X.global() will have a NULL trig
+  if (trig)
+    vd = find_var_cntx(&GET_TRIG_VARS(trig), var, 0);
+  if (!vd)
+    vd = find_var_cntx(&(sc->global_vars), var, sc->context);
+  if (!vd)
+    vd = find_var_cntx(&worlds_vars, var, sc->context);
 
-	*str = '\0';
+  *str = '\0';
 
-	if (!field || !*field)
-	{
-		if (vd)
-		{
-			strcpy(str, vd->value);
-		}
-		else
-		{
-			if (!str_cmp(var, "self"))
-			{
-				long uid;
-				// заменить на UID
-				switch (type)
-				{
-				case MOB_TRIGGER:
-					uid = GET_ID((CHAR_DATA *)go);
-					uid_type = UID_CHAR;
-					break;
+  if (!field || !*field) {
+    if (vd) {
+      strcpy(str, vd->value);
+    } else {
+      if (!str_cmp(var, "self")) {
+        long uid;
+        // заменить на UID
+        switch (type) {
+          case MOB_TRIGGER: uid = GET_ID((CHAR_DATA *) go);
+            uid_type = UID_CHAR;
+            break;
 
-				case OBJ_TRIGGER:
-					uid = ((OBJ_DATA *)go)->get_id();
-					uid_type = UID_OBJ;
-					break;
+          case OBJ_TRIGGER: uid = ((OBJ_DATA *) go)->get_id();
+            uid_type = UID_OBJ;
+            break;
 
-				case WLD_TRIGGER:
-					uid = find_room_uid(((ROOM_DATA *)go)->number);
-					uid_type = UID_ROOM;
-					break;
+          case WLD_TRIGGER: uid = find_room_uid(((ROOM_DATA *) go)->number);
+            uid_type = UID_ROOM;
+            break;
 
-				default:
-					strcpy(str, "self");
-					return;
-				}
-				sprintf(str, "%c%ld", uid_type, uid);
-			}
-			else if (!str_cmp(var, "door"))
-				strcpy(str, door[type]);
-			else if (!str_cmp(var, "force"))
-				strcpy(str, force[type]);
-			else if (!str_cmp(var, "load"))
-				strcpy(str, load[type]);
-			else if (!str_cmp(var, "purge"))
-				strcpy(str, purge[type]);
-			else if (!str_cmp(var, "teleport"))
-				strcpy(str, teleport[type]);
-			else if (!str_cmp(var, "damage"))
-				strcpy(str, damage[type]);
-			else if (!str_cmp(var, "send"))
-				strcpy(str, send_cmd[type]);
-			else if (!str_cmp(var, "echo"))
-				strcpy(str, echo_cmd[type]);
-			else if (!str_cmp(var, "echoaround"))
-				strcpy(str, echoaround_cmd[type]);
-			else if (!str_cmp(var, "featturn"))
-				strcpy(str, featturn[type]);
-			else if (!str_cmp(var, "skillturn"))
-				strcpy(str, skillturn[type]);
-			else if (!str_cmp(var, "skilladd"))
-				strcpy(str, skilladd[type]);
-			else if (!str_cmp(var, "spellturn"))
-				strcpy(str, spellturn[type]);
-			else if (!str_cmp(var, "spelladd"))
-				strcpy(str, spelladd[type]);
-			else if (!str_cmp(var, "spellitem"))
-				strcpy(str, spellitem[type]);
-			else if (!str_cmp(var, "portal"))
-				strcpy(str, portal[type]);
-		}
-		return;
-	}
+          default: strcpy(str, "self");
+            return;
+        }
+        sprintf(str, "%c%ld", uid_type, uid);
+      } else if (!str_cmp(var, "door"))
+        strcpy(str, door[type]);
+      else if (!str_cmp(var, "force"))
+        strcpy(str, force[type]);
+      else if (!str_cmp(var, "load"))
+        strcpy(str, load[type]);
+      else if (!str_cmp(var, "purge"))
+        strcpy(str, purge[type]);
+      else if (!str_cmp(var, "teleport"))
+        strcpy(str, teleport[type]);
+      else if (!str_cmp(var, "damage"))
+        strcpy(str, damage[type]);
+      else if (!str_cmp(var, "send"))
+        strcpy(str, send_cmd[type]);
+      else if (!str_cmp(var, "echo"))
+        strcpy(str, echo_cmd[type]);
+      else if (!str_cmp(var, "echoaround"))
+        strcpy(str, echoaround_cmd[type]);
+      else if (!str_cmp(var, "featturn"))
+        strcpy(str, featturn[type]);
+      else if (!str_cmp(var, "skillturn"))
+        strcpy(str, skillturn[type]);
+      else if (!str_cmp(var, "skilladd"))
+        strcpy(str, skilladd[type]);
+      else if (!str_cmp(var, "spellturn"))
+        strcpy(str, spellturn[type]);
+      else if (!str_cmp(var, "spelladd"))
+        strcpy(str, spelladd[type]);
+      else if (!str_cmp(var, "spellitem"))
+        strcpy(str, spellitem[type]);
+      else if (!str_cmp(var, "portal"))
+        strcpy(str, portal[type]);
+    }
+    return;
+  }
 
-	if (vd)
-	{
-		name = vd->value;
-		switch (type)
-		{
-		case MOB_TRIGGER:
-			ch = (CHAR_DATA *)go;
-			if (!name)
-			{
-				log("SYSERROR: null name (%s:%d %s)", __FILE__, __LINE__, __func__);
-				break;
-			}
-			if (!ch)
-			{
-				log("SYSERROR: null ch (%s:%d %s)", __FILE__, __LINE__, __func__);
-				break;
-			}
-			if ((o = get_object_in_equip(ch, name)));
-			else if ((o = get_obj_in_list(name, ch->carrying)));
-			else if ((c = get_char_room(name, ch->in_room)));
-			else if ((o = get_obj_in_list(name, world[ch->in_room]->contents)));
-			else if ((c = get_char(name, GET_TRIG_VNUM(trig))));
-			else if ((o = get_obj(name, GET_TRIG_VNUM(trig))));
-			else if ((r = get_room(name)))
-			{
-			}
-			break;
-		case OBJ_TRIGGER:
-			obj = (OBJ_DATA *)go;
-			if ((c = get_char_by_obj(obj, name)));
-			else if ((o = get_obj_by_obj(obj, name)));
-			else if ((r = get_room(name)))
-			{
-			}
-			break;
-		case WLD_TRIGGER:
-			room = (ROOM_DATA *)go;
-			if ((c = get_char_by_room(room, name)));
-			else if ((o = get_obj_by_room(room, name)));
-			else if ((r = get_room(name)))
-			{
-			}
-			break;
-		}
-	}
-	else
-	{
-		if (!str_cmp(var, "self"))
-		{
-			switch (type)
-			{
-			case MOB_TRIGGER:
-				c = (CHAR_DATA *)go;
-				break;
-			case OBJ_TRIGGER:
-				o = (OBJ_DATA *)go;
-				break;
-			case WLD_TRIGGER:
-				r = (ROOM_DATA *)go;
-				break;
-			}
-		}
-		else if (!str_cmp(var, "exist"))
-		{
-			if (!str_cmp(field, "mob") && (num = atoi(subfield)) > 0)
-			{
-				num = count_char_vnum(num);
-				if (num >= 0)
-					sprintf(str, "%c", num > 0 ? '1' : '0');
-			}
-			else if (!str_cmp(field, "obj") && (num = atoi(subfield)) > 0)
-			{
-				num = gcount_obj_vnum(num);
-				if (num >= 0)
-					sprintf(str, "%c", num > 0 ? '1' : '0');
-			}
-			return;
-		}
-		else if (!str_cmp(var, "world"))
-		{
-			num = atoi(subfield);
-			if ((!str_cmp(field, "curobj") || !str_cmp(field, "curobjs")) && num > 0)
-			{
-				const auto rnum = real_object(num);
-				const auto count = count_obj_vnum(num);
-				if (count >= 0 && 0 <= rnum)
-				{
-					if (check_unlimited_timer(obj_proto[rnum].get()))
-					{
-						sprintf(str, "0");
-					}
-					else
-					{
-						sprintf(str, "%d", count);
-					}
-				}
-				else
-				{
-					sprintf(str, "0");
-				}
-			}
-			else if ((!str_cmp(field, "gameobj") || !str_cmp(field, "gameobjs")) && num > 0)
-			{
-				num = gcount_obj_vnum(num);
-				if (num >= 0)
-					sprintf(str, "%d", num);
-			}
-			else if (!str_cmp(field, "people") && num > 0)
-			{
-				sprintf(str, "%d", trgvar_in_room(num));
-			}
-			else if ((!str_cmp(field, "curmob") || !str_cmp(field, "curmobs")) && num > 0)
-			{
-				num = count_char_vnum(num);
-				if (num >= 0)
-					sprintf(str, "%d", num);
-			}
-			else if ((!str_cmp(field, "gamemob") || !str_cmp(field, "gamemobs")) && num > 0)
-			{
-				num = gcount_char_vnum(num);
-				if (num >= 0)
-					sprintf(str, "%d", num);
-			}
-			else if (!str_cmp(field, "zreset") && num > 0)
-			{
-				for (zone_rnum i = 0; i < static_cast<zone_rnum>(zone_table.size()); i++)
-				{
-					if (zone_table[i].number == num)
-					{
-						reset_zone(i);
-					}
-				}
-			}
-			else if (!str_cmp(field, "mob") && num > 0)
-			{
-				num = find_char_vnum(num);
-				if (num >= 0)
-					sprintf(str, "%c%d", UID_CHAR, num);
-			}
-			else if (!str_cmp(field, "obj") && num > 0)
-			{
-				num = find_obj_by_id_vnum__find_replacement(num);
+  if (vd) {
+    name = vd->value;
+    switch (type) {
+      case MOB_TRIGGER: ch = (CHAR_DATA *) go;
+        if (!name) {
+          log("SYSERROR: null name (%s:%d %s)", __FILE__, __LINE__, __func__);
+          break;
+        }
+        if (!ch) {
+          log("SYSERROR: null ch (%s:%d %s)", __FILE__, __LINE__, __func__);
+          break;
+        }
+        if ((o = get_object_in_equip(ch, name)));
+        else if ((o = get_obj_in_list(name, ch->carrying)));
+        else if ((c = get_char_room(name, ch->in_room)));
+        else if ((o = get_obj_in_list(name, world[ch->in_room]->contents)));
+        else if ((c = get_char(name, GET_TRIG_VNUM(trig))));
+        else if ((o = get_obj(name, GET_TRIG_VNUM(trig))));
+        else if ((r = get_room(name))) {
+        }
+        break;
+      case OBJ_TRIGGER: obj = (OBJ_DATA *) go;
+        if ((c = get_char_by_obj(obj, name)));
+        else if ((o = get_obj_by_obj(obj, name)));
+        else if ((r = get_room(name))) {
+        }
+        break;
+      case WLD_TRIGGER: room = (ROOM_DATA *) go;
+        if ((c = get_char_by_room(room, name)));
+        else if ((o = get_obj_by_room(room, name)));
+        else if ((r = get_room(name))) {
+        }
+        break;
+    }
+  } else {
+    if (!str_cmp(var, "self")) {
+      switch (type) {
+        case MOB_TRIGGER: c = (CHAR_DATA *) go;
+          break;
+        case OBJ_TRIGGER: o = (OBJ_DATA *) go;
+          break;
+        case WLD_TRIGGER: r = (ROOM_DATA *) go;
+          break;
+      }
+    } else if (!str_cmp(var, "exist")) {
+      if (!str_cmp(field, "mob") && (num = atoi(subfield)) > 0) {
+        num = count_char_vnum(num);
+        if (num >= 0)
+          sprintf(str, "%c", num > 0 ? '1' : '0');
+      } else if (!str_cmp(field, "obj") && (num = atoi(subfield)) > 0) {
+        num = gcount_obj_vnum(num);
+        if (num >= 0)
+          sprintf(str, "%c", num > 0 ? '1' : '0');
+      }
+      return;
+    } else if (!str_cmp(var, "world")) {
+      num = atoi(subfield);
+      if ((!str_cmp(field, "curobj") || !str_cmp(field, "curobjs")) && num > 0) {
+        const auto rnum = real_object(num);
+        const auto count = count_obj_vnum(num);
+        if (count >= 0 && 0 <= rnum) {
+          if (check_unlimited_timer(obj_proto[rnum].get())) {
+            sprintf(str, "0");
+          } else {
+            sprintf(str, "%d", count);
+          }
+        } else {
+          sprintf(str, "0");
+        }
+      } else if ((!str_cmp(field, "gameobj") || !str_cmp(field, "gameobjs")) && num > 0) {
+        num = gcount_obj_vnum(num);
+        if (num >= 0)
+          sprintf(str, "%d", num);
+      } else if (!str_cmp(field, "people") && num > 0) {
+        sprintf(str, "%d", trgvar_in_room(num));
+      } else if ((!str_cmp(field, "curmob") || !str_cmp(field, "curmobs")) && num > 0) {
+        num = count_char_vnum(num);
+        if (num >= 0)
+          sprintf(str, "%d", num);
+      } else if ((!str_cmp(field, "gamemob") || !str_cmp(field, "gamemobs")) && num > 0) {
+        num = gcount_char_vnum(num);
+        if (num >= 0)
+          sprintf(str, "%d", num);
+      } else if (!str_cmp(field, "zreset") && num > 0) {
+        for (zone_rnum i = 0; i < static_cast<zone_rnum>(zone_table.size()); i++) {
+          if (zone_table[i].number == num) {
+            reset_zone(i);
+          }
+        }
+      } else if (!str_cmp(field, "mob") && num > 0) {
+        num = find_char_vnum(num);
+        if (num >= 0)
+          sprintf(str, "%c%d", UID_CHAR, num);
+      } else if (!str_cmp(field, "obj") && num > 0) {
+        num = find_obj_by_id_vnum__find_replacement(num);
 
-				if (num >= 0)
-					sprintf(str, "%c%d", UID_OBJ, num);
-			}
-			else if (!str_cmp(field, "room") && num > 0)
-			{
-				num = find_room_uid(num);
-				if (num >= 0)
-					sprintf(str, "%c%d", UID_ROOM, num);
-			}
-			//Polud world.maxobj(vnum) показывает максимальное количество предметов в мире,
-			//которое прописано в самом предмете с указанным vnum
-			else if ((!str_cmp(field, "maxobj") || !str_cmp(field, "maxobjs")) && num > 0)
-			{
-				num = real_object(num);
-				if (num >= 0)
-				{
-					// если у прототипа беск.таймер,
-					// то их оч много в мире
-					if (check_unlimited_timer(obj_proto[num].get()) || (GET_OBJ_MIW(obj_proto[num]) < 0))
-						sprintf(str, "9999999");
-					else
-						sprintf(str, "%d", GET_OBJ_MIW(obj_proto[num]));
-				}
-			}
-			//-Polud
-			return;
-		}
-		else if (!str_cmp(var, "weather"))
-		{
-			if (!str_cmp(field, "temp"))
-			{
-				sprintf(str, "%d", weather_info.temperature);
-			}
-			else if (!str_cmp(field, "moon"))
-			{
-				sprintf(str, "%d", weather_info.moon_day);
-			}
-			else if (!str_cmp(field, "sky"))
-			{
-				num = -1;
-				if ((num = atoi(subfield)) > 0)
-					num = real_room(num);
-				if (num != NOWHERE)
-					sprintf(str, "%d", GET_ROOM_SKY(num));
-				else
-					sprintf(str, "%d", weather_info.sky);
-			}
-			else if (!str_cmp(field, "type"))
-			{
-				char c;
-				int wt = weather_info.weather_type;
-				num = -1;
-				if ((num = atoi(subfield)) > 0)
-					num = real_room(num);
-				if (num != NOWHERE && world[num]->weather.duration > 0)
-					wt = world[num]->weather.weather_type;
-				for (c = 'a'; wt; ++c, wt >>= 1)
-					if (wt & 1)
-						sprintf(str + strlen(str), "%c", c);
-			}
-			else if (!str_cmp(field, "sunlight"))
-			{
-				switch (weather_info.sunlight)
-				{
-				case SUN_DARK:
-					strcpy(str, "ночь");
-					break;
-				case SUN_SET:
-					strcpy(str, "закат");
-					break;
-				case SUN_LIGHT:
-					strcpy(str, "день");
-					break;
-				case SUN_RISE:
-					strcpy(str, "рассвет");
-					break;
-				}
+        if (num >= 0)
+          sprintf(str, "%c%d", UID_OBJ, num);
+      } else if (!str_cmp(field, "room") && num > 0) {
+        num = find_room_uid(num);
+        if (num >= 0)
+          sprintf(str, "%c%d", UID_ROOM, num);
+      }
+        //Polud world.maxobj(vnum) показывает максимальное количество предметов в мире,
+        //которое прописано в самом предмете с указанным vnum
+      else if ((!str_cmp(field, "maxobj") || !str_cmp(field, "maxobjs")) && num > 0) {
+        num = real_object(num);
+        if (num >= 0) {
+          // если у прототипа беск.таймер,
+          // то их оч много в мире
+          if (check_unlimited_timer(obj_proto[num].get()) || (GET_OBJ_MIW(obj_proto[num]) < 0))
+            sprintf(str, "9999999");
+          else
+            sprintf(str, "%d", GET_OBJ_MIW(obj_proto[num]));
+        }
+      }
+      //-Polud
+      return;
+    } else if (!str_cmp(var, "weather")) {
+      if (!str_cmp(field, "temp")) {
+        sprintf(str, "%d", weather_info.temperature);
+      } else if (!str_cmp(field, "moon")) {
+        sprintf(str, "%d", weather_info.moon_day);
+      } else if (!str_cmp(field, "sky")) {
+        num = -1;
+        if ((num = atoi(subfield)) > 0)
+          num = real_room(num);
+        if (num != NOWHERE)
+          sprintf(str, "%d", GET_ROOM_SKY(num));
+        else
+          sprintf(str, "%d", weather_info.sky);
+      } else if (!str_cmp(field, "type")) {
+        char c;
+        int wt = weather_info.weather_type;
+        num = -1;
+        if ((num = atoi(subfield)) > 0)
+          num = real_room(num);
+        if (num != NOWHERE && world[num]->weather.duration > 0)
+          wt = world[num]->weather.weather_type;
+        for (c = 'a'; wt; ++c, wt >>= 1)
+          if (wt & 1)
+            sprintf(str + strlen(str), "%c", c);
+      } else if (!str_cmp(field, "sunlight")) {
+        switch (weather_info.sunlight) {
+          case SUN_DARK: strcpy(str, "ночь");
+            break;
+          case SUN_SET: strcpy(str, "закат");
+            break;
+          case SUN_LIGHT: strcpy(str, "день");
+            break;
+          case SUN_RISE: strcpy(str, "рассвет");
+            break;
+        }
 
-			}
-			else if (!str_cmp(field, "season"))
-			{
-				switch (weather_info.season)
-				{
-				case SEASON_WINTER:
-					strcat(str, "зима");
-					break;
-				case SEASON_SPRING:
-					strcat(str, "весна");
-					break;
-				case SEASON_SUMMER:
-					strcat(str, "лето");
-					break;
-				case SEASON_AUTUMN:
-					strcat(str, "осень");
-					break;
-				}
-			}
-			return;
-		}
-		else if (!str_cmp(var, "time"))
-		{
-			if (!str_cmp(field, "hour"))
-				sprintf(str, "%d", time_info.hours);
-			else if (!str_cmp(field, "day"))
-				sprintf(str, "%d", time_info.day + 1);
-			else if (!str_cmp(field, "month"))
-				sprintf(str, "%d", time_info.month + 1);
-			else if (!str_cmp(field, "year"))
-				sprintf(str, "%d", time_info.year);
-			return;
-		}
-		else if (!str_cmp(var, "date"))
-		{
-			time_t now_time = time(0);
-			if (!str_cmp(field, "unix"))
-			{
-				sprintf(str, "%ld", static_cast<long>(now_time));
-			}
-			else if (!str_cmp(field, "yday"))
-			{
-				strftime(str, MAX_INPUT_LENGTH, "%j", localtime(&now_time));
-			}
-			else if (!str_cmp(field, "wday"))
-			{
-				strftime(str, MAX_INPUT_LENGTH, "%w", localtime(&now_time));
-			}
-			else if (!str_cmp(field, "minute"))
-			{
-				strftime(str, MAX_INPUT_LENGTH, "%M", localtime(&now_time));
-			}
-			else if (!str_cmp(field, "hour"))
-			{
-				strftime(str, MAX_INPUT_LENGTH, "%H", localtime(&now_time));
-			}
-			else if (!str_cmp(field, "day"))
-			{
-				strftime(str, MAX_INPUT_LENGTH, "%d", localtime(&now_time));
-			}
-			else if (!str_cmp(field, "month"))
-			{
-				strftime(str, MAX_INPUT_LENGTH, "%m", localtime(&now_time));
-			}
-			else if (!str_cmp(field, "year"))
-			{
-				strftime(str, MAX_INPUT_LENGTH, "%y", localtime(&now_time));
-			}
-			return;
-		}
-		else if (!str_cmp(var, "random"))
-		{
-			if (!str_cmp(field, "char")
-				|| !str_cmp(field, "pc")
-				|| !str_cmp(field, "npc")
-				|| !str_cmp(field, "all"))
-			{
-				rndm = NULL;
-				count = 0;
-				if (type == MOB_TRIGGER)
-				{
-					ch = (CHAR_DATA *)go;
-					for (const auto c : world[ch->in_room]->people)
-					{
-						if (GET_INVIS_LEV(c)
-							|| (c == ch)
-							|| !CAN_SEE(ch, c))
-						{
-							continue;
-						}
+      } else if (!str_cmp(field, "season")) {
+        switch (weather_info.season) {
+          case SEASON_WINTER: strcat(str, "зима");
+            break;
+          case SEASON_SPRING: strcat(str, "весна");
+            break;
+          case SEASON_SUMMER: strcat(str, "лето");
+            break;
+          case SEASON_AUTUMN: strcat(str, "осень");
+            break;
+        }
+      }
+      return;
+    } else if (!str_cmp(var, "time")) {
+      if (!str_cmp(field, "hour"))
+        sprintf(str, "%d", time_info.hours);
+      else if (!str_cmp(field, "day"))
+        sprintf(str, "%d", time_info.day + 1);
+      else if (!str_cmp(field, "month"))
+        sprintf(str, "%d", time_info.month + 1);
+      else if (!str_cmp(field, "year"))
+        sprintf(str, "%d", time_info.year);
+      return;
+    } else if (!str_cmp(var, "date")) {
+      time_t now_time = time(0);
+      if (!str_cmp(field, "unix")) {
+        sprintf(str, "%ld", static_cast<long>(now_time));
+      } else if (!str_cmp(field, "yday")) {
+        strftime(str, MAX_INPUT_LENGTH, "%j", localtime(&now_time));
+      } else if (!str_cmp(field, "wday")) {
+        strftime(str, MAX_INPUT_LENGTH, "%w", localtime(&now_time));
+      } else if (!str_cmp(field, "minute")) {
+        strftime(str, MAX_INPUT_LENGTH, "%M", localtime(&now_time));
+      } else if (!str_cmp(field, "hour")) {
+        strftime(str, MAX_INPUT_LENGTH, "%H", localtime(&now_time));
+      } else if (!str_cmp(field, "day")) {
+        strftime(str, MAX_INPUT_LENGTH, "%d", localtime(&now_time));
+      } else if (!str_cmp(field, "month")) {
+        strftime(str, MAX_INPUT_LENGTH, "%m", localtime(&now_time));
+      } else if (!str_cmp(field, "year")) {
+        strftime(str, MAX_INPUT_LENGTH, "%y", localtime(&now_time));
+      }
+      return;
+    } else if (!str_cmp(var, "random")) {
+      if (!str_cmp(field, "char")
+          || !str_cmp(field, "pc")
+          || !str_cmp(field, "npc")
+          || !str_cmp(field, "all")) {
+        rndm = NULL;
+        count = 0;
+        if (type == MOB_TRIGGER) {
+          ch = (CHAR_DATA *) go;
+          for (const auto c : world[ch->in_room]->people) {
+            if (GET_INVIS_LEV(c)
+                || (c == ch)
+                || !CAN_SEE(ch, c)) {
+              continue;
+            }
 
-						if ((*field == 'a')
-							|| (*field == 'p' && !IS_NPC(c))
-							|| (*field == 'n' && IS_NPC(c) && !IS_CHARMED(c))
-							|| (*field == 'c' && (!IS_NPC(c) || IS_CHARMED(c))))
-						{
-							if (!number(0, count))
-							{
-								rndm = c;
-							}
+            if ((*field == 'a')
+                || (*field == 'p' && !IS_NPC(c))
+                || (*field == 'n' && IS_NPC(c) && !IS_CHARMED(c))
+                || (*field == 'c' && (!IS_NPC(c) || IS_CHARMED(c)))) {
+              if (!number(0, count)) {
+                rndm = c;
+              }
 
-							count++;
-						}
-					}
-				}
-				else if (type == OBJ_TRIGGER)
-				{
-					for (const auto c : world[obj_room((OBJ_DATA *)go)]->people)
-					{
-						if (GET_INVIS_LEV(c))
-						{
-							continue;
-						}
+              count++;
+            }
+          }
+        } else if (type == OBJ_TRIGGER) {
+          for (const auto c : world[obj_room((OBJ_DATA *) go)]->people) {
+            if (GET_INVIS_LEV(c)) {
+              continue;
+            }
 
-						if ((*field == 'a')
-							|| (*field == 'p' && !IS_NPC(c))
-							|| (*field == 'n' && IS_NPC(c) && !IS_CHARMED(c))
-							|| (*field == 'c' && (!IS_NPC(c) || IS_CHARMED(c))))
-						{
-							if (!number(0, count))
-							{
-								rndm = c;
-							}
+            if ((*field == 'a')
+                || (*field == 'p' && !IS_NPC(c))
+                || (*field == 'n' && IS_NPC(c) && !IS_CHARMED(c))
+                || (*field == 'c' && (!IS_NPC(c) || IS_CHARMED(c)))) {
+              if (!number(0, count)) {
+                rndm = c;
+              }
 
-							count++;
-						}
-					}
-				}
-				else if (type == WLD_TRIGGER)
-				{
-					for (const auto c : ((ROOM_DATA *)go)->people)
-					{
-						if (GET_INVIS_LEV(c))
-						{
-							continue;
-						}
+              count++;
+            }
+          }
+        } else if (type == WLD_TRIGGER) {
+          for (const auto c : ((ROOM_DATA *) go)->people) {
+            if (GET_INVIS_LEV(c)) {
+              continue;
+            }
 
-						if ((*field == 'a')
-							|| (*field == 'p' && !IS_NPC(c))
-							|| (*field == 'n' && IS_NPC(c) && !IS_CHARMED(c))
-							|| (*field == 'c' && (!IS_NPC(c) || IS_CHARMED(c))))
-						{
-							if (!number(0, count))
-							{
-								rndm = c;
-							}
+            if ((*field == 'a')
+                || (*field == 'p' && !IS_NPC(c))
+                || (*field == 'n' && IS_NPC(c) && !IS_CHARMED(c))
+                || (*field == 'c' && (!IS_NPC(c) || IS_CHARMED(c)))) {
+              if (!number(0, count)) {
+                rndm = c;
+              }
 
-							count++;
-						}
-					}
-				}
+              count++;
+            }
+          }
+        }
 
-				if (rndm)
-				{
-					sprintf(str, "%c%ld", UID_CHAR, GET_ID(rndm));
-				}
-			}
-			else
-			{
-				if (!str_cmp(field, "num"))
-				{
-					num = atoi(subfield);
-				}
-				else
-				{
-					num = atoi(field);
-				}
-				sprintf(str, "%d", (num > 0) ? number(1, num) : 0);
-			}
+        if (rndm) {
+          sprintf(str, "%c%ld", UID_CHAR, GET_ID(rndm));
+        }
+      } else {
+        if (!str_cmp(field, "num")) {
+          num = atoi(subfield);
+        } else {
+          num = atoi(field);
+        }
+        sprintf(str, "%d", (num > 0) ? number(1, num) : 0);
+      }
 
-			return;
-		}
-		else if (!str_cmp(var, "array"))
-		{
-			if (!str_cmp(field, "item")) {
-				char *p = strchr(subfield, ',');
-				int n = 0;
-				int i = 1;
-				if (!p) {
-					p = subfield;
-					while (p[i] != '\0') {
-						if (p[i] == ' ' && (p[i + 1] == ' ' ||  p[i + 1] == '\0')) {
-							i++;
-							continue;
-						}
-						if (p[i] == ' ')
-							n++;
-					i++;
-					}
-					sprintf(str, "%d", n + 1);
-					return;
-				}
-				else {
-					*(p++) = '\0';
-					n = atoi(p);
-				}
-				p = subfield;
-				while (n) {
-					char *retval = p;
-					char tmp;
-					for (; n; p++) {
-						if (*p == ' ' || *p == '\0') {
-							n--;
-							if (n&&*p == '\0') {
-								str[0] = '\0';
-								return;
-							}
-							if (!n) {
-								tmp = *p;
-								*p = '\0';
-								sprintf(str, "%s", retval);
-								*p = tmp;
-								return;
-							}
-							else {
-								retval = p + 1;
-							}
-						}
-					}
-				}
-			}
-			/*Вот тут можно наделать вот так еще:
+      return;
+    } else if (!str_cmp(var, "array")) {
+      if (!str_cmp(field, "item")) {
+        char *p = strchr(subfield, ',');
+        int n = 0;
+        int i = 1;
+        if (!p) {
+          p = subfield;
+          while (p[i] != '\0') {
+            if (p[i] == ' ' && (p[i + 1] == ' ' || p[i + 1] == '\0')) {
+              i++;
+              continue;
+            }
+            if (p[i] == ' ')
+              n++;
+            i++;
+          }
+          sprintf(str, "%d", n + 1);
+          return;
+        } else {
+          *(p++) = '\0';
+          n = atoi(p);
+        }
+        p = subfield;
+        while (n) {
+          char *retval = p;
+          char tmp;
+          for (; n; p++) {
+            if (*p == ' ' || *p == '\0') {
+              n--;
+              if (n && *p == '\0') {
+                str[0] = '\0';
+                return;
+              }
+              if (!n) {
+                tmp = *p;
+                *p = '\0';
+                sprintf(str, "%s", retval);
+                *p = tmp;
+                return;
+              } else {
+                retval = p + 1;
+              }
+            }
+          }
+        }
+      }
+      /*Вот тут можно наделать вот так еще:
 			else if (!str_cmp(field, "pop")) {}
 			else if (!str_cmp(field, "shift")) {}
 			else if (!str_cmp(field, "push")) {}
 			else if (!str_cmp(field, "unshift")) {}
 			*/
-		}
-	}
+    }
+  }
 
-	if (c)
-	{
-		if (!IS_NPC(c)
-			&& !c->desc)
-		{
-			CharacterLinkDrop = true;
-		}
+  if (c) {
+    if (!IS_NPC(c)
+        && !c->desc) {
+      CharacterLinkDrop = true;
+    }
 
-		auto done = true;
-		if (text_processed(field, subfield, vd, str))
-		{
-			return;
-		}
-		else if (!str_cmp(field, "global"))  	// get global of something else
-		{
-			if (IS_NPC(c))
-			{
-				find_replacement(go, c->script.get(), NULL, MOB_TRIGGER, subfield, NULL, NULL, str);
-			}
-		}
-		else if (!str_cmp(field, "iname"))
-			strcpy(str, GET_PAD(c, 0));
-		else if (!str_cmp(field, "rname"))
-			strcpy(str, GET_PAD(c, 1));
-		else if (!str_cmp(field, "dname"))
-			strcpy(str, GET_PAD(c, 2));
-		else if (!str_cmp(field, "vname"))
-			strcpy(str, GET_PAD(c, 3));
-		else if (!str_cmp(field, "tname"))
-			strcpy(str, GET_PAD(c, 4));
-		else if (!str_cmp(field, "pname"))
-			strcpy(str, GET_PAD(c, 5));
-		else if (!str_cmp(field, "name"))
-			strcpy(str, GET_NAME(c));
-		else if (!str_cmp(field, "id"))
-			sprintf(str, "%c%ld", UID_CHAR, GET_ID(c));
-		else if (!str_cmp(field, "uniq"))
-		{
-			if (!IS_NPC(c))
-				sprintf(str, "%d", GET_UNIQUE(c));
-		}
-		else if (!str_cmp(field, "alias"))
-			strcpy(str, GET_PC_NAME(c));
-		else if (!str_cmp(field, "level"))
-			sprintf(str, "%d", GET_LEVEL(c));
-		else if (!str_cmp(field, "remort"))
-		{
-			if (!IS_NPC(c))
-				sprintf(str, "%d", GET_REMORT(c));
-		}
-		else if (!str_cmp(field, "hitp"))
-		{
-			GET_HIT(c) = (int)MAX(1, gm_char_field(c, field, subfield, (long)GET_HIT(c)));
-			sprintf(str, "%d", GET_HIT(c));
-		}
-		else if (!str_cmp(field, "arenahp"))
-		{
-			CHAR_DATA *k;
-			struct follow_type *f;
-			int arena_hp = GET_HIT(c);
-			int can_use = 0;
+    auto done = true;
+    if (text_processed(field, subfield, vd, str)) {
+      return;
+    } else if (!str_cmp(field, "global"))    // get global of something else
+    {
+      if (IS_NPC(c)) {
+        find_replacement(go, c->script.get(), NULL, MOB_TRIGGER, subfield, NULL, NULL, str);
+      }
+    } else if (!str_cmp(field, "iname"))
+      strcpy(str, GET_PAD(c, 0));
+    else if (!str_cmp(field, "rname"))
+      strcpy(str, GET_PAD(c, 1));
+    else if (!str_cmp(field, "dname"))
+      strcpy(str, GET_PAD(c, 2));
+    else if (!str_cmp(field, "vname"))
+      strcpy(str, GET_PAD(c, 3));
+    else if (!str_cmp(field, "tname"))
+      strcpy(str, GET_PAD(c, 4));
+    else if (!str_cmp(field, "pname"))
+      strcpy(str, GET_PAD(c, 5));
+    else if (!str_cmp(field, "name"))
+      strcpy(str, GET_NAME(c));
+    else if (!str_cmp(field, "id"))
+      sprintf(str, "%c%ld", UID_CHAR, GET_ID(c));
+    else if (!str_cmp(field, "uniq")) {
+      if (!IS_NPC(c))
+        sprintf(str, "%d", GET_UNIQUE(c));
+    } else if (!str_cmp(field, "alias"))
+      strcpy(str, GET_PC_NAME(c));
+    else if (!str_cmp(field, "level"))
+      sprintf(str, "%d", GET_LEVEL(c));
+    else if (!str_cmp(field, "remort")) {
+      if (!IS_NPC(c))
+        sprintf(str, "%d", GET_REMORT(c));
+    } else if (!str_cmp(field, "hitp")) {
+      GET_HIT(c) = (int) MAX(1, gm_char_field(c, field, subfield, (long) GET_HIT(c)));
+      sprintf(str, "%d", GET_HIT(c));
+    } else if (!str_cmp(field, "arenahp")) {
+      CHAR_DATA *k;
+      struct follow_type *f;
+      int arena_hp = GET_HIT(c);
+      int can_use = 0;
 
-			if (!IS_NPC(c))
-			{
-				k = (c->has_master() ? c->get_master() : c);
-				if (GET_CLASS(c) == 8)//чернок может дрыниться
-				{
-					can_use = 2;
-				}
-				else if (GET_CLASS(c) == 0 || GET_CLASS(c) == 13)//Клер или волхв может использовать покровительство
-				{
-					can_use = 1;
-				}
-				else if (AFF_FLAGGED(k, EAffectFlag::AFF_GROUP))
-				{
-					if (!IS_NPC(k) && (GET_CLASS(k) == 8 || GET_CLASS(k) == 13) //чернок или волхв может использовать ужи на согруппов
-						&& world[IN_ROOM(k)]->zone == world[IN_ROOM(c)]->zone) //но только если находится в той же зоне
-					{
-						can_use = 1;
-					}
-					if (!can_use)
-					{
-						for (f = k->followers; f; f = f->next)
-						{
-							if (IS_NPC(f->follower)
-								|| !AFF_FLAGGED(f->follower, EAffectFlag::AFF_GROUP))
-							{
-								continue;
-							}
-							if ((GET_CLASS(f->follower) == 8
-								|| GET_CLASS(f->follower) == 13) //чернок или волхв может использовать ужи на согруппов
-								&& world[IN_ROOM(f->follower)]->zone == world[IN_ROOM(c)]->zone) //но только если находится в той же зоне
-							{
-								can_use = 1;
-								break;
-							}
-						}
-					}
-				}
-				if (can_use == 2)//дрын
-				{
-					arena_hp = GET_REAL_MAX_HIT(c) + GET_REAL_MAX_HIT(c) * GET_LEVEL(c) / 10;
-				}
-				else if (can_use == 1)//ужи и покров
-				{
-					arena_hp = GET_REAL_MAX_HIT(c) + GET_REAL_MAX_HIT(c) * 33 / 100;
-				}
-				else
-				{
-					arena_hp = GET_REAL_MAX_HIT(c);
-				}
-			}
-			sprintf(str, "%d", arena_hp);
-		}
-		else if (!str_cmp(field, "hitpadd"))
-		{
-			GET_HIT_ADD(c) = (int)gm_char_field(c, field, subfield, (long)GET_HIT_ADD(c));
-			sprintf(str, "%d", GET_HIT_ADD(c));
-		}
-		else if (!str_cmp(field, "maxhitp"))
-		{
-			// if (!IS_NPC(c))
-			//   GET_MAX_HIT(c) = (sh_int) MAX(1,gm_char_field(c,field,subfield,(long)GET_MAX_HIT(c)));
-			sprintf(str, "%d", GET_MAX_HIT(c));
-		}
-		else if (!str_cmp(field, "hitpreg"))
-		{
-			GET_HITREG(c) = (int)gm_char_field(c, field, subfield, (long)GET_HITREG(c));
-			sprintf(str, "%d", GET_HITREG(c));
-		}
-		else if (!str_cmp(field, "mana"))
-		{
-			if (!IS_NPC(c))
-				GET_MANA_STORED(c) =
-				MAX(0, gm_char_field(c, field, subfield, (long)GET_MANA_STORED(c)));
-			sprintf(str, "%d", GET_MANA_STORED(c));
-		}
-		else if (!str_cmp(field, "manareg"))
-		{
-			GET_MANAREG(c) = (int)gm_char_field(c, field, subfield, (long)GET_MANAREG(c));
-			sprintf(str, "%d", GET_MANAREG(c));
-		}
-		else if (!str_cmp(field, "maxmana"))
-			sprintf(str, "%d", GET_MAX_MANA(c));
-		else if (!str_cmp(field, "move"))
-		{
-			if (!IS_NPC(c))
-				GET_MOVE(c) =
-				(sh_int)MAX(0, gm_char_field(c, field, subfield, (long)GET_MOVE(c)));
-			sprintf(str, "%d", GET_MOVE(c));
-		}
-		else if (!str_cmp(field, "maxmove"))
-		{
-			//GET_MAX_MOVE(c) = (sh_int) MAX(1,gm_char_field(c,field,subfield,(long)GET_MAX_MOVE(c)));
-			sprintf(str, "%d", GET_MAX_MOVE(c));
-		}
-		else if (!str_cmp(field, "moveadd"))
-		{
-			GET_MOVE_ADD(c) = (int)gm_char_field(c, field, subfield, (long)GET_MOVE_ADD(c));
-			sprintf(str, "%d", GET_MOVE_ADD(c));
-		}
-		else if (!str_cmp(field, "movereg"))
-		{
-			GET_MOVEREG(c) = (int)gm_char_field(c, field, subfield, (long)GET_MOVEREG(c));
-			sprintf(str, "%d", GET_MOVEREG(c));
-		}
-		else if (!str_cmp(field, "castsucc"))
-		{
-			GET_CAST_SUCCESS(c) =
-				(int)gm_char_field(c, field, subfield, (long)GET_CAST_SUCCESS(c));
-			sprintf(str, "%d", GET_CAST_SUCCESS(c));
-		}
-		else if (!str_cmp(field, "ageadd"))
-		{
-			if (!IS_NPC(c))
-			{
-				GET_AGE_ADD(c) = (int)gm_char_field(c, field, subfield, (long)GET_AGE_ADD(c));
-				sprintf(str, "%d", GET_AGE_ADD(c));
-			}
-		}
-		else if (!str_cmp(field, "age"))
-		{
-			if (!IS_NPC(c))
-				sprintf(str, "%d", GET_REAL_AGE(c));
-		}
-		else if (!str_cmp(field, "hrbase"))
-		{
-			//GET_HR(c) = (int) gm_char_field(c,field,subfield,(long)GET_HR(c));
-			sprintf(str, "%d", GET_HR(c));
-		}
-		else if (!str_cmp(field, "hradd"))
-		{
-			GET_HR_ADD(c) = (int)gm_char_field(c, field, subfield, (long)GET_HR(c));
-			sprintf(str, "%d", GET_HR_ADD(c));
-		}
-		else if (!str_cmp(field, "hr"))
-		{
-			sprintf(str, "%d", GET_REAL_HR(c));
-		}
-		else if (!str_cmp(field, "drbase"))
-		{
-			//GET_DR(c) = (int) gm_char_field(c,field,subfield,(long)GET_DR(c));
-			sprintf(str, "%d", GET_DR(c));
-		}
-		else if (!str_cmp(field, "dradd"))
-		{
-			GET_DR_ADD(c) = (int)gm_char_field(c, field, subfield, (long)GET_DR(c));
-			sprintf(str, "%d", GET_DR_ADD(c));
-		}
-		else if (!str_cmp(field, "dr"))
-		{
-			sprintf(str, "%d", GET_REAL_DR(c));
-		}
-		else if (!str_cmp(field, "acbase"))
-		{
-			//GET_AC(c) = (int) gm_char_field(c,field,subfield,(long)GET_AC(c));
-			sprintf(str, "%d", GET_AC(c));
-		}
-		else if (!str_cmp(field, "acadd"))
-		{
-			GET_AC_ADD(c) = (int)gm_char_field(c, field, subfield, (long)GET_AC(c));
-			sprintf(str, "%d", GET_AC_ADD(c));
-		}
-		else if (!str_cmp(field, "ac"))
-		{
-			sprintf(str, "%d", GET_REAL_AC(c));
-		}
-		else if (!str_cmp(field, "morale")) // общая сумма морали
-		{
-			//GET_MORALE(c) = (int) gm_char_field(c, field, subfield, (long) GET_MORALE(c));
-			sprintf(str, "%d", c->calc_morale());
-		}
-		else if (!str_cmp(field, "moraleadd")) // добавочная мораль
-		{
-			GET_MORALE(c) = (int)gm_char_field(c, field, subfield, (long)GET_MORALE(c));
-			sprintf(str, "%d", GET_MORALE(c));
-		}
-		else if (!str_cmp(field, "poison"))
-		{
-			GET_POISON(c) = (int)gm_char_field(c, field, subfield, (long)GET_POISON(c));
-			sprintf(str, "%d", GET_POISON(c));
-		}
-		else if (!str_cmp(field, "initiative"))
-		{
-			GET_INITIATIVE(c) = (int)gm_char_field(c, field, subfield, (long)GET_INITIATIVE(c));
-			sprintf(str, "%d", GET_INITIATIVE(c));
-		}
-		else if (!str_cmp(field, "align"))
-		{
-			if (*subfield)
-			{
-				if (*subfield == '-')
-					GET_ALIGNMENT(c) -= MAX(1, atoi(subfield + 1));
-				else if (*subfield == '+')
-					GET_ALIGNMENT(c) += MAX(1, atoi(subfield + 1));
-			}
-			sprintf(str, "%d", GET_ALIGNMENT(c));
-		}
-		else if (!str_cmp(field, "religion"))
-		{
-			if (*subfield && ((atoi(subfield) == RELIGION_POLY) || (atoi(subfield) == RELIGION_MONO)))
-				GET_RELIGION(c) = atoi(subfield);
-			else
-				sprintf(str, "%d", GET_RELIGION(c));
-		}
-		else if ((!str_cmp(field, "restore")) || (!str_cmp(field, "fullrestore")))
-		{
-			/* Так, тупо, но иначе ругается, мол слишком много блоков*/
-			if (!str_cmp(field, "fullrestore"))
-			{
-				do_arena_restore(c, (char *)c->get_name().c_str(), 0, SCMD_RESTORE_TRIGGER);
-				trig_log(trig, "был произведен вызов do_arena_restore!");
-			}
-			else
-			{
-				do_restore(c, (char *)c->get_name().c_str(), 0, SCMD_RESTORE_TRIGGER);
-				trig_log(trig, "был произведен вызов do_restore!");
-			}
-		}
-		else if (!str_cmp(field, "dispel"))
-		{
-			if (!c->affected.empty())
-			{
-				send_to_char("Вы словно заново родились!\r\n", c);
-			}
+      if (!IS_NPC(c)) {
+        k = (c->has_master() ? c->get_master() : c);
+        if (GET_CLASS(c) == 8)//чернок может дрыниться
+        {
+          can_use = 2;
+        } else if (GET_CLASS(c) == 0 || GET_CLASS(c) == 13)//Клер или волхв может использовать покровительство
+        {
+          can_use = 1;
+        } else if (AFF_FLAGGED(k, EAffectFlag::AFF_GROUP)) {
+          if (!IS_NPC(k)
+              && (GET_CLASS(k) == 8 || GET_CLASS(k) == 13) //чернок или волхв может использовать ужи на согруппов
+              && world[IN_ROOM(k)]->zone == world[IN_ROOM(c)]->zone) //но только если находится в той же зоне
+          {
+            can_use = 1;
+          }
+          if (!can_use) {
+            for (f = k->followers; f; f = f->next) {
+              if (IS_NPC(f->follower)
+                  || !AFF_FLAGGED(f->follower, EAffectFlag::AFF_GROUP)) {
+                continue;
+              }
+              if ((GET_CLASS(f->follower) == 8
+                  || GET_CLASS(f->follower) == 13) //чернок или волхв может использовать ужи на согруппов
+                  && world[IN_ROOM(f->follower)]->zone
+                      == world[IN_ROOM(c)]->zone) //но только если находится в той же зоне
+              {
+                can_use = 1;
+                break;
+              }
+            }
+          }
+        }
+        if (can_use == 2)//дрын
+        {
+          arena_hp = GET_REAL_MAX_HIT(c) + GET_REAL_MAX_HIT(c) * GET_LEVEL(c) / 10;
+        } else if (can_use == 1)//ужи и покров
+        {
+          arena_hp = GET_REAL_MAX_HIT(c) + GET_REAL_MAX_HIT(c) * 33 / 100;
+        } else {
+          arena_hp = GET_REAL_MAX_HIT(c);
+        }
+      }
+      sprintf(str, "%d", arena_hp);
+    } else if (!str_cmp(field, "hitpadd")) {
+      GET_HIT_ADD(c) = (int) gm_char_field(c, field, subfield, (long) GET_HIT_ADD(c));
+      sprintf(str, "%d", GET_HIT_ADD(c));
+    } else if (!str_cmp(field, "maxhitp")) {
+      // if (!IS_NPC(c))
+      //   GET_MAX_HIT(c) = (sh_int) MAX(1,gm_char_field(c,field,subfield,(long)GET_MAX_HIT(c)));
+      sprintf(str, "%d", GET_MAX_HIT(c));
+    } else if (!str_cmp(field, "hitpreg")) {
+      GET_HITREG(c) = (int) gm_char_field(c, field, subfield, (long) GET_HITREG(c));
+      sprintf(str, "%d", GET_HITREG(c));
+    } else if (!str_cmp(field, "mana")) {
+      if (!IS_NPC(c))
+        GET_MANA_STORED(c) =
+            MAX(0, gm_char_field(c, field, subfield, (long) GET_MANA_STORED(c)));
+      sprintf(str, "%d", GET_MANA_STORED(c));
+    } else if (!str_cmp(field, "manareg")) {
+      GET_MANAREG(c) = (int) gm_char_field(c, field, subfield, (long) GET_MANAREG(c));
+      sprintf(str, "%d", GET_MANAREG(c));
+    } else if (!str_cmp(field, "maxmana"))
+      sprintf(str, "%d", GET_MAX_MANA(c));
+    else if (!str_cmp(field, "move")) {
+      if (!IS_NPC(c))
+        GET_MOVE(c) =
+            (sh_int) MAX(0, gm_char_field(c, field, subfield, (long) GET_MOVE(c)));
+      sprintf(str, "%d", GET_MOVE(c));
+    } else if (!str_cmp(field, "maxmove")) {
+      //GET_MAX_MOVE(c) = (sh_int) MAX(1,gm_char_field(c,field,subfield,(long)GET_MAX_MOVE(c)));
+      sprintf(str, "%d", GET_MAX_MOVE(c));
+    } else if (!str_cmp(field, "moveadd")) {
+      GET_MOVE_ADD(c) = (int) gm_char_field(c, field, subfield, (long) GET_MOVE_ADD(c));
+      sprintf(str, "%d", GET_MOVE_ADD(c));
+    } else if (!str_cmp(field, "movereg")) {
+      GET_MOVEREG(c) = (int) gm_char_field(c, field, subfield, (long) GET_MOVEREG(c));
+      sprintf(str, "%d", GET_MOVEREG(c));
+    } else if (!str_cmp(field, "castsucc")) {
+      GET_CAST_SUCCESS(c) =
+          (int) gm_char_field(c, field, subfield, (long) GET_CAST_SUCCESS(c));
+      sprintf(str, "%d", GET_CAST_SUCCESS(c));
+    } else if (!str_cmp(field, "ageadd")) {
+      if (!IS_NPC(c)) {
+        GET_AGE_ADD(c) = (int) gm_char_field(c, field, subfield, (long) GET_AGE_ADD(c));
+        sprintf(str, "%d", GET_AGE_ADD(c));
+      }
+    } else if (!str_cmp(field, "age")) {
+      if (!IS_NPC(c))
+        sprintf(str, "%d", GET_REAL_AGE(c));
+    } else if (!str_cmp(field, "hrbase")) {
+      //GET_HR(c) = (int) gm_char_field(c,field,subfield,(long)GET_HR(c));
+      sprintf(str, "%d", GET_HR(c));
+    } else if (!str_cmp(field, "hradd")) {
+      GET_HR_ADD(c) = (int) gm_char_field(c, field, subfield, (long) GET_HR(c));
+      sprintf(str, "%d", GET_HR_ADD(c));
+    } else if (!str_cmp(field, "hr")) {
+      sprintf(str, "%d", GET_REAL_HR(c));
+    } else if (!str_cmp(field, "drbase")) {
+      //GET_DR(c) = (int) gm_char_field(c,field,subfield,(long)GET_DR(c));
+      sprintf(str, "%d", GET_DR(c));
+    } else if (!str_cmp(field, "dradd")) {
+      GET_DR_ADD(c) = (int) gm_char_field(c, field, subfield, (long) GET_DR(c));
+      sprintf(str, "%d", GET_DR_ADD(c));
+    } else if (!str_cmp(field, "dr")) {
+      sprintf(str, "%d", GET_REAL_DR(c));
+    } else if (!str_cmp(field, "acbase")) {
+      //GET_AC(c) = (int) gm_char_field(c,field,subfield,(long)GET_AC(c));
+      sprintf(str, "%d", GET_AC(c));
+    } else if (!str_cmp(field, "acadd")) {
+      GET_AC_ADD(c) = (int) gm_char_field(c, field, subfield, (long) GET_AC(c));
+      sprintf(str, "%d", GET_AC_ADD(c));
+    } else if (!str_cmp(field, "ac")) {
+      sprintf(str, "%d", GET_REAL_AC(c));
+    } else if (!str_cmp(field, "morale")) // общая сумма морали
+    {
+      //GET_MORALE(c) = (int) gm_char_field(c, field, subfield, (long) GET_MORALE(c));
+      sprintf(str, "%d", c->calc_morale());
+    } else if (!str_cmp(field, "moraleadd")) // добавочная мораль
+    {
+      GET_MORALE(c) = (int) gm_char_field(c, field, subfield, (long) GET_MORALE(c));
+      sprintf(str, "%d", GET_MORALE(c));
+    } else if (!str_cmp(field, "poison")) {
+      GET_POISON(c) = (int) gm_char_field(c, field, subfield, (long) GET_POISON(c));
+      sprintf(str, "%d", GET_POISON(c));
+    } else if (!str_cmp(field, "initiative")) {
+      GET_INITIATIVE(c) = (int) gm_char_field(c, field, subfield, (long) GET_INITIATIVE(c));
+      sprintf(str, "%d", GET_INITIATIVE(c));
+    } else if (!str_cmp(field, "align")) {
+      if (*subfield) {
+        if (*subfield == '-')
+          GET_ALIGNMENT(c) -= MAX(1, atoi(subfield + 1));
+        else if (*subfield == '+')
+          GET_ALIGNMENT(c) += MAX(1, atoi(subfield + 1));
+      }
+      sprintf(str, "%d", GET_ALIGNMENT(c));
+    } else if (!str_cmp(field, "religion")) {
+      if (*subfield && ((atoi(subfield) == RELIGION_POLY) || (atoi(subfield) == RELIGION_MONO)))
+        GET_RELIGION(c) = atoi(subfield);
+      else
+        sprintf(str, "%d", GET_RELIGION(c));
+    } else if ((!str_cmp(field, "restore")) || (!str_cmp(field, "fullrestore"))) {
+      /* Так, тупо, но иначе ругается, мол слишком много блоков*/
+      if (!str_cmp(field, "fullrestore")) {
+        do_arena_restore(c, (char *) c->get_name().c_str(), 0, SCMD_RESTORE_TRIGGER);
+        trig_log(trig, "был произведен вызов do_arena_restore!");
+      } else {
+        do_restore(c, (char *) c->get_name().c_str(), 0, SCMD_RESTORE_TRIGGER);
+        trig_log(trig, "был произведен вызов do_restore!");
+      }
+    } else if (!str_cmp(field, "dispel")) {
+      if (!c->affected.empty()) {
+        send_to_char("Вы словно заново родились!\r\n", c);
+      }
 
-			while (!c->affected.empty())
-			{
-				c->affect_remove(c->affected.begin());
-			}
-		}
-		else
-		{
-			done = false;
-		}
+      while (!c->affected.empty()) {
+        c->affect_remove(c->affected.begin());
+      }
+    } else {
+      done = false;
+    }
 
-		if (done)
-		{
-		}
-		else if (!str_cmp(field, "hryvn"))
-		{
-			const long before = c->get_hryvn();
-			int value;
-			c->set_hryvn(MAX(0, gm_char_field(c, field, subfield, c->get_hryvn())));
-			value = c->get_hryvn() - before;
-			sprintf(buf, "<%s> {%d} получил триггером %d %s. [Trigger: %s, Vnum: %d]", GET_PAD(c, 0), GET_ROOM_VNUM(c->in_room), value, desc_count(value, WHAT_TORCu), GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig));
-			mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-			sprintf(str, "%d", c->get_hryvn());
-		}
-		else if (!str_cmp(field, "gold"))
-		{
-			const long before = c->get_gold();
-			int value;
-			c->set_gold(MAX(0, gm_char_field(c, field, subfield, c->get_gold())));
-			value = c->get_gold() - before;
-			sprintf(buf, "<%s> {%d} получил триггером %d %s. [Trigger: %s, Vnum: %d]", GET_PAD(c, 0), GET_ROOM_VNUM(c->in_room), value, desc_count(value, WHAT_MONEYu), GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig));
-			mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-			sprintf(str, "%ld", c->get_gold());
-			// клан-налог
-			const long diff = c->get_gold() - before;
-			split_or_clan_tax(c, diff);
-			// стата для show money
-			if (!IS_NPC(c) && IN_ROOM(c) > 0)
-			{
-				MoneyDropStat::add(
-					zone_table[world[IN_ROOM(c)]->zone].number, diff);
-			}
-		}
-		else if (!str_cmp(field, "bank"))
-		{
-			const long before = c->get_bank();
-			c->set_bank(MAX(0, gm_char_field(c, field, subfield, c->get_bank())));
-			sprintf(str, "%ld", c->get_bank());
-			// клан-налог
-			const long diff = c->get_bank() - before;
-			split_or_clan_tax(c, diff);
-			// стата для show money
-			if (!IS_NPC(c) && IN_ROOM(c) > 0)
-			{
-				MoneyDropStat::add(
-					zone_table[world[IN_ROOM(c)]->zone].number, diff);
-			}
-		}
-		else if (!str_cmp(field, "exp") || !str_cmp(field, "questbodrich"))
-		{
-			if (!str_cmp(field, "questbodrich"))
-			{
-				if (*subfield)
-				{
-					c->dquest(atoi(subfield));
-				}
-			}
-			else
-			{
-				if (*subfield)
-				{
-					if (*subfield == '-')
-					{
-						gain_exp(c, -MAX(1, atoi(subfield + 1)));
-						sprintf(buf, "SCRIPT_LOG (exp) у %s уменьшен опыт на %d в триггере %d", GET_NAME(c), MAX(1, atoi(subfield + 1)), GET_TRIG_VNUM(trig));
-						mudlog(buf, BRF, LVL_GRGOD, ERRLOG, 1);
-					}
-					else if (*subfield == '+')
-					{
-						gain_exp(c, +MAX(1, atoi(subfield + 1)));
-						sprintf(buf, "SCRIPT_LOG (exp) у %s увеличен опыт на %d в триггере %d", GET_NAME(c), MAX(1, atoi(subfield + 1)), GET_TRIG_VNUM(trig));
-						mudlog(buf, BRF, LVL_GRGOD, ERRLOG, 1);
-					}
-					else
-					{
-						sprintf(buf, "SCRIPT_LOG (exp) ОШИБКА! у %s напрямую указан опыт %d в триггере %d", GET_NAME(c), atoi(subfield + 1), GET_TRIG_VNUM(trig));
-						mudlog(buf, BRF, LVL_GRGOD, ERRLOG, 1);
-					}
-				}
-				else
-					sprintf(str, "%ld", GET_EXP(c));
-			}
-		}
-		else if (!str_cmp(field, "sex"))
-			sprintf(str, "%d", (int)GET_SEX(c));
-		else if (!str_cmp(field, "clan"))
-		{
-			if (CLAN(c))
-			{
-				sprintf(str, "%s", CLAN(c)->GetAbbrev());
-				for (i = 0; str[i]; i++)
-					str[i] = LOWER(str[i]);
-			}
-			else
-				sprintf(str, "0");
-		}
-		else if (!str_cmp(field, "clanrank"))
-		{
-			if (CLAN(c) && CLAN_MEMBER(c))
-				sprintf(str, "%d", CLAN_MEMBER(c)->rank_num);
-			else
-				sprintf(str, "0");
-		}
-		else if (!str_cmp(field, "clanlevel"))
-		{
-			if (CLAN(c) && CLAN_MEMBER(c))
-				sprintf(str, "%d", CLAN(c)->GetClanLevel());
-			else
-				sprintf(str, "0");
-		}
-		else if (!str_cmp(field, "m"))
-			strcpy(str, HMHR(c));
-		else if (!str_cmp(field, "s"))
-			strcpy(str, HSHR(c));
-		else if (!str_cmp(field, "e"))
-			strcpy(str, HSSH(c));
-		else if (!str_cmp(field, "g"))
-			strcpy(str, GET_CH_SUF_1(c));
-		else if (!str_cmp(field, "u"))
-			strcpy(str, GET_CH_SUF_2(c));
-		else if (!str_cmp(field, "w"))
-			strcpy(str, GET_CH_SUF_3(c));
-		else if (!str_cmp(field, "q"))
-			strcpy(str, GET_CH_SUF_4(c));
-		else if (!str_cmp(field, "y"))
-			strcpy(str, GET_CH_SUF_5(c));
-		else if (!str_cmp(field, "a"))
-			strcpy(str, GET_CH_SUF_6(c));
-		else if (!str_cmp(field, "r"))
-			strcpy(str, GET_CH_SUF_7(c));
-		else if (!str_cmp(field, "x"))
-			strcpy(str, GET_CH_SUF_8(c));
-		else if (!str_cmp(field, "weight"))
-			sprintf(str, "%d", GET_WEIGHT(c));
-		else if (!str_cmp(field, "canbeseen"))
-		{
-			if ((type == MOB_TRIGGER) && !CAN_SEE(((CHAR_DATA *)go), c))
-			{
-				strcpy(str, "0");
-			}
-			else
-			{
-				strcpy(str, "1");
-			}
-		}
-		else if (!str_cmp(field, "class"))
-		{
-			sprintf(str, "%d", (int)GET_CLASS(c));
-		}
-		else if (!str_cmp(field, "race"))
-		{
-			sprintf(str, "%d", (int)GET_RACE(c));
-		}
-		else if (!str_cmp(field, "fighting"))
-		{
-			if (c->get_fighting())
-			{
-				sprintf(str, "%c%ld", UID_CHAR, GET_ID(c->get_fighting()));
-			}
-		}
-		else if (!str_cmp(field, "is_killer"))
-		{
-			if (PLR_FLAGGED(c, PLR_KILLER))
-			{
-				strcpy(str, "1");
-			}
-			else
-			{
-				strcpy(str, "0");
-			}
-		}
-		else if (!str_cmp(field, "is_thief"))
-		{
-			if (PLR_FLAGGED(c, PLR_THIEF))
-			{
-				strcpy(str, "1");
-			}
-			else
-			{
-				strcpy(str, "0");
-			}
-		}
-		else if (!str_cmp(field, "rentable"))
-		{
-			if (!IS_NPC(c) && RENTABLE(c))
-			{
-				strcpy(str, "0");
-			}
-			else
-			{
-				strcpy(str, "1");
-			}
-		}
-		else if (!str_cmp(field, "can_get_skill"))
-		{
-			if ((num = fix_name_and_find_skill_num(subfield)) > 0)
-			{
-				if (can_get_skill(c, num))
-				{
-					strcpy(str, "1");
-				}
-				else
-				{
-					strcpy(str, "0");
-				}
-			}
-			else
-			{
-				sprintf(buf, "wrong skill name '%s'!", subfield);
-				trig_log(trig, buf);
-				strcpy(str, "0");
-			}
-		}
-		else if (!str_cmp(field, "can_get_spell"))
-		{
-			if ((num = fix_name_and_find_spell_num(subfield)) > 0)
-			{
-				if (can_get_spell(c, num))
-				{
-					strcpy(str, "1");
-				}
-				else
-				{
-					strcpy(str, "0");
-				}
-			}
-			else
-			{
-				sprintf(buf, "wrong spell name '%s'!", subfield);
-				trig_log(trig, buf);
-				strcpy(str, "0");
-			}
-		}
-		else if (!str_cmp(field, "can_get_feat"))
-		{
-			if ((num = find_feat_num(subfield)) > 0)
-			{
-				if (can_get_feat(c, num))
-					strcpy(str, "1");
-				else
-					strcpy(str, "0");
-			}
-			else
-			{
-				sprintf(buf, "wrong feature name '%s'!", subfield);
-				trig_log(trig, buf);
-				strcpy(str, "0");
-			}
-		}
-		else if (!str_cmp(field, "agressor"))
-		{
-			if (AGRESSOR(c))
-				sprintf(str, "%d", AGRESSOR(c));
-			else
-				strcpy(str, "0");
-		}
-		else if (!str_cmp(field, "vnum"))
-		{
-			sprintf(str, "%d", GET_MOB_VNUM(c));
-		}
-		else if (!str_cmp(field, "str"))
-		{
-			//GET_STR(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_STR(c)));
-			sprintf(str, "%d", c->get_str());
-		}
-		else if (!str_cmp(field, "stradd"))
-			sprintf(str, "%d", GET_STR_ADD(c));
-		else if (!str_cmp(field, "int"))
-		{
-			//GET_INT(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_INT(c)));
-			sprintf(str, "%d", c->get_int());
-		}
-		else if (!str_cmp(field, "intadd"))
-			sprintf(str, "%d", GET_INT_ADD(c));
-		else if (!str_cmp(field, "wis"))
-		{
-			//GET_WIS(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_WIS(c)));
-			sprintf(str, "%d", c->get_wis());
-		}
-		else if (!str_cmp(field, "wisadd"))
-			sprintf(str, "%d", GET_WIS_ADD(c));
-		else if (!str_cmp(field, "dex"))
-		{
-			//GET_DEX(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_DEX(c)));
-			sprintf(str, "%d", c->get_dex());
-		}
-		else if (!str_cmp(field, "dexadd"))
-			sprintf(str, "%d", c->get_dex_add());
-		else if (!str_cmp(field, "con"))
-		{
-			//GET_CON(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_CON(c)));
-			sprintf(str, "%d", c->get_con());
-		}
-		else if (!str_cmp(field, "conadd"))
-		{
-			sprintf(str, "%d", GET_CON_ADD(c));
-		}
-		else if (!str_cmp(field, "cha"))
-		{
-			//GET_CHA(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_CHA(c)));
-			sprintf(str, "%d", c->get_cha());
-		}
-		else if (!str_cmp(field, "chaadd"))
-			sprintf(str, "%d", GET_CHA_ADD(c));
-		else if (!str_cmp(field, "size"))
-		{
-			//GET_SIZE(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_SIZE(c)));
-			sprintf(str, "%d", GET_SIZE(c));
-		}
-		else if (!str_cmp(field, "sizeadd"))
-		{
-			GET_SIZE_ADD(c) =
-				(sbyte)MAX(1,
-					gm_char_field(c, field, subfield,
-					(long)GET_SIZE_ADD(c)));
-			sprintf(str, "%d", GET_SIZE_ADD(c));
-		}
-		else if (!str_cmp(field, "room"))
-		{
-			int n = find_room_uid(world[IN_ROOM(c)]->number);
-			if (n >= 0)
-				sprintf(str, "%c%d", UID_ROOM, n);
-		}
-		else if (!str_cmp(field, "realroom"))
-			sprintf(str, "%d", world[IN_ROOM(c)]->number);
-		else if (!str_cmp(field, "loadroom"))
-		{
-			int pos;
-			if (!IS_NPC(c))
-			{
-				if (!*subfield || !(pos = atoi(subfield)))
-					sprintf(str, "%d", GET_LOADROOM(c));
-				else
-				{
-					GET_LOADROOM(c) = pos;
-					c->save_char();
-					sprintf(str, "%d", real_room(pos)); // TODO: почему тогда тут рнум?
-				}
-			}
-		}
-		else if (!str_cmp(field, "maxskill"))
-		{
-			sprintf(str, "%d", MIN(MAX_EXP_PERCENT + GET_REMORT(c) * 5, CAP_SKILLS));
-		}
-		else if (!str_cmp(field, "skill"))
-		{
-			strcpy(str, skill_percent(trig, c, subfield));
-		}
-		else if (!str_cmp(field, "feat"))
-		{
-			if (feat_owner(trig, c, subfield))
-				strcpy(str, "1");
-			else
-				strcpy(str, "0");
-		}
-		else if (!str_cmp(field, "spellcount"))
-			strcpy(str, spell_count(trig, c, subfield));
-		else if (!str_cmp(field, "spelltype"))
-			strcpy(str, spell_knowledge(trig, c, subfield));
-		else if (!str_cmp(field, "quested"))
-		{
-			if (*subfield && (num = atoi(subfield)) > 0)
-			{
-				if (c->quested_get(num))
-					strcpy(str, "1");
-				else
-					strcpy(str, "0");
-			}
-		}
-		else if (!str_cmp(field, "getquest"))
-		{
-			if (*subfield && (num = atoi(subfield)) > 0)
-			{
-				strcpy(str, (c->quested_get_text(num)).c_str());
-			}
-		}
-		else if (!str_cmp(field, "setquest"))
-		{
-			if (*subfield)
-			{
-				subfield = one_argument(subfield, buf);
-				skip_spaces(&subfield);
-				if ((num = atoi(buf)) > 0)
-				{
-					c->quested_add(c, num, subfield);
-				}
-			}
-		}
-		// все эти блоки надо переписать на что-нибудь другое, их слишком много
-		else if (!str_cmp(field, "unsetquest") || !str_cmp(field, "alliance"))
-		{
-			if (!str_cmp(field, "alliance"))
-			{
-				if (*subfield)
-				{
-					subfield = one_argument(subfield, buf);
-					if (ClanSystem::is_alliance(c, buf))
-						strcpy(str, "1");
-					else
-						strcpy(str, "0");
-				}
-			}
-			else
-			{
-				if (*subfield && (num = atoi(subfield)) > 0)
-				{
-					c->quested_remove(num);
-					strcpy(str, "1");
-				}
-			}
-		}
-		else if (!str_cmp(field, "eq"))
-		{
-			int pos = -1;
-			if (a_isdigit(*subfield))
-				pos = atoi(subfield);
-			else if (*subfield)
-				pos = find_eq_pos(c, NULL, subfield);
-			if (!*subfield || pos < 0 || pos >= NUM_WEARS)
-				strcpy(str, "");
-			else
-			{
-				if (!GET_EQ(c, pos))
-					strcpy(str, "");
-				else
-					sprintf(str, "%c%ld", UID_OBJ, GET_EQ(c, pos)->get_id());
-			}
-		}
-		else if (!str_cmp(field, "haveobj") || !str_cmp(field, "haveobjs"))
-		{
-			int pos;
-			if (a_isdigit(*subfield))
-			{
-				pos = atoi(subfield);
-				for (obj = c->carrying; obj; obj = obj->get_next_content())
-				{
-					if (GET_OBJ_VNUM(obj) == pos)
-					{
-						break;
-					}
-				}
-			}
-			else
-			{
-				obj = get_obj_in_list_vis(c, subfield, c->carrying);
-			}
+    if (done) {
+    } else if (!str_cmp(field, "hryvn")) {
+      const long before = c->get_hryvn();
+      int value;
+      c->set_hryvn(MAX(0, gm_char_field(c, field, subfield, c->get_hryvn())));
+      value = c->get_hryvn() - before;
+      sprintf(buf,
+              "<%s> {%d} получил триггером %d %s. [Trigger: %s, Vnum: %d]",
+              GET_PAD(c, 0),
+              GET_ROOM_VNUM(c->in_room),
+              value,
+              desc_count(value, WHAT_TORCu),
+              GET_TRIG_NAME(trig),
+              GET_TRIG_VNUM(trig));
+      mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+      sprintf(str, "%d", c->get_hryvn());
+    } else if (!str_cmp(field, "gold")) {
+      const long before = c->get_gold();
+      int value;
+      c->set_gold(MAX(0, gm_char_field(c, field, subfield, c->get_gold())));
+      value = c->get_gold() - before;
+      sprintf(buf,
+              "<%s> {%d} получил триггером %d %s. [Trigger: %s, Vnum: %d]",
+              GET_PAD(c, 0),
+              GET_ROOM_VNUM(c->in_room),
+              value,
+              desc_count(value, WHAT_MONEYu),
+              GET_TRIG_NAME(trig),
+              GET_TRIG_VNUM(trig));
+      mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+      sprintf(str, "%ld", c->get_gold());
+      // клан-налог
+      const long diff = c->get_gold() - before;
+      split_or_clan_tax(c, diff);
+      // стата для show money
+      if (!IS_NPC(c) && IN_ROOM(c) > 0) {
+        MoneyDropStat::add(
+            zone_table[world[IN_ROOM(c)]->zone].number, diff);
+      }
+    } else if (!str_cmp(field, "bank")) {
+      const long before = c->get_bank();
+      c->set_bank(MAX(0, gm_char_field(c, field, subfield, c->get_bank())));
+      sprintf(str, "%ld", c->get_bank());
+      // клан-налог
+      const long diff = c->get_bank() - before;
+      split_or_clan_tax(c, diff);
+      // стата для show money
+      if (!IS_NPC(c) && IN_ROOM(c) > 0) {
+        MoneyDropStat::add(
+            zone_table[world[IN_ROOM(c)]->zone].number, diff);
+      }
+    } else if (!str_cmp(field, "exp") || !str_cmp(field, "questbodrich")) {
+      if (!str_cmp(field, "questbodrich")) {
+        if (*subfield) {
+          c->dquest(atoi(subfield));
+        }
+      } else {
+        if (*subfield) {
+          if (*subfield == '-') {
+            gain_exp(c, -MAX(1, atoi(subfield + 1)));
+            sprintf(buf,
+                    "SCRIPT_LOG (exp) у %s уменьшен опыт на %d в триггере %d",
+                    GET_NAME(c),
+                    MAX(1, atoi(subfield + 1)),
+                    GET_TRIG_VNUM(trig));
+            mudlog(buf, BRF, LVL_GRGOD, ERRLOG, 1);
+          } else if (*subfield == '+') {
+            gain_exp(c, +MAX(1, atoi(subfield + 1)));
+            sprintf(buf,
+                    "SCRIPT_LOG (exp) у %s увеличен опыт на %d в триггере %d",
+                    GET_NAME(c),
+                    MAX(1, atoi(subfield + 1)),
+                    GET_TRIG_VNUM(trig));
+            mudlog(buf, BRF, LVL_GRGOD, ERRLOG, 1);
+          } else {
+            sprintf(buf,
+                    "SCRIPT_LOG (exp) ОШИБКА! у %s напрямую указан опыт %d в триггере %d",
+                    GET_NAME(c),
+                    atoi(subfield + 1),
+                    GET_TRIG_VNUM(trig));
+            mudlog(buf, BRF, LVL_GRGOD, ERRLOG, 1);
+          }
+        } else
+          sprintf(str, "%ld", GET_EXP(c));
+      }
+    } else if (!str_cmp(field, "sex"))
+      sprintf(str, "%d", (int) GET_SEX(c));
+    else if (!str_cmp(field, "clan")) {
+      if (CLAN(c)) {
+        sprintf(str, "%s", CLAN(c)->GetAbbrev());
+        for (i = 0; str[i]; i++)
+          str[i] = LOWER(str[i]);
+      } else
+        sprintf(str, "0");
+    } else if (!str_cmp(field, "clanrank")) {
+      if (CLAN(c) && CLAN_MEMBER(c))
+        sprintf(str, "%d", CLAN_MEMBER(c)->rank_num);
+      else
+        sprintf(str, "0");
+    } else if (!str_cmp(field, "clanlevel")) {
+      if (CLAN(c) && CLAN_MEMBER(c))
+        sprintf(str, "%d", CLAN(c)->GetClanLevel());
+      else
+        sprintf(str, "0");
+    } else if (!str_cmp(field, "m"))
+      strcpy(str, HMHR(c));
+    else if (!str_cmp(field, "s"))
+      strcpy(str, HSHR(c));
+    else if (!str_cmp(field, "e"))
+      strcpy(str, HSSH(c));
+    else if (!str_cmp(field, "g"))
+      strcpy(str, GET_CH_SUF_1(c));
+    else if (!str_cmp(field, "u"))
+      strcpy(str, GET_CH_SUF_2(c));
+    else if (!str_cmp(field, "w"))
+      strcpy(str, GET_CH_SUF_3(c));
+    else if (!str_cmp(field, "q"))
+      strcpy(str, GET_CH_SUF_4(c));
+    else if (!str_cmp(field, "y"))
+      strcpy(str, GET_CH_SUF_5(c));
+    else if (!str_cmp(field, "a"))
+      strcpy(str, GET_CH_SUF_6(c));
+    else if (!str_cmp(field, "r"))
+      strcpy(str, GET_CH_SUF_7(c));
+    else if (!str_cmp(field, "x"))
+      strcpy(str, GET_CH_SUF_8(c));
+    else if (!str_cmp(field, "weight"))
+      sprintf(str, "%d", GET_WEIGHT(c));
+    else if (!str_cmp(field, "canbeseen")) {
+      if ((type == MOB_TRIGGER) && !CAN_SEE(((CHAR_DATA *) go), c)) {
+        strcpy(str, "0");
+      } else {
+        strcpy(str, "1");
+      }
+    } else if (!str_cmp(field, "class")) {
+      sprintf(str, "%d", (int) GET_CLASS(c));
+    } else if (!str_cmp(field, "race")) {
+      sprintf(str, "%d", (int) GET_RACE(c));
+    } else if (!str_cmp(field, "fighting")) {
+      if (c->get_fighting()) {
+        sprintf(str, "%c%ld", UID_CHAR, GET_ID(c->get_fighting()));
+      }
+    } else if (!str_cmp(field, "is_killer")) {
+      if (PLR_FLAGGED(c, PLR_KILLER)) {
+        strcpy(str, "1");
+      } else {
+        strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "is_thief")) {
+      if (PLR_FLAGGED(c, PLR_THIEF)) {
+        strcpy(str, "1");
+      } else {
+        strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "rentable")) {
+      if (!IS_NPC(c) && RENTABLE(c)) {
+        strcpy(str, "0");
+      } else {
+        strcpy(str, "1");
+      }
+    } else if (!str_cmp(field, "can_get_skill")) {
+      if ((num = fix_name_and_find_skill_num(subfield)) > 0) {
+        if (IsAbleToGetSkill(c, num)) {
+          strcpy(str, "1");
+        } else {
+          strcpy(str, "0");
+        }
+      } else {
+        sprintf(buf, "wrong skill name '%s'!", subfield);
+        trig_log(trig, buf);
+        strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "can_get_spell")) {
+      if ((num = fix_name_and_find_spell_num(subfield)) > 0) {
+        if (can_get_spell(c, num)) {
+          strcpy(str, "1");
+        } else {
+          strcpy(str, "0");
+        }
+      } else {
+        sprintf(buf, "wrong spell name '%s'!", subfield);
+        trig_log(trig, buf);
+        strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "can_get_feat")) {
+      if ((num = find_feat_num(subfield)) > 0) {
+        if (can_get_feat(c, num))
+          strcpy(str, "1");
+        else
+          strcpy(str, "0");
+      } else {
+        sprintf(buf, "wrong feature name '%s'!", subfield);
+        trig_log(trig, buf);
+        strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "agressor")) {
+      if (AGRESSOR(c))
+        sprintf(str, "%d", AGRESSOR(c));
+      else
+        strcpy(str, "0");
+    } else if (!str_cmp(field, "vnum")) {
+      sprintf(str, "%d", GET_MOB_VNUM(c));
+    } else if (!str_cmp(field, "str")) {
+      //GET_STR(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_STR(c)));
+      sprintf(str, "%d", c->get_str());
+    } else if (!str_cmp(field, "stradd"))
+      sprintf(str, "%d", GET_STR_ADD(c));
+    else if (!str_cmp(field, "int")) {
+      //GET_INT(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_INT(c)));
+      sprintf(str, "%d", c->get_int());
+    } else if (!str_cmp(field, "intadd"))
+      sprintf(str, "%d", GET_INT_ADD(c));
+    else if (!str_cmp(field, "wis")) {
+      //GET_WIS(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_WIS(c)));
+      sprintf(str, "%d", c->get_wis());
+    } else if (!str_cmp(field, "wisadd"))
+      sprintf(str, "%d", GET_WIS_ADD(c));
+    else if (!str_cmp(field, "dex")) {
+      //GET_DEX(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_DEX(c)));
+      sprintf(str, "%d", c->get_dex());
+    } else if (!str_cmp(field, "dexadd"))
+      sprintf(str, "%d", c->get_dex_add());
+    else if (!str_cmp(field, "con")) {
+      //GET_CON(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_CON(c)));
+      sprintf(str, "%d", c->get_con());
+    } else if (!str_cmp(field, "conadd")) {
+      sprintf(str, "%d", GET_CON_ADD(c));
+    } else if (!str_cmp(field, "cha")) {
+      //GET_CHA(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_CHA(c)));
+      sprintf(str, "%d", c->get_cha());
+    } else if (!str_cmp(field, "chaadd"))
+      sprintf(str, "%d", GET_CHA_ADD(c));
+    else if (!str_cmp(field, "size")) {
+      //GET_SIZE(c)=(sbyte) MAX(1,gm_char_field(c,field,subfield,(long) GET_SIZE(c)));
+      sprintf(str, "%d", GET_SIZE(c));
+    } else if (!str_cmp(field, "sizeadd")) {
+      GET_SIZE_ADD(c) =
+          (sbyte) MAX(1,
+                      gm_char_field(c, field, subfield,
+                                    (long) GET_SIZE_ADD(c)));
+      sprintf(str, "%d", GET_SIZE_ADD(c));
+    } else if (!str_cmp(field, "room")) {
+      int n = find_room_uid(world[IN_ROOM(c)]->number);
+      if (n >= 0)
+        sprintf(str, "%c%d", UID_ROOM, n);
+    } else if (!str_cmp(field, "realroom"))
+      sprintf(str, "%d", world[IN_ROOM(c)]->number);
+    else if (!str_cmp(field, "loadroom")) {
+      int pos;
+      if (!IS_NPC(c)) {
+        if (!*subfield || !(pos = atoi(subfield)))
+          sprintf(str, "%d", GET_LOADROOM(c));
+        else {
+          GET_LOADROOM(c) = pos;
+          c->save_char();
+          sprintf(str, "%d", real_room(pos)); // TODO: почему тогда тут рнум?
+        }
+      }
+    } else if (!str_cmp(field, "maxskill")) {
+      const ESkill skillnum = fix_name_and_find_skill_num(subfield);
+      if (skillnum > 0) {
+        sprintf(str, "%d", CalcSkillMinCap(ch, skillnum));
+      } else {
+        strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "skill")) {
+      strcpy(str, skill_percent(trig, c, subfield));
+    } else if (!str_cmp(field, "feat")) {
+      if (feat_owner(trig, c, subfield)) {
+        strcpy(str, "1");
+      } else {
+        strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "spellcount"))
+      strcpy(str, spell_count(trig, c, subfield));
+    else if (!str_cmp(field, "spelltype"))
+      strcpy(str, spell_knowledge(trig, c, subfield));
+    else if (!str_cmp(field, "quested")) {
+      if (*subfield && (num = atoi(subfield)) > 0) {
+        if (c->quested_get(num))
+          strcpy(str, "1");
+        else
+          strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "getquest")) {
+      if (*subfield && (num = atoi(subfield)) > 0) {
+        strcpy(str, (c->quested_get_text(num)).c_str());
+      }
+    } else if (!str_cmp(field, "setquest")) {
+      if (*subfield) {
+        subfield = one_argument(subfield, buf);
+        skip_spaces(&subfield);
+        if ((num = atoi(buf)) > 0) {
+          c->quested_add(c, num, subfield);
+        }
+      }
+    }
+      // все эти блоки надо переписать на что-нибудь другое, их слишком много
+    else if (!str_cmp(field, "unsetquest") || !str_cmp(field, "alliance")) {
+      if (!str_cmp(field, "alliance")) {
+        if (*subfield) {
+          subfield = one_argument(subfield, buf);
+          if (ClanSystem::is_alliance(c, buf))
+            strcpy(str, "1");
+          else
+            strcpy(str, "0");
+        }
+      } else {
+        if (*subfield && (num = atoi(subfield)) > 0) {
+          c->quested_remove(num);
+          strcpy(str, "1");
+        }
+      }
+    } else if (!str_cmp(field, "eq")) {
+      int pos = -1;
+      if (a_isdigit(*subfield))
+        pos = atoi(subfield);
+      else if (*subfield)
+        pos = find_eq_pos(c, NULL, subfield);
+      if (!*subfield || pos < 0 || pos >= NUM_WEARS)
+        strcpy(str, "");
+      else {
+        if (!GET_EQ(c, pos))
+          strcpy(str, "");
+        else
+          sprintf(str, "%c%ld", UID_OBJ, GET_EQ(c, pos)->get_id());
+      }
+    } else if (!str_cmp(field, "haveobj") || !str_cmp(field, "haveobjs")) {
+      int pos;
+      if (a_isdigit(*subfield)) {
+        pos = atoi(subfield);
+        for (obj = c->carrying; obj; obj = obj->get_next_content()) {
+          if (GET_OBJ_VNUM(obj) == pos) {
+            break;
+          }
+        }
+      } else {
+        obj = get_obj_in_list_vis(c, subfield, c->carrying);
+      }
 
-			if (obj)
-			{
-				sprintf(str, "%c%ld", UID_OBJ, obj->get_id());
-			}
-			else
-			{
-				strcpy(str, "0");
-			}
-		}
-		else if (!str_cmp(field, "varexist") || !str_cmp(field, "varexists"))
-		{
-			strcpy(str, "0");
-			if (find_var_cntx(&((SCRIPT(c))->global_vars), subfield, sc->context))
-			{
-				strcpy(str, "1");
-			}
-		}
-		else if (!str_cmp(field, "next_in_room"))
-		{
-			CHAR_DATA* next = nullptr;
-			const auto room = world[c->in_room];
+      if (obj) {
+        sprintf(str, "%c%ld", UID_OBJ, obj->get_id());
+      } else {
+        strcpy(str, "0");
+      }
+    } else if (!str_cmp(field, "varexist") || !str_cmp(field, "varexists")) {
+      strcpy(str, "0");
+      if (find_var_cntx(&((SCRIPT(c))->global_vars), subfield, sc->context)) {
+        strcpy(str, "1");
+      }
+    } else if (!str_cmp(field, "next_in_room")) {
+      CHAR_DATA *next = nullptr;
+      const auto room = world[c->in_room];
 
-			auto people_i = std::find(room->people.begin(), room->people.end(), c);
+      auto people_i = std::find(room->people.begin(), room->people.end(), c);
 
-			if (people_i != room->people.end())
-			{
-				++people_i;
-				people_i = std::find_if(people_i, room->people.end(),
-					[](const CHAR_DATA* ch)
-				{
-					return !GET_INVIS_LEV(ch);
-				});
+      if (people_i != room->people.end()) {
+        ++people_i;
+        people_i = std::find_if(people_i, room->people.end(),
+                                [](const CHAR_DATA *ch) {
+                                  return !GET_INVIS_LEV(ch);
+                                });
 
-				if (people_i != room->people.end())
-				{
-					next = *people_i;
-				}
-			}
+        if (people_i != room->people.end()) {
+          next = *people_i;
+        }
+      }
 
-			if (next)
-			{
-				sprintf(str, "%c%ld", UID_CHAR, GET_ID(next));
-			}
-			else
-			{
-				strcpy(str, "");
-			}
-		}
-		else if (!str_cmp(field, "position"))
-		{
-			int pos;
+      if (next) {
+        sprintf(str, "%c%ld", UID_CHAR, GET_ID(next));
+      } else {
+        strcpy(str, "");
+      }
+    } else if (!str_cmp(field, "position")) {
+      int pos;
 
-			if (!*subfield || (pos = atoi(subfield)) <= POS_DEAD)
-				sprintf(str, "%d", GET_POS(c));
-			else if (!WAITLESS(c))
-			{
-				if (c->ahorse())
-				{
-					c->dismount();
-				}
-				GET_POS(c) = pos;
-			}
-		}
-		else if (!str_cmp(field, "wait") || !str_cmp(field, "lag"))
-		{
-			int pos;
+      if (!*subfield || (pos = atoi(subfield)) <= POS_DEAD)
+        sprintf(str, "%d", GET_POS(c));
+      else if (!WAITLESS(c)) {
+        if (c->ahorse()) {
+          c->dismount();
+        }
+        GET_POS(c) = pos;
+      }
+    } else if (!str_cmp(field, "wait") || !str_cmp(field, "lag")) {
+      int pos;
 
-			if (!*subfield || (pos = atoi(subfield)) <= 0)
-			{
-				sprintf(str, "%d", GET_WAIT(c));
-			}
-			else if (!WAITLESS(c))
-			{
-				WAIT_STATE(c, pos * PULSE_VIOLENCE);
-			}
-		}
-		else if (!str_cmp(field, "affect"))
-		{
-			c->char_specials.saved.affected_by.gm_flag(subfield, affected_bits, str);
-		}
+      if (!*subfield || (pos = atoi(subfield)) <= 0) {
+        sprintf(str, "%d", GET_WAIT(c));
+      } else if (!WAITLESS(c)) {
+        WAIT_STATE(c, pos * PULSE_VIOLENCE);
+      }
+    } else if (!str_cmp(field, "affect")) {
+      c->char_specials.saved.affected_by.gm_flag(subfield, affected_bits, str);
+    }
 
-		//added by WorM
-		//собственно подозреваю что никто из билдеров даже не вкурсе насчет всего функционала этого affect
-		//тупизм какой-то проверять аффекты обездвижен,летит и т.п.
-		//к тому же они в том списке не все кличи например никак там не отображаются
-		else if (!str_cmp(field, "affected_by"))
-		{
-			if ((num = fix_name_and_find_spell_num(subfield)) > 0)
-			{
-				sprintf(str, "%d", (int)affected_by_spell(c, num));
-			}
-		}
-		else if (!str_cmp(field, "action"))
-		{
-			if (IS_NPC(c))
-			{
-				c->char_specials.saved.act.gm_flag(subfield, action_bits, str);
-			}
-		}
-		else if (!str_cmp(field, "leader"))
-		{
-			if (c->has_master())
-			{
-				sprintf(str, "%c%ld", UID_CHAR, GET_ID(c->get_master()));
-			}
-		}
-		else if (!str_cmp(field, "group"))
-		{
-			CHAR_DATA *l;
-			struct follow_type *f;
-			if (!AFF_FLAGGED(c, EAffectFlag::AFF_GROUP))
-			{
-				return;
-			}
-			l = c->get_master();
-			if (!l)
-			{
-				l = c;
-			}
-			// l - лидер группы
-			sprintf(str + strlen(str), "%c%ld ", UID_CHAR, GET_ID(l));
-			for (f = l->followers; f; f = f->next)
-			{
-				if (!AFF_FLAGGED(f->follower, EAffectFlag::AFF_GROUP))
-				{
-					continue;
-				}
-				sprintf(str + strlen(str), "%c%ld ", UID_CHAR, GET_ID(f->follower));
-			}
-		}
-		else if (!str_cmp(field, "attackers"))
-		{
-			CHAR_DATA *t;
-			size_t str_length = strlen(str);
-			for (t = combat_list; t; t = t->next_fighting)
-			{
-				if (t->get_fighting() != c)
-				{
-					continue;
-				}
-				int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(t));
-				if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
-				{
-					strcpy(str + str_length, tmp);
-					str_length += n;
-				}
-				else {
-					break; // too many attackers
-				}
-			}
-		}
-		else if (!str_cmp(field, "people"))
-		{
-			//const auto first_char = world[IN_ROOM(c)]->first_character();
-			const auto room = world[IN_ROOM(c)]->people;
-			const auto first_char = std::find_if(room.begin(), room.end(),
-				[](CHAR_DATA* ch)
-			{
-				return !GET_INVIS_LEV(ch);
-			});
+      //added by WorM
+      //собственно подозреваю что никто из билдеров даже не вкурсе насчет всего функционала этого affect
+      //тупизм какой-то проверять аффекты обездвижен,летит и т.п.
+      //к тому же они в том списке не все кличи например никак там не отображаются
+    else if (!str_cmp(field, "affected_by")) {
+      if ((num = fix_name_and_find_spell_num(subfield)) > 0) {
+        sprintf(str, "%d", (int) affected_by_spell(c, num));
+      }
+    } else if (!str_cmp(field, "action")) {
+      if (IS_NPC(c)) {
+        c->char_specials.saved.act.gm_flag(subfield, action_bits, str);
+      }
+    } else if (!str_cmp(field, "leader")) {
+      if (c->has_master()) {
+        sprintf(str, "%c%ld", UID_CHAR, GET_ID(c->get_master()));
+      }
+    } else if (!str_cmp(field, "group")) {
+      CHAR_DATA *l;
+      struct follow_type *f;
+      if (!AFF_FLAGGED(c, EAffectFlag::AFF_GROUP)) {
+        return;
+      }
+      l = c->get_master();
+      if (!l) {
+        l = c;
+      }
+      // l - лидер группы
+      sprintf(str + strlen(str), "%c%ld ", UID_CHAR, GET_ID(l));
+      for (f = l->followers; f; f = f->next) {
+        if (!AFF_FLAGGED(f->follower, EAffectFlag::AFF_GROUP)) {
+          continue;
+        }
+        sprintf(str + strlen(str), "%c%ld ", UID_CHAR, GET_ID(f->follower));
+      }
+    } else if (!str_cmp(field, "attackers")) {
+      CHAR_DATA *t;
+      size_t str_length = strlen(str);
+      for (t = combat_list; t; t = t->next_fighting) {
+        if (t->get_fighting() != c) {
+          continue;
+        }
+        int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(t));
+        if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
+        {
+          strcpy(str + str_length, tmp);
+          str_length += n;
+        } else {
+          break; // too many attackers
+        }
+      }
+    } else if (!str_cmp(field, "people")) {
+      //const auto first_char = world[IN_ROOM(c)]->first_character();
+      const auto room = world[IN_ROOM(c)]->people;
+      const auto first_char = std::find_if(room.begin(), room.end(),
+                                           [](CHAR_DATA *ch) {
+                                             return !GET_INVIS_LEV(ch);
+                                           });
 
-			if (first_char != room.end())
-			{
-				sprintf(str, "%c%ld", UID_CHAR, GET_ID(*first_char));
-			}
-			else
-			{
-				strcpy(str, "");
-			}
-		}
-		//Polud обработка поля objs у чара, возвращает строку со списком UID предметов в инвентаре
-		else if (!str_cmp(field, "objs"))
-		{
-			size_t str_length = strlen(str);
-			for (obj = c->carrying; obj; obj = obj->get_next_content())
-			{
-				int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_OBJ, obj->get_id());
-				if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
-				{
-					strcpy(str + str_length, tmp);
-					str_length += n;
-				}
-				else {
-					break; // too many carying objects
-				}
-			}
-		}
-		//-Polud
-		else if (!str_cmp(field, "char")
-			|| !str_cmp(field, "pc")
-			|| !str_cmp(field, "npc")
-			|| !str_cmp(field, "all"))
-		{
-			int inroom;
+      if (first_char != room.end()) {
+        sprintf(str, "%c%ld", UID_CHAR, GET_ID(*first_char));
+      } else {
+        strcpy(str, "");
+      }
+    }
+      //Polud обработка поля objs у чара, возвращает строку со списком UID предметов в инвентаре
+    else if (!str_cmp(field, "objs")) {
+      size_t str_length = strlen(str);
+      for (obj = c->carrying; obj; obj = obj->get_next_content()) {
+        int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_OBJ, obj->get_id());
+        if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
+        {
+          strcpy(str + str_length, tmp);
+          str_length += n;
+        } else {
+          break; // too many carying objects
+        }
+      }
+    }
+      //-Polud
+    else if (!str_cmp(field, "char")
+        || !str_cmp(field, "pc")
+        || !str_cmp(field, "npc")
+        || !str_cmp(field, "all")) {
+      int inroom;
 
-			// Составление списка (для mob)
-			inroom = IN_ROOM(c);
-			if (inroom == NOWHERE)
-			{
-				trig_log(trig, "mob-построитель списка в NOWHERE");
-				return;
-			}
+      // Составление списка (для mob)
+      inroom = IN_ROOM(c);
+      if (inroom == NOWHERE) {
+        trig_log(trig, "mob-построитель списка в NOWHERE");
+        return;
+      }
 
-			size_t str_length = strlen(str);
-			for (const auto rndm : world[inroom]->people)
-			{
-				if (!CAN_SEE(c, rndm)
-					|| GET_INVIS_LEV(rndm))
-				{
-					continue;
-				}
+      size_t str_length = strlen(str);
+      for (const auto rndm : world[inroom]->people) {
+        if (!CAN_SEE(c, rndm)
+            || GET_INVIS_LEV(rndm)) {
+          continue;
+        }
 
-				if ((*field == 'a')
-					|| (!IS_NPC(rndm)
-						&& *field != 'n'
-						&& rndm->desc)
-					|| (IS_NPC(rndm)
-						&& IS_CHARMED(rndm)
-						&& *field == 'c')
-					|| (IS_NPC(rndm)
-						&& !IS_CHARMED(rndm)
-						&& *field == 'n'))
-				{
-					int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(rndm));
-					if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
-					{
-						strcpy(str + str_length, tmp);
-						str_length += n;
-					}
-					else
-					{
-						break; // too many characters
-					}
-				}
-			}
+        if ((*field == 'a')
+            || (!IS_NPC(rndm)
+                && *field != 'n'
+                && rndm->desc)
+            || (IS_NPC(rndm)
+                && IS_CHARMED(rndm)
+                && *field == 'c')
+            || (IS_NPC(rndm)
+                && !IS_CHARMED(rndm)
+                && *field == 'n')) {
+          int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(rndm));
+          if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
+          {
+            strcpy(str + str_length, tmp);
+            str_length += n;
+          } else {
+            break; // too many characters
+          }
+        }
+      }
 
-			return;
-		}
-		else if (!str_cmp(field, "is_noob"))
-		{
-			strcpy(str, Noob::is_noob(c) ? "1" : "0");
-		}
-		else if (!str_cmp(field, "noob_outfit"))
-		{
-			std::string vnum_str = Noob::print_start_outfit(c);
-			snprintf(str, MAX_INPUT_LENGTH, "%s", vnum_str.c_str());
-		}
-		else
-		{
-			vd = find_var_cntx(&((SCRIPT(c))->global_vars), field,
-				sc->context);
-			if (vd)
-				sprintf(str, "%s", vd->value);
-			else
-			{
-				sprintf(buf2, "unknown char field: '%s'", field);
-				trig_log(trig, buf2);
-			}
-		}
-	}
-	else if (o)
-	{
-		if (text_processed(field, subfield, vd, str))
-		{
-			return;
-		}
-		else if (!str_cmp(field, "iname"))
-		{
-			if (!o->get_PName(0).empty())
-			{
-				strcpy(str, o->get_PName(0).c_str());
-			}
-			else
-			{
-				strcpy(str, o->get_aliases().c_str());
-			}
-		}
-		else if (!str_cmp(field, "rname"))
-		{
-			if (!o->get_PName(1).empty())
-			{
-				strcpy(str, o->get_PName(1).c_str());
-			}
-			else
-			{
-				strcpy(str, o->get_aliases().c_str());
-			}
-		}
-		else if (!str_cmp(field, "dname"))
-		{
-			if (!o->get_PName(2).empty())
-			{
-				strcpy(str, o->get_PName(2).c_str());
-			}
-			else
-			{
-				strcpy(str, o->get_aliases().c_str());
-			}
-		}
-		else if (!str_cmp(field, "vname"))
-		{
-			if (!o->get_PName(3).empty())
-			{
-				strcpy(str, o->get_PName(3).c_str());
-			}
-			else
-			{
-				strcpy(str, o->get_aliases().c_str());
-			}
-		}
-		else if (!str_cmp(field, "tname"))
-		{
-			if (!o->get_PName(4).empty())
-			{
-				strcpy(str, o->get_PName(4).c_str());
-			}
-			else
-			{
-				strcpy(str, o->get_aliases().c_str());
-			}
-		}
-		else if (!str_cmp(field, "pname"))
-		{
-			if (!o->get_PName(5).empty())
-			{
-				strcpy(str, o->get_PName(5).c_str());
-			}
-			else
-			{
-				strcpy(str, o->get_aliases().c_str());
-			}
-		}
-		else if (!str_cmp(field, "name"))
-		{
-			strcpy(str, o->get_aliases().c_str());
-		}
-		else if (!str_cmp(field, "id"))
-		{
-			sprintf(str, "%c%ld", UID_OBJ, o->get_id());
-		}
-		else if (!str_cmp(field, "uid"))
-		{
-			if (!GET_OBJ_UID(o))
-			{
-				set_uid(o);
-			}
-			sprintf(str, "%u", GET_OBJ_UID(o));
-		}
-		else if (!str_cmp(field, "skill"))
-		{
-			sprintf(str, "%d", GET_OBJ_SKILL(o));
-		}
-		else if (!str_cmp(field, "shortdesc"))
-		{
-			strcpy(str, o->get_short_description().c_str());
-		}
-		else if (!str_cmp(field, "vnum"))
-		{
-			sprintf(str, "%d", GET_OBJ_VNUM(o));
-		}
-		else if (!str_cmp(field, "type"))
-		{
-			sprintf(str, "%d", (int)GET_OBJ_TYPE(o));
-		}
-		else if (!str_cmp(field, "timer"))
-		{
-			sprintf(str, "%d", o->get_timer());
-		}
-		else if (!str_cmp(field, "val0"))
-		{
-			if (*subfield)
-			{
-				skip_spaces(&subfield);
-				o->set_val(0, atoi(subfield));
-			}
-			else
-			{
-				sprintf(str, "%d", GET_OBJ_VAL(o, 0));
-			}
-		}
-		else if (!str_cmp(field, "val1"))
-		{
-			if (*subfield)
-			{
-				skip_spaces(&subfield);
-				o->set_val(1, atoi(subfield));
-			}
-			else
-			{
-				sprintf(str, "%d", GET_OBJ_VAL(o, 1));
-			}
-		}
-		else if (!str_cmp(field, "val2"))
-		{
-			if (*subfield)
-			{
-				skip_spaces(&subfield);
-				o->set_val(2, atoi(subfield));
-			}
-			else
-			{
-				sprintf(str, "%d", GET_OBJ_VAL(o, 2));
-			}
-		}
-		else if (!str_cmp(field, "val3"))
-		{
-			if (*subfield)
-			{
-				skip_spaces(&subfield);
-				o->set_val(3, atoi(subfield));
-			}
-			else
-			{
-				sprintf(str, "%d", GET_OBJ_VAL(o, 3));
-			}
-		}
-		else if (!str_cmp(field, "maker"))
-		{
-			sprintf(str, "%d", GET_OBJ_MAKER(o));
-		}
-		else if (!str_cmp(field, "effect"))
-		{
-			o->gm_extra_flag(subfield, extra_bits, str);
-		}
-		else if (!str_cmp(field, "affect"))
-		{
-			o->gm_affect_flag(subfield, weapon_affects, str);
-		}
-		else if (!str_cmp(field, "carried_by"))
-		{
-			if (o->get_carried_by())
-			{
-				sprintf(str, "%c%ld", UID_CHAR, GET_ID(o->get_carried_by()));
-			}
-			else
-			{
-				strcpy(str, "");
-			}
-		}
-		else if (!str_cmp(field, "worn_by"))
-		{
-			if (o->get_worn_by())
-			{
-				sprintf(str, "%c%ld", UID_CHAR, GET_ID(o->get_worn_by()));
-			}
-			else
-			{
-				strcpy(str, "");
-			}
-		}
-		else if (!str_cmp(field, "g"))
-			strcpy(str, GET_OBJ_SUF_1(o));
-		else if (!str_cmp(field, "q"))
-			strcpy(str, GET_OBJ_SUF_4(o));
-		else if (!str_cmp(field, "u"))
-			strcpy(str, GET_OBJ_SUF_2(o));
-		else if (!str_cmp(field, "w"))
-			strcpy(str, GET_OBJ_SUF_3(o));
-		else if (!str_cmp(field, "y"))
-			strcpy(str, GET_OBJ_SUF_5(o));
-		else if (!str_cmp(field, "a"))
-			strcpy(str, GET_OBJ_SUF_6(o));
-		else if (!str_cmp(field, "count"))
-			strcpy(str, get_objs_in_world(o));
-		else if (!str_cmp(field, "sex"))
-			sprintf(str, "%d", (int)GET_OBJ_SEX(o));
-		else if (!str_cmp(field, "room"))
-		{
-			if (o->get_carried_by())
-			{
-				sprintf(str, "%d", world[IN_ROOM(o->get_carried_by())]->number);
-			}
-			else if (o->get_worn_by())
-			{
-				sprintf(str, "%d", world[IN_ROOM(o->get_worn_by())]->number);
-			}
-			else if (o->get_in_room() != NOWHERE)
-			{
-				sprintf(str, "%d", world[o->get_in_room()]->number);
-			}
-			else
-			{
-				strcpy(str, "");
-			}
-		}
-		//Polud обработка %obj.put(UID)% - пытается поместить объект в контейнер, комнату или инвентарь чара, в зависимости от UIDа
-		else if (!str_cmp(field, "put"))
-		{
-			OBJ_DATA *obj_to = NULL;
-			CHAR_DATA *char_to = NULL;
-			ROOM_DATA *room_to = NULL;
-			if (!((*subfield == UID_CHAR) || (*subfield == UID_OBJ) || (*subfield == UID_ROOM)))
-			{
-				trig_log(trig, "object.put: недопустимый аргумент, необходимо указать UID");
-				return;
-			}
-			if (*subfield == UID_OBJ)
-			{
-				obj_to = find_obj_by_id(atoi(subfield + 1));
-				if (!(obj_to
-					&& GET_OBJ_TYPE(obj_to) == OBJ_DATA::ITEM_CONTAINER))
-				{
-					trig_log(trig, "object.put: объект-приемник не найден или не является контейнером");
-					return;
-				}
-			}
-			if (*subfield == UID_CHAR)
-			{
-				char_to = find_char(atoi(subfield + 1));
-				if (!(char_to && can_take_obj(char_to, o)))
-				{
-					trig_log(trig, "object.put: субъект-приемник не найден или не может нести этот объект");
-					return;
-				}
-			}
-			if (*subfield == UID_ROOM)
-			{
-				room_to = find_room(atoi(subfield + 1));
-				if (!(room_to && (room_to->number != NOWHERE)))
-				{
-					trig_log(trig, "object.put: недопустимая комната для размещения объекта");
-					return;
-				}
-			}
-			//found something to put our object
-			//let's make it nobody's!
-			if (o->get_worn_by())
-			{
-				unequip_char(o->get_worn_by(), o->get_worn_on());
-			}
-			else if (o->get_carried_by())
-			{
-				obj_from_char(o);
-			}
-			else if (o->get_in_obj())
-			{
-				obj_from_obj(o);
-			}
-			else if (o->get_in_room() > NOWHERE)
-			{
-				obj_from_room(o);
-			}
-			else
-			{
-				trig_log(trig, "object.put: не удалось извлечь объект");
-				return;
-			}
-			//finally, put it to destination
-			if (char_to)
-				obj_to_char(o, char_to);
-			else if (obj_to)
-				obj_to_obj(o, obj_to);
-			else if (room_to)
-				obj_to_room(o, real_room(room_to->number));
-			else
-			{
-				sprintf(buf2, "object.put: ATTENTION! за время подготовки объекта >%s< к передаче перестал существовать адресат. Объект сейчас в NOWHERE",
-					o->get_short_description().c_str());
-				trig_log(trig, buf2);
-				return;
-			}
-		}
-		//-Polud
-		else if (!str_cmp(field, "char") ||
-			!str_cmp(field, "pc") || !str_cmp(field, "npc") || !str_cmp(field, "all"))
-		{
-			int inroom;
+      return;
+    } else if (!str_cmp(field, "is_noob")) {
+      strcpy(str, Noob::is_noob(c) ? "1" : "0");
+    } else if (!str_cmp(field, "noob_outfit")) {
+      std::string vnum_str = Noob::print_start_outfit(c);
+      snprintf(str, MAX_INPUT_LENGTH, "%s", vnum_str.c_str());
+    } else {
+      vd = find_var_cntx(&((SCRIPT(c))->global_vars), field,
+                         sc->context);
+      if (vd)
+        sprintf(str, "%s", vd->value);
+      else {
+        sprintf(buf2, "unknown char field: '%s'", field);
+        trig_log(trig, buf2);
+      }
+    }
+  } else if (o) {
+    if (text_processed(field, subfield, vd, str)) {
+      return;
+    } else if (!str_cmp(field, "iname")) {
+      if (!o->get_PName(0).empty()) {
+        strcpy(str, o->get_PName(0).c_str());
+      } else {
+        strcpy(str, o->get_aliases().c_str());
+      }
+    } else if (!str_cmp(field, "rname")) {
+      if (!o->get_PName(1).empty()) {
+        strcpy(str, o->get_PName(1).c_str());
+      } else {
+        strcpy(str, o->get_aliases().c_str());
+      }
+    } else if (!str_cmp(field, "dname")) {
+      if (!o->get_PName(2).empty()) {
+        strcpy(str, o->get_PName(2).c_str());
+      } else {
+        strcpy(str, o->get_aliases().c_str());
+      }
+    } else if (!str_cmp(field, "vname")) {
+      if (!o->get_PName(3).empty()) {
+        strcpy(str, o->get_PName(3).c_str());
+      } else {
+        strcpy(str, o->get_aliases().c_str());
+      }
+    } else if (!str_cmp(field, "tname")) {
+      if (!o->get_PName(4).empty()) {
+        strcpy(str, o->get_PName(4).c_str());
+      } else {
+        strcpy(str, o->get_aliases().c_str());
+      }
+    } else if (!str_cmp(field, "pname")) {
+      if (!o->get_PName(5).empty()) {
+        strcpy(str, o->get_PName(5).c_str());
+      } else {
+        strcpy(str, o->get_aliases().c_str());
+      }
+    } else if (!str_cmp(field, "name")) {
+      strcpy(str, o->get_aliases().c_str());
+    } else if (!str_cmp(field, "id")) {
+      sprintf(str, "%c%ld", UID_OBJ, o->get_id());
+    } else if (!str_cmp(field, "uid")) {
+      if (!GET_OBJ_UID(o)) {
+        set_uid(o);
+      }
+      sprintf(str, "%u", GET_OBJ_UID(o));
+    } else if (!str_cmp(field, "skill")) {
+      sprintf(str, "%d", GET_OBJ_SKILL(o));
+    } else if (!str_cmp(field, "shortdesc")) {
+      strcpy(str, o->get_short_description().c_str());
+    } else if (!str_cmp(field, "vnum")) {
+      sprintf(str, "%d", GET_OBJ_VNUM(o));
+    } else if (!str_cmp(field, "type")) {
+      sprintf(str, "%d", (int) GET_OBJ_TYPE(o));
+    } else if (!str_cmp(field, "timer")) {
+      sprintf(str, "%d", o->get_timer());
+    } else if (!str_cmp(field, "val0")) {
+      if (*subfield) {
+        skip_spaces(&subfield);
+        o->set_val(0, atoi(subfield));
+      } else {
+        sprintf(str, "%d", GET_OBJ_VAL(o, 0));
+      }
+    } else if (!str_cmp(field, "val1")) {
+      if (*subfield) {
+        skip_spaces(&subfield);
+        o->set_val(1, atoi(subfield));
+      } else {
+        sprintf(str, "%d", GET_OBJ_VAL(o, 1));
+      }
+    } else if (!str_cmp(field, "val2")) {
+      if (*subfield) {
+        skip_spaces(&subfield);
+        o->set_val(2, atoi(subfield));
+      } else {
+        sprintf(str, "%d", GET_OBJ_VAL(o, 2));
+      }
+    } else if (!str_cmp(field, "val3")) {
+      if (*subfield) {
+        skip_spaces(&subfield);
+        o->set_val(3, atoi(subfield));
+      } else {
+        sprintf(str, "%d", GET_OBJ_VAL(o, 3));
+      }
+    } else if (!str_cmp(field, "maker")) {
+      sprintf(str, "%d", GET_OBJ_MAKER(o));
+    } else if (!str_cmp(field, "effect")) {
+      o->gm_extra_flag(subfield, extra_bits, str);
+    } else if (!str_cmp(field, "affect")) {
+      o->gm_affect_flag(subfield, weapon_affects, str);
+    } else if (!str_cmp(field, "carried_by")) {
+      if (o->get_carried_by()) {
+        sprintf(str, "%c%ld", UID_CHAR, GET_ID(o->get_carried_by()));
+      } else {
+        strcpy(str, "");
+      }
+    } else if (!str_cmp(field, "worn_by")) {
+      if (o->get_worn_by()) {
+        sprintf(str, "%c%ld", UID_CHAR, GET_ID(o->get_worn_by()));
+      } else {
+        strcpy(str, "");
+      }
+    } else if (!str_cmp(field, "g"))
+      strcpy(str, GET_OBJ_SUF_1(o));
+    else if (!str_cmp(field, "q"))
+      strcpy(str, GET_OBJ_SUF_4(o));
+    else if (!str_cmp(field, "u"))
+      strcpy(str, GET_OBJ_SUF_2(o));
+    else if (!str_cmp(field, "w"))
+      strcpy(str, GET_OBJ_SUF_3(o));
+    else if (!str_cmp(field, "y"))
+      strcpy(str, GET_OBJ_SUF_5(o));
+    else if (!str_cmp(field, "a"))
+      strcpy(str, GET_OBJ_SUF_6(o));
+    else if (!str_cmp(field, "count"))
+      strcpy(str, get_objs_in_world(o));
+    else if (!str_cmp(field, "sex"))
+      sprintf(str, "%d", (int) GET_OBJ_SEX(o));
+    else if (!str_cmp(field, "room")) {
+      if (o->get_carried_by()) {
+        sprintf(str, "%d", world[IN_ROOM(o->get_carried_by())]->number);
+      } else if (o->get_worn_by()) {
+        sprintf(str, "%d", world[IN_ROOM(o->get_worn_by())]->number);
+      } else if (o->get_in_room() != NOWHERE) {
+        sprintf(str, "%d", world[o->get_in_room()]->number);
+      } else {
+        strcpy(str, "");
+      }
+    }
+      //Polud обработка %obj.put(UID)% - пытается поместить объект в контейнер, комнату или инвентарь чара, в зависимости от UIDа
+    else if (!str_cmp(field, "put")) {
+      OBJ_DATA *obj_to = NULL;
+      CHAR_DATA *char_to = NULL;
+      ROOM_DATA *room_to = NULL;
+      if (!((*subfield == UID_CHAR) || (*subfield == UID_OBJ) || (*subfield == UID_ROOM))) {
+        trig_log(trig, "object.put: недопустимый аргумент, необходимо указать UID");
+        return;
+      }
+      if (*subfield == UID_OBJ) {
+        obj_to = find_obj_by_id(atoi(subfield + 1));
+        if (!(obj_to
+            && GET_OBJ_TYPE(obj_to) == OBJ_DATA::ITEM_CONTAINER)) {
+          trig_log(trig, "object.put: объект-приемник не найден или не является контейнером");
+          return;
+        }
+      }
+      if (*subfield == UID_CHAR) {
+        char_to = find_char(atoi(subfield + 1));
+        if (!(char_to && can_take_obj(char_to, o))) {
+          trig_log(trig, "object.put: субъект-приемник не найден или не может нести этот объект");
+          return;
+        }
+      }
+      if (*subfield == UID_ROOM) {
+        room_to = find_room(atoi(subfield + 1));
+        if (!(room_to && (room_to->number != NOWHERE))) {
+          trig_log(trig, "object.put: недопустимая комната для размещения объекта");
+          return;
+        }
+      }
+      //found something to put our object
+      //let's make it nobody's!
+      if (o->get_worn_by()) {
+        unequip_char(o->get_worn_by(), o->get_worn_on());
+      } else if (o->get_carried_by()) {
+        obj_from_char(o);
+      } else if (o->get_in_obj()) {
+        obj_from_obj(o);
+      } else if (o->get_in_room() > NOWHERE) {
+        obj_from_room(o);
+      } else {
+        trig_log(trig, "object.put: не удалось извлечь объект");
+        return;
+      }
+      //finally, put it to destination
+      if (char_to)
+        obj_to_char(o, char_to);
+      else if (obj_to)
+        obj_to_obj(o, obj_to);
+      else if (room_to)
+        obj_to_room(o, real_room(room_to->number));
+      else {
+        sprintf(buf2,
+                "object.put: ATTENTION! за время подготовки объекта >%s< к передаче перестал существовать адресат. Объект сейчас в NOWHERE",
+                o->get_short_description().c_str());
+        trig_log(trig, buf2);
+        return;
+      }
+    }
+      //-Polud
+    else if (!str_cmp(field, "char") ||
+        !str_cmp(field, "pc") || !str_cmp(field, "npc") || !str_cmp(field, "all")) {
+      int inroom;
 
-			// Составление списка (для obj)
-			inroom = obj_room(o);
-			if (inroom == NOWHERE)
-			{
-				trig_log(trig, "obj-построитель списка в NOWHERE");
-				return;
-			}
+      // Составление списка (для obj)
+      inroom = obj_room(o);
+      if (inroom == NOWHERE) {
+        trig_log(trig, "obj-построитель списка в NOWHERE");
+        return;
+      }
 
-			size_t str_length = strlen(str);
-			for (const auto rndm : world[inroom]->people)
-			{
-				if (GET_INVIS_LEV(rndm))
-					continue;
+      size_t str_length = strlen(str);
+      for (const auto rndm : world[inroom]->people) {
+        if (GET_INVIS_LEV(rndm))
+          continue;
 
-				if ((*field == 'a')
-					|| (!IS_NPC(rndm)
-						&& *field != 'n')
-					|| (IS_NPC(rndm)
-						&& IS_CHARMED(rndm)
-						&& *field == 'c')
-					|| (IS_NPC(rndm)
-						&& !IS_CHARMED(rndm)
-						&& *field == 'n'))
-				{
-					int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(rndm));
-					if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
-					{
-						strcpy(str + str_length, tmp);
-						str_length += n;
-					}
-					else
-					{
-						break; // too many characters
-					}
-				}
-			}
+        if ((*field == 'a')
+            || (!IS_NPC(rndm)
+                && *field != 'n')
+            || (IS_NPC(rndm)
+                && IS_CHARMED(rndm)
+                && *field == 'c')
+            || (IS_NPC(rndm)
+                && !IS_CHARMED(rndm)
+                && *field == 'n')) {
+          int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(rndm));
+          if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
+          {
+            strcpy(str + str_length, tmp);
+            str_length += n;
+          } else {
+            break; // too many characters
+          }
+        }
+      }
 
-			return;
-		}
-		else if (!str_cmp(field, "owner"))
-		{
-			if (*subfield)
-			{
-				skip_spaces(&subfield);
-				int num = atoi(subfield);
-				// Убрал пока проверку. По идее 0 -- отсутствие владельца.
-				// Понадобилась возможность обнулить владельца из трига.
-				o->set_owner(num);
-			}
-			else
-			{
-				sprintf(str, "%d", GET_OBJ_OWNER(o));
-			}
-		}
-		else if (!str_cmp(field, "varexists"))
-		{
-			strcpy(str, "0");
-			if (find_var_cntx(&o->get_script()->global_vars, subfield, sc->context))
-			{
-				strcpy(str, "1");
-			}
-		}
-		else if (!str_cmp(field, "cost"))
-		{
-			if (*subfield && a_isdigit(*subfield))
-			{
-				skip_spaces(&subfield);
-				o->set_cost(atoi(subfield));
-			}
-			else
-			{
-				sprintf(str, "%d", GET_OBJ_COST(o));
-			}
-		}
-		else if (!str_cmp(field, "rent"))
-		{
-			if (*subfield && a_isdigit(*subfield))
-			{
-				skip_spaces(&subfield);
-				o->set_rent_off(atoi(subfield));
-			}
-			else
-			{
-				sprintf(str, "%d", GET_OBJ_RENT(o));
-			}
-		}
-		else if (!str_cmp(field, "rent_eq"))
-		{
-			if (*subfield && a_isdigit(*subfield))
-			{
-				skip_spaces(&subfield);
-				o->set_rent_on(atoi(subfield));
-			}
-			else
-			{
-				sprintf(str, "%d", GET_OBJ_RENTEQ(o));
-			}
-		}
-		else //get global var. obj.varname
-		{
-			vd = find_var_cntx(&o->get_script()->global_vars, field, sc->context);
-			if (vd)
-			{
-				sprintf(str, "%s", vd->value);
-			}
-			else
-			{
-				sprintf(buf2, "Type: %d. unknown object field: '%s'", type, field);
-				trig_log(trig, buf2);
-			}
-		}
-	}
-	else if (r)
-	{
-		if (text_processed(field, subfield, vd, str))
-		{
-			return;
-		}
-		else if (!str_cmp(field, "name"))
-		{
-			if (*subfield)
-			{
-				if (r->name)
-					free(r->name);
-				if (strlen(subfield) > MAX_ROOM_NAME)
-					subfield[MAX_ROOM_NAME - 1] = '\0';
-				r->name = str_dup(subfield);
-			}
-			else
-				strcpy(str, r->name);
-		}
-		else if (!str_cmp(field, "north"))
-		{
-			if (r->dir_option[NORTH])
-			{
-				sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[NORTH]->to_room())));
-			}
-		}
-		else if (!str_cmp(field, "east"))
-		{
-			if (r->dir_option[EAST])
-			{
-				sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[EAST]->to_room())));
-			}
-		}
-		else if (!str_cmp(field, "south"))
-		{
-			if (r->dir_option[SOUTH])
-			{
-				sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[SOUTH]->to_room())));
-			}
-		}
-		else if (!str_cmp(field, "west"))
-		{
-			if (r->dir_option[WEST])
-			{
-				sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[WEST]->to_room())));
-			}
-		}
-		else if (!str_cmp(field, "up"))
-		{
-			if (r->dir_option[UP])
-			{
-				sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[UP]->to_room())));
-			}
-		}
-		else if (!str_cmp(field, "down"))
-		{
-			if (r->dir_option[DOWN])
-			{
-				sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[DOWN]->to_room())));
-			}
-		}
-		else if (!str_cmp(field, "vnum"))
-		{
-			sprintf(str, "%d", r->number);
-		}
-		else if (!str_cmp(field, "sectortype"))//Polud возвращает строку - тип комнаты
-		{
-			sprinttype(r->sector_type, sector_types, str);
-		}
-		else if (!str_cmp(field, "id"))
-		{
-			sprintf(str, "%c%d", UID_ROOM, find_room_uid(r->number));
-		}
-		else if (!str_cmp(field, "flag"))
-		{
-			r->gm_flag(subfield, room_bits, str);
-		}
-		else if (!str_cmp(field, "people"))
-		{
-			const auto first_char = r->first_character();
-			if (first_char)
-			{
-				sprintf(str, "%c%ld", UID_CHAR, GET_ID(first_char));
-			}
-		}
-		else if (!str_cmp(field, "char")
-			|| !str_cmp(field, "pc")
-			|| !str_cmp(field, "npc")
-			|| !str_cmp(field, "all"))
-		{
-			int inroom;
+      return;
+    } else if (!str_cmp(field, "owner")) {
+      if (*subfield) {
+        skip_spaces(&subfield);
+        int num = atoi(subfield);
+        // Убрал пока проверку. По идее 0 -- отсутствие владельца.
+        // Понадобилась возможность обнулить владельца из трига.
+        o->set_owner(num);
+      } else {
+        sprintf(str, "%d", GET_OBJ_OWNER(o));
+      }
+    } else if (!str_cmp(field, "varexists")) {
+      strcpy(str, "0");
+      if (find_var_cntx(&o->get_script()->global_vars, subfield, sc->context)) {
+        strcpy(str, "1");
+      }
+    } else if (!str_cmp(field, "cost")) {
+      if (*subfield && a_isdigit(*subfield)) {
+        skip_spaces(&subfield);
+        o->set_cost(atoi(subfield));
+      } else {
+        sprintf(str, "%d", GET_OBJ_COST(o));
+      }
+    } else if (!str_cmp(field, "rent")) {
+      if (*subfield && a_isdigit(*subfield)) {
+        skip_spaces(&subfield);
+        o->set_rent_off(atoi(subfield));
+      } else {
+        sprintf(str, "%d", GET_OBJ_RENT(o));
+      }
+    } else if (!str_cmp(field, "rent_eq")) {
+      if (*subfield && a_isdigit(*subfield)) {
+        skip_spaces(&subfield);
+        o->set_rent_on(atoi(subfield));
+      } else {
+        sprintf(str, "%d", GET_OBJ_RENTEQ(o));
+      }
+    } else //get global var. obj.varname
+    {
+      vd = find_var_cntx(&o->get_script()->global_vars, field, sc->context);
+      if (vd) {
+        sprintf(str, "%s", vd->value);
+      } else {
+        sprintf(buf2, "Type: %d. unknown object field: '%s'", type, field);
+        trig_log(trig, buf2);
+      }
+    }
+  } else if (r) {
+    if (text_processed(field, subfield, vd, str)) {
+      return;
+    } else if (!str_cmp(field, "name")) {
+      if (*subfield) {
+        if (r->name)
+          free(r->name);
+        if (strlen(subfield) > MAX_ROOM_NAME)
+          subfield[MAX_ROOM_NAME - 1] = '\0';
+        r->name = str_dup(subfield);
+      } else
+        strcpy(str, r->name);
+    } else if (!str_cmp(field, "north")) {
+      if (r->dir_option[NORTH]) {
+        sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[NORTH]->to_room())));
+      }
+    } else if (!str_cmp(field, "east")) {
+      if (r->dir_option[EAST]) {
+        sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[EAST]->to_room())));
+      }
+    } else if (!str_cmp(field, "south")) {
+      if (r->dir_option[SOUTH]) {
+        sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[SOUTH]->to_room())));
+      }
+    } else if (!str_cmp(field, "west")) {
+      if (r->dir_option[WEST]) {
+        sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[WEST]->to_room())));
+      }
+    } else if (!str_cmp(field, "up")) {
+      if (r->dir_option[UP]) {
+        sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[UP]->to_room())));
+      }
+    } else if (!str_cmp(field, "down")) {
+      if (r->dir_option[DOWN]) {
+        sprintf(str, "%d", find_room_vnum(GET_ROOM_VNUM(r->dir_option[DOWN]->to_room())));
+      }
+    } else if (!str_cmp(field, "vnum")) {
+      sprintf(str, "%d", r->number);
+    } else if (!str_cmp(field, "sectortype"))//Polud возвращает строку - тип комнаты
+    {
+      sprinttype(r->sector_type, sector_types, str);
+    } else if (!str_cmp(field, "id")) {
+      sprintf(str, "%c%d", UID_ROOM, find_room_uid(r->number));
+    } else if (!str_cmp(field, "flag")) {
+      r->gm_flag(subfield, room_bits, str);
+    } else if (!str_cmp(field, "people")) {
+      const auto first_char = r->first_character();
+      if (first_char) {
+        sprintf(str, "%c%ld", UID_CHAR, GET_ID(first_char));
+      }
+    } else if (!str_cmp(field, "char")
+        || !str_cmp(field, "pc")
+        || !str_cmp(field, "npc")
+        || !str_cmp(field, "all")) {
+      int inroom;
 
-			// Составление списка (для room)
-			inroom = real_room(r->number);
-			if (inroom == NOWHERE)
-			{
-				trig_log(trig, "room-построитель списка в NOWHERE");
-				return;
-			}
+      // Составление списка (для room)
+      inroom = real_room(r->number);
+      if (inroom == NOWHERE) {
+        trig_log(trig, "room-построитель списка в NOWHERE");
+        return;
+      }
 
-			size_t str_length = strlen(str);
-			for (const auto rndm : world[inroom]->people)
-			{
-				if (GET_INVIS_LEV(rndm))
-					continue;
+      size_t str_length = strlen(str);
+      for (const auto rndm : world[inroom]->people) {
+        if (GET_INVIS_LEV(rndm))
+          continue;
 
-				if ((*field == 'a')
-					|| (!IS_NPC(rndm)
-						&& *field != 'n')
-					|| (IS_NPC(rndm)
-						&& IS_CHARMED(rndm)
-						&& *field == 'c')
-					|| (IS_NPC(rndm)
-						&& !IS_CHARMED(rndm)
-						&& *field == 'n'))
-				{
-					int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(rndm));
-					if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
-					{
-						strcpy(str + str_length, tmp);
-						str_length += n;
-					}
-					else
-					{
-						break; // too many characters
-					}
-				}
-			}
+        if ((*field == 'a')
+            || (!IS_NPC(rndm)
+                && *field != 'n')
+            || (IS_NPC(rndm)
+                && IS_CHARMED(rndm)
+                && *field == 'c')
+            || (IS_NPC(rndm)
+                && !IS_CHARMED(rndm)
+                && *field == 'n')) {
+          int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(rndm));
+          if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
+          {
+            strcpy(str + str_length, tmp);
+            str_length += n;
+          } else {
+            break; // too many characters
+          }
+        }
+      }
 
-			return;
-		}
-		else if (!str_cmp(field, "objects"))
-		{
-			//mixaz  Выдаем список объектов в комнате
-			int inroom;
-			// Составление списка (для room)
-			inroom = real_room(r->number);
-			if (inroom == NOWHERE)
-			{
-				trig_log(trig, "room-построитель списка в NOWHERE");
-				return;
-			}
+      return;
+    } else if (!str_cmp(field, "objects")) {
+      //mixaz  Выдаем список объектов в комнате
+      int inroom;
+      // Составление списка (для room)
+      inroom = real_room(r->number);
+      if (inroom == NOWHERE) {
+        trig_log(trig, "room-построитель списка в NOWHERE");
+        return;
+      }
 
-			size_t str_length = strlen(str);
-			for (obj = world[inroom]->contents; obj; obj = obj->get_next_content())
-			{
-				int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_OBJ, obj->get_id());
-				if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
-				{
-					strcpy(str + str_length, tmp);
-					str_length += n;
-				}
-				else {
-					break; // too many objects
-				}
-			}
-			return;
-			//mixaz - end
-		}
-		else if (!str_cmp(field, "varexists"))
-		{
-			//room.varexists<0;1>
-			strcpy(str, "0");
-			if (find_var_cntx(&((SCRIPT(r))->global_vars), subfield, sc->context))
-			{
-				strcpy(str, "1");
-			}
-		}
-		else //get global var. room.varname
-		{
-			vd = find_var_cntx(&((SCRIPT(r))->global_vars), field, sc->context);
-			if (vd)
-			{
-				sprintf(str, "%s", vd->value);
-			}
-			else
-			{
-				sprintf(buf2, "Type: %d. unknown room field: '%s'", type, field);
-				trig_log(trig, buf2);
-			}
-		}
-	}
-	else if (text_processed(field, subfield, vd, str))
-	{
-		return;
-	}
+      size_t str_length = strlen(str);
+      for (obj = world[inroom]->contents; obj; obj = obj->get_next_content()) {
+        int n = snprintf(tmp, MAX_INPUT_LENGTH, "%c%ld ", UID_OBJ, obj->get_id());
+        if (str_length + n < MAX_INPUT_LENGTH) // not counting the terminating null character
+        {
+          strcpy(str + str_length, tmp);
+          str_length += n;
+        } else {
+          break; // too many objects
+        }
+      }
+      return;
+      //mixaz - end
+    } else if (!str_cmp(field, "varexists")) {
+      //room.varexists<0;1>
+      strcpy(str, "0");
+      if (find_var_cntx(&((SCRIPT(r))->global_vars), subfield, sc->context)) {
+        strcpy(str, "1");
+      }
+    } else //get global var. room.varname
+    {
+      vd = find_var_cntx(&((SCRIPT(r))->global_vars), field, sc->context);
+      if (vd) {
+        sprintf(str, "%s", vd->value);
+      } else {
+        sprintf(buf2, "Type: %d. unknown room field: '%s'", type, field);
+        trig_log(trig, buf2);
+      }
+    }
+  } else if (text_processed(field, subfield, vd, str)) {
+    return;
+  }
 }
 
 // substitutes any variables into line and returns it as buf
-void var_subst(void* go, SCRIPT_DATA* sc, TRIG_DATA* trig, int type, const char* line, char* buf)
-{
-	char tmp[MAX_INPUT_LENGTH], repl_str[MAX_INPUT_LENGTH], *var, *field, *p;
-	char *subfield_p, subfield[MAX_INPUT_LENGTH];
-	char *local_p, local[MAX_INPUT_LENGTH];
-	int paren_count = 0;
+void var_subst(void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type, const char *line, char *buf) {
+  char tmp[MAX_INPUT_LENGTH], repl_str[MAX_INPUT_LENGTH], *var, *field, *p;
+  char *subfield_p, subfield[MAX_INPUT_LENGTH];
+  char *local_p, local[MAX_INPUT_LENGTH];
+  int paren_count = 0;
 
-	if (!strchr(line, '%'))
-	{
-		strcpy(buf, line);
-		return;
-	}
+  if (!strchr(line, '%')) {
+    strcpy(buf, line);
+    return;
+  }
 
-	p = strcpy(tmp, line);
-	subfield_p = subfield;
+  p = strcpy(tmp, line);
+  subfield_p = subfield;
 
-	size_t left = MAX_INPUT_LENGTH - 1;
-	while (*p && (left > 0))
-	{
-		while (*p && (*p != '%') && (left > 0))
-		{
-			*(buf++) = *(p++);
-			left--;
-		}
+  size_t left = MAX_INPUT_LENGTH - 1;
+  while (*p && (left > 0)) {
+    while (*p && (*p != '%') && (left > 0)) {
+      *(buf++) = *(p++);
+      left--;
+    }
 
-		*buf = '\0';
+    *buf = '\0';
 
-		if (*p && (*(++p) == '%') && (left > 0))
-		{
-			*(buf++) = *(p++);
-			*buf = '\0';
-			left--;
-			continue;
-		}
-		else if (*p && (left > 0))
-		{
-			for (var = p; *p && (*p != '%') && (*p != '.'); p++);
+    if (*p && (*(++p) == '%') && (left > 0)) {
+      *(buf++) = *(p++);
+      *buf = '\0';
+      left--;
+      continue;
+    } else if (*p && (left > 0)) {
+      for (var = p; *p && (*p != '%') && (*p != '.'); p++);
 
-			field = p;
-			subfield_p = subfield;	//new
-			if (*p == '.')
-			{
-				*(p++) = '\0';
-				local_p = local;
-				for (field = p; *p && local_p && ((*p != '%') || (paren_count)); p++)
-				{
-					if (*p == '(')
-					{
-						if (!paren_count)
-							*p = '\0';
-						else
-							*local_p++ = *p;
-						paren_count++;
-					}
-					else if (*p == ')')
-					{
-						if (paren_count == 1)
-							*p = '\0';
-						else
-							*local_p++ = *p;
-						paren_count--;
-						if (!paren_count)
-						{
-							*local_p = '\0';
-							var_subst(go, sc, trig, type, local, subfield_p);
-							local_p = NULL;
-							subfield_p = subfield + strlen(subfield);
-						}
-					}
-					else if (paren_count)
-					{
-						*local_p++ = *p;
-					}
-				}
-			}
-			*(p++) = '\0';
-			*subfield_p = '\0';
-			*repl_str = '\0';
-			find_replacement(go, sc, trig, type, var, field, subfield, repl_str);
+      field = p;
+      subfield_p = subfield;    //new
+      if (*p == '.') {
+        *(p++) = '\0';
+        local_p = local;
+        for (field = p; *p && local_p && ((*p != '%') || (paren_count)); p++) {
+          if (*p == '(') {
+            if (!paren_count)
+              *p = '\0';
+            else
+              *local_p++ = *p;
+            paren_count++;
+          } else if (*p == ')') {
+            if (paren_count == 1)
+              *p = '\0';
+            else
+              *local_p++ = *p;
+            paren_count--;
+            if (!paren_count) {
+              *local_p = '\0';
+              var_subst(go, sc, trig, type, local, subfield_p);
+              local_p = NULL;
+              subfield_p = subfield + strlen(subfield);
+            }
+          } else if (paren_count) {
+            *local_p++ = *p;
+          }
+        }
+      }
+      *(p++) = '\0';
+      *subfield_p = '\0';
+      *repl_str = '\0';
+      find_replacement(go, sc, trig, type, var, field, subfield, repl_str);
 
-			strncat(buf, repl_str, left);
-			size_t len = std::min(strlen(repl_str), left);
-			buf += len;
-			left -= len;
-		}
-	}
+      strncat(buf, repl_str, left);
+      size_t len = std::min(strlen(repl_str), left);
+      buf += len;
+      left -= len;
+    }
+  }
 }
 
 // returns 1 if string is all digits, else 0
-int is_num(const char *num)
-{
-	while (*num
-		&& (a_isdigit(*num)
-			|| *num == '-'))
-	{
-		num++;
-	}
+int is_num(const char *num) {
+  while (*num
+      && (a_isdigit(*num)
+          || *num == '-')) {
+    num++;
+  }
 
-	return (!*num || a_isspace(*num)) ? 1 : 0;
+  return (!*num || a_isspace(*num)) ? 1 : 0;
 }
 
 // evaluates 'lhs op rhs', and copies to result
-void eval_op(const char *op, char *lhs, const char *const_rhs, char *result, void* /*go*/, SCRIPT_DATA* /*sc*/, TRIG_DATA* /*trig*/)
-{
-	char *p = nullptr;
-	int n;
+void eval_op(const char *op,
+             char *lhs,
+             const char *const_rhs,
+             char *result,
+             void * /*go*/,
+             SCRIPT_DATA * /*sc*/,
+             TRIG_DATA * /*trig*/) {
+  char *p = nullptr;
+  int n;
 
-	// strip off extra spaces at begin and end
-	while (*lhs && a_isspace(*lhs))
-	{
-		lhs++;
-	}
+  // strip off extra spaces at begin and end
+  while (*lhs && a_isspace(*lhs)) {
+    lhs++;
+  }
 
-	char* rhs = nullptr;
-	std::shared_ptr<char> rhs_guard(rhs = str_dup(const_rhs), free);
+  char *rhs = nullptr;
+  std::shared_ptr<char> rhs_guard(rhs = str_dup(const_rhs), free);
 
-	while (*rhs && a_isspace(*rhs))
-	{
-		rhs++;
-	}
+  while (*rhs && a_isspace(*rhs)) {
+    rhs++;
+  }
 
-	for (p = lhs + strlen(lhs) - 1; (p >= lhs) && a_isspace(*p); *p-- = '\0');
-	for (p = rhs + strlen(rhs) - 1; (p >= rhs) && a_isspace(*p); *p-- = '\0');
+  for (p = lhs + strlen(lhs) - 1; (p >= lhs) && a_isspace(*p); *p-- = '\0');
+  for (p = rhs + strlen(rhs) - 1; (p >= rhs) && a_isspace(*p); *p-- = '\0');
 
-	// find the op, and figure out the value
-	if (!strcmp("||", op))
-	{
-		if ((!*lhs || (*lhs == '0')) && (!*rhs || (*rhs == '0')))
-			strcpy(result, "0");
-		else
-			strcpy(result, "1");
-	}
-	else if (!strcmp("&&", op))
-	{
-		if (!*lhs || (*lhs == '0') || !*rhs || (*rhs == '0'))
-			strcpy(result, "0");
-		else
-			strcpy(result, "1");
-	}
-	else if (!strcmp("==", op))
-	{
-		if (is_num(lhs) && is_num(rhs))
-			sprintf(result, "%d", atoi(lhs) == atoi(rhs));
-		else
-			sprintf(result, "%d", !str_cmp(lhs, rhs));
-	}
-	else if (!strcmp("!=", op))
-	{
-		if (is_num(lhs) && is_num(rhs))
-			sprintf(result, "%d", atoi(lhs) != atoi(rhs));
-		else
-			sprintf(result, "%d", str_cmp(lhs, rhs));
-	}
-	else if (!strcmp("<=", op))
-	{
-		if (is_num(lhs) && is_num(rhs))
-			sprintf(result, "%d", atoi(lhs) <= atoi(rhs));
-		else
-			sprintf(result, "%d", str_cmp(lhs, rhs) <= 0);
-	}
-	else if (!strcmp(">=", op))
-	{
-		if (is_num(lhs) && is_num(rhs))
-			sprintf(result, "%d", atoi(lhs) >= atoi(rhs));
-		else
-			sprintf(result, "%d", str_cmp(lhs, rhs) <= 0);
-	}
-	else if (!strcmp("<", op))
-	{
-		if (is_num(lhs) && is_num(rhs))
-			sprintf(result, "%d", atoi(lhs) < atoi(rhs));
-		else
-			sprintf(result, "%d", str_cmp(lhs, rhs) < 0);
-	}
-	else if (!strcmp(">", op))
-	{
-		if (is_num(lhs) && is_num(rhs))
-			sprintf(result, "%d", atoi(lhs) > atoi(rhs));
-		else
-			sprintf(result, "%d", str_cmp(lhs, rhs) > 0);
-	}
-	else if (!strcmp("/=", op))
-		sprintf(result, "%c", str_str(lhs, rhs) ? '1' : '0');
-	else if (!strcmp("*", op))
-		sprintf(result, "%d", atoi(lhs) * atoi(rhs));
-	else if (!strcmp("/", op))
-		sprintf(result, "%d", (n = atoi(rhs)) ? (atoi(lhs) / n) : 0);
-	else if (!strcmp("+", op))
-		sprintf(result, "%d", atoi(lhs) + atoi(rhs));
-	else if (!strcmp("-", op))
-		sprintf(result, "%d", atoi(lhs) - atoi(rhs));
-	else if (!strcmp("!", op))
-	{
-		if (is_num(rhs))
-			sprintf(result, "%d", !atoi(rhs));
-		else
-			sprintf(result, "%d", !*rhs);
-	}
+  // find the op, and figure out the value
+  if (!strcmp("||", op)) {
+    if ((!*lhs || (*lhs == '0')) && (!*rhs || (*rhs == '0')))
+      strcpy(result, "0");
+    else
+      strcpy(result, "1");
+  } else if (!strcmp("&&", op)) {
+    if (!*lhs || (*lhs == '0') || !*rhs || (*rhs == '0'))
+      strcpy(result, "0");
+    else
+      strcpy(result, "1");
+  } else if (!strcmp("==", op)) {
+    if (is_num(lhs) && is_num(rhs))
+      sprintf(result, "%d", atoi(lhs) == atoi(rhs));
+    else
+      sprintf(result, "%d", !str_cmp(lhs, rhs));
+  } else if (!strcmp("!=", op)) {
+    if (is_num(lhs) && is_num(rhs))
+      sprintf(result, "%d", atoi(lhs) != atoi(rhs));
+    else
+      sprintf(result, "%d", str_cmp(lhs, rhs));
+  } else if (!strcmp("<=", op)) {
+    if (is_num(lhs) && is_num(rhs))
+      sprintf(result, "%d", atoi(lhs) <= atoi(rhs));
+    else
+      sprintf(result, "%d", str_cmp(lhs, rhs) <= 0);
+  } else if (!strcmp(">=", op)) {
+    if (is_num(lhs) && is_num(rhs))
+      sprintf(result, "%d", atoi(lhs) >= atoi(rhs));
+    else
+      sprintf(result, "%d", str_cmp(lhs, rhs) <= 0);
+  } else if (!strcmp("<", op)) {
+    if (is_num(lhs) && is_num(rhs))
+      sprintf(result, "%d", atoi(lhs) < atoi(rhs));
+    else
+      sprintf(result, "%d", str_cmp(lhs, rhs) < 0);
+  } else if (!strcmp(">", op)) {
+    if (is_num(lhs) && is_num(rhs))
+      sprintf(result, "%d", atoi(lhs) > atoi(rhs));
+    else
+      sprintf(result, "%d", str_cmp(lhs, rhs) > 0);
+  } else if (!strcmp("/=", op))
+    sprintf(result, "%c", str_str(lhs, rhs) ? '1' : '0');
+  else if (!strcmp("*", op))
+    sprintf(result, "%d", atoi(lhs) * atoi(rhs));
+  else if (!strcmp("/", op))
+    sprintf(result, "%d", (n = atoi(rhs)) ? (atoi(lhs) / n) : 0);
+  else if (!strcmp("+", op))
+    sprintf(result, "%d", atoi(lhs) + atoi(rhs));
+  else if (!strcmp("-", op))
+    sprintf(result, "%d", atoi(lhs) - atoi(rhs));
+  else if (!strcmp("!", op)) {
+    if (is_num(rhs))
+      sprintf(result, "%d", !atoi(rhs));
+    else
+      sprintf(result, "%d", !*rhs);
+  }
 }
-
 
 /*
  * p points to the first quote, returns the matching
  * end quote, or the last non-null char in p.
 */
-char *matching_quote(char *p)
-{
-	for (p++; *p && (*p != '"'); p++)
-	{
-		if (*p == '\\')
-			p++;
-	}
+char *matching_quote(char *p) {
+  for (p++; *p && (*p != '"'); p++) {
+    if (*p == '\\')
+      p++;
+  }
 
-	if (!*p)
-		p--;
+  if (!*p)
+    p--;
 
-	return p;
+  return p;
 }
 
 /*
  * p points to the first paren.  returns a pointer to the
  * matching closing paren, or the last non-null char in p.
  */
-char *matching_paren(char *p)
-{
-	int i;
+char *matching_paren(char *p) {
+  int i;
 
-	for (p++, i = 1; *p && i; p++)
-	{
-		if (*p == '(')
-			i++;
-		else if (*p == ')')
-			i--;
-		else if (*p == '"')
-			p = matching_quote(p);
-	}
+  for (p++, i = 1; *p && i; p++) {
+    if (*p == '(')
+      i++;
+    else if (*p == ')')
+      i--;
+    else if (*p == '"')
+      p = matching_quote(p);
+  }
 
-	return --p;
+  return --p;
 }
 
 // evaluates line, and returns answer in result
-void eval_expr(const char *line, char *result, void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type)
-{
-	char expr[MAX_INPUT_LENGTH], *p;
+void eval_expr(const char *line, char *result, void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type) {
+  char expr[MAX_INPUT_LENGTH], *p;
 
-	while (*line && a_isspace(*line))
-	{
-		line++;
-	}
+  while (*line && a_isspace(*line)) {
+    line++;
+  }
 
-	if (eval_lhs_op_rhs(line, result, go, sc, trig, type))
-	{
-		;
-	}
-	else if (*line == '(')
-	{
-		strcpy(expr, line);
-		p = matching_paren(expr);
-		*p = '\0';
-		eval_expr(expr + 1, result, go, sc, trig, type);
-	}
-	else
-	{
-		var_subst(go, sc, trig, type, line, result);
-	}
+  if (eval_lhs_op_rhs(line, result, go, sc, trig, type)) { ;
+  } else if (*line == '(') {
+    strcpy(expr, line);
+    p = matching_paren(expr);
+    *p = '\0';
+    eval_expr(expr + 1, result, go, sc, trig, type);
+  } else {
+    var_subst(go, sc, trig, type, line, result);
+  }
 }
 
 /*
  * evaluates expr if it is in the form lhs op rhs, and copies
  * answer in result.  returns 1 if expr is evaluated, else 0
  */
-int eval_lhs_op_rhs(const char *expr, char *result, void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type)
-{
-	char *p, *tokens[MAX_INPUT_LENGTH];
-	char line[MAX_INPUT_LENGTH], lhr[MAX_INPUT_LENGTH], rhr[MAX_INPUT_LENGTH];
-	int i, j;
+int eval_lhs_op_rhs(const char *expr, char *result, void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type) {
+  char *p, *tokens[MAX_INPUT_LENGTH];
+  char line[MAX_INPUT_LENGTH], lhr[MAX_INPUT_LENGTH], rhr[MAX_INPUT_LENGTH];
+  int i, j;
 
-	/*
+  /*
 	 * valid operands, in order of priority
 	 * each must also be defined in eval_op()
 	 */
-	static const char *ops[] =
-	{
-		"||",
-		"&&",
-		"==",
-		"!=",
-		"<=",
-		">=",
-		"<",
-		">",
-		"/=",
-		"-",
-		"+",
-		"/",
-		"*",
-		"!",
-		"\n"
-	};
+  static const char *ops[] =
+      {
+          "||",
+          "&&",
+          "==",
+          "!=",
+          "<=",
+          ">=",
+          "<",
+          ">",
+          "/=",
+          "-",
+          "+",
+          "/",
+          "*",
+          "!",
+          "\n"
+      };
 
-	p = strcpy(line, expr);
+  p = strcpy(line, expr);
 
-	/*
+  /*
 	 * initialize tokens, an array of pointers to locations
 	 * in line where the ops could possibly occur.
 	 */
-	for (j = 0; *p; j++)
-	{
-		tokens[j] = p;
-		if (*p == '(')
-			p = matching_paren(p) + 1;
-		else if (*p == '"')
-			p = matching_quote(p) + 1;
-		else if (a_isalnum(*p))
-			for (p++; *p && (a_isalnum(*p) || a_isspace(*p)); p++);
-		else
-			p++;
-	}
-	tokens[j] = NULL;
+  for (j = 0; *p; j++) {
+    tokens[j] = p;
+    if (*p == '(')
+      p = matching_paren(p) + 1;
+    else if (*p == '"')
+      p = matching_quote(p) + 1;
+    else if (a_isalnum(*p))
+      for (p++; *p && (a_isalnum(*p) || a_isspace(*p)); p++);
+    else
+      p++;
+  }
+  tokens[j] = NULL;
 
-	for (i = 0; *ops[i] != '\n'; i++)
-		for (j = 0; tokens[j]; j++)
-			if (!strn_cmp(ops[i], tokens[j], strlen(ops[i])))
-			{
-				*tokens[j] = '\0';
-				p = tokens[j] + strlen(ops[i]);
+  for (i = 0; *ops[i] != '\n'; i++)
+    for (j = 0; tokens[j]; j++)
+      if (!strn_cmp(ops[i], tokens[j], strlen(ops[i]))) {
+        *tokens[j] = '\0';
+        p = tokens[j] + strlen(ops[i]);
 
-				eval_expr(line, lhr, go, sc, trig, type);
-				eval_expr(p, rhr, go, sc, trig, type);
-				eval_op(ops[i], lhr, rhr, result, go, sc, trig);
+        eval_expr(line, lhr, go, sc, trig, type);
+        eval_expr(p, rhr, go, sc, trig, type);
+        eval_op(ops[i], lhr, rhr, result, go, sc, trig);
 
-				return 1;
-			}
+        return 1;
+      }
 
-	return 0;
+  return 0;
 }
 
 const auto FOREACH_LIST_GUID = "{18B3D8D1-240E-4D60-AEAB-6748580CA460}";
@@ -4211,836 +3315,715 @@ foreach i <список>
 Иначе i = след. элемент и выполнить тело
 --*/
 // returns 1 if next iteration, else 0
-int process_foreach_begin(const char* cond, void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type)
-{
-	char name[MAX_INPUT_LENGTH];
-	char list_str[MAX_INPUT_LENGTH];
-	char value[MAX_INPUT_LENGTH];
+int process_foreach_begin(const char *cond, void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type) {
+  char name[MAX_INPUT_LENGTH];
+  char list_str[MAX_INPUT_LENGTH];
+  char value[MAX_INPUT_LENGTH];
 
-	skip_spaces(&cond);
-	auto p = one_argument(cond, name);
-	skip_spaces(&p);
+  skip_spaces(&cond);
+  auto p = one_argument(cond, name);
+  skip_spaces(&p);
 
-	if (!*name)
-	{
-		trig_log(trig, "foreach begin w/o an variable");
-		return 0;
-	}
+  if (!*name) {
+    trig_log(trig, "foreach begin w/o an variable");
+    return 0;
+  }
 
-	eval_expr(p, list_str, go, sc, trig, type);
-	p = list_str;
-	skip_spaces(&p);
-	if (!p || !*p)
-	{
-		return 0;
-	}
+  eval_expr(p, list_str, go, sc, trig, type);
+  p = list_str;
+  skip_spaces(&p);
+  if (!p || !*p) {
+    return 0;
+  }
 
-	int v_strpos;
-	auto pos = strchr(p, ' ');
-	if (!pos)
-	{
-		strcpy(value, p);
-		v_strpos = static_cast<int>(strlen(p));
-	}
-	else
-	{
-		strncpy(value, p, pos - p);
-		value[pos - p] = '\0';
-		skip_spaces(&pos);
-		v_strpos = pos - p;
-	}
+  int v_strpos;
+  auto pos = strchr(p, ' ');
+  if (!pos) {
+    strcpy(value, p);
+    v_strpos = static_cast<int>(strlen(p));
+  } else {
+    strncpy(value, p, pos - p);
+    value[pos - p] = '\0';
+    skip_spaces(&pos);
+    v_strpos = pos - p;
+  }
 
-	add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
-	sprintf(value, "%s%s", name, FOREACH_LIST_GUID);
-	add_var_cntx(&GET_TRIG_VARS(trig), value, list_str, 0);
+  add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
+  sprintf(value, "%s%s", name, FOREACH_LIST_GUID);
+  add_var_cntx(&GET_TRIG_VARS(trig), value, list_str, 0);
 
-	strcat(name, FOREACH_LIST_POS_GUID);
-	sprintf(value, "%d", v_strpos);
-	add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
+  strcat(name, FOREACH_LIST_POS_GUID);
+  sprintf(value, "%d", v_strpos);
+  add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
 
-	return 1;
+  return 1;
 }
 
-int process_foreach_done(const char* cond, void *, SCRIPT_DATA *, TRIG_DATA * trig, int)
-{
-	char name[MAX_INPUT_LENGTH];
-	char value[MAX_INPUT_LENGTH];
+int process_foreach_done(const char *cond, void *, SCRIPT_DATA *, TRIG_DATA *trig, int) {
+  char name[MAX_INPUT_LENGTH];
+  char value[MAX_INPUT_LENGTH];
 
-	skip_spaces(&cond);
-	one_argument(cond, name);
+  skip_spaces(&cond);
+  one_argument(cond, name);
 
-	if (!*name)
-	{
-		trig_log(trig, "foreach done w/o an variable");
-		return 0;
-	}
+  if (!*name) {
+    trig_log(trig, "foreach done w/o an variable");
+    return 0;
+  }
 
-	sprintf(value, "%s%s", name, FOREACH_LIST_GUID);
-	const auto var_list = find_var_cntx(&GET_TRIG_VARS(trig), value, 0);
+  sprintf(value, "%s%s", name, FOREACH_LIST_GUID);
+  const auto var_list = find_var_cntx(&GET_TRIG_VARS(trig), value, 0);
 
-	sprintf(value, "%s%s", name, FOREACH_LIST_POS_GUID);
-	const auto var_list_pos = find_var_cntx(&GET_TRIG_VARS(trig), value, 0);
+  sprintf(value, "%s%s", name, FOREACH_LIST_POS_GUID);
+  const auto var_list_pos = find_var_cntx(&GET_TRIG_VARS(trig), value, 0);
 
-	if (!var_list || !var_list_pos)
-	{
-		trig_log(trig, "foreach utility vars not found");
-		return 0;
-	}
+  if (!var_list || !var_list_pos) {
+    trig_log(trig, "foreach utility vars not found");
+    return 0;
+  }
 
-	const auto p = var_list->value + static_cast<unsigned int>(atoi(var_list_pos->value));
-	if (!p || !*p)
-	{
-		remove_var_cntx(&GET_TRIG_VARS(trig), name, 0);
+  const auto p = var_list->value + static_cast<unsigned int>(atoi(var_list_pos->value));
+  if (!p || !*p) {
+    remove_var_cntx(&GET_TRIG_VARS(trig), name, 0);
 
-		sprintf(value, "%s%s", name, FOREACH_LIST_GUID);
-		remove_var_cntx(&GET_TRIG_VARS(trig), value, 0);
+    sprintf(value, "%s%s", name, FOREACH_LIST_GUID);
+    remove_var_cntx(&GET_TRIG_VARS(trig), value, 0);
 
-		sprintf(value, "%s%s", name, FOREACH_LIST_POS_GUID);
-		remove_var_cntx(&GET_TRIG_VARS(trig), value, 0);
+    sprintf(value, "%s%s", name, FOREACH_LIST_POS_GUID);
+    remove_var_cntx(&GET_TRIG_VARS(trig), value, 0);
 
-		return 0;
-	}
+    return 0;
+  }
 
-	int v_strpos;
-	auto pos = strchr(p, ' ');
-	if (!pos)
-	{
-		strcpy(value, p);
-		v_strpos = static_cast<int>(strlen(var_list->value));
-	}
-	else
-	{
-		strncpy(value, p, pos - p);
-		value[pos - p] = '\0';
-		skip_spaces(&pos);
-		v_strpos = pos - var_list->value;
-	}
+  int v_strpos;
+  auto pos = strchr(p, ' ');
+  if (!pos) {
+    strcpy(value, p);
+    v_strpos = static_cast<int>(strlen(var_list->value));
+  } else {
+    strncpy(value, p, pos - p);
+    value[pos - p] = '\0';
+    skip_spaces(&pos);
+    v_strpos = pos - var_list->value;
+  }
 
-	add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
+  add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
 
-	strcat(name, FOREACH_LIST_POS_GUID);
-	sprintf(value, "%d", v_strpos);
-	add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
+  strcat(name, FOREACH_LIST_POS_GUID);
+  sprintf(value, "%d", v_strpos);
+  add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
 
-	return 1;
+  return 1;
 }
 
 // returns 1 if cond is true, else 0
-int process_if(const char *cond, void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type)
-{
-	char result[MAX_INPUT_LENGTH], *p;
+int process_if(const char *cond, void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type) {
+  char result[MAX_INPUT_LENGTH], *p;
 
-	eval_expr(cond, result, go, sc, trig, type);
+  eval_expr(cond, result, go, sc, trig, type);
 
-	p = result;
-	skip_spaces(&p);
+  p = result;
+  skip_spaces(&p);
 
-	if (!*p || *p == '0')
-	{
-		return 0;
-	}
-	else
-	{
-		return 1;
-	}
+  if (!*p || *p == '0') {
+    return 0;
+  } else {
+    return 1;
+  }
 }
-
 
 /*
  * scans for end of if-block.
  * returns the line containg 'end', or NULL
  */
-cmdlist_element::shared_ptr find_end(TRIG_DATA * trig, cmdlist_element::shared_ptr cl)
-{
-	char tmpbuf[MAX_INPUT_LENGTH];
-	const char *p = nullptr;
+cmdlist_element::shared_ptr find_end(TRIG_DATA *trig, cmdlist_element::shared_ptr cl) {
+  char tmpbuf[MAX_INPUT_LENGTH];
+  const char *p = nullptr;
 #ifdef DG_CODE_ANALYZE
-	const char *cmd = cl ? cl->cmd.c_str() : "<NULL>";
+  const char *cmd = cl ? cl->cmd.c_str() : "<NULL>";
 #endif
 
-	while ((cl = cl ? cl->next : cl) != NULL)
-	{
-		for (p = cl->cmd.c_str(); *p && a_isspace(*p); p++);
+  while ((cl = cl ? cl->next : cl) != NULL) {
+    for (p = cl->cmd.c_str(); *p && a_isspace(*p); p++);
 
-		if (!strn_cmp("if ", p, 3))
-		{
-			cl = find_end(trig, cl);
-		}
-		else if (!strn_cmp("end", p, 3))
-		{
-			break;
-		}
-	}
+    if (!strn_cmp("if ", p, 3)) {
+      cl = find_end(trig, cl);
+    } else if (!strn_cmp("end", p, 3)) {
+      break;
+    }
+  }
 
 #ifdef DG_CODE_ANALYZE
-	if (!cl)
-	{
-		sprintf(tmpbuf, "end not found for '%s'.", cmd);
-		trig_log(trig, tmpbuf);
-	}
+  if (!cl) {
+    sprintf(tmpbuf, "end not found for '%s'.", cmd);
+    trig_log(trig, tmpbuf);
+  }
 #endif
 
-	return cl;
+  return cl;
 }
-
 
 /*
  * searches for valid elseif, else, or end to continue execution at.
  * returns line of elseif, else, or end if found, or NULL.
  */
-cmdlist_element::shared_ptr find_else_end(TRIG_DATA * trig, cmdlist_element::shared_ptr cl, void *go, SCRIPT_DATA * sc, int type)
-{
-	const char *p = nullptr;
+cmdlist_element::shared_ptr find_else_end(TRIG_DATA *trig,
+                                          cmdlist_element::shared_ptr cl,
+                                          void *go,
+                                          SCRIPT_DATA *sc,
+                                          int type) {
+  const char *p = nullptr;
 #ifdef DG_CODE_ANALYZE
-	const char *cmd = cl ? cl->cmd.c_str() : "<NULL>";
+  const char *cmd = cl ? cl->cmd.c_str() : "<NULL>";
 #endif
 
-	while ((cl = cl ? cl->next : cl) != NULL)
-	{
-		for (p = cl->cmd.c_str(); *p && a_isspace(*p); p++);
+  while ((cl = cl ? cl->next : cl) != NULL) {
+    for (p = cl->cmd.c_str(); *p && a_isspace(*p); p++);
 
-		if (!strn_cmp("if ", p, 3))
-		{
-			cl = find_end(trig, cl);
-		}
-		else if (!strn_cmp("elseif ", p, 7))
-		{
-			if (process_if(p + 7, go, sc, trig, type))
-			{
-				GET_TRIG_DEPTH(trig)++;
-			}
-			else
-			{
-				cl = find_else_end(trig, cl, go, sc, type);
-			}
+    if (!strn_cmp("if ", p, 3)) {
+      cl = find_end(trig, cl);
+    } else if (!strn_cmp("elseif ", p, 7)) {
+      if (process_if(p + 7, go, sc, trig, type)) {
+        GET_TRIG_DEPTH(trig)++;
+      } else {
+        cl = find_else_end(trig, cl, go, sc, type);
+      }
 
-			break;
-		}
-		else if (!strn_cmp("else", p, 4))
-		{
-			GET_TRIG_DEPTH(trig)++;
-			break;
-		}
-		else if (!strn_cmp("end", p, 3))
-		{
-			break;
-		}
-	}
+      break;
+    } else if (!strn_cmp("else", p, 4)) {
+      GET_TRIG_DEPTH(trig)++;
+      break;
+    } else if (!strn_cmp("end", p, 3)) {
+      break;
+    }
+  }
 
 #ifdef DG_CODE_ANALYZE
-	if (!cl)
-	{
-		sprintf(buf, "closing 'else/end' is not found for '%s'", cmd);
-		trig_log(trig, buf);
-	}
+  if (!cl) {
+    sprintf(buf, "closing 'else/end' is not found for '%s'", cmd);
+    trig_log(trig, buf);
+  }
 #endif
 
-	return cl;
+  return cl;
 }
-
 
 /*
 * scans for end of while/foreach/switch-blocks.
 * returns the line containg 'end', or NULL
 */
-cmdlist_element::shared_ptr find_done(TRIG_DATA * trig, cmdlist_element::shared_ptr cl)
-{
-	const char *p = nullptr;
+cmdlist_element::shared_ptr find_done(TRIG_DATA *trig, cmdlist_element::shared_ptr cl) {
+  const char *p = nullptr;
 #ifdef DG_CODE_ANALYZE
-	const char *cmd = cl ? cl->cmd.c_str() : "<NULL>";
+  const char *cmd = cl ? cl->cmd.c_str() : "<NULL>";
 #endif
 
-	while ((cl = cl ? cl->next : cl) != NULL)
-	{
-		for (p = cl->cmd.c_str(); *p && isspace(*reinterpret_cast<const unsigned char*>(p)); p++);
+  while ((cl = cl ? cl->next : cl) != NULL) {
+    for (p = cl->cmd.c_str(); *p && isspace(*reinterpret_cast<const unsigned char *>(p)); p++);
 
-		if (!strn_cmp("while ", p, 6) || !strn_cmp("switch ", p, 7) || !strn_cmp("foreach ", p, 8))
-		{
-			cl = find_done(trig, cl);
-		}
-		else if (!strn_cmp("done", p, 4))
-		{
-			break;
-		}
-	}
+    if (!strn_cmp("while ", p, 6) || !strn_cmp("switch ", p, 7) || !strn_cmp("foreach ", p, 8)) {
+      cl = find_done(trig, cl);
+    } else if (!strn_cmp("done", p, 4)) {
+      break;
+    }
+  }
 
 #ifdef DG_CODE_ANALYZE
-	if (!cl)
-	{
-		sprintf(buf, "closing 'done' is not found for '%s'", cmd);
-		trig_log(trig, buf);
-	}
+  if (!cl) {
+    sprintf(buf, "closing 'done' is not found for '%s'", cmd);
+    trig_log(trig, buf);
+  }
 #endif
 
-	return cl;
+  return cl;
 }
 
 /*
 * scans for a case/default instance
 * returns the line containg the correct case instance, or NULL
 */
-cmdlist_element::shared_ptr find_case(TRIG_DATA * trig, cmdlist_element::shared_ptr cl, void *go, SCRIPT_DATA * sc, int type, const char *cond)
-{
-	char result[MAX_INPUT_LENGTH];
-	const char *p = nullptr;
+cmdlist_element::shared_ptr find_case(TRIG_DATA *trig,
+                                      cmdlist_element::shared_ptr cl,
+                                      void *go,
+                                      SCRIPT_DATA *sc,
+                                      int type,
+                                      const char *cond) {
+  char result[MAX_INPUT_LENGTH];
+  const char *p = nullptr;
 #ifdef DG_CODE_ANALYZE
-	const char *cmd = cl ? cl->cmd.c_str() : "<NULL>";
+  const char *cmd = cl ? cl->cmd.c_str() : "<NULL>";
 #endif
 
-	eval_expr(cond, result, go, sc, trig, type);
+  eval_expr(cond, result, go, sc, trig, type);
 
-	while ((cl = cl ? cl->next : cl) != NULL)
-	{
-		for (p = cl->cmd.c_str(); *p && isspace(*reinterpret_cast<const unsigned char*>(p)); p++);
+  while ((cl = cl ? cl->next : cl) != NULL) {
+    for (p = cl->cmd.c_str(); *p && isspace(*reinterpret_cast<const unsigned char *>(p)); p++);
 
-		if (!strn_cmp("while ", p, 6) || !strn_cmp("switch ", p, 7) || !strn_cmp("foreach ", p, 8))
-		{
-			cl = find_done(trig, cl);
-		}
-		else if (!strn_cmp("case ", p, 5))
-		{
-			char *tmpbuf = (char *)malloc(MAX_STRING_LENGTH);
-			eval_op("==", result, p + 5, tmpbuf, go, sc, trig);
-			if (*tmpbuf && *tmpbuf != '0')
-			{
-				free(tmpbuf);
-				break;
-			}
-			free(tmpbuf);
-		}
-		else if (!strn_cmp("default", p, 7))
-		{
-			break;
-		}
-		else if (!strn_cmp("done", p, 4))
-		{
-			break;
-		}
-	}
+    if (!strn_cmp("while ", p, 6) || !strn_cmp("switch ", p, 7) || !strn_cmp("foreach ", p, 8)) {
+      cl = find_done(trig, cl);
+    } else if (!strn_cmp("case ", p, 5)) {
+      char *tmpbuf = (char *) malloc(MAX_STRING_LENGTH);
+      eval_op("==", result, p + 5, tmpbuf, go, sc, trig);
+      if (*tmpbuf && *tmpbuf != '0') {
+        free(tmpbuf);
+        break;
+      }
+      free(tmpbuf);
+    } else if (!strn_cmp("default", p, 7)) {
+      break;
+    } else if (!strn_cmp("done", p, 4)) {
+      break;
+    }
+  }
 
 #ifdef DG_CODE_ANALYZE
-	if (!cl)
-	{
-		sprintf(buf, "closing 'done' not found for '%s'", cmd);
-		trig_log(trig, buf);
-	}
+  if (!cl) {
+    sprintf(buf, "closing 'done' not found for '%s'", cmd);
+    trig_log(trig, buf);
+  }
 #endif
 
-	return cl;
+  return cl;
 }
 
 // processes any 'wait' commands in a trigger
-void process_wait(void *go, TRIG_DATA * trig, int type, char *cmd, const cmdlist_element::shared_ptr& cl)
-{
-	char *arg;
-	struct wait_event_data *wait_event_obj;
-	long time = 0, hr, min, ntime;
-	char c;
+void process_wait(void *go, TRIG_DATA *trig, int type, char *cmd, const cmdlist_element::shared_ptr &cl) {
+  char *arg;
+  struct wait_event_data *wait_event_obj;
+  long time = 0, hr, min, ntime;
+  char c;
 
-	extern TIME_INFO_DATA time_info;
+  extern TIME_INFO_DATA time_info;
 
-	if (trig->get_attach_type() == MOB_TRIGGER
-		&& IS_SET(GET_TRIG_TYPE(trig), MTRIG_DEATH))
-	{
-		sprintf(buf,
-			"&YВНИМАНИЕ&G Используется wait в DEATH триггере '%s' (VNUM=%d).",
-			GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig));
-		mudlog(buf, BRF, LVL_BUILDER, ERRLOG, TRUE);
-		sprintf(buf, "&GКод триггера после wait выполнен НЕ БУДЕТ!");
-		mudlog(buf, BRF, LVL_BUILDER, ERRLOG, TRUE);
-	}
+  if (trig->get_attach_type() == MOB_TRIGGER
+      && IS_SET(GET_TRIG_TYPE(trig), MTRIG_DEATH)) {
+    sprintf(buf,
+            "&YВНИМАНИЕ&G Используется wait в DEATH триггере '%s' (VNUM=%d).",
+            GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig));
+    mudlog(buf, BRF, LVL_BUILDER, ERRLOG, TRUE);
+    sprintf(buf, "&GКод триггера после wait выполнен НЕ БУДЕТ!");
+    mudlog(buf, BRF, LVL_BUILDER, ERRLOG, TRUE);
+  }
 
-	arg = any_one_arg(cmd, buf);
-	skip_spaces(&arg);
+  arg = any_one_arg(cmd, buf);
+  skip_spaces(&arg);
 
-	if (!*arg)
-	{
-		sprintf(buf2, "wait w/o an arg: '%s'", cl->cmd.c_str());
-		trig_log(trig, buf2);
-	}
-	else if (!strn_cmp(arg, "until ", 6))  	// valid forms of time are 14:30 and 1430
-	{
-		if (sscanf(arg, "until %ld:%ld", &hr, &min) == 2)
-			min += (hr * 60);
-		else
-			min = (hr % 100) + ((hr / 100) * 60);
+  if (!*arg) {
+    sprintf(buf2, "wait w/o an arg: '%s'", cl->cmd.c_str());
+    trig_log(trig, buf2);
+  } else if (!strn_cmp(arg, "until ", 6))    // valid forms of time are 14:30 and 1430
+  {
+    if (sscanf(arg, "until %ld:%ld", &hr, &min) == 2)
+      min += (hr * 60);
+    else
+      min = (hr % 100) + ((hr / 100) * 60);
 
-		// calculate the pulse of the day of "until" time
-		ntime = (min * SECS_PER_MUD_HOUR * PASSES_PER_SEC) / 60;
+    // calculate the pulse of the day of "until" time
+    ntime = (min * SECS_PER_MUD_HOUR * PASSES_PER_SEC) / 60;
 
-		// calculate pulse of day of current time
-		time = (GlobalObjects::heartbeat().global_pulse_number() % (SECS_PER_MUD_HOUR * PASSES_PER_SEC))
-			+ (time_info.hours * SECS_PER_MUD_HOUR * PASSES_PER_SEC);
+    // calculate pulse of day of current time
+    time = (GlobalObjects::heartbeat().global_pulse_number() % (SECS_PER_MUD_HOUR * PASSES_PER_SEC))
+        + (time_info.hours * SECS_PER_MUD_HOUR * PASSES_PER_SEC);
 
-		if (time >= ntime)	// adjust for next day
-			time = (SECS_PER_MUD_DAY * PASSES_PER_SEC) - time + ntime;
-		else
-			time = ntime - time;
-	}
-	else
-	{
-		if (sscanf(arg, "%ld %c", &time, &c) == 2)
-		{
-			if (c == 't')
-				time *= PULSES_PER_MUD_HOUR;
-			else if (c == 's')
-				time *= PASSES_PER_SEC;
-		}
-	}
+    if (time >= ntime)    // adjust for next day
+      time = (SECS_PER_MUD_DAY * PASSES_PER_SEC) - time + ntime;
+    else
+      time = ntime - time;
+  } else {
+    if (sscanf(arg, "%ld %c", &time, &c) == 2) {
+      if (c == 't')
+        time *= PULSES_PER_MUD_HOUR;
+      else if (c == 's')
+        time *= PASSES_PER_SEC;
+    }
+  }
 
-	CREATE(wait_event_obj, 1);
-	wait_event_obj->trigger = trig;
-	wait_event_obj->go = go;
-	wait_event_obj->type = type;
+  CREATE(wait_event_obj, 1);
+  wait_event_obj->trigger = trig;
+  wait_event_obj->go = go;
+  wait_event_obj->type = type;
 
-	if (GET_TRIG_WAIT(trig))
-	{
-		trig_log(trig, "Wait structure already allocated for trigger");
-	}
+  if (GET_TRIG_WAIT(trig)) {
+    trig_log(trig, "Wait structure already allocated for trigger");
+  }
 
-	GET_TRIG_WAIT(trig) = add_event(time, trig_wait_event, wait_event_obj);
-	trig->curr_state = cl->next;
+  GET_TRIG_WAIT(trig) = add_event(time, trig_wait_event, wait_event_obj);
+  trig->curr_state = cl->next;
 }
 
 // processes a script set command
-void process_set(SCRIPT_DATA* /*sc*/, TRIG_DATA * trig, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], name[MAX_INPUT_LENGTH], *value;
+void process_set(SCRIPT_DATA * /*sc*/, TRIG_DATA *trig, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], name[MAX_INPUT_LENGTH], *value;
 
-	value = two_arguments(cmd, arg, name);
+  value = two_arguments(cmd, arg, name);
 
-	skip_spaces(&value);
+  skip_spaces(&value);
 
-	if (!*name)
-	{
-		sprintf(buf2, "set w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*name) {
+    sprintf(buf2, "set w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
+  add_var_cntx(&GET_TRIG_VARS(trig), name, value, 0);
 }
 
 // processes a script eval command
-void process_eval(void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], name[MAX_INPUT_LENGTH];
-	char result[MAX_INPUT_LENGTH], *expr;
+void process_eval(void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], name[MAX_INPUT_LENGTH];
+  char result[MAX_INPUT_LENGTH], *expr;
 
-	expr = two_arguments(cmd, arg, name);
+  expr = two_arguments(cmd, arg, name);
 
-	skip_spaces(&expr);
+  skip_spaces(&expr);
 
-	if (!*name)
-	{
-		sprintf(buf2, "eval w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*name) {
+    sprintf(buf2, "eval w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	eval_expr(expr, result, go, sc, trig, type);
-	add_var_cntx(&GET_TRIG_VARS(trig), name, result, 0);
+  eval_expr(expr, result, go, sc, trig, type);
+  add_var_cntx(&GET_TRIG_VARS(trig), name, result, 0);
 }
 
 // script attaching a trigger to something
-void process_attach(void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], trignum_s[MAX_INPUT_LENGTH];
-	char result[MAX_INPUT_LENGTH], *id_p;
-	TRIG_DATA *newtrig;
-	CHAR_DATA *c = NULL;
-	OBJ_DATA *o = NULL;
-	ROOM_DATA *r = NULL;
-	long trignum;
+void process_attach(void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], trignum_s[MAX_INPUT_LENGTH];
+  char result[MAX_INPUT_LENGTH], *id_p;
+  TRIG_DATA *newtrig;
+  CHAR_DATA *c = NULL;
+  OBJ_DATA *o = NULL;
+  ROOM_DATA *r = NULL;
+  long trignum;
 
-	id_p = two_arguments(cmd, arg, trignum_s);
-	skip_spaces(&id_p);
+  id_p = two_arguments(cmd, arg, trignum_s);
+  skip_spaces(&id_p);
 
-	if (!*trignum_s)
-	{
-		sprintf(buf2, "attach w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*trignum_s) {
+    sprintf(buf2, "attach w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!id_p || !*id_p || atoi(id_p + 1) == 0)
-	{
-		sprintf(buf2, "attach invalid id(1) arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!id_p || !*id_p || atoi(id_p + 1) == 0) {
+    sprintf(buf2, "attach invalid id(1) arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	// parse and locate the id specified
-	eval_expr(id_p, result, go, sc, trig, type);
+  // parse and locate the id specified
+  eval_expr(id_p, result, go, sc, trig, type);
 
-	c = get_char(id_p);
-	if (!c)
-	{
-		o = get_obj(id_p);
-		if (!o)
-		{
-			r = get_room(id_p);
-			if (!r)
-			{
-				sprintf(buf2, "attach invalid id arg(3): '%s'", cmd);
-				trig_log(trig, buf2);
-				return;
-			}
-		}
-	}
+  c = get_char(id_p);
+  if (!c) {
+    o = get_obj(id_p);
+    if (!o) {
+      r = get_room(id_p);
+      if (!r) {
+        sprintf(buf2, "attach invalid id arg(3): '%s'", cmd);
+        trig_log(trig, buf2);
+        return;
+      }
+    }
+  }
 
-	// locate and load the trigger specified
-	trignum = real_trigger(atoi(trignum_s));
-	if (trignum >= 0
-		&& (((c) && trig_index[trignum]->proto->get_attach_type() != MOB_TRIGGER)
-			|| ((o) && trig_index[trignum]->proto->get_attach_type() != OBJ_TRIGGER)
-			|| ((r) && trig_index[trignum]->proto->get_attach_type() != WLD_TRIGGER)))
-	{
-		sprintf(buf2, "attach trigger : '%s' invalid attach_type: %s expected %s", trignum_s,
-			attach_name[(int)trig_index[trignum]->proto->get_attach_type()],
-			attach_name[(c ? 0 : (o ? 1 : (r ? 2 : 3)))]);
-		trig_log(trig, buf2);
-		return;
-	}
+  // locate and load the trigger specified
+  trignum = real_trigger(atoi(trignum_s));
+  if (trignum >= 0
+      && (((c) && trig_index[trignum]->proto->get_attach_type() != MOB_TRIGGER)
+          || ((o) && trig_index[trignum]->proto->get_attach_type() != OBJ_TRIGGER)
+          || ((r) && trig_index[trignum]->proto->get_attach_type() != WLD_TRIGGER))) {
+    sprintf(buf2, "attach trigger : '%s' invalid attach_type: %s expected %s", trignum_s,
+            attach_name[(int) trig_index[trignum]->proto->get_attach_type()],
+            attach_name[(c ? 0 : (o ? 1 : (r ? 2 : 3)))]);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (trignum < 0 || !(newtrig = read_trigger(trignum)))
-	{
-		sprintf(buf2, "attach invalid trigger: '%s'", trignum_s);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (trignum < 0 || !(newtrig = read_trigger(trignum))) {
+    sprintf(buf2, "attach invalid trigger: '%s'", trignum_s);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (c)
-	{
-		if (add_trigger(SCRIPT(c).get(), newtrig, -1))
-		{
-			add_trig_to_owner(trig_index[trig->get_rnum()]->vnum, trig_index[trignum]->vnum, GET_MOB_VNUM(c));
-		}
-		else
-		{
-			extract_trigger(newtrig);
-		}
+  if (c) {
+    if (add_trigger(SCRIPT(c).get(), newtrig, -1)) {
+      add_trig_to_owner(trig_index[trig->get_rnum()]->vnum, trig_index[trignum]->vnum, GET_MOB_VNUM(c));
+    } else {
+      extract_trigger(newtrig);
+    }
 
-		return;
-	}
+    return;
+  }
 
-	if (o)
-	{
-		if (add_trigger(o->get_script().get(), newtrig, -1))
-		{
-			add_trig_to_owner(trig_index[trig->get_rnum()]->vnum, trig_index[trignum]->vnum, GET_OBJ_VNUM(o));
-		}
-		else
-		{
-			extract_trigger(newtrig);
-		}
-		return;
-	}
+  if (o) {
+    if (add_trigger(o->get_script().get(), newtrig, -1)) {
+      add_trig_to_owner(trig_index[trig->get_rnum()]->vnum, trig_index[trignum]->vnum, GET_OBJ_VNUM(o));
+    } else {
+      extract_trigger(newtrig);
+    }
+    return;
+  }
 
-	if (r)
-	{
-		if (add_trigger(SCRIPT(r).get(), newtrig, -1))
-		{
-			add_trig_to_owner(trig_index[trig->get_rnum()]->vnum, trig_index[trignum]->vnum, r->number);
-		}
-		else
-		{
-			extract_trigger(newtrig);
-		}
-		return;
-	}
+  if (r) {
+    if (add_trigger(SCRIPT(r).get(), newtrig, -1)) {
+      add_trig_to_owner(trig_index[trig->get_rnum()]->vnum, trig_index[trignum]->vnum, r->number);
+    } else {
+      extract_trigger(newtrig);
+    }
+    return;
+  }
 
-	return;
+  return;
 }
 
 // script detaching a trigger from something
-TRIG_DATA *process_detach(void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], trignum_s[MAX_INPUT_LENGTH];
-	char result[MAX_INPUT_LENGTH], *id_p;
-	CHAR_DATA *c = NULL;
-	OBJ_DATA *o = NULL;
-	ROOM_DATA *r = NULL;
-	TRIG_DATA *retval = trig;
+TRIG_DATA *process_detach(void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], trignum_s[MAX_INPUT_LENGTH];
+  char result[MAX_INPUT_LENGTH], *id_p;
+  CHAR_DATA *c = NULL;
+  OBJ_DATA *o = NULL;
+  ROOM_DATA *r = NULL;
+  TRIG_DATA *retval = trig;
 
-	id_p = two_arguments(cmd, arg, trignum_s);
-	skip_spaces(&id_p);
+  id_p = two_arguments(cmd, arg, trignum_s);
+  skip_spaces(&id_p);
 
-	if (!*trignum_s)
-	{
-		sprintf(buf2, "detach w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return retval;
-	}
+  if (!*trignum_s) {
+    sprintf(buf2, "detach w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return retval;
+  }
 
-	if (!id_p || !*id_p || atoi(id_p + 1) == 0)
-	{
-		sprintf(buf2, "detach invalid id arg(1): '%s'", cmd);
-		trig_log(trig, buf2);
-		return retval;
-	}
+  if (!id_p || !*id_p || atoi(id_p + 1) == 0) {
+    sprintf(buf2, "detach invalid id arg(1): '%s'", cmd);
+    trig_log(trig, buf2);
+    return retval;
+  }
 
-	// parse and locate the id specified
-	eval_expr(id_p, result, go, sc, trig, type);
+  // parse and locate the id specified
+  eval_expr(id_p, result, go, sc, trig, type);
 
-	c = get_char(id_p);
-	if (!c)
-	{
-		o = get_obj(id_p);
-		if (!o)
-		{
-			r = get_room(id_p);
-			if (!r)
-			{
-				sprintf(buf2, "detach invalid id arg(3): '%s'", cmd);
-				trig_log(trig, buf2);
-				return retval;
-			}
-		}
-	}
+  c = get_char(id_p);
+  if (!c) {
+    o = get_obj(id_p);
+    if (!o) {
+      r = get_room(id_p);
+      if (!r) {
+        sprintf(buf2, "detach invalid id arg(3): '%s'", cmd);
+        trig_log(trig, buf2);
+        return retval;
+      }
+    }
+  }
 
-	if (c && SCRIPT(c)->has_triggers())
-	{
-		SCRIPT(c)->remove_trigger(trignum_s, retval);
+  if (c && SCRIPT(c)->has_triggers()) {
+    SCRIPT(c)->remove_trigger(trignum_s, retval);
 
-		return retval;
-	}
+    return retval;
+  }
 
-	if (o && o->get_script()->has_triggers())
-	{
-		o->get_script()->remove_trigger(trignum_s, retval);
+  if (o && o->get_script()->has_triggers()) {
+    o->get_script()->remove_trigger(trignum_s, retval);
 
-		return retval;
-	}
+    return retval;
+  }
 
-	if (r && SCRIPT(r)->has_triggers())
-	{
-		SCRIPT(r)->remove_trigger(trignum_s, retval);
+  if (r && SCRIPT(r)->has_triggers()) {
+    SCRIPT(r)->remove_trigger(trignum_s, retval);
 
-		return retval;
-	}
+    return retval;
+  }
 
-	return retval;
+  return retval;
 }
 
 /* script run a trigger for something
    return TRUE   - trigger find and runned
 		  FALSE  - trigger not runned
 */
-int process_run(void *go, SCRIPT_DATA ** sc, TRIG_DATA ** trig, int type, char *cmd, int *retval)
-{
-	char arg[MAX_INPUT_LENGTH], trignum_s[MAX_INPUT_LENGTH], *name, *cname;
-	char result[MAX_INPUT_LENGTH], *id_p;
-	TRIG_DATA *runtrig = NULL;
-	//	SCRIPT_DATA *runsc = NULL;
-	struct trig_var_data *vd;
-	CHAR_DATA *c = NULL;
-	OBJ_DATA *o = NULL;
-	ROOM_DATA *r = NULL;
-	void *trggo = NULL;
-	int trgtype = 0, num = 0;
-	bool is_string = false;
+int process_run(void *go, SCRIPT_DATA **sc, TRIG_DATA **trig, int type, char *cmd, int *retval) {
+  char arg[MAX_INPUT_LENGTH], trignum_s[MAX_INPUT_LENGTH], *name, *cname;
+  char result[MAX_INPUT_LENGTH], *id_p;
+  TRIG_DATA *runtrig = NULL;
+  //	SCRIPT_DATA *runsc = NULL;
+  struct trig_var_data *vd;
+  CHAR_DATA *c = NULL;
+  OBJ_DATA *o = NULL;
+  ROOM_DATA *r = NULL;
+  void *trggo = NULL;
+  int trgtype = 0, num = 0;
+  bool is_string = false;
 
-	id_p = two_arguments(cmd, arg, trignum_s);
-	skip_spaces(&id_p);
+  id_p = two_arguments(cmd, arg, trignum_s);
+  skip_spaces(&id_p);
 
-	if (!*trignum_s)
-	{
-		sprintf(buf2, "run w/o an arg: '%s'", cmd);
-		trig_log(*trig, buf2);
-		return (FALSE);
-	}
+  if (!*trignum_s) {
+    sprintf(buf2, "run w/o an arg: '%s'", cmd);
+    trig_log(*trig, buf2);
+    return (FALSE);
+  }
 
-	if (!id_p || !*id_p || atoi(id_p + 1) == 0)
-	{
-		sprintf(buf2, "run invalid id arg(1): '%s'", cmd);
-		trig_log(*trig, buf2);
-		return (FALSE);
-	}
+  if (!id_p || !*id_p || atoi(id_p + 1) == 0) {
+    sprintf(buf2, "run invalid id arg(1): '%s'", cmd);
+    trig_log(*trig, buf2);
+    return (FALSE);
+  }
 
-	// parse and locate the id specified
-	eval_expr(id_p, result, go, *sc, *trig, type);
+  // parse and locate the id specified
+  eval_expr(id_p, result, go, *sc, *trig, type);
 
-	c = get_char(id_p);
-	if (!c)
-	{
-		o = get_obj(id_p);
-		if (!o)
-		{
-			r = get_room(id_p);
-			if (!r)
-			{
-				sprintf(buf2, "run invalid id arg(3): '%s'", cmd);
-				trig_log(*trig, buf2);
-				return (FALSE);
-			}
-		}
-	}
+  c = get_char(id_p);
+  if (!c) {
+    o = get_obj(id_p);
+    if (!o) {
+      r = get_room(id_p);
+      if (!r) {
+        sprintf(buf2, "run invalid id arg(3): '%s'", cmd);
+        trig_log(*trig, buf2);
+        return (FALSE);
+      }
+    }
+  }
 
-	name = trignum_s;
-	if ((cname = strchr(name, '.')) || (!a_isdigit(*name)))
-	{
-		is_string = true;
-		if (cname)
-		{
-			*cname = '\0';
-			num = atoi(name);
-			name = ++cname;
-		}
-	}
-	else
-	{
-		num = atoi(name);
-	}
+  name = trignum_s;
+  if ((cname = strchr(name, '.')) || (!a_isdigit(*name))) {
+    is_string = true;
+    if (cname) {
+      *cname = '\0';
+      num = atoi(name);
+      name = ++cname;
+    }
+  } else {
+    num = atoi(name);
+  }
 
-	if (c && SCRIPT(c)->has_triggers())
-	{
-		runtrig = SCRIPT(c)->trig_list.find(is_string, name, num);
-		trgtype = MOB_TRIGGER;
-		trggo = (void *)c;
-	}
-	else if (o && o->get_script()->has_triggers())
-	{
-		runtrig = o->get_script()->trig_list.find(is_string, name, num);
-		trgtype = OBJ_TRIGGER;
-		trggo = (void *)o;
-	}
-	else if (r && SCRIPT(r)->has_triggers())
-	{
-		runtrig = SCRIPT(r)->trig_list.find(is_string, name, num);
-		trgtype = WLD_TRIGGER;
-		trggo = (void *)r;
-	};
+  if (c && SCRIPT(c)->has_triggers()) {
+    runtrig = SCRIPT(c)->trig_list.find(is_string, name, num);
+    trgtype = MOB_TRIGGER;
+    trggo = (void *) c;
+  } else if (o && o->get_script()->has_triggers()) {
+    runtrig = o->get_script()->trig_list.find(is_string, name, num);
+    trgtype = OBJ_TRIGGER;
+    trggo = (void *) o;
+  } else if (r && SCRIPT(r)->has_triggers()) {
+    runtrig = SCRIPT(r)->trig_list.find(is_string, name, num);
+    trgtype = WLD_TRIGGER;
+    trggo = (void *) r;
+  };
 
-	if (!runtrig)
-	{
-		return (FALSE);
-	}
+  if (!runtrig) {
+    return (FALSE);
+  }
 
-	// copy variables
-	if (*trig && runtrig)
-	{
-		for (vd = GET_TRIG_VARS(*trig); vd; vd = vd->next)
-		{
-			if (vd->context)
-			{
-				sprintf(buf2, "Local variable %s with nonzero context %ld", vd->name, vd->context);
-				trig_log(*trig, buf2);
-			}
-			add_var_cntx(&GET_TRIG_VARS(runtrig), vd->name, vd->value, 0);
-		}
-	}
+  // copy variables
+  if (*trig && runtrig) {
+    for (vd = GET_TRIG_VARS(*trig); vd; vd = vd->next) {
+      if (vd->context) {
+        sprintf(buf2, "Local variable %s with nonzero context %ld", vd->name, vd->context);
+        trig_log(*trig, buf2);
+      }
+      add_var_cntx(&GET_TRIG_VARS(runtrig), vd->name, vd->value, 0);
+    }
+  }
 
-	if (!GET_TRIG_DEPTH(runtrig))
-	{
-		*retval = script_driver(trggo, runtrig, trgtype, TRIG_NEW);
-	}
+  if (!GET_TRIG_DEPTH(runtrig)) {
+    *retval = script_driver(trggo, runtrig, trgtype, TRIG_NEW);
+  }
 
-	//TODO: Why only for char?
-	if (go && type == MOB_TRIGGER && reinterpret_cast<CHAR_DATA *>(go)->purged())
-	{
-		*sc = NULL;
-		*trig = NULL;
-		return (FALSE);
-	}
+  //TODO: Why only for char?
+  if (go && type == MOB_TRIGGER && reinterpret_cast<CHAR_DATA *>(go)->purged()) {
+    *sc = NULL;
+    *trig = NULL;
+    return (FALSE);
+  }
 
-	runtrig = nullptr;
-	//TODO: How that possible?
-	if (!go || (type == MOB_TRIGGER ? SCRIPT((CHAR_DATA *)go).get() :
-		type == OBJ_TRIGGER ? ((OBJ_DATA *)go)->get_script().get() :
-		type == WLD_TRIGGER ? SCRIPT((ROOM_DATA *)go).get() : nullptr) != *sc)
-	{
-		*sc = NULL;
-		*trig = NULL;
-	}
-	else
-	{
-		TriggersList* triggers_list = nullptr;
-		switch (type)
-		{
-		case MOB_TRIGGER:
-			triggers_list = &SCRIPT((CHAR_DATA *)go)->trig_list;
-			break;
+  runtrig = nullptr;
+  //TODO: How that possible?
+  if (!go || (type == MOB_TRIGGER ? SCRIPT((CHAR_DATA *) go).get() :
+              type == OBJ_TRIGGER ? ((OBJ_DATA *) go)->get_script().get() :
+              type == WLD_TRIGGER ? SCRIPT((ROOM_DATA *) go).get() : nullptr) != *sc) {
+    *sc = NULL;
+    *trig = NULL;
+  } else {
+    TriggersList *triggers_list = nullptr;
+    switch (type) {
+      case MOB_TRIGGER: triggers_list = &SCRIPT((CHAR_DATA *) go)->trig_list;
+        break;
 
-		case OBJ_TRIGGER:
-			triggers_list = &((OBJ_DATA *)go)->get_script()->trig_list;
-			break;
+      case OBJ_TRIGGER: triggers_list = &((OBJ_DATA *) go)->get_script()->trig_list;
+        break;
 
-		case WLD_TRIGGER:
-			triggers_list = &SCRIPT((ROOM_DATA *)go)->trig_list;
-			break;
-		}
+      case WLD_TRIGGER: triggers_list = &SCRIPT((ROOM_DATA *) go)->trig_list;
+        break;
+    }
 
-		if (triggers_list
-			&& triggers_list->has_trigger(*trig))
-		{
-			runtrig = *trig;
-		}
-	}
+    if (triggers_list
+        && triggers_list->has_trigger(*trig)) {
+      runtrig = *trig;
+    }
+  }
 
-	*trig = runtrig;
+  *trig = runtrig;
 
-	return (TRUE);
+  return (TRUE);
 }
-CHAR_DATA *dg_caster_owner_obj(OBJ_DATA * obj) {
+CHAR_DATA *dg_caster_owner_obj(OBJ_DATA *obj) {
 
-	if (obj->get_carried_by()) {
-		return obj->get_carried_by();
-	}
-	if (obj->get_worn_by()) {
-		return obj->get_worn_by();
-	}
+  if (obj->get_carried_by()) {
+    return obj->get_carried_by();
+  }
+  if (obj->get_worn_by()) {
+    return obj->get_worn_by();
+  }
 }
 
-ROOM_DATA *dg_room_of_obj(OBJ_DATA * obj) {
+ROOM_DATA *dg_room_of_obj(OBJ_DATA *obj) {
 
-	if (obj->get_in_room() > NOWHERE) {
-		return world[obj->get_in_room()];
-	}
+  if (obj->get_in_room() > NOWHERE) {
+    return world[obj->get_in_room()];
+  }
 
-	if (obj->get_carried_by()) {
-		return world[obj->get_carried_by()->in_room];
-	}
+  if (obj->get_carried_by()) {
+    return world[obj->get_carried_by()->in_room];
+  }
 
-	if (obj->get_worn_by())	{
-		return world[obj->get_worn_by()->in_room];
-	}
+  if (obj->get_worn_by()) {
+    return world[obj->get_worn_by()->in_room];
+  }
 
-	if (obj->get_in_obj()) {
-		return dg_room_of_obj(obj->get_in_obj());
-	}
+  if (obj->get_in_obj()) {
+    return dg_room_of_obj(obj->get_in_obj());
+  }
 
-	return nullptr;
+  return nullptr;
 }
-
 
 // create a UID variable from the id number
-void makeuid_var(void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
-	char result[MAX_INPUT_LENGTH], *uid_p;
-	char uid[MAX_INPUT_LENGTH];
+void makeuid_var(void *go, SCRIPT_DATA *sc, TRIG_DATA *trig, int type, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
+  char result[MAX_INPUT_LENGTH], *uid_p;
+  char uid[MAX_INPUT_LENGTH];
 
-	uid_p = two_arguments(cmd, arg, varname);
-	skip_spaces(&uid_p);
+  uid_p = two_arguments(cmd, arg, varname);
+  skip_spaces(&uid_p);
 
-	if (!*varname)
-	{
-		sprintf(buf2, "makeuid w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*varname) {
+    sprintf(buf2, "makeuid w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!uid_p || !*uid_p || atoi(uid_p + 1) == 0)
-	{
-		sprintf(buf2, "makeuid invalid id arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!uid_p || !*uid_p || atoi(uid_p + 1) == 0) {
+    sprintf(buf2, "makeuid invalid id arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	eval_expr(uid_p, result, go, sc, trig, type);
-	sprintf(uid, "%s", result);
-	add_var_cntx(&GET_TRIG_VARS(trig), varname, uid, 0);
+  eval_expr(uid_p, result, go, sc, trig, type);
+  sprintf(uid, "%s", result);
+  add_var_cntx(&GET_TRIG_VARS(trig), varname, uid, 0);
 }
 
 /**
@@ -5049,85 +4032,71 @@ void makeuid_var(void *go, SCRIPT_DATA * sc, TRIG_DATA * trig, int type, char *c
 * calcuid <переменная куда пишется id> <внум> <room|mob|obj> <порядковый номер от 1 до х>
 * если порядковый не указан - возвращается первое вхождение.
 */
-void calcuid_var(void* go, SCRIPT_DATA* /*sc*/, TRIG_DATA * trig, int type, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
-	char *t, vnum[MAX_INPUT_LENGTH], what[MAX_INPUT_LENGTH];
-	char uid[MAX_INPUT_LENGTH], count[MAX_INPUT_LENGTH];
-	char uid_type;
-	int result = -1;
+void calcuid_var(void *go, SCRIPT_DATA * /*sc*/, TRIG_DATA *trig, int type, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
+  char *t, vnum[MAX_INPUT_LENGTH], what[MAX_INPUT_LENGTH];
+  char uid[MAX_INPUT_LENGTH], count[MAX_INPUT_LENGTH];
+  char uid_type;
+  int result = -1;
 
-	t = two_arguments(cmd, arg, varname);
-	three_arguments(t, vnum, what, count);
+  t = two_arguments(cmd, arg, varname);
+  three_arguments(t, vnum, what, count);
 
-	if (!*varname)
-	{
-		sprintf(buf2, "calcuid w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*varname) {
+    sprintf(buf2, "calcuid w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!*vnum || (result = atoi(vnum)) == 0)
-	{
-		sprintf(buf2, "calcuid invalid VNUM arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*vnum || (result = atoi(vnum)) == 0) {
+    sprintf(buf2, "calcuid invalid VNUM arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!*what)
-	{
-		sprintf(buf2, "calcuid exceed TYPE arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*what) {
+    sprintf(buf2, "calcuid exceed TYPE arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	int count_num = 0;
-	if (*count)
-	{
-		count_num = atoi(count) - 1;	//В dg индексация с 1
-		if (count_num < 0)
-		{
-			//Произойдет, если в dg пришел индекс 0 (ошибка)
-			sprintf(buf2, "calcuid invalid count: '%s'", count);
-			trig_log(trig, buf2);
-			return;
-		}
-	}
+  int count_num = 0;
+  if (*count) {
+    count_num = atoi(count) - 1;    //В dg индексация с 1
+    if (count_num < 0) {
+      //Произойдет, если в dg пришел индекс 0 (ошибка)
+      sprintf(buf2, "calcuid invalid count: '%s'", count);
+      trig_log(trig, buf2);
+      return;
+    }
+  }
 
-	if (!str_cmp(what, "room"))
-	{
-		uid_type = UID_ROOM;
-		result = find_room_uid(result);
-	}
-	else if (!str_cmp(what, "mob"))
-	{
-		uid_type = UID_CHAR;
-		result = find_char_vnum(result, count_num);
-	}
-	else if (!str_cmp(what, "obj"))
-	{
-		uid_type = UID_OBJ;
-		result = find_obj_by_id_vnum__calcuid(result, count_num, type, go);
-	}
-	else
-	{
-		sprintf(buf2, "calcuid unknown TYPE arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!str_cmp(what, "room")) {
+    uid_type = UID_ROOM;
+    result = find_room_uid(result);
+  } else if (!str_cmp(what, "mob")) {
+    uid_type = UID_CHAR;
+    result = find_char_vnum(result, count_num);
+  } else if (!str_cmp(what, "obj")) {
+    uid_type = UID_OBJ;
+    result = find_obj_by_id_vnum__calcuid(result, count_num, type, go);
+  } else {
+    sprintf(buf2, "calcuid unknown TYPE arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (result <= -1)
-	{
-		sprintf(buf2, "calcuid target not found vnum: %s, count: %d.", vnum, count_num + 1);
-		trig_log(trig, buf2);
+  if (result <= -1) {
+    sprintf(buf2, "calcuid target not found vnum: %s, count: %d.", vnum, count_num + 1);
+    trig_log(trig, buf2);
 
-		*uid = '\0';
+    *uid = '\0';
 
-		return;
-	}
+    return;
+  }
 
-	sprintf(uid, "%c%d", uid_type, result);
-	add_var_cntx(&GET_TRIG_VARS(trig), varname, uid, 0);
+  sprintf(uid, "%c%d", uid_type, result);
+  add_var_cntx(&GET_TRIG_VARS(trig), varname, uid, 0);
 }
 
 /*
@@ -5135,251 +4104,218 @@ void calcuid_var(void* go, SCRIPT_DATA* /*sc*/, TRIG_DATA * trig, int type, char
  * Возвращает в указанную переменную UID первого PC, с именем которого
  * совпадает аргумент
  */
-void charuid_var(void* /*go*/, SCRIPT_DATA* /*sc*/, TRIG_DATA * trig, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
-	char who[MAX_INPUT_LENGTH], uid[MAX_INPUT_LENGTH];
-	char uid_type = UID_CHAR;
+void charuid_var(void * /*go*/, SCRIPT_DATA * /*sc*/, TRIG_DATA *trig, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
+  char who[MAX_INPUT_LENGTH], uid[MAX_INPUT_LENGTH];
+  char uid_type = UID_CHAR;
 
-	int result = -1;
+  int result = -1;
 
-	three_arguments(cmd, arg, varname, who);
+  three_arguments(cmd, arg, varname, who);
 
-	if (!*varname)
-	{
-		sprintf(buf2, "charuid w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*varname) {
+    sprintf(buf2, "charuid w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!*who)
-	{
-		sprintf(buf2, "charuid name is missing: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*who) {
+    sprintf(buf2, "charuid name is missing: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	for (const auto tch : character_list)
-	{
-		if (IS_NPC(tch)
-			|| !HERE(tch)
-			|| (*who
-				&& !isname(who, GET_NAME(tch))))
-		{
-			continue;
-		}
+  for (const auto tch : character_list) {
+    if (IS_NPC(tch)
+        || !HERE(tch)
+        || (*who
+            && !isname(who, GET_NAME(tch)))) {
+      continue;
+    }
 
-		if (IN_ROOM(tch) != NOWHERE)
-		{
-			result = GET_ID(tch);
-		}
-	}
+    if (IN_ROOM(tch) != NOWHERE) {
+      result = GET_ID(tch);
+    }
+  }
 
-	if (result <= -1)
-	{
-		sprintf(buf2, "charuid target not found, name: '%s'", who);
-		trig_log(trig, buf2);
-		*uid = '\0';
-		return;
-	}
+  if (result <= -1) {
+    sprintf(buf2, "charuid target not found, name: '%s'", who);
+    trig_log(trig, buf2);
+    *uid = '\0';
+    return;
+  }
 
-	sprintf(uid, "%c%d", uid_type, result);
-	add_var_cntx(&GET_TRIG_VARS(trig), varname, uid, 0);
+  sprintf(uid, "%c%d", uid_type, result);
+  add_var_cntx(&GET_TRIG_VARS(trig), varname, uid, 0);
 }
 
 // * Поиск мобов для calcuidall_var.
-bool find_all_char_vnum(long n, char *str)
-{
-	int count = 0;
-	for (const auto ch : character_list)
-	{
-		if (n == GET_MOB_VNUM(ch) && ch->in_room != NOWHERE && count < 25)
-		{
-			snprintf(str + strlen(str), MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(ch));
-			++count;
-		}
-	}
+bool find_all_char_vnum(long n, char *str) {
+  int count = 0;
+  for (const auto ch : character_list) {
+    if (n == GET_MOB_VNUM(ch) && ch->in_room != NOWHERE && count < 25) {
+      snprintf(str + strlen(str), MAX_INPUT_LENGTH, "%c%ld ", UID_CHAR, GET_ID(ch));
+      ++count;
+    }
+  }
 
-	return count ? true : false;
+  return count ? true : false;
 }
 
 // * Поиск предметов для calcuidall_var.
-bool find_all_obj_vnum(long n, char *str)
-{
-	int count = 0;
+bool find_all_obj_vnum(long n, char *str) {
+  int count = 0;
 
-	const int LIMIT = 25;
-	world_objects.foreach_with_vnum(n, [&](const OBJ_DATA::shared_ptr& i)
-	{
-		if (count < LIMIT)
-		{
-			snprintf(str + strlen(str), MAX_INPUT_LENGTH, "%c%ld ", UID_OBJ, i->get_id());
-			++count;
-		}
-	});
+  const int LIMIT = 25;
+  world_objects.foreach_with_vnum(n, [&](const OBJ_DATA::shared_ptr &i) {
+    if (count < LIMIT) {
+      snprintf(str + strlen(str), MAX_INPUT_LENGTH, "%c%ld ", UID_OBJ, i->get_id());
+      ++count;
+    }
+  });
 
-	return count ? true : false;
+  return count ? true : false;
 }
 
 // * Копи-паст с calcuid_var для возврата строки со всеми найденными уидами мобов/предметов (до 25ти вхождений).
-void calcuidall_var(void* /*go*/, SCRIPT_DATA* /*sc*/, TRIG_DATA * trig, int/* type*/, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
-	char *t, vnum[MAX_INPUT_LENGTH], what[MAX_INPUT_LENGTH];
-	char uid[MAX_INPUT_LENGTH];
-	int result = -1;
+void calcuidall_var(void * /*go*/, SCRIPT_DATA * /*sc*/, TRIG_DATA *trig, int/* type*/, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], varname[MAX_INPUT_LENGTH];
+  char *t, vnum[MAX_INPUT_LENGTH], what[MAX_INPUT_LENGTH];
+  char uid[MAX_INPUT_LENGTH];
+  int result = -1;
 
-	uid[0] = '\0';
-	t = two_arguments(cmd, arg, varname);
-	two_arguments(t, vnum, what);
+  uid[0] = '\0';
+  t = two_arguments(cmd, arg, varname);
+  two_arguments(t, vnum, what);
 
-	if (!*varname)
-	{
-		sprintf(buf2, "calcuidall w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*varname) {
+    sprintf(buf2, "calcuidall w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!*vnum || (result = atoi(vnum)) == 0)
-	{
-		sprintf(buf2, "calcuidall invalid VNUM arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*vnum || (result = atoi(vnum)) == 0) {
+    sprintf(buf2, "calcuidall invalid VNUM arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!*what)
-	{
-		sprintf(buf2, "calcuidall exceed TYPE arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*what) {
+    sprintf(buf2, "calcuidall exceed TYPE arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!str_cmp(what, "mob"))
-	{
-		result = find_all_char_vnum(result, uid);
-	}
-	else if (!str_cmp(what, "obj"))
-	{
-		result = find_all_obj_vnum(result, uid);
-	}
-	else
-	{
-		sprintf(buf2, "calcuidall unknown TYPE arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!str_cmp(what, "mob")) {
+    result = find_all_char_vnum(result, uid);
+  } else if (!str_cmp(what, "obj")) {
+    result = find_all_obj_vnum(result, uid);
+  } else {
+    sprintf(buf2, "calcuidall unknown TYPE arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!result)
-	{
-		sprintf(buf2, "calcuidall target not found '%s'", vnum);
-		trig_log(trig, buf2);
-		*uid = '\0';
-		return;
-	}
-	add_var_cntx(&GET_TRIG_VARS(trig), varname, uid, 0);
+  if (!result) {
+    sprintf(buf2, "calcuidall target not found '%s'", vnum);
+    trig_log(trig, buf2);
+    *uid = '\0';
+    return;
+  }
+  add_var_cntx(&GET_TRIG_VARS(trig), varname, uid, 0);
 }
 
 /*
  * processes a script return command.
  * returns the new value for the script to return.
  */
-int process_return(TRIG_DATA * trig, char *cmd)
-{
-	char arg1[MAX_INPUT_LENGTH], arg2[MAX_INPUT_LENGTH];
+int process_return(TRIG_DATA *trig, char *cmd) {
+  char arg1[MAX_INPUT_LENGTH], arg2[MAX_INPUT_LENGTH];
 
-	two_arguments(cmd, arg1, arg2);
+  two_arguments(cmd, arg1, arg2);
 
-	if (!*arg2)
-	{
-		sprintf(buf2, "return w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return 1;
-	}
+  if (!*arg2) {
+    sprintf(buf2, "return w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return 1;
+  }
 
-	return atoi(arg2);
+  return atoi(arg2);
 }
-
 
 /*
  * removes a variable from the global vars of sc,
  * or the local vars of trig if not found in global list.
  */
-void process_unset(SCRIPT_DATA * sc, TRIG_DATA * trig, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], *var;
+void process_unset(SCRIPT_DATA *sc, TRIG_DATA *trig, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], *var;
 
-	var = any_one_arg(cmd, arg);
+  var = any_one_arg(cmd, arg);
 
-	skip_spaces(&var);
+  skip_spaces(&var);
 
-	if (!*var)
-	{
-		sprintf(buf2, "unset w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*var) {
+    sprintf(buf2, "unset w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!remove_var_cntx(&worlds_vars, var, sc->context))
-		if (!remove_var_cntx(&(sc->global_vars), var, sc->context))
-			remove_var_cntx(&GET_TRIG_VARS(trig), var, 0);
+  if (!remove_var_cntx(&worlds_vars, var, sc->context))
+    if (!remove_var_cntx(&(sc->global_vars), var, sc->context))
+      remove_var_cntx(&GET_TRIG_VARS(trig), var, 0);
 }
-
 
 /*
  * copy a locally owned variable to the globals of another script
  *     'remote <variable_name> <uid>'
  */
-void process_remote(SCRIPT_DATA * sc, TRIG_DATA * trig, char *cmd)
-{
-	struct trig_var_data *vd;
-	SCRIPT_DATA *sc_remote = NULL;
-	char *line, *var, *uid_p;
-	char arg[MAX_INPUT_LENGTH];
-	long uid, context;
-	ROOM_DATA *room;
-	CHAR_DATA *mob;
-	OBJ_DATA *obj;
+void process_remote(SCRIPT_DATA *sc, TRIG_DATA *trig, char *cmd) {
+  struct trig_var_data *vd;
+  SCRIPT_DATA *sc_remote = NULL;
+  char *line, *var, *uid_p;
+  char arg[MAX_INPUT_LENGTH];
+  long uid, context;
+  ROOM_DATA *room;
+  CHAR_DATA *mob;
+  OBJ_DATA *obj;
 
-	line = any_one_arg(cmd, arg);
-	two_arguments(line, buf, buf2);
-	var = buf;
-	uid_p = buf2;
-	skip_spaces(&var);
-	skip_spaces(&uid_p);
+  line = any_one_arg(cmd, arg);
+  two_arguments(line, buf, buf2);
+  var = buf;
+  uid_p = buf2;
+  skip_spaces(&var);
+  skip_spaces(&uid_p);
 
+  if (!*buf || !*buf2) {
+    sprintf(buf2, "remote: invalid arguments '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!*buf || !*buf2)
-	{
-		sprintf(buf2, "remote: invalid arguments '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  // find the locally owned variable
+  vd = find_var_cntx(&GET_TRIG_VARS(trig), var, 0);
+  if (!vd)
+    vd = find_var_cntx(&(sc->global_vars), var, sc->context);
 
-	// find the locally owned variable
-	vd = find_var_cntx(&GET_TRIG_VARS(trig), var, 0);
-	if (!vd)
-		vd = find_var_cntx(&(sc->global_vars), var, sc->context);
+  if (!vd) {
+    sprintf(buf2, "local var '%s' not found in remote call", buf);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!vd)
-	{
-		sprintf(buf2, "local var '%s' not found in remote call", buf);
-		trig_log(trig, buf2);
-		return;
-	}
-
-	// find the target script from the uid number
-	uid = atoi(buf2 + 1);
-	if (uid <= 0) {
+  // find the target script from the uid number
+  uid = atoi(buf2 + 1);
+  if (uid <= 0) {
 //		std::stringstream buffer;
 //		buffer << "remote: illegal uid " << buf2;
 //		sprintf(buf, buffer.str());
-		sprintf(buf, "remote: illegal uid '%s'", buf2);
-		trig_log(trig, buf);
-		return;
-	}
+    sprintf(buf, "remote: illegal uid '%s'", buf2);
+    trig_log(trig, buf);
+    return;
+  }
 
-	// for all but PC's, context comes from the existing context.
-	// for PC's, context is 0 (global)
+  // for all but PC's, context comes from the existing context.
+  // for PC's, context is 0 (global)
 //  context = vd->context;
 // Контекст можно брать как vd->context или sc->context
 // Если брать vd->context, то теряем контекст при переносе локальной переменной
@@ -5388,292 +4324,240 @@ void process_remote(SCRIPT_DATA * sc, TRIG_DATA * trig, char *cmd)
 // если есть желание перенести локальную переменную заранее установите
 // контекст в 0. Для глобальной переменной переменная с контекстом 0
 // "покрывает" отсутствующие контексты
-	context = sc->context;
+  context = sc->context;
 
-	if ((room = get_room(buf2)))
-	{
-		sc_remote = SCRIPT(room).get();
-	}
-	else if ((mob = get_char(buf2)))
-	{
-		sc_remote = SCRIPT(mob).get();
-		if (!IS_NPC(mob))
-		{
-			context = 0;
-		}
-	}
-	else if ((obj = get_obj(buf2)))
-	{
-		sc_remote = obj->get_script().get();
-	}
-	else
-	{
-		sprintf(buf, "remote: uid '%ld' invalid", uid);
-		trig_log(trig, buf);
-		return;
-	}
+  if ((room = get_room(buf2))) {
+    sc_remote = SCRIPT(room).get();
+  } else if ((mob = get_char(buf2))) {
+    sc_remote = SCRIPT(mob).get();
+    if (!IS_NPC(mob)) {
+      context = 0;
+    }
+  } else if ((obj = get_obj(buf2))) {
+    sc_remote = obj->get_script().get();
+  } else {
+    sprintf(buf, "remote: uid '%ld' invalid", uid);
+    trig_log(trig, buf);
+    return;
+  }
 
-	if (sc_remote == NULL)
-	{
-		return;		// no script to assign
-	}
+  if (sc_remote == NULL) {
+    return;        // no script to assign
+  }
 
-	add_var_cntx(&(sc_remote->global_vars), vd->name, vd->value, context);
+  add_var_cntx(&(sc_remote->global_vars), vd->name, vd->value, context);
 }
 
 /*
  * command-line interface to rdelete
  * named vdelete so people didn't think it was to delete rooms
  */
-void do_vdelete(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	//  struct trig_var_data *vd, *vd_prev=NULL;
-	SCRIPT_DATA *sc_remote = NULL;
-	char *var, *uid_p;
-	long uid; //, context;
-	ROOM_DATA *room;
-	CHAR_DATA *mob;
-	OBJ_DATA *obj;
+void do_vdelete(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  //  struct trig_var_data *vd, *vd_prev=NULL;
+  SCRIPT_DATA *sc_remote = NULL;
+  char *var, *uid_p;
+  long uid; //, context;
+  ROOM_DATA *room;
+  CHAR_DATA *mob;
+  OBJ_DATA *obj;
 
-	argument = two_arguments(argument, buf, buf2);
-	var = buf;
-	uid_p = buf2;
-	skip_spaces(&var);
-	skip_spaces(&uid_p);
+  argument = two_arguments(argument, buf, buf2);
+  var = buf;
+  uid_p = buf2;
+  skip_spaces(&var);
+  skip_spaces(&uid_p);
 
-
-	if (!*buf || !*buf2)
-	{
-		send_to_char("Usage: vdelete <variablename> <id>\r\n", ch);
-		return;
-	}
+  if (!*buf || !*buf2) {
+    send_to_char("Usage: vdelete <variablename> <id>\r\n", ch);
+    return;
+  }
 
 
-	// find the target script from the uid number
-	uid = atoi(buf2 + 1);
-	if (uid <= 0)
-	{
-		send_to_char("vdelete: illegal id specified.\r\n", ch);
-		return;
-	}
+  // find the target script from the uid number
+  uid = atoi(buf2 + 1);
+  if (uid <= 0) {
+    send_to_char("vdelete: illegal id specified.\r\n", ch);
+    return;
+  }
 
+  if ((room = get_room(buf2))) {
+    sc_remote = SCRIPT(room).get();
+  } else if ((mob = get_char(buf2))) {
+    sc_remote = SCRIPT(mob).get();
+  } else if ((obj = get_obj(buf2))) {
+    sc_remote = obj->get_script().get();
+  } else {
+    send_to_char("vdelete: cannot resolve specified id.\r\n", ch);
+    return;
+  }
 
-	if ((room = get_room(buf2)))
-	{
-		sc_remote = SCRIPT(room).get();
-	}
-	else if ((mob = get_char(buf2)))
-	{
-		sc_remote = SCRIPT(mob).get();
-	}
-	else if ((obj = get_obj(buf2)))
-	{
-		sc_remote = obj->get_script().get();
-	}
-	else
-	{
-		send_to_char("vdelete: cannot resolve specified id.\r\n", ch);
-		return;
-	}
+  if ((sc_remote == NULL) || (sc_remote->global_vars == NULL)) {
+    send_to_char("That id represents no global variables.\r\n", ch);
+    return;
+  }
 
-	if ((sc_remote == NULL) || (sc_remote->global_vars == NULL))
-	{
-		send_to_char("That id represents no global variables.\r\n", ch);
-		return;
-	}
-
-	// find the global
-	if (remove_var_cntx(&(sc_remote->global_vars), var, 0))
-	{
-		send_to_char("Deleted.\r\n", ch);
-	}
-	else
-	{
-		send_to_char("That variable cannot be located.\r\n", ch);
-	}
+  // find the global
+  if (remove_var_cntx(&(sc_remote->global_vars), var, 0)) {
+    send_to_char("Deleted.\r\n", ch);
+  } else {
+    send_to_char("That variable cannot be located.\r\n", ch);
+  }
 }
 
 /*
  * delete a variable from the globals of another script
  *     'rdelete <variable_name> <uid>'
  */
-void process_rdelete(SCRIPT_DATA * sc, TRIG_DATA * trig, char *cmd)
-{
-	//  struct trig_var_data *vd, *vd_prev=NULL;
-	SCRIPT_DATA *sc_remote = NULL;
-	char *line, *var, *uid_p;
-	char arg[MAX_INPUT_LENGTH];
-	long uid; //, context;
-	ROOM_DATA *room;
-	CHAR_DATA *mob;
-	OBJ_DATA *obj;
+void process_rdelete(SCRIPT_DATA *sc, TRIG_DATA *trig, char *cmd) {
+  //  struct trig_var_data *vd, *vd_prev=NULL;
+  SCRIPT_DATA *sc_remote = NULL;
+  char *line, *var, *uid_p;
+  char arg[MAX_INPUT_LENGTH];
+  long uid; //, context;
+  ROOM_DATA *room;
+  CHAR_DATA *mob;
+  OBJ_DATA *obj;
 
-	line = any_one_arg(cmd, arg);
-	two_arguments(line, buf, buf2);
-	var = buf;
-	uid_p = buf2;
-	skip_spaces(&var);
-	skip_spaces(&uid_p);
+  line = any_one_arg(cmd, arg);
+  two_arguments(line, buf, buf2);
+  var = buf;
+  uid_p = buf2;
+  skip_spaces(&var);
+  skip_spaces(&uid_p);
 
-
-
-	if (!*buf || !*buf2)
-	{
-		sprintf(buf2, "rdelete: invalid arguments '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*buf || !*buf2) {
+    sprintf(buf2, "rdelete: invalid arguments '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
 
-	// find the target script from the uid number
-	uid = atoi(buf2 + 1);
-	if (uid <= 0)
-	{
-		sprintf(buf, "rdelete: illegal uid '%s'", buf2);
-		trig_log(trig, buf);
-		return;
-	}
+  // find the target script from the uid number
+  uid = atoi(buf2 + 1);
+  if (uid <= 0) {
+    sprintf(buf, "rdelete: illegal uid '%s'", buf2);
+    trig_log(trig, buf);
+    return;
+  }
 
+  if ((room = get_room(buf2))) {
+    sc_remote = SCRIPT(room).get();
+  } else if ((mob = get_char(buf2))) {
+    sc_remote = SCRIPT(mob).get();
+  } else if ((obj = get_obj(buf2))) {
+    sc_remote = obj->get_script().get();
+  } else {
+    sprintf(buf, "remote: uid '%ld' invalid", uid);
+    trig_log(trig, buf);
+    return;
+  }
 
-	if ((room = get_room(buf2)))
-	{
-		sc_remote = SCRIPT(room).get();
-	}
-	else if ((mob = get_char(buf2)))
-	{
-		sc_remote = SCRIPT(mob).get();
-	}
-	else if ((obj = get_obj(buf2)))
-	{
-		sc_remote = obj->get_script().get();
-	}
-	else
-	{
-		sprintf(buf, "remote: uid '%ld' invalid", uid);
-		trig_log(trig, buf);
-		return;
-	}
+  if (sc_remote == NULL) {
+    return;        // no script to delete a trigger from
+  }
+  if (sc_remote->global_vars == NULL) {
+    return;        // no script globals
+  }
 
-	if (sc_remote == NULL)
-	{
-		return;		// no script to delete a trigger from
-	}
-	if (sc_remote->global_vars == NULL)
-	{
-		return;		// no script globals
-	}
-
-	// find the global
-	remove_var_cntx(&(sc_remote->global_vars), var, sc->context);
+  // find the global
+  remove_var_cntx(&(sc_remote->global_vars), var, sc->context);
 }
 
-
 // * makes a local variable into a global variable
-void process_global(SCRIPT_DATA * sc, TRIG_DATA * trig, char *cmd, long id)
-{
-	struct trig_var_data *vd;
-	char arg[MAX_INPUT_LENGTH], *var;
+void process_global(SCRIPT_DATA *sc, TRIG_DATA *trig, char *cmd, long id) {
+  struct trig_var_data *vd;
+  char arg[MAX_INPUT_LENGTH], *var;
 
-	var = any_one_arg(cmd, arg);
+  var = any_one_arg(cmd, arg);
 
-	skip_spaces(&var);
+  skip_spaces(&var);
 
-	if (!*var)
-	{
-		sprintf(buf2, "global w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*var) {
+    sprintf(buf2, "global w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	vd = find_var_cntx(&GET_TRIG_VARS(trig), var, 0);
+  vd = find_var_cntx(&GET_TRIG_VARS(trig), var, 0);
 
-	if (!vd)
-	{
-		sprintf(buf2, "local var '%s' not found in global call", var);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!vd) {
+    sprintf(buf2, "local var '%s' not found in global call", var);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	add_var_cntx(&(sc->global_vars), vd->name, vd->value, id);
-	remove_var_cntx(&GET_TRIG_VARS(trig), vd->name, 0);
+  add_var_cntx(&(sc->global_vars), vd->name, vd->value, id);
+  remove_var_cntx(&GET_TRIG_VARS(trig), vd->name, 0);
 }
 
 // * makes a local variable into a world variable
-void process_worlds(SCRIPT_DATA* /*sc*/, TRIG_DATA * trig, char *cmd, long id)
-{
-	struct trig_var_data *vd;
-	char arg[MAX_INPUT_LENGTH], *var;
+void process_worlds(SCRIPT_DATA * /*sc*/, TRIG_DATA *trig, char *cmd, long id) {
+  struct trig_var_data *vd;
+  char arg[MAX_INPUT_LENGTH], *var;
 
-	var = any_one_arg(cmd, arg);
+  var = any_one_arg(cmd, arg);
 
-	skip_spaces(&var);
+  skip_spaces(&var);
 
-	if (!*var)
-	{
-		sprintf(buf2, "worlds w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*var) {
+    sprintf(buf2, "worlds w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	vd = find_var_cntx(&GET_TRIG_VARS(trig), var, 0);
+  vd = find_var_cntx(&GET_TRIG_VARS(trig), var, 0);
 
-	if (!vd)
-	{
-		sprintf(buf2, "local var '%s' not found in worlds call", var);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!vd) {
+    sprintf(buf2, "local var '%s' not found in worlds call", var);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	add_var_cntx(&(worlds_vars), vd->name, vd->value, id);
-	remove_var_cntx(&GET_TRIG_VARS(trig), vd->name, 0);
+  add_var_cntx(&(worlds_vars), vd->name, vd->value, id);
+  remove_var_cntx(&GET_TRIG_VARS(trig), vd->name, 0);
 }
 
 // set the current context for a script
-void process_context(SCRIPT_DATA * sc, TRIG_DATA * trig, char *cmd)
-{
-	char arg[MAX_INPUT_LENGTH], *var;
+void process_context(SCRIPT_DATA *sc, TRIG_DATA *trig, char *cmd) {
+  char arg[MAX_INPUT_LENGTH], *var;
 
-	var = any_one_arg(cmd, arg);
+  var = any_one_arg(cmd, arg);
 
-	skip_spaces(&var);
+  skip_spaces(&var);
 
-	if (!*var)
-	{
-		sprintf(buf2, "context w/o an arg: '%s'", cmd);
-		trig_log(trig, buf2);
-		return;
-	}
+  if (!*var) {
+    sprintf(buf2, "context w/o an arg: '%s'", cmd);
+    trig_log(trig, buf2);
+    return;
+  }
 
-	sc->context = atol(var);
+  sc->context = atol(var);
 }
 
-void extract_value(SCRIPT_DATA* /*sc*/, TRIG_DATA * trig, char* cmd)
-{
-	char buf2[MAX_INPUT_LENGTH];
-	char *buf3;
-	char to[128];
-	int num;
+void extract_value(SCRIPT_DATA * /*sc*/, TRIG_DATA *trig, char *cmd) {
+  char buf2[MAX_INPUT_LENGTH];
+  char *buf3;
+  char to[128];
+  int num;
 
-	buf3 = any_one_arg(cmd, buf);
-	half_chop(buf3, buf2, buf);
-	strcpy(to, buf2);
+  buf3 = any_one_arg(cmd, buf);
+  half_chop(buf3, buf2, buf);
+  strcpy(to, buf2);
 
-	num = atoi(buf);
-	if (num < 1)
-	{
-		trig_log(trig, "extract number < 1!");
-		return;
-	}
+  num = atoi(buf);
+  if (num < 1) {
+    trig_log(trig, "extract number < 1!");
+    return;
+  }
 
-	half_chop(buf, buf3, buf2);
+  half_chop(buf, buf3, buf2);
 
-	while (num > 0)
-	{
-		half_chop(buf2, buf, buf2);
-		num--;
-	}
+  while (num > 0) {
+    half_chop(buf2, buf, buf2);
+    num--;
+  }
 
-	add_var_cntx(&GET_TRIG_VARS(trig), to, buf, 0);
+  add_var_cntx(&GET_TRIG_VARS(trig), to, buf, 0);
 }
 
 //  This is the core driver for scripts.
@@ -5681,11 +4565,10 @@ void extract_value(SCRIPT_DATA* /*sc*/, TRIG_DATA * trig, char* cmd)
 #define TIMED_SCRIPT
 
 #ifdef TIMED_SCRIPT
-int timed_script_driver(void *go, TRIG_DATA* trig, int type, int mode);
+int timed_script_driver(void *go, TRIG_DATA *trig, int type, int mode);
 
-int script_driver(void *go, TRIG_DATA * trig, int type, int mode)
-{
-	struct timeval start, stop, result;
+int script_driver(void *go, TRIG_DATA *trig, int type, int mode) {
+  struct timeval start, stop, result;
 /*	std::string start_string_trig = "First Line";
 	std::string finish_string_trig = "<Last line is undefined because it is dangerous to obtain it>";
 	if (trig->curr_state)
@@ -5693,17 +4576,16 @@ int script_driver(void *go, TRIG_DATA * trig, int type, int mode)
 		start_string_trig = trig->curr_state->cmd;
 	}
 */
-	CharacterLinkDrop = false;
-	const auto vnum = GET_TRIG_VNUM(trig);
-	gettimeofday(&start, NULL);
-	const auto return_code = timed_script_driver(go, trig, type, mode);
+  CharacterLinkDrop = false;
+  const auto vnum = GET_TRIG_VNUM(trig);
+  gettimeofday(&start, NULL);
+  const auto return_code = timed_script_driver(go, trig, type, mode);
 
-	gettimeofday(&stop, NULL);
-	timediff(&result, &stop, &start);
+  gettimeofday(&stop, NULL);
+  timediff(&result, &stop, &start);
 
-	if (result.tv_sec > 0 || result.tv_usec >= MAX_TRIG_USEC)
-	{
-		/*
+  if (result.tv_sec > 0 || result.tv_usec >= MAX_TRIG_USEC) {
+    /*
 		 * We cannot get access to trig fields here because the last command
 		 * might be "detach". In this case trigger will be deleted. Therefore
 		 * we will get the core dump here in the best case.
@@ -5713,1206 +4595,978 @@ int script_driver(void *go, TRIG_DATA * trig, int type, int mode)
 			finish_string_trig = trig->curr_state->cmd;
 		}
 		*/
-		snprintf(buf, MAX_STRING_LENGTH, "[TrigVNum: %d] : ", vnum);
-		const auto current_buffer_length = strlen(buf);
+    snprintf(buf, MAX_STRING_LENGTH, "[TrigVNum: %d] : ", vnum);
+    const auto current_buffer_length = strlen(buf);
 /*		snprintf(buf + current_buffer_length, MAX_STRING_LENGTH - current_buffer_length,
 			"work time overflow %ld sec. %ld us.\r\n StartString: %s\r\nFinishLine: %s",
 			result.tv_sec, result.tv_usec, start_string_trig.c_str(), finish_string_trig.c_str());
 */
-		snprintf(buf + current_buffer_length, MAX_STRING_LENGTH - current_buffer_length,
-			"work time overflow %ld sec. %ld us.",
-			result.tv_sec, result.tv_usec);
-		mudlog(buf, BRF, -1, ERRLOG, TRUE);
-	};
-	// Stop time
-	return return_code;
+    snprintf(buf + current_buffer_length, MAX_STRING_LENGTH - current_buffer_length,
+             "work time overflow %ld sec. %ld us.",
+             result.tv_sec, result.tv_usec);
+    mudlog(buf, BRF, -1, ERRLOG, TRUE);
+  };
+  // Stop time
+  return return_code;
 }
 
-void do_dg_add_ice_currency(void* /*go*/, SCRIPT_DATA* /*sc*/, TRIG_DATA* trig, int/* script_type*/, char *cmd)
-{
-	CHAR_DATA *ch = NULL;
-	int value;
-	char junk[MAX_INPUT_LENGTH];
-	char charname[MAX_INPUT_LENGTH], value_c[MAX_INPUT_LENGTH];
+void do_dg_add_ice_currency(void * /*go*/, SCRIPT_DATA * /*sc*/, TRIG_DATA *trig, int/* script_type*/, char *cmd) {
+  CHAR_DATA *ch = NULL;
+  int value;
+  char junk[MAX_INPUT_LENGTH];
+  char charname[MAX_INPUT_LENGTH], value_c[MAX_INPUT_LENGTH];
 
-	half_chop(cmd, junk, cmd);
-	half_chop(cmd, charname, cmd);
-	half_chop(cmd, value_c, cmd);
+  half_chop(cmd, junk, cmd);
+  half_chop(cmd, charname, cmd);
+  half_chop(cmd, value_c, cmd);
 
+  if (!*charname || !*value_c) {
+    sprintf(buf2, "dg_addicecurrency usage: <target> <value>");
+    trig_log(trig, buf2);
+    return;
+  }
 
-	if (!*charname || !*value_c)
-	{
-		sprintf(buf2, "dg_addicecurrency usage: <target> <value>");
-		trig_log(trig, buf2);
-		return;
-	}
-
-	value = atoi(value_c);
-	// locate the target
-	ch = get_char(charname);
-	if (!ch)
-	{
-		sprintf(buf2, "dg_addicecurrency: cannot locate target!");
-		trig_log(trig, buf2);
-		return;
-	}
-	ch->add_ice_currency(value);
+  value = atoi(value_c);
+  // locate the target
+  ch = get_char(charname);
+  if (!ch) {
+    sprintf(buf2, "dg_addicecurrency: cannot locate target!");
+    trig_log(trig, buf2);
+    return;
+  }
+  ch->add_ice_currency(value);
 }
 
-int timed_script_driver(void *go, TRIG_DATA * trig, int type, int mode)
+int timed_script_driver(void *go, TRIG_DATA *trig, int type, int mode)
 #else
 int script_driver(void *go, TRIG_DATA * trig, int type, int mode)
 #endif
 {
-	static int depth = 0;
-	int ret_val = 1, stop = FALSE;
-	char cmd[MAX_INPUT_LENGTH];
-	SCRIPT_DATA *sc = 0;
-	unsigned long loops = 0;
-	TRIG_DATA *prev_trig;
+  static int depth = 0;
+  int ret_val = 1, stop = FALSE;
+  char cmd[MAX_INPUT_LENGTH];
+  SCRIPT_DATA *sc = 0;
+  unsigned long loops = 0;
+  TRIG_DATA *prev_trig;
 
-	void mob_command_interpreter(CHAR_DATA* ch, char* argument);
-	void obj_command_interpreter(OBJ_DATA* obj, char* argument);
-	void wld_command_interpreter(ROOM_DATA* room, char* argument);
+  void mob_command_interpreter(CHAR_DATA *ch, char *argument);
+  void obj_command_interpreter(OBJ_DATA *obj, char *argument);
+  void wld_command_interpreter(ROOM_DATA *room, char *argument);
 
-	if (depth > MAX_SCRIPT_DEPTH)
-	{
-		trig_log(trig, "Triggers recursed beyond maximum allowed depth.");
-		return ret_val;
-	}
+  if (depth > MAX_SCRIPT_DEPTH) {
+    trig_log(trig, "Triggers recursed beyond maximum allowed depth.");
+    return ret_val;
+  }
 
-	switch (type)
-	{
-	case MOB_TRIGGER:
-		sc = SCRIPT((CHAR_DATA *)go).get();
-		break;
+  switch (type) {
+    case MOB_TRIGGER: sc = SCRIPT((CHAR_DATA *) go).get();
+      break;
 
-	case OBJ_TRIGGER:
-		sc = ((OBJ_DATA *)go)->get_script().get();
-		break;
+    case OBJ_TRIGGER: sc = ((OBJ_DATA *) go)->get_script().get();
+      break;
 
-	case WLD_TRIGGER:
-		sc = SCRIPT((ROOM_DATA *)go).get();
-		break;
-	}
+    case WLD_TRIGGER: sc = SCRIPT((ROOM_DATA *) go).get();
+      break;
+  }
 
-	if (sc->is_purged())
-	{
-		return ret_val;
-	}
+  if (sc->is_purged()) {
+    return ret_val;
+  }
 
-	prev_trig = cur_trig;
-	cur_trig = trig;
+  prev_trig = cur_trig;
+  cur_trig = trig;
 
-	depth++;
-	last_trig_vnum = GET_TRIG_VNUM(trig);
+  depth++;
+  last_trig_vnum = GET_TRIG_VNUM(trig);
 
-	if (mode == TRIG_NEW)
-	{
-		GET_TRIG_DEPTH(trig) = 1;
-		GET_TRIG_LOOPS(trig) = 0;
-		sc->context = 0;
-	}
+  if (mode == TRIG_NEW) {
+    GET_TRIG_DEPTH(trig) = 1;
+    GET_TRIG_LOOPS(trig) = 0;
+    sc->context = 0;
+  }
 
-	for (auto cl = (mode == TRIG_NEW) ? *trig->cmdlist : trig->curr_state; !stop && cl && trig && GET_TRIG_DEPTH(trig); cl = cl ? cl->next : cl)  	//log("Drive go <%s>",cl->cmd);
-	{
-		if (CharacterLinkDrop)
-		{
-			sprintf(buf, "[TrigVnum: %d] Character in LinkDrop in 'Drive go'.", last_trig_vnum);
-			mudlog(buf, BRF, -1, ERRLOG, TRUE);
-			break;
-		}
-		const char* p = nullptr;
-		for (p = cl->cmd.c_str(); !stop && trig && *p && a_isspace(*p); p++);
+  for (auto cl = (mode == TRIG_NEW) ? *trig->cmdlist : trig->curr_state; !stop && cl && trig && GET_TRIG_DEPTH(trig);
+       cl = cl ? cl->next : cl)    //log("Drive go <%s>",cl->cmd);
+  {
+    if (CharacterLinkDrop) {
+      sprintf(buf, "[TrigVnum: %d] Character in LinkDrop in 'Drive go'.", last_trig_vnum);
+      mudlog(buf, BRF, -1, ERRLOG, TRUE);
+      break;
+    }
+    const char *p = nullptr;
+    for (p = cl->cmd.c_str(); !stop && trig && *p && a_isspace(*p); p++);
 
-		if (*p == '*' || *p == '/')	// comment
-		{
-			continue;
-		}
-		else if (!strn_cmp(p, "if ", 3))
-		{
-			if (process_if(p + 3, go, sc, trig, type))
-			{
-				GET_TRIG_DEPTH(trig)++;
-			}
-			else
-			{
-				cl = find_else_end(trig, cl, go, sc, type);
-			}
-			if (CharacterLinkDrop)
-			{
-				sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
-				mudlog(buf, BRF, -1, ERRLOG, TRUE);
-				break;
-			}
-		}
-		else if (!strn_cmp("elseif ", p, 7) || !strn_cmp("else", p, 4))
-		{
-			cl = find_end(trig, cl);
-			GET_TRIG_DEPTH(trig)--;
-			if (CharacterLinkDrop)
-			{
-				sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
-				mudlog(buf, BRF, -1, ERRLOG, TRUE);
-				break;
-			}
-		}
-		else if (!strn_cmp("while ", p, 6))
-		{
-			const auto temp = find_done(trig, cl);
-			if (process_if(p + 6, go, sc, trig, type))
-			{
-				if (temp)
-				{
-					temp->original = cl;
-				}
-			}
-			else
-			{
-				cl = temp;
-				loops = 0;
-			}
-			if (CharacterLinkDrop)
-			{
-				sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
-				mudlog(buf, BRF, -1, ERRLOG, TRUE);
-				break;
-			}
-		}
-		else if (!strn_cmp("foreach ", p, 8))
-		{
-			const auto temp = find_done(trig, cl);
-			if (process_foreach_begin(p + 8, go, sc, trig, type))
-			{
-				if (temp)
-				{
-					temp->original = cl;
-				}
-			}
-			else
-			{
-				cl = temp;
-				loops = 0;
-			}
-			if (CharacterLinkDrop)
-			{
-				sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
-				mudlog(buf, BRF, -1, ERRLOG, TRUE);
-				break;
-			}
-		}
-		else if (!strn_cmp("switch ", p, 7))
-		{
-			cl = find_case(trig, cl, go, sc, type, p + 7);
-			if (CharacterLinkDrop)
-			{
-				sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
-				mudlog(buf, BRF, -1, ERRLOG, TRUE);
-				break;
-			}
-		}
-		else if (!strn_cmp("end", p, 3))
-		{
-			GET_TRIG_DEPTH(trig)--;
-		}
-		else if (!strn_cmp("done", p, 4))
-		{
-			if (cl->original)
-			{
-				auto orig_cmd = cl->original->cmd.c_str();
-				while (*orig_cmd && a_isspace(*orig_cmd))
-				{
-					orig_cmd++;
-				}
+    if (*p == '*' || *p == '/')    // comment
+    {
+      continue;
+    } else if (!strn_cmp(p, "if ", 3)) {
+      if (process_if(p + 3, go, sc, trig, type)) {
+        GET_TRIG_DEPTH(trig)++;
+      } else {
+        cl = find_else_end(trig, cl, go, sc, type);
+      }
+      if (CharacterLinkDrop) {
+        sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
+        mudlog(buf, BRF, -1, ERRLOG, TRUE);
+        break;
+      }
+    } else if (!strn_cmp("elseif ", p, 7) || !strn_cmp("else", p, 4)) {
+      cl = find_end(trig, cl);
+      GET_TRIG_DEPTH(trig)--;
+      if (CharacterLinkDrop) {
+        sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
+        mudlog(buf, BRF, -1, ERRLOG, TRUE);
+        break;
+      }
+    } else if (!strn_cmp("while ", p, 6)) {
+      const auto temp = find_done(trig, cl);
+      if (process_if(p + 6, go, sc, trig, type)) {
+        if (temp) {
+          temp->original = cl;
+        }
+      } else {
+        cl = temp;
+        loops = 0;
+      }
+      if (CharacterLinkDrop) {
+        sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
+        mudlog(buf, BRF, -1, ERRLOG, TRUE);
+        break;
+      }
+    } else if (!strn_cmp("foreach ", p, 8)) {
+      const auto temp = find_done(trig, cl);
+      if (process_foreach_begin(p + 8, go, sc, trig, type)) {
+        if (temp) {
+          temp->original = cl;
+        }
+      } else {
+        cl = temp;
+        loops = 0;
+      }
+      if (CharacterLinkDrop) {
+        sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
+        mudlog(buf, BRF, -1, ERRLOG, TRUE);
+        break;
+      }
+    } else if (!strn_cmp("switch ", p, 7)) {
+      cl = find_case(trig, cl, go, sc, type, p + 7);
+      if (CharacterLinkDrop) {
+        sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
+        mudlog(buf, BRF, -1, ERRLOG, TRUE);
+        break;
+      }
+    } else if (!strn_cmp("end", p, 3)) {
+      GET_TRIG_DEPTH(trig)--;
+    } else if (!strn_cmp("done", p, 4)) {
+      if (cl->original) {
+        auto orig_cmd = cl->original->cmd.c_str();
+        while (*orig_cmd && a_isspace(*orig_cmd)) {
+          orig_cmd++;
+        }
 
-				if ((*orig_cmd == 'w' && process_if(orig_cmd + 6, go, sc, trig, type))
-					|| (*orig_cmd == 'f' && process_foreach_done(orig_cmd + 8, go, sc, trig, type)))
-				{
-					cl = cl->original;
-					loops++;
-					GET_TRIG_LOOPS(trig)++;
-					if (loops == 30)
-					{
-						snprintf(buf2, MAX_STRING_LENGTH, "wait 1");
-						process_wait(go, trig, type, buf2, cl);
-						depth--;
-						cur_trig = prev_trig;
-						return ret_val;
-					}
+        if ((*orig_cmd == 'w' && process_if(orig_cmd + 6, go, sc, trig, type))
+            || (*orig_cmd == 'f' && process_foreach_done(orig_cmd + 8, go, sc, trig, type))) {
+          cl = cl->original;
+          loops++;
+          GET_TRIG_LOOPS(trig)++;
+          if (loops == 30) {
+            snprintf(buf2, MAX_STRING_LENGTH, "wait 1");
+            process_wait(go, trig, type, buf2, cl);
+            depth--;
+            cur_trig = prev_trig;
+            return ret_val;
+          }
 
-					if (GET_TRIG_LOOPS(trig) == 300)
-					{
-						trig_log(trig, "looping 300 times.", LGH);
-					}
+          if (GET_TRIG_LOOPS(trig) == 300) {
+            trig_log(trig, "looping 300 times.", LGH);
+          }
 
-					if (GET_TRIG_LOOPS(trig) == 1000)
-					{
-						trig_log(trig, "looping 1000 times.", DEF);
-					}
-				}
-			}
-		}
-		else if (!strn_cmp("break", p, 5))
-		{
-			cl = find_done(trig, cl);
-		}
-		else if (!strn_cmp("case", p, 4))  	// Do nothing, this allows multiple cases to a single instance
-		{
-		}
-		else
-		{
-			var_subst(go, sc, trig, type, p, cmd);
-			if (CharacterLinkDrop)
-			{
-				sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
-				mudlog(buf, BRF, -1, ERRLOG, TRUE);
-				break;
-			}
-			if (!strn_cmp(cmd, "eval ", 5))
-			{
-				process_eval(go, sc, trig, type, cmd);
-			}
-			else if (!strn_cmp(cmd, "nop ", 4))
-			{
-				;	// nop: do nothing
-			}
-			else if (!strn_cmp(cmd, "extract ", 8))
-			{
-				extract_value(sc, trig, cmd);
-			}
-			else if (!strn_cmp(cmd, "makeuid ", 8))
-			{
-				makeuid_var(go, sc, trig, type, cmd);
-			}
-			else if (!strn_cmp(cmd, "calcuid ", 8))
-			{
-				calcuid_var(go, sc, trig, type, cmd);
-			}
-			else if (!strn_cmp(cmd, "calcuidall ", 11))
-			{
-				calcuidall_var(go, sc, trig, type, cmd);
-			}
-			else if (!strn_cmp(cmd, "charuid ", 8))
-			{
-				charuid_var(go, sc, trig, cmd);
-			}
-			else if (!strn_cmp(cmd, "halt", 4))
-			{
-				break;
-			}
-			else if (!strn_cmp(cmd, "dg_cast ", 8))
-			{
-				do_dg_cast(go, sc, trig, type, cmd);
-				if (type == MOB_TRIGGER && reinterpret_cast<CHAR_DATA *>(go)->purged())
-				{
-					depth--;
-					cur_trig = prev_trig;
-					return ret_val;
-				}
-			}
-			else if (!strn_cmp(cmd, "dg_affect ", 10))
-			{
-				do_dg_affect(go, sc, trig, type, cmd);
-			}
-			else if (!strn_cmp(cmd, "global ", 7))
-			{
-				process_global(sc, trig, cmd, sc->context);
-			}
-			else if (!strn_cmp(cmd, "addicecurrency ", 15))
-			{
-				do_dg_add_ice_currency(go, sc, trig, type, cmd);
-			}
-			else if (!strn_cmp(cmd, "bonus ", 6))
-			{
-				Bonus::dg_do_bonus(cmd + 6);
-			}
-			else if (!strn_cmp(cmd, "worlds ", 7))
-			{
-				process_worlds(sc, trig, cmd, sc->context);
-			}
-			else if (!strn_cmp(cmd, "context ", 8))
-			{
-				process_context(sc, trig, cmd);
-			}
-			else if (!strn_cmp(cmd, "remote ", 7))
-			{
-				process_remote(sc, trig, cmd);
-			}
-			else if (!strn_cmp(cmd, "rdelete ", 8))
-			{
-				process_rdelete(sc, trig, cmd);
-			}
-			else if (!strn_cmp(cmd, "return ", 7))
-			{
-				ret_val = process_return(trig, cmd);
-			}
-			else if (!strn_cmp(cmd, "set ", 4))
-			{
-				process_set(sc, trig, cmd);
-			}
-			else if (!strn_cmp(cmd, "unset ", 6))
-			{
-				process_unset(sc, trig, cmd);
-			}
-			else if (!strn_cmp(cmd, "log ", 4))
-			{
-				trig_log(trig, cmd + 4);
-			}
-			else if (!strn_cmp(cmd, "wait ", 5))
-			{
-				process_wait(go, trig, type, cmd, cl);
-				depth--;
-				cur_trig = prev_trig;
-				return ret_val;
-			}
-			else if (!strn_cmp(cmd, "attach ", 7))
-			{
-				process_attach(go, sc, trig, type, cmd);
-			}
-			else if (!strn_cmp(cmd, "detach ", 7))
-			{
-				trig = process_detach(go, sc, trig, type, cmd);
-			}
-			else if (!strn_cmp(cmd, "run ", 4))
-			{
-				process_run(go, &sc, &trig, type, cmd, &ret_val);
-				if (!trig || !sc)
-				{
-					depth--;
-					cur_trig = prev_trig;
-					return ret_val;
-				}
-				stop = ret_val;
-			}
-			else if (!strn_cmp(cmd, "exec ", 5))
-			{
-				process_run(go, &sc, &trig, type, cmd, &ret_val);
-				if (!trig || !sc)
-				{
-					depth--;
-					cur_trig = prev_trig;
-					return ret_val;
-				}
-			}
-			else if (!strn_cmp(cmd, "version", 7))
-			{
-				mudlog(DG_SCRIPT_VERSION, BRF, LVL_BUILDER, SYSLOG, TRUE);
-			}
-			else
-			{
-				switch (type)
-				{
-				case MOB_TRIGGER:
-					//last_trig_vnum = GET_TRIG_VNUM(trig);
-					mob_command_interpreter((CHAR_DATA *)(go), cmd);
-					break;
+          if (GET_TRIG_LOOPS(trig) == 1000) {
+            trig_log(trig, "looping 1000 times.", DEF);
+          }
+        }
+      }
+    } else if (!strn_cmp("break", p, 5)) {
+      cl = find_done(trig, cl);
+    } else if (!strn_cmp("case", p, 4))    // Do nothing, this allows multiple cases to a single instance
+    {
+    } else {
+      var_subst(go, sc, trig, type, p, cmd);
+      if (CharacterLinkDrop) {
+        sprintf(buf, "[TrigVnum: %d] Character in LinkDrop.\r\n", last_trig_vnum);
+        mudlog(buf, BRF, -1, ERRLOG, TRUE);
+        break;
+      }
+      if (!strn_cmp(cmd, "eval ", 5)) {
+        process_eval(go, sc, trig, type, cmd);
+      } else if (!strn_cmp(cmd, "nop ", 4)) { ;    // nop: do nothing
+      } else if (!strn_cmp(cmd, "extract ", 8)) {
+        extract_value(sc, trig, cmd);
+      } else if (!strn_cmp(cmd, "makeuid ", 8)) {
+        makeuid_var(go, sc, trig, type, cmd);
+      } else if (!strn_cmp(cmd, "calcuid ", 8)) {
+        calcuid_var(go, sc, trig, type, cmd);
+      } else if (!strn_cmp(cmd, "calcuidall ", 11)) {
+        calcuidall_var(go, sc, trig, type, cmd);
+      } else if (!strn_cmp(cmd, "charuid ", 8)) {
+        charuid_var(go, sc, trig, cmd);
+      } else if (!strn_cmp(cmd, "halt", 4)) {
+        break;
+      } else if (!strn_cmp(cmd, "dg_cast ", 8)) {
+        do_dg_cast(go, sc, trig, type, cmd);
+        if (type == MOB_TRIGGER && reinterpret_cast<CHAR_DATA *>(go)->purged()) {
+          depth--;
+          cur_trig = prev_trig;
+          return ret_val;
+        }
+      } else if (!strn_cmp(cmd, "dg_affect ", 10)) {
+        do_dg_affect(go, sc, trig, type, cmd);
+      } else if (!strn_cmp(cmd, "global ", 7)) {
+        process_global(sc, trig, cmd, sc->context);
+      } else if (!strn_cmp(cmd, "addicecurrency ", 15)) {
+        do_dg_add_ice_currency(go, sc, trig, type, cmd);
+      } else if (!strn_cmp(cmd, "bonus ", 6)) {
+        Bonus::dg_do_bonus(cmd + 6);
+      } else if (!strn_cmp(cmd, "worlds ", 7)) {
+        process_worlds(sc, trig, cmd, sc->context);
+      } else if (!strn_cmp(cmd, "context ", 8)) {
+        process_context(sc, trig, cmd);
+      } else if (!strn_cmp(cmd, "remote ", 7)) {
+        process_remote(sc, trig, cmd);
+      } else if (!strn_cmp(cmd, "rdelete ", 8)) {
+        process_rdelete(sc, trig, cmd);
+      } else if (!strn_cmp(cmd, "return ", 7)) {
+        ret_val = process_return(trig, cmd);
+      } else if (!strn_cmp(cmd, "set ", 4)) {
+        process_set(sc, trig, cmd);
+      } else if (!strn_cmp(cmd, "unset ", 6)) {
+        process_unset(sc, trig, cmd);
+      } else if (!strn_cmp(cmd, "log ", 4)) {
+        trig_log(trig, cmd + 4);
+      } else if (!strn_cmp(cmd, "wait ", 5)) {
+        process_wait(go, trig, type, cmd, cl);
+        depth--;
+        cur_trig = prev_trig;
+        return ret_val;
+      } else if (!strn_cmp(cmd, "attach ", 7)) {
+        process_attach(go, sc, trig, type, cmd);
+      } else if (!strn_cmp(cmd, "detach ", 7)) {
+        trig = process_detach(go, sc, trig, type, cmd);
+      } else if (!strn_cmp(cmd, "run ", 4)) {
+        process_run(go, &sc, &trig, type, cmd, &ret_val);
+        if (!trig || !sc) {
+          depth--;
+          cur_trig = prev_trig;
+          return ret_val;
+        }
+        stop = ret_val;
+      } else if (!strn_cmp(cmd, "exec ", 5)) {
+        process_run(go, &sc, &trig, type, cmd, &ret_val);
+        if (!trig || !sc) {
+          depth--;
+          cur_trig = prev_trig;
+          return ret_val;
+        }
+      } else if (!strn_cmp(cmd, "version", 7)) {
+        mudlog(DG_SCRIPT_VERSION, BRF, LVL_BUILDER, SYSLOG, TRUE);
+      } else {
+        switch (type) {
+          case MOB_TRIGGER:
+            //last_trig_vnum = GET_TRIG_VNUM(trig);
+            mob_command_interpreter((CHAR_DATA *) (go), cmd);
+            break;
 
-				case OBJ_TRIGGER:
-					//last_trig_vnum = GET_TRIG_VNUM(trig);
-					obj_command_interpreter((OBJ_DATA *)go, cmd);
-					break;
+          case OBJ_TRIGGER:
+            //last_trig_vnum = GET_TRIG_VNUM(trig);
+            obj_command_interpreter((OBJ_DATA *) go, cmd);
+            break;
 
-				case WLD_TRIGGER:
-					//last_trig_vnum = GET_TRIG_VNUM(trig);
-					wld_command_interpreter((ROOM_DATA *)go, cmd);
-					break;
-				}
-			}
+          case WLD_TRIGGER:
+            //last_trig_vnum = GET_TRIG_VNUM(trig);
+            wld_command_interpreter((ROOM_DATA *) go, cmd);
+            break;
+        }
+      }
 
-			if (sc->is_purged() || (type == MOB_TRIGGER && reinterpret_cast<CHAR_DATA *>(go)->purged()))
-			{
-				depth--;
-				cur_trig = prev_trig;
-				return ret_val;
-			}
-		}
-	}
+      if (sc->is_purged() || (type == MOB_TRIGGER && reinterpret_cast<CHAR_DATA *>(go)->purged())) {
+        depth--;
+        cur_trig = prev_trig;
+        return ret_val;
+      }
+    }
+  }
 
-	if (trig)
-	{
-		trig->clear_var_list();
-		GET_TRIG_VARS(trig) = NULL;
-		GET_TRIG_DEPTH(trig) = 0;
-	}
+  if (trig) {
+    trig->clear_var_list();
+    GET_TRIG_VARS(trig) = NULL;
+    GET_TRIG_DEPTH(trig) = 0;
+  }
 
-	depth--;
-	cur_trig = prev_trig;
-	return ret_val;
+  depth--;
+  cur_trig = prev_trig;
+  return ret_val;
 }
 
-void do_tlist(CHAR_DATA *ch, char *argument, int cmd, int/* subcmd*/)
-{
-	int first, last, nr, found = 0;
-	char pagebuf[65536];
+void do_tlist(CHAR_DATA *ch, char *argument, int cmd, int/* subcmd*/) {
+  int first, last, nr, found = 0;
+  char pagebuf[65536];
 
-	strcpy(pagebuf, "");
+  strcpy(pagebuf, "");
 
-	two_arguments(argument, buf, buf2);
+  two_arguments(argument, buf, buf2);
 
-	first = atoi(buf);
+  first = atoi(buf);
 
-	if (!(Privilege::can_do_priv(ch,std::string(cmd_info[cmd].command), 0, 0, false)) && (GET_OLC_ZONE(ch) != first))
-	{
-		send_to_char("Чаво?\r\n", ch);
-		return;
-	}
+  if (!(Privilege::can_do_priv(ch, std::string(cmd_info[cmd].command), 0, 0, false)) && (GET_OLC_ZONE(ch) != first)) {
+    send_to_char("Чаво?\r\n", ch);
+    return;
+  }
 
-	if (!*buf)
-	{
-		send_to_char("Usage: tlist <begining number or zone> [<ending number>]\r\n", ch);
-		return;
-	}
+  if (!*buf) {
+    send_to_char("Usage: tlist <begining number or zone> [<ending number>]\r\n", ch);
+    return;
+  }
 
-	first = atoi(buf);
-	if (*buf2)
-		last = atoi(buf2);
-	else
-	{
-		first *= 100;
-		last = first + 99;
-	}
+  first = atoi(buf);
+  if (*buf2)
+    last = atoi(buf2);
+  else {
+    first *= 100;
+    last = first + 99;
+  }
 
-	if ((first < 0) || (first > MAX_PROTO_NUMBER) || (last < 0) || (last > MAX_PROTO_NUMBER))
-	{
-		sprintf(buf, "Значения должны быть между 0 и %d.\n\r", MAX_PROTO_NUMBER);
-		send_to_char(buf, ch);
-	}
+  if ((first < 0) || (first > MAX_PROTO_NUMBER) || (last < 0) || (last > MAX_PROTO_NUMBER)) {
+    sprintf(buf, "Значения должны быть между 0 и %d.\n\r", MAX_PROTO_NUMBER);
+    send_to_char(buf, ch);
+  }
 
-	if (first >= last)
-	{
-		send_to_char("Второе значение должно быть больше первого.\n\r", ch);
-		return;
-	}
+  if (first >= last) {
+    send_to_char("Второе значение должно быть больше первого.\n\r", ch);
+    return;
+  }
 
-	if (first + 200 < last)
-	{
-		send_to_char("Максимальный показываемый промежуток - 200.\n\r", ch);
-		return;
-	}
+  if (first + 200 < last) {
+    send_to_char("Максимальный показываемый промежуток - 200.\n\r", ch);
+    return;
+  }
 
+  for (nr = 0; nr < top_of_trigt && (trig_index[nr]->vnum <= last); nr++) {
+    if (trig_index[nr]->vnum >= first) {
+      std::string out = "";
+      if (trig_index[nr]->proto->get_attach_type() == MOB_TRIGGER) {
+        out += "[MOB_TRIG]";
+      }
 
-	for (nr = 0; nr < top_of_trigt && (trig_index[nr]->vnum <= last); nr++)
-	{
-		if (trig_index[nr]->vnum >= first)
-		{
-			std::string out = "";
-			if (trig_index[nr]->proto->get_attach_type() == MOB_TRIGGER)
-			{
-				out += "[MOB_TRIG]";
-			}
+      if (trig_index[nr]->proto->get_attach_type() == OBJ_TRIGGER) {
+        out += "[OBJ_TRIG]";
+      }
 
-			if (trig_index[nr]->proto->get_attach_type() == OBJ_TRIGGER)
-			{
-				out += "[OBJ_TRIG]";
-			}
+      if (trig_index[nr]->proto->get_attach_type() == WLD_TRIGGER) {
+        out += "[WLD_TRIG]";
+      }
 
-			if (trig_index[nr]->proto->get_attach_type() == WLD_TRIGGER)
-			{
-				out += "[WLD_TRIG]";
-			}
+      sprintf(buf,
+              "%5d. [%5d] %s\r\nПрикрепленные триггеры: ",
+              ++found,
+              trig_index[nr]->vnum,
+              trig_index[nr]->proto->get_name().c_str());
+      out += buf;
+      if (!owner_trig[trig_index[nr]->vnum].empty()) {
+        for (auto it = owner_trig[trig_index[nr]->vnum].begin(); it != owner_trig[trig_index[nr]->vnum].end(); ++it) {
+          out += "[";
+          std::string out_tmp = "";
+          for (const auto trigger_vnum : it->second) {
+            sprintf(buf, " [%d]", trigger_vnum);
+            out_tmp += buf;
+          }
 
-			sprintf(buf, "%5d. [%5d] %s\r\nПрикрепленные триггеры: ", ++found, trig_index[nr]->vnum, trig_index[nr]->proto->get_name().c_str());
-			out += buf;
-			if (!owner_trig[trig_index[nr]->vnum].empty())
-			{
-				for (auto it = owner_trig[trig_index[nr]->vnum].begin(); it != owner_trig[trig_index[nr]->vnum].end(); ++it)
-				{
-					out += "[";
-					std::string  out_tmp = "";
-					for (const auto trigger_vnum : it->second)
-					{
-						sprintf(buf, " [%d]", trigger_vnum);
-						out_tmp += buf;
-					}
+          if (it->first != -1) {
+            out += std::to_string(it->first) + " : ";
+          }
 
-					if (it->first != -1)
-					{
-						out += std::to_string(it->first) + " : ";
-					}
+          out += out_tmp + "]";
+        }
 
-					out += out_tmp + "]";
-				}
+        out += "\r\n";
+      } else {
+        out += "Отсутствуют\r\n";
+      }
+      strcat(pagebuf, out.c_str());
+    }
+  }
 
-				out += "\r\n";
-			}
-			else
-			{
-				out += "Отсутствуют\r\n";
-			}
-			strcat(pagebuf, out.c_str());
-		}
-	}
-
-	if (!found)
-	{
-		send_to_char("No triggers were found in those parameters.\n\r", ch);
-	}
-	else
-	{
-		page_string(ch->desc, pagebuf, TRUE);
-	}
+  if (!found) {
+    send_to_char("No triggers were found in those parameters.\n\r", ch);
+  } else {
+    page_string(ch->desc, pagebuf, TRUE);
+  }
 }
 
-int real_trigger(int vnum)
-{
-	int rnum;
+int real_trigger(int vnum) {
+  int rnum;
 
-	for (rnum = 0; rnum < top_of_trigt; rnum++)
-	{
-		if (trig_index[rnum]->vnum == vnum)
-			break;
-	}
+  for (rnum = 0; rnum < top_of_trigt; rnum++) {
+    if (trig_index[rnum]->vnum == vnum)
+      break;
+  }
 
-	if (rnum == top_of_trigt)
-		rnum = -1;
-	return (rnum);
+  if (rnum == top_of_trigt)
+    rnum = -1;
+  return (rnum);
 }
 
-void do_tstat(CHAR_DATA *ch, char *argument, int  cmd, int/* subcmd*/)
-{
-	int vnum, rnum;
-	char str[MAX_INPUT_LENGTH];
+void do_tstat(CHAR_DATA *ch, char *argument, int cmd, int/* subcmd*/) {
+  int vnum, rnum;
+  char str[MAX_INPUT_LENGTH];
 
-	half_chop(argument, str, argument);
+  half_chop(argument, str, argument);
 
-	auto first = atoi(str);
-	if (!(Privilege::can_do_priv(ch,std::string(cmd_info[cmd].command), 0, 0, false)) && (GET_OLC_ZONE(ch) != first))
-	{
-		send_to_char("Чаво?\r\n", ch);
-		return;
-	}
+  auto first = atoi(str);
+  if (!(Privilege::can_do_priv(ch, std::string(cmd_info[cmd].command), 0, 0, false)) && (GET_OLC_ZONE(ch) != first)) {
+    send_to_char("Чаво?\r\n", ch);
+    return;
+  }
 
-	if (*str)
-	{
-		vnum = atoi(str);
-		rnum = real_trigger(vnum);
-		if (rnum < 0)
-		{
-			send_to_char("That vnum does not exist.\r\n", ch);
-			return;
-		}
+  if (*str) {
+    vnum = atoi(str);
+    rnum = real_trigger(vnum);
+    if (rnum < 0) {
+      send_to_char("That vnum does not exist.\r\n", ch);
+      return;
+    }
 
-		do_stat_trigger(ch, trig_index[rnum]->proto);
-	}
-	else
-		send_to_char("Usage: tstat <vnum>\r\n", ch);
+    do_stat_trigger(ch, trig_index[rnum]->proto);
+  } else
+    send_to_char("Usage: tstat <vnum>\r\n", ch);
 }
 
 // read a line in from a file, return the number of chars read
-int fgetline(FILE * file, char *p)
-{
-	int count = 0;
+int fgetline(FILE *file, char *p) {
+  int count = 0;
 
-	do
-	{
-		*p = fgetc(file);
-		if (*p != '\n' && !feof(file))
-		{
-			p++;
-			count++;
-		}
-	} while (*p != '\n' && !feof(file));
+  do {
+    *p = fgetc(file);
+    if (*p != '\n' && !feof(file)) {
+      p++;
+      count++;
+    }
+  } while (*p != '\n' && !feof(file));
 
-	if (*p == '\n')
-		*p = '\0';
+  if (*p == '\n')
+    *p = '\0';
 
-	return count;
+  return count;
 }
 
 // load in a character's saved variables
-void read_saved_vars(CHAR_DATA * ch)
-{
-	FILE *file;
-	long context;
-	char fn[127];
-	char input_line[1024], *p;
-	char varname[32], *v;
-	char context_str[16], *c;
+void read_saved_vars(CHAR_DATA *ch) {
+  FILE *file;
+  long context;
+  char fn[127];
+  char input_line[1024], *p;
+  char varname[32], *v;
+  char context_str[16], *c;
 
-	// find the file that holds the saved variables and open it
-	get_filename(GET_NAME(ch), fn, SCRIPT_VARS_FILE);
-	file = fopen(fn, "r");
+  // find the file that holds the saved variables and open it
+  get_filename(GET_NAME(ch), fn, SCRIPT_VARS_FILE);
+  file = fopen(fn, "r");
 
-	// if we failed to open the file, return
-	if (!file)
-	{
-		return;
-	}
+  // if we failed to open the file, return
+  if (!file) {
+    return;
+  }
 
-	// walk through each line in the file parsing variables
-	do
-	{
-		if (fgetline(file, input_line) > 0)
-		{
-			p = input_line;
-			v = varname;
-			c = context_str;
-			skip_spaces(&p);
-			while (*p && *p != ' ' && *p != '\t')
-				*v++ = *p++;
-			*v = '\0';
-			skip_spaces(&p);
-			while (*p && *p != ' ' && *p != '\t')
-				*c++ = *p++;
-			*c = '\0';
-			skip_spaces(&p);
+  // walk through each line in the file parsing variables
+  do {
+    if (fgetline(file, input_line) > 0) {
+      p = input_line;
+      v = varname;
+      c = context_str;
+      skip_spaces(&p);
+      while (*p && *p != ' ' && *p != '\t')
+        *v++ = *p++;
+      *v = '\0';
+      skip_spaces(&p);
+      while (*p && *p != ' ' && *p != '\t')
+        *c++ = *p++;
+      *c = '\0';
+      skip_spaces(&p);
 
-			context = atol(context_str);
-			add_var_cntx(&(SCRIPT(ch)->global_vars), varname, p, context);
-		}
-	} while (!feof(file));
+      context = atol(context_str);
+      add_var_cntx(&(SCRIPT(ch)->global_vars), varname, p, context);
+    }
+  } while (!feof(file));
 
-	// close the file and return
-	fclose(file);
+  // close the file and return
+  fclose(file);
 }
 
 // save a characters variables out to disk
-void save_char_vars(CHAR_DATA * ch)
-{
-	FILE *file;
-	char fn[127];
-	struct trig_var_data *vars;
+void save_char_vars(CHAR_DATA *ch) {
+  FILE *file;
+  char fn[127];
+  struct trig_var_data *vars;
 
-	// we should never be called for an NPC, but just in case...
-	if (IS_NPC(ch))
-		return;
+  // we should never be called for an NPC, but just in case...
+  if (IS_NPC(ch))
+    return;
 
-	get_filename(GET_NAME(ch), fn, SCRIPT_VARS_FILE);
-	std::remove(fn);
+  get_filename(GET_NAME(ch), fn, SCRIPT_VARS_FILE);
+  std::remove(fn);
 
-	// make sure this char has global variables to save
-	if (ch->script->global_vars == NULL)
-		return;
+  // make sure this char has global variables to save
+  if (ch->script->global_vars == NULL)
+    return;
 
-	vars = ch->script->global_vars;
+  vars = ch->script->global_vars;
 
-	file = fopen(fn, "wt");
+  file = fopen(fn, "wt");
 
-	// note that currently, context will always be zero. this may change
-	// in the future
-	while (vars)
-	{
-		if (*vars->name != '-')	// don't save if it begins with -
-			fprintf(file, "%s %ld %s\n", vars->name, vars->context, vars->value);
-		vars = vars->next;
-	}
+  // note that currently, context will always be zero. this may change
+  // in the future
+  while (vars) {
+    if (*vars->name != '-')    // don't save if it begins with -
+      fprintf(file, "%s %ld %s\n", vars->name, vars->context, vars->value);
+    vars = vars->next;
+  }
 
-	fclose(file);
+  fclose(file);
 }
 
-class TriggerRemoveObserverI : public TriggerEventObserver
-{
-public:
-	TriggerRemoveObserverI(TriggersList::iterator* owner) : m_owner(owner) {}
+class TriggerRemoveObserverI : public TriggerEventObserver {
+ public:
+  TriggerRemoveObserverI(TriggersList::iterator *owner) : m_owner(owner) {}
 
-	virtual void notify(TRIG_DATA* trigger) override;
+  virtual void notify(TRIG_DATA *trigger) override;
 
-private:
-	TriggersList::iterator* m_owner;
+ private:
+  TriggersList::iterator *m_owner;
 };
 
-void TriggerRemoveObserverI::notify(TRIG_DATA* trigger)
-{
-	m_owner->remove_event(trigger);
+void TriggerRemoveObserverI::notify(TRIG_DATA *trigger) {
+  m_owner->remove_event(trigger);
 }
 
-TriggersList::iterator::iterator(TriggersList* owner, const IteratorPosition position) : m_owner(owner), m_removed(false)
-{
-	m_iterator = position == BEGIN ? m_owner->m_list.begin() : m_owner->m_list.end();
-	setup_observer();
+TriggersList::iterator::iterator(TriggersList *owner, const IteratorPosition position)
+    : m_owner(owner), m_removed(false) {
+  m_iterator = position == BEGIN ? m_owner->m_list.begin() : m_owner->m_list.end();
+  setup_observer();
 }
 
-TriggersList::iterator::iterator(const iterator& rhv) : m_owner(rhv.m_owner), m_iterator(rhv.m_iterator), m_removed(rhv.m_removed)
-{
-	setup_observer();
+TriggersList::iterator::iterator(const iterator &rhv)
+    : m_owner(rhv.m_owner), m_iterator(rhv.m_iterator), m_removed(rhv.m_removed) {
+  setup_observer();
 }
 
-TriggersList::iterator::~iterator()
-{
-	m_owner->unregister_observer(m_observer);
+TriggersList::iterator::~iterator() {
+  m_owner->unregister_observer(m_observer);
 }
 
-TriggersList::TriggersList::iterator& TriggersList::iterator::operator++()
-{
-	if (!m_removed)
-	{
-		++m_iterator;
-	}
-	else
-	{
-		m_removed = false;
-	}
+TriggersList::TriggersList::iterator &TriggersList::iterator::operator++() {
+  if (!m_removed) {
+    ++m_iterator;
+  } else {
+    m_removed = false;
+  }
 
-	return *this;
+  return *this;
 }
 
-void TriggersList::iterator::setup_observer()
-{
-	m_observer = std::make_shared<TriggerRemoveObserverI>(this);
-	m_owner->register_observer(m_observer);
+void TriggersList::iterator::setup_observer() {
+  m_observer = std::make_shared<TriggerRemoveObserverI>(this);
+  m_owner->register_observer(m_observer);
 }
 
-void TriggersList::iterator::remove_event(TRIG_DATA* trigger)
-{
-	if (m_iterator != m_owner->m_list.end()
-		&& *m_iterator == trigger)
-	{
-		++m_iterator;
-		m_removed = true;
-	}
+void TriggersList::iterator::remove_event(TRIG_DATA *trigger) {
+  if (m_iterator != m_owner->m_list.end()
+      && *m_iterator == trigger) {
+    ++m_iterator;
+    m_removed = true;
+  }
 }
 
-class TriggerRemoveObserver : public TriggerEventObserver
-{
-public:
-	TriggerRemoveObserver(TriggersList* owner) : m_owner(owner) {}
+class TriggerRemoveObserver : public TriggerEventObserver {
+ public:
+  TriggerRemoveObserver(TriggersList *owner) : m_owner(owner) {}
 
-	virtual void notify(TRIG_DATA* trigger) override;
+  virtual void notify(TRIG_DATA *trigger) override;
 
-private:
-	TriggersList * m_owner;
+ private:
+  TriggersList *m_owner;
 };
 
-void TriggerRemoveObserver::notify(TRIG_DATA* trigger)
-{
-	m_owner->remove(trigger);
+void TriggerRemoveObserver::notify(TRIG_DATA *trigger) {
+  m_owner->remove(trigger);
 }
 
-TriggersList::TriggersList()
-{
-	m_observer = std::make_shared<TriggerRemoveObserver>(this);
+TriggersList::TriggersList() {
+  m_observer = std::make_shared<TriggerRemoveObserver>(this);
 }
 
-TriggersList::~TriggersList()
-{
-	clear();
+TriggersList::~TriggersList() {
+  clear();
 }
 
 // Return true if trigger successfully added
 // Return false if trigger with same rnum already exists and can not be added
-bool TriggersList::add(TRIG_DATA* trigger, const bool to_front /*= false*/)
-{
-	for (const auto& i : m_list)
-	{
-		if (trigger->get_rnum() == i->get_rnum())
-		{
-			//Мы не можем здесь заменить имеющийся триггер на новый
-			//т.к. имеющийся триггер может уже использоваться или быть в ожидание (wait command)
-			return false;
-		}
-	}
+bool TriggersList::add(TRIG_DATA *trigger, const bool to_front /*= false*/) {
+  for (const auto &i : m_list) {
+    if (trigger->get_rnum() == i->get_rnum()) {
+      //Мы не можем здесь заменить имеющийся триггер на новый
+      //т.к. имеющийся триггер может уже использоваться или быть в ожидание (wait command)
+      return false;
+    }
+  }
 
-	trigger_list.register_remove_observer(trigger, m_observer);
+  trigger_list.register_remove_observer(trigger, m_observer);
 
-	if (to_front)
-	{
-		m_list.push_front(trigger);
-	}
-	else
-	{
-		m_list.push_back(trigger);
-	}
+  if (to_front) {
+    m_list.push_front(trigger);
+  } else {
+    m_list.push_back(trigger);
+  }
 
-	return true;
+  return true;
 }
 
-void TriggersList::remove(TRIG_DATA* const trigger)
-{
-	const auto i = std::find(m_list.begin(), m_list.end(), trigger);
-	if (i != m_list.end())
-	{
-		remove(i);
-	}
+void TriggersList::remove(TRIG_DATA *const trigger) {
+  const auto i = std::find(m_list.begin(), m_list.end(), trigger);
+  if (i != m_list.end()) {
+    remove(i);
+  }
 }
 
-TriggersList::triggers_list_t::iterator TriggersList::remove(const triggers_list_t::iterator& iterator)
-{
-	TRIG_DATA* trigger = *iterator;
-	trigger_list.unregister_remove_observer(trigger, m_observer);
+TriggersList::triggers_list_t::iterator TriggersList::remove(const triggers_list_t::iterator &iterator) {
+  TRIG_DATA *trigger = *iterator;
+  trigger_list.unregister_remove_observer(trigger, m_observer);
 
-	for (const auto& observer : m_iterator_observers)
-	{
-		observer->notify(trigger);
-	}
+  for (const auto &observer : m_iterator_observers) {
+    observer->notify(trigger);
+  }
 
-	triggers_list_t::iterator result = m_list.erase(iterator);
+  triggers_list_t::iterator result = m_list.erase(iterator);
 
-	extract_trigger(trigger);
+  extract_trigger(trigger);
 
-	return result;
+  return result;
 }
 
-void TriggersList::register_observer(const TriggerEventObserver::shared_ptr& observer)
-{
-	m_iterator_observers.insert(observer);
+void TriggersList::register_observer(const TriggerEventObserver::shared_ptr &observer) {
+  m_iterator_observers.insert(observer);
 }
 
-void TriggersList::unregister_observer(const TriggerEventObserver::shared_ptr& observer)
-{
-	m_iterator_observers.erase(observer);
+void TriggersList::unregister_observer(const TriggerEventObserver::shared_ptr &observer) {
+  m_iterator_observers.erase(observer);
 }
 
-TRIG_DATA* TriggersList::find(const bool by_name, const char* name, const int vnum_or_position)
-{
-	if (by_name)
-	{
-		return find_by_name(name, vnum_or_position);
-	}
-	else
-	{
-		return find_by_vnum_or_position(vnum_or_position);
-	}
+TRIG_DATA *TriggersList::find(const bool by_name, const char *name, const int vnum_or_position) {
+  if (by_name) {
+    return find_by_name(name, vnum_or_position);
+  } else {
+    return find_by_vnum_or_position(vnum_or_position);
+  }
 }
 
-TRIG_DATA* TriggersList::find_by_name(const char* name, const int number)
-{
-	TRIG_DATA* result = nullptr;
+TRIG_DATA *TriggersList::find_by_name(const char *name, const int number) {
+  TRIG_DATA *result = nullptr;
 
-	int n = 0;
-	for (const auto& i : m_list)
-	{
-		if (isname(name, GET_TRIG_NAME(i)))
-		{
-			++n;
-			if (n >= number)
-			{
-				result = i;
-				break;
-			}
-		}
-	}
+  int n = 0;
+  for (const auto &i : m_list) {
+    if (isname(name, GET_TRIG_NAME(i))) {
+      ++n;
+      if (n >= number) {
+        result = i;
+        break;
+      }
+    }
+  }
 
-	return result;
+  return result;
 }
 
-TRIG_DATA* TriggersList::find_by_vnum_or_position(const int vnum_or_position)
-{
-	TRIG_DATA* result = nullptr;
+TRIG_DATA *TriggersList::find_by_vnum_or_position(const int vnum_or_position) {
+  TRIG_DATA *result = nullptr;
 
-	int n = 0;
-	for (const auto& i : m_list)
-	{
-		++n;
-		if (n >= vnum_or_position)
-		{
-			result = i;
-			break;
-		}
+  int n = 0;
+  for (const auto &i : m_list) {
+    ++n;
+    if (n >= vnum_or_position) {
+      result = i;
+      break;
+    }
 
-		if (trig_index[i->get_rnum()]->vnum == vnum_or_position)
-		{
-			result = i;
-			break;
-		}
-	}
+    if (trig_index[i->get_rnum()]->vnum == vnum_or_position) {
+      result = i;
+      break;
+    }
+  }
 
-	return result;
+  return result;
 }
 
-TRIG_DATA* TriggersList::find_by_vnum(const int vnum)
-{
-	TRIG_DATA* result = nullptr;
+TRIG_DATA *TriggersList::find_by_vnum(const int vnum) {
+  TRIG_DATA *result = nullptr;
 
-	for (const auto& i : m_list)
-	{
-		if (trig_index[i->get_rnum()]->vnum == vnum)
-		{
-			result = i;
-			break;
-		}
-	}
+  for (const auto &i : m_list) {
+    if (trig_index[i->get_rnum()]->vnum == vnum) {
+      result = i;
+      break;
+    }
+  }
 
-	return result;
+  return result;
 }
 
-TRIG_DATA* TriggersList::remove_by_name(const char* name, const int number)
-{
-	TRIG_DATA* to_remove = find_by_name(name, number);
+TRIG_DATA *TriggersList::remove_by_name(const char *name, const int number) {
+  TRIG_DATA *to_remove = find_by_name(name, number);
 
-	if (to_remove)
-	{
-		remove(to_remove);
-	}
+  if (to_remove) {
+    remove(to_remove);
+  }
 
-	return to_remove;
+  return to_remove;
 }
 
-TRIG_DATA* TriggersList::remove_by_vnum_or_position(const int vnum_or_position)
-{
-	TRIG_DATA* to_remove = find_by_vnum_or_position(vnum_or_position);
+TRIG_DATA *TriggersList::remove_by_vnum_or_position(const int vnum_or_position) {
+  TRIG_DATA *to_remove = find_by_vnum_or_position(vnum_or_position);
 
-	if (to_remove)
-	{
-		remove(to_remove);
-	}
+  if (to_remove) {
+    remove(to_remove);
+  }
 
-	return to_remove;
+  return to_remove;
 }
 
-TRIG_DATA* TriggersList::remove_by_vnum(const int vnum)
-{
-	TRIG_DATA* to_remove = find_by_vnum(vnum);
+TRIG_DATA *TriggersList::remove_by_vnum(const int vnum) {
+  TRIG_DATA *to_remove = find_by_vnum(vnum);
 
-	if (to_remove)
-	{
-		remove(to_remove);
-	}
+  if (to_remove) {
+    remove(to_remove);
+  }
 
-	return to_remove;
+  return to_remove;
 }
 
-long TriggersList::get_type() const
-{
-	long result = 0;
-	for (const auto& i : m_list)
-	{
-		result |= i->get_trigger_type();
-	}
+long TriggersList::get_type() const {
+  long result = 0;
+  for (const auto &i : m_list) {
+    result |= i->get_trigger_type();
+  }
 
-	return result;
+  return result;
 }
 
-bool TriggersList::has_trigger(const TRIG_DATA* const trigger)
-{
-	for (const auto& i : m_list)
-	{
-		if (i == trigger)
-		{
-			return true;
-		}
-	}
+bool TriggersList::has_trigger(const TRIG_DATA *const trigger) {
+  for (const auto &i : m_list) {
+    if (i == trigger) {
+      return true;
+    }
+  }
 
-	return false;
+  return false;
 }
 
-void TriggersList::clear()
-{
-	while (!m_list.empty())
-	{
-		remove(*m_list.begin());	// Do all stuff related to removing trigger from the list. Specifically, unregister all observers.
-	}
+void TriggersList::clear() {
+  while (!m_list.empty()) {
+    remove(*m_list.begin());    // Do all stuff related to removing trigger from the list. Specifically, unregister all observers.
+  }
 }
 
-std::ostream& TriggersList::dump(std::ostream& os) const
-{
-	bool first = true;
-	for (const auto t : m_list)
-	{
-		if (!first)
-		{
-			os << ", ";
-		}
-		os << trig_index[t->get_rnum()]->vnum;
-		first = false;
-	}
+std::ostream &TriggersList::dump(std::ostream &os) const {
+  bool first = true;
+  for (const auto t : m_list) {
+    if (!first) {
+      os << ", ";
+    }
+    os << trig_index[t->get_rnum()]->vnum;
+    first = false;
+  }
 
-	return os;
+  return os;
 }
 
 SCRIPT_DATA::SCRIPT_DATA() :
-	types(0),
-	global_vars(nullptr),
-	context(0),
-	m_purged(false)
-{
+    types(0),
+    global_vars(nullptr),
+    context(0),
+    m_purged(false) {
 }
 
 // don't copy anything for now
-SCRIPT_DATA::SCRIPT_DATA(const SCRIPT_DATA&) :
-	types(0),
-	global_vars(nullptr),
-	context(0),
-	m_purged(false)
-{
+SCRIPT_DATA::SCRIPT_DATA(const SCRIPT_DATA &) :
+    types(0),
+    global_vars(nullptr),
+    context(0),
+    m_purged(false) {
 }
 
-SCRIPT_DATA::~SCRIPT_DATA()
-{
-	trig_list.clear();
-	clear_global_vars();
+SCRIPT_DATA::~SCRIPT_DATA() {
+  trig_list.clear();
+  clear_global_vars();
 }
 
-int SCRIPT_DATA::remove_trigger(char *name, TRIG_DATA*& trig_addr)
-{
-	int num = 0;
-	char *cname;
+int SCRIPT_DATA::remove_trigger(char *name, TRIG_DATA *&trig_addr) {
+  int num = 0;
+  char *cname;
 
-	bool string = false;
-	if ((cname = strchr(name, '.')) || (!a_isdigit(*name)))
-	{
-		string = true;
-		if (cname)
-		{
-			*cname = '\0';
-			num = atoi(name);
-			name = ++cname;
-		}
-	}
-	else
-	{
-		num = atoi(name);
-	}
+  bool string = false;
+  if ((cname = strchr(name, '.')) || (!a_isdigit(*name))) {
+    string = true;
+    if (cname) {
+      *cname = '\0';
+      num = atoi(name);
+      name = ++cname;
+    }
+  } else {
+    num = atoi(name);
+  }
 
-	TRIG_DATA *address_of_removed_trigger = nullptr;
-	if (string)
-	{
-		address_of_removed_trigger = trig_list.remove_by_name(name, num);
-	}
-	else
-	{
-		address_of_removed_trigger = trig_list.remove_by_vnum_or_position(num);
-	}
+  TRIG_DATA *address_of_removed_trigger = nullptr;
+  if (string) {
+    address_of_removed_trigger = trig_list.remove_by_name(name, num);
+  } else {
+    address_of_removed_trigger = trig_list.remove_by_vnum_or_position(num);
+  }
 
-	if (!address_of_removed_trigger)
-	{
-		return 0;	// nothing has been removed
-	}
+  if (!address_of_removed_trigger) {
+    return 0;    // nothing has been removed
+  }
 
-	if (address_of_removed_trigger == trig_addr)
-	{
-		trig_addr = nullptr;	// mark that this trigger was removed: trig_addr is not null if trigger is still in the memory
-	}
+  if (address_of_removed_trigger == trig_addr) {
+    trig_addr =
+        nullptr;    // mark that this trigger was removed: trig_addr is not null if trigger is still in the memory
+  }
 
-	// update the script type bitvector
-	types = trig_list.get_type();
+  // update the script type bitvector
+  types = trig_list.get_type();
 
-	return 1;
+  return 1;
 }
 
-int SCRIPT_DATA::remove_trigger(char *name)
-{
-	TRIG_DATA* dummy = nullptr;
-	return remove_trigger(name, dummy);
+int SCRIPT_DATA::remove_trigger(char *name) {
+  TRIG_DATA *dummy = nullptr;
+  return remove_trigger(name, dummy);
 }
 
-void SCRIPT_DATA::clear_global_vars()
-{
-	for (auto i = global_vars; i;)
-	{
-		auto j = i;
-		i = i->next;
-		if (j->name)
-			free(j->name);
-		if (j->value)
-			free(j->value);
-		free(j);
-	}
+void SCRIPT_DATA::clear_global_vars() {
+  for (auto i = global_vars; i;) {
+    auto j = i;
+    i = i->next;
+    if (j->name)
+      free(j->name);
+    if (j->value)
+      free(j->value);
+    free(j);
+  }
 }
 
-void SCRIPT_DATA::cleanup()
-{
-	trig_list.clear();
+void SCRIPT_DATA::cleanup() {
+  trig_list.clear();
 
-	clear_global_vars();
-	global_vars = nullptr;
+  clear_global_vars();
+  global_vars = nullptr;
 }
 
-const char* TRIG_DATA::DEFAULT_TRIGGER_NAME = "no name";
+const char *TRIG_DATA::DEFAULT_TRIGGER_NAME = "no name";
 
 TRIG_DATA::TRIG_DATA() :
-	cmdlist(new cmdlist_element::shared_ptr()),
-	narg(0),
-	depth(0),
-	loops(-1),
-	wait_event(nullptr),
-	var_list(nullptr),
-	nr(NOTHING),
-	attach_type(0),
-	name(DEFAULT_TRIGGER_NAME),
-	trigger_type(0)
-{
+    cmdlist(new cmdlist_element::shared_ptr()),
+    narg(0),
+    depth(0),
+    loops(-1),
+    wait_event(nullptr),
+    var_list(nullptr),
+    nr(NOTHING),
+    attach_type(0),
+    name(DEFAULT_TRIGGER_NAME),
+    trigger_type(0) {
 }
 
-TRIG_DATA::TRIG_DATA(const sh_int rnum, const char* name, const byte attach_type, const long trigger_type) :
-	cmdlist(new cmdlist_element::shared_ptr()),
-	narg(0),
-	depth(0),
-	loops(-1),
-	wait_event(nullptr),
-	var_list(nullptr),
-	nr(rnum),
-	attach_type(attach_type),
-	name(name),
-	trigger_type(trigger_type)
-{
+TRIG_DATA::TRIG_DATA(const sh_int rnum, const char *name, const byte attach_type, const long trigger_type) :
+    cmdlist(new cmdlist_element::shared_ptr()),
+    narg(0),
+    depth(0),
+    loops(-1),
+    wait_event(nullptr),
+    var_list(nullptr),
+    nr(rnum),
+    attach_type(attach_type),
+    name(name),
+    trigger_type(trigger_type) {
 }
 
-TRIG_DATA::TRIG_DATA(const sh_int rnum, std::string&& name, const byte attach_type, const long trigger_type) :
-	cmdlist(new cmdlist_element::shared_ptr()),
-	narg(0),
-	depth(0),
-	loops(-1),
-	wait_event(nullptr),
-	var_list(nullptr),
-	nr(rnum),
-	attach_type(attach_type),
-	name(name),
-	trigger_type(trigger_type)
-{
+TRIG_DATA::TRIG_DATA(const sh_int rnum, std::string &&name, const byte attach_type, const long trigger_type) :
+    cmdlist(new cmdlist_element::shared_ptr()),
+    narg(0),
+    depth(0),
+    loops(-1),
+    wait_event(nullptr),
+    var_list(nullptr),
+    nr(rnum),
+    attach_type(attach_type),
+    name(name),
+    trigger_type(trigger_type) {
 }
 
-TRIG_DATA::TRIG_DATA(const sh_int rnum, const char* name, const long trigger_type) : TRIG_DATA(rnum, name, 0, trigger_type)
-{
+TRIG_DATA::TRIG_DATA(const sh_int rnum, const char *name, const long trigger_type) : TRIG_DATA(rnum,
+                                                                                               name,
+                                                                                               0,
+                                                                                               trigger_type) {
 }
 
-TRIG_DATA::TRIG_DATA(const TRIG_DATA& from) :
-	cmdlist(from.cmdlist),
-	narg(from.narg),
-	arglist(from.arglist),
-	depth(from.depth),
-	loops(from.loops),
-	wait_event(nullptr),
-	var_list(nullptr),
-	nr(from.nr),
-	attach_type(from.attach_type),
-	name(from.name),
-	trigger_type(from.trigger_type)
-{
+TRIG_DATA::TRIG_DATA(const TRIG_DATA &from) :
+    cmdlist(from.cmdlist),
+    narg(from.narg),
+    arglist(from.arglist),
+    depth(from.depth),
+    loops(from.loops),
+    wait_event(nullptr),
+    var_list(nullptr),
+    nr(from.nr),
+    attach_type(from.attach_type),
+    name(from.name),
+    trigger_type(from.trigger_type) {
 }
 
-void TRIG_DATA::reset()
-{
-	nr = NOTHING;
-	attach_type = 0;
-	name = DEFAULT_TRIGGER_NAME;
-	trigger_type = 0;
-	cmdlist.reset();
-	curr_state.reset();
-	narg = 0;
-	arglist.clear();
-	depth = 0;
-	loops = -1;
-	wait_event = nullptr;
-	var_list = nullptr;
+void TRIG_DATA::reset() {
+  nr = NOTHING;
+  attach_type = 0;
+  name = DEFAULT_TRIGGER_NAME;
+  trigger_type = 0;
+  cmdlist.reset();
+  curr_state.reset();
+  narg = 0;
+  arglist.clear();
+  depth = 0;
+  loops = -1;
+  wait_event = nullptr;
+  var_list = nullptr;
 }
 
-TRIG_DATA& TRIG_DATA::operator=(const TRIG_DATA& right)
-{
-	reset();
+TRIG_DATA &TRIG_DATA::operator=(const TRIG_DATA &right) {
+  reset();
 
-	nr = right.nr;
-	set_attach_type(right.get_attach_type());
-	name = right.name;
-	trigger_type = right.trigger_type;
-	cmdlist = right.cmdlist;
-	narg = right.narg;
-	arglist = right.arglist;
+  nr = right.nr;
+  set_attach_type(right.get_attach_type());
+  name = right.name;
+  trigger_type = right.trigger_type;
+  cmdlist = right.cmdlist;
+  narg = right.narg;
+  arglist = right.arglist;
 
-	return *this;
+  return *this;
 }
 
-void TRIG_DATA::clear_var_list()
-{
-	for (auto i = var_list; i;)
-	{
-		auto j = i;
-		i = i->next;
-		if (j->name)
-			free(j->name);
-		if (j->value)
-			free(j->value);
-		free(j);
-	}
+void TRIG_DATA::clear_var_list() {
+  for (auto i = var_list; i;) {
+    auto j = i;
+    i = i->next;
+    if (j->name)
+      free(j->name);
+    if (j->value)
+      free(j->value);
+    free(j);
+  }
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/dg_script/dg_scripts.cpp
+++ b/src/dg_script/dg_scripts.cpp
@@ -2326,7 +2326,7 @@ void find_replacement(void *go,
     } else if (!str_cmp(field, "maxskill")) {
       const ESkill skillnum = fix_name_and_find_skill_num(subfield);
       if (skillnum > 0) {
-        sprintf(str, "%d", CalcSkillMinCap(ch, skillnum));
+        sprintf(str, "%d", CalcSkillMinCap(c, skillnum));
       } else {
         strcpy(str, "0");
       }

--- a/src/fightsystem/fight.cpp
+++ b/src/fightsystem/fight.cpp
@@ -1791,7 +1791,7 @@ void using_mob_skills(CHAR_DATA *ch)
 //sprintf(buf, "%s башат предфункция\r\n",GET_NAME(caster));
 //mudlog(buf, LGH, MAX(LVL_IMMORT, GET_INVIS_LEV(ch)), SYSLOG, TRUE);
 					if (GET_POS(caster) >= POS_FIGHTING
-						|| calculate_skill(ch, SKILL_BASH, caster) > number(50, 80))
+						|| CalcCurrentSkill(ch, SKILL_BASH, caster) > number(50, 80))
 					{
 						sk_use = 0;
 						go_bash(ch, caster);
@@ -1804,7 +1804,7 @@ void using_mob_skills(CHAR_DATA *ch)
 //                mudlog(buf, LGH, MAX(LVL_IMMORT, GET_INVIS_LEV(ch)), SYSLOG, TRUE);
 
 					if (GET_POS(caster) >= POS_FIGHTING
-						|| calculate_skill(ch, SKILL_CHOPOFF, caster) > number(50, 80))
+						|| CalcCurrentSkill(ch, SKILL_CHOPOFF, caster) > number(50, 80))
 					{
 						sk_use = 0;
 						go_chopoff(ch, caster);
@@ -1832,7 +1832,7 @@ void using_mob_skills(CHAR_DATA *ch)
 						}
 					}
 					else if (GET_POS(damager) >= POS_FIGHTING
-						|| calculate_skill(ch, SKILL_BASH, damager) > number(50, 80))
+						|| CalcCurrentSkill(ch, SKILL_BASH, damager) > number(50, 80))
 					{
 						sk_use = 0;
 						go_bash(ch, damager);
@@ -1846,7 +1846,7 @@ void using_mob_skills(CHAR_DATA *ch)
 						go_chopoff(ch, damager->get_horse());
 					}
 					else if (GET_POS(damager) >= POS_FIGHTING
-						|| calculate_skill(ch, SKILL_CHOPOFF, damager) > number(50, 80))
+						|| CalcCurrentSkill(ch, SKILL_CHOPOFF, damager) > number(50, 80))
 					{
 						sk_use = 0;
 						go_chopoff(ch, damager);
@@ -2554,7 +2554,7 @@ int calc_leadership(CHAR_DATA * ch)
 	}
 
 	percent = number(1, 101);
-	prob = calculate_skill(leader, SKILL_LEADERSHIP, 0);
+	prob = CalcCurrentSkill(leader, SKILL_LEADERSHIP, 0);
 	if (percent > prob)
 	{
 		return (FALSE);

--- a/src/fightsystem/fight_hit.cpp
+++ b/src/fightsystem/fight_hit.cpp
@@ -1460,6 +1460,7 @@ void hit_parry(CHAR_DATA *ch, CHAR_DATA *victim, int skill, int hit_type, int *d
     int prob = CalcCurrentSkill(victim, SKILL_PARRY, ch);
     prob = prob * 100 / range;
     TrainSkill(victim, SKILL_PARRY, prob < 100, ch);
+    SendSkillBalanceMsg(ch, skill_info[SKILL_PARRY].name, range, prob, prob >= 70);
     if (prob < 70
         || ((skill == SKILL_BOWS || hit_type == FightSystem::type_maul)
             && !IS_IMMORTAL(victim)
@@ -1525,6 +1526,7 @@ void hit_multyparry(CHAR_DATA *ch, CHAR_DATA *victim, int skill, int hit_type, i
     }
 
     TrainSkill(victim, SKILL_MULTYPARRY, prob >= 50, ch);
+    SendSkillBalanceMsg(ch, skill_info[SKILL_MULTYPARRY].name, range, prob, prob >= 50);
     if (prob < 50) {
       act("Вы не смогли отбить атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
       act("$N не сумел$G отбить вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
@@ -1559,9 +1561,10 @@ void hit_block(CHAR_DATA *ch, CHAR_DATA *victim, int *dam) {
   } else {
     int range = number(1, skill_info[SKILL_BLOCK].fail_percent);
     int prob = CalcCurrentSkill(victim, SKILL_BLOCK, ch);
-    TrainSkill(victim, SKILL_BLOCK, prob > 99, ch);
     prob = prob * 100 / range;
     BATTLECNTR(victim)++;
+    TrainSkill(victim, SKILL_BLOCK, prob > 99, ch);
+    SendSkillBalanceMsg(ch, skill_info[SKILL_BLOCK].name, range, prob, prob > 99);
     if (prob < 100) {
       act("Вы не смогли отразить атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
       act("$N не сумел$G отразить вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
@@ -2609,6 +2612,7 @@ void HitData::try_mighthit_dam(CHAR_DATA *ch, CHAR_DATA *victim) {
     prob = 0;
   }
 
+  SendSkillBalanceMsg(ch, skill_info[SKILL_MIGHTHIT].name, percent, prob, percent <= prob);
   if (percent > prob || dam == 0) {
     sprintf(buf, "&c&qВаш богатырский удар пропал впустую.&Q&n\r\n");
     send_to_char(buf, ch);
@@ -2691,6 +2695,7 @@ void HitData::try_stupor_dam(CHAR_DATA *ch, CHAR_DATA *victim) {
   int percent = number(1, skill_info[SKILL_STUPOR].fail_percent);
   int prob = CalcCurrentSkill(ch, SKILL_STUPOR, victim);
   TrainSkill(ch, SKILL_STUPOR, prob >= percent, victim);
+  SendSkillBalanceMsg(ch, skill_info[SKILL_STUPOR].name, percent, prob, prob >= percent);
   int lag = 0;
 
   if (GET_MOB_HOLD(victim)) {

--- a/src/fightsystem/fight_hit.cpp
+++ b/src/fightsystem/fight_hit.cpp
@@ -18,798 +18,758 @@
 
 // extern
 int extra_aco(int class_num, int level);
-void alt_equip(CHAR_DATA * ch, int pos, int dam, int chance);
+void alt_equip(CHAR_DATA *ch, int pos, int dam, int chance);
 int thaco(int class_num, int level);
-void npc_groupbattle(CHAR_DATA * ch);
-void set_wait(CHAR_DATA * ch, int waittime, int victim_in_room);
-void go_autoassist(CHAR_DATA * ch);
+void npc_groupbattle(CHAR_DATA *ch);
+void set_wait(CHAR_DATA *ch, int waittime, int victim_in_room);
+void go_autoassist(CHAR_DATA *ch);
 
-int armor_class_limit(CHAR_DATA * ch) {
-	if (IS_CHARMICE(ch)) {
-		return -200;
-	};
-	if (IS_NPC(ch)) {
+int armor_class_limit(CHAR_DATA *ch) {
+  if (IS_CHARMICE(ch)) {
+    return -200;
+  };
+  if (IS_NPC(ch)) {
 
-		return -300;
-	};
-	switch (GET_CLASS(ch)) {
-	case CLASS_PALADINE:
-		return -270;
-		break;
-	case CLASS_ASSASINE:
-	case CLASS_THIEF:
-	case CLASS_GUARD:
-		return -250;
-		break;
-	case CLASS_MERCHANT:
-	case CLASS_WARRIOR:
-	case CLASS_RANGER:
-	case CLASS_SMITH:
-		return -200;
-		break;
-	case CLASS_CLERIC:
-	case CLASS_DRUID:
-		return -170;
-		break;
-	case CLASS_BATTLEMAGE:
-	case CLASS_DEFENDERMAGE:
-	case CLASS_CHARMMAGE:
-	case CLASS_NECROMANCER:
-		return -150;
-		break;
-	}
-	return -300;
+    return -300;
+  };
+  switch (GET_CLASS(ch)) {
+    case CLASS_PALADINE: return -270;
+      break;
+    case CLASS_ASSASINE:
+    case CLASS_THIEF:
+    case CLASS_GUARD: return -250;
+      break;
+    case CLASS_MERCHANT:
+    case CLASS_WARRIOR:
+    case CLASS_RANGER:
+    case CLASS_SMITH: return -200;
+      break;
+    case CLASS_CLERIC:
+    case CLASS_DRUID: return -170;
+      break;
+    case CLASS_BATTLEMAGE:
+    case CLASS_DEFENDERMAGE:
+    case CLASS_CHARMMAGE:
+    case CLASS_NECROMANCER: return -150;
+      break;
+  }
+  return -300;
 }
 
-int compute_armor_class(CHAR_DATA * ch)
-{
-	int armorclass = GET_REAL_AC(ch);
+int compute_armor_class(CHAR_DATA *ch) {
+  int armorclass = GET_REAL_AC(ch);
 
-	if (AWAKE(ch))
-	{
-		int high_stat = GET_REAL_DEX(ch);
-		// у игроков для ац берется макс стат: ловкость или 3/4 инты
-		if (!IS_NPC(ch))
-		{
-			high_stat = std::max(high_stat, GET_REAL_INT(ch) * 3 / 4);
-		}
-		armorclass -= dex_ac_bonus(high_stat) * 10;
-		armorclass += extra_aco((int) GET_CLASS(ch), (int) GET_LEVEL(ch));
-	};
+  if (AWAKE(ch)) {
+    int high_stat = GET_REAL_DEX(ch);
+    // у игроков для ац берется макс стат: ловкость или 3/4 инты
+    if (!IS_NPC(ch)) {
+      high_stat = std::max(high_stat, GET_REAL_INT(ch) * 3 / 4);
+    }
+    armorclass -= dex_ac_bonus(high_stat) * 10;
+    armorclass += extra_aco((int) GET_CLASS(ch), (int) GET_LEVEL(ch));
+  };
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_BERSERK))
-	{
-		armorclass -= (240 * ((GET_REAL_MAX_HIT(ch) / 2) - GET_HIT(ch)) / GET_REAL_MAX_HIT(ch));
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BERSERK)) {
+    armorclass -= (240 * ((GET_REAL_MAX_HIT(ch) / 2) - GET_HIT(ch)) / GET_REAL_MAX_HIT(ch));
+  }
 
-	if (PRF_FLAGS(ch).get(PRF_IRON_WIND))
-	{
-		armorclass += ch->get_skill(SKILL_IRON_WIND) / 2;
-	}
+  if (PRF_FLAGS(ch).get(PRF_IRON_WIND)) {
+    armorclass += ch->get_skill(SKILL_IRON_WIND) / 2;
+  }
 
-	armorclass += (size_app[GET_POS_SIZE(ch)].ac * 10);
+  armorclass += (size_app[GET_POS_SIZE(ch)].ac * 10);
 
-	if (GET_AF_BATTLE(ch, EAF_PUNCTUAL))
-	{
-		if (GET_EQ(ch, WEAR_WIELD))
-		{
-			if (GET_EQ(ch, WEAR_HOLD))
-				armorclass +=
-					10 * MAX(-1,
-							 (GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD)) +
-							  GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))) / 5 - 6);
-			else
-				armorclass += 10 * MAX(-1, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD)) / 5 - 6);
-		}
-		if (GET_EQ(ch, WEAR_BOTHS))
-			armorclass += 10 * MAX(-1, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS)) / 5 - 6);
-	}
+  if (GET_AF_BATTLE(ch, EAF_PUNCTUAL)) {
+    if (GET_EQ(ch, WEAR_WIELD)) {
+      if (GET_EQ(ch, WEAR_HOLD))
+        armorclass +=
+            10 * MAX(-1,
+                     (GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD)) +
+                         GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))) / 5 - 6);
+      else
+        armorclass += 10 * MAX(-1, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD)) / 5 - 6);
+    }
+    if (GET_EQ(ch, WEAR_BOTHS))
+      armorclass += 10 * MAX(-1, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS)) / 5 - 6);
+  }
 
-	// Bonus for leadership
-	if (calc_leadership(ch)) {
-			armorclass -= 20;
-	}
+  // Bonus for leadership
+  if (calc_leadership(ch)) {
+    armorclass -= 20;
+  }
 
-	armorclass = MIN(100, armorclass);
-	return (MAX(armor_class_limit(ch), armorclass));
+  armorclass = MIN(100, armorclass);
+  return (MAX(armor_class_limit(ch), armorclass));
 }
 
-void haemorragia(CHAR_DATA * ch, int percent)
-{
-	AFFECT_DATA<EApplyLocation> af[3];
+void haemorragia(CHAR_DATA *ch, int percent) {
+  AFFECT_DATA<EApplyLocation> af[3];
 
-	af[0].type = SPELL_HAEMORRAGIA;
-	af[0].location = APPLY_HITREG;
-	af[0].modifier = -percent;
-	//TODO: Отрицательное время, если тело больше 31?
-	af[0].duration = pc_duration(ch, number(1, 31 - GET_REAL_CON(ch)), 0, 0, 0, 0);
-	af[0].bitvector = 0;
-	af[0].battleflag = 0;
-	af[1].type = SPELL_HAEMORRAGIA;
-	af[1].location = APPLY_MOVEREG;
-	af[1].modifier = -percent;
-	af[1].duration = af[0].duration;
-	af[1].bitvector = 0;
-	af[1].battleflag = 0;
-	af[2].type = SPELL_HAEMORRAGIA;
-	af[2].location = APPLY_MANAREG;
-	af[2].modifier = -percent;
-	af[2].duration = af[0].duration;
-	af[2].bitvector = 0;
-	af[2].battleflag = 0;
+  af[0].type = SPELL_HAEMORRAGIA;
+  af[0].location = APPLY_HITREG;
+  af[0].modifier = -percent;
+  //TODO: Отрицательное время, если тело больше 31?
+  af[0].duration = pc_duration(ch, number(1, 31 - GET_REAL_CON(ch)), 0, 0, 0, 0);
+  af[0].bitvector = 0;
+  af[0].battleflag = 0;
+  af[1].type = SPELL_HAEMORRAGIA;
+  af[1].location = APPLY_MOVEREG;
+  af[1].modifier = -percent;
+  af[1].duration = af[0].duration;
+  af[1].bitvector = 0;
+  af[1].battleflag = 0;
+  af[2].type = SPELL_HAEMORRAGIA;
+  af[2].location = APPLY_MANAREG;
+  af[2].modifier = -percent;
+  af[2].duration = af[0].duration;
+  af[2].bitvector = 0;
+  af[2].battleflag = 0;
 
-	for (int i = 0; i < 3; i++)
-	{
-		affect_join(ch, af[i], TRUE, FALSE, TRUE, FALSE);
-	}
+  for (int i = 0; i < 3; i++) {
+    affect_join(ch, af[i], TRUE, FALSE, TRUE, FALSE);
+  }
 }
 
-void HitData::compute_critical(CHAR_DATA * ch, CHAR_DATA * victim)
-{
-	const char *to_char = NULL, *to_vict = NULL;
-	AFFECT_DATA<EApplyLocation> af[4];
-	OBJ_DATA *obj;
-	int unequip_pos = 0;
+void HitData::compute_critical(CHAR_DATA *ch, CHAR_DATA *victim) {
+  const char *to_char = NULL, *to_vict = NULL;
+  AFFECT_DATA<EApplyLocation> af[4];
+  OBJ_DATA *obj;
+  int unequip_pos = 0;
 
-	for (int i = 0; i < 4; i++)
-	{
-		af[i].type = 0;
-		af[i].location = APPLY_NONE;
-		af[i].bitvector = 0;
-		af[i].modifier = 0;
-		af[i].battleflag = 0;
-		af[i].duration = pc_duration(victim, 2, 0, 0, 0, 0);
-	}
+  for (int i = 0; i < 4; i++) {
+    af[i].type = 0;
+    af[i].location = APPLY_NONE;
+    af[i].bitvector = 0;
+    af[i].modifier = 0;
+    af[i].battleflag = 0;
+    af[i].duration = pc_duration(victim, 2, 0, 0, 0, 0);
+  }
 
-	switch (number(1, 10))
-	{
-	case 1:
-	case 2:
-	case 3:
-	case 4:		// FEETS
-		switch (dam_critic)
-		{
-		case 1:
-		case 2:
-		case 3:
-			// Nothing
-			return;
-		case 4:	// Hit genus, victim bashed, speed/2
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 10);
-			if (GET_POS(victim) > POS_SITTING)
-				GET_POS(victim) = POS_SITTING;
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			to_char = "повалило $N3 на землю";
-			to_vict = "повредило вам колено, повалив на землю";
-			break;
-		case 5:	// victim bashed
-			if (GET_POS(victim) > POS_SITTING)
-				GET_POS(victim) = POS_SITTING;
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			to_char = "повалило $N3 на землю";
-			to_vict = "повредило вам колено, повалив на землю";
-			break;
-		case 6:	// foot damaged, speed/2
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 9);
-			to_char = "замедлило движения $N1";
-			to_vict = "сломало вам лодыжку";
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 7:
-		case 9:	// armor damaged else foot damaged, speed/4
-			if (GET_EQ(victim, WEAR_LEGS))
-				alt_equip(victim, WEAR_LEGS, 100, 100);
-			else
-			{
-				dam *= (ch->get_skill(SKILL_PUNCTUAL) / 8);
-				to_char = "замедлило движения $N1";
-				to_vict = "сломало вам ногу";
-				af[0].type = SPELL_BATTLE;
-				af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-				SET_AF_BATTLE(victim, EAF_SLOW);
-			}
-			break;
-		case 8:	// femor damaged, no speed
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
-			to_char = "сильно замедлило движения $N1";
-			to_vict = "сломало вам бедро";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 20);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 10:	// genus damaged, no speed, -2HR
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
-			to_char = "сильно замедлило движения $N1";
-			to_vict = "раздробило вам колено";
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_HITROLL;
-			af[0].modifier = -2;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 11:	// femor damaged, no speed, no attack
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
-			to_char = "вывело $N3 из строя";
-			to_vict = "раздробило вам бедро";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			af[1].type = SPELL_BATTLE;
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 20);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		default:	// femor damaged, no speed, no attack
-			if (dam_critic > 12)
-				dam *= (ch->get_skill(SKILL_PUNCTUAL) / 5);
-			else
-				dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
-			to_char = "вывело $N3 из строя";
-			to_vict = "изуродовало вам ногу";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			af[1].type = SPELL_BATTLE;
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 50);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		}
-		break;
-	case 5:		//  ABDOMINAL
-		switch (dam_critic)
-		{
-		case 1:
-		case 2:
-		case 3:
-			// nothing
-			return;
-		case 4:	// waits 1d6
-			WAIT_STATE(victim, number(2, 6) * PULSE_VIOLENCE);
-			to_char = "сбило $N2 дыхание";
-			to_vict = "сбило вам дыхание";
-			break;
+  switch (number(1, 10)) {
+    case 1:
+    case 2:
+    case 3:
+    case 4:        // FEETS
+      switch (dam_critic) {
+        case 1:
+        case 2:
+        case 3:
+          // Nothing
+          return;
+        case 4:    // Hit genus, victim bashed, speed/2
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 10);
+          if (GET_POS(victim) > POS_SITTING)
+            GET_POS(victim) = POS_SITTING;
+          WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          to_char = "повалило $N3 на землю";
+          to_vict = "повредило вам колено, повалив на землю";
+          break;
+        case 5:    // victim bashed
+          if (GET_POS(victim) > POS_SITTING)
+            GET_POS(victim) = POS_SITTING;
+          WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          to_char = "повалило $N3 на землю";
+          to_vict = "повредило вам колено, повалив на землю";
+          break;
+        case 6:    // foot damaged, speed/2
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 9);
+          to_char = "замедлило движения $N1";
+          to_vict = "сломало вам лодыжку";
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 7:
+        case 9:    // armor damaged else foot damaged, speed/4
+          if (GET_EQ(victim, WEAR_LEGS))
+            alt_equip(victim, WEAR_LEGS, 100, 100);
+          else {
+            dam *= (ch->get_skill(SKILL_PUNCTUAL) / 8);
+            to_char = "замедлило движения $N1";
+            to_vict = "сломало вам ногу";
+            af[0].type = SPELL_BATTLE;
+            af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+            SET_AF_BATTLE(victim, EAF_SLOW);
+          }
+          break;
+        case 8:    // femor damaged, no speed
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
+          to_char = "сильно замедлило движения $N1";
+          to_vict = "сломало вам бедро";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 20);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 10:    // genus damaged, no speed, -2HR
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
+          to_char = "сильно замедлило движения $N1";
+          to_vict = "раздробило вам колено";
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_HITROLL;
+          af[0].modifier = -2;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 11:    // femor damaged, no speed, no attack
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
+          to_char = "вывело $N3 из строя";
+          to_vict = "раздробило вам бедро";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          af[1].type = SPELL_BATTLE;
+          af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 20);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        default:    // femor damaged, no speed, no attack
+          if (dam_critic > 12)
+            dam *= (ch->get_skill(SKILL_PUNCTUAL) / 5);
+          else
+            dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
+          to_char = "вывело $N3 из строя";
+          to_vict = "изуродовало вам ногу";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          af[1].type = SPELL_BATTLE;
+          af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 50);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+      }
+      break;
+    case 5:        //  ABDOMINAL
+      switch (dam_critic) {
+        case 1:
+        case 2:
+        case 3:
+          // nothing
+          return;
+        case 4:    // waits 1d6
+          WAIT_STATE(victim, number(2, 6) * PULSE_VIOLENCE);
+          to_char = "сбило $N2 дыхание";
+          to_vict = "сбило вам дыхание";
+          break;
 
-		case 5:	// abdomin damaged, waits 1, speed/2
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 8);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			to_char = "ранило $N3 в живот";
-			to_vict = "ранило вас в живот";
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 6:	// armor damaged else dam*3, waits 1d6
-			WAIT_STATE(victim, number(2, 6) * PULSE_VIOLENCE);
-			if (GET_EQ(victim, WEAR_WAIST))
-				alt_equip(victim, WEAR_WAIST, 100, 100);
-			else
-				dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
-			to_char = "повредило $N2 живот";
-			to_vict = "повредило вам живот";
-			break;
-		case 7:
-		case 8:	// abdomin damage, speed/2, HR-2
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
-			to_char = "ранило $N3 в живот";
-			to_vict = "ранило вас в живот";
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_HITROLL;
-			af[0].modifier = -2;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 9:	// armor damaged, abdomin damaged, speed/2, HR-2
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 5);
-			alt_equip(victim, WEAR_BODY, 100, 100);
-			to_char = "ранило $N3 в живот";
-			to_vict = "ранило вас в живот";
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_HITROLL;
-			af[0].modifier = -2;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 20);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 10:	// abdomin damaged, no speed, no attack
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
-			to_char = "повредило $N2 живот";
-			to_vict = "повредило вам живот";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			af[1].type = SPELL_BATTLE;
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 20);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 11:	// abdomin damaged, no speed, no attack
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 3);
-			to_char = "разорвало $N2 живот";
-			to_vict = "разорвало вам живот";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			af[1].type = SPELL_BATTLE;
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 40);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		default:	// abdomin damaged, hits = 0
-			dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
-			to_char = "размозжило $N2 живот";
-			to_vict = "размозжило вам живот";
-			haemorragia(victim, 60);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		}
-		break;
-	case 6:
-	case 7:		// CHEST
-		switch (dam_critic)
-		{
-		case 1:
-		case 2:
-		case 3:
-			// nothing
-			return;
-		case 4:	// waits 1d4, bashed
-			WAIT_STATE(victim, number(2, 5) * PULSE_VIOLENCE);
-			if (GET_POS(victim) > POS_SITTING)
-				GET_POS(victim) = POS_SITTING;
-			to_char = "повредило $N2 грудь, свалив $S с ног";
-			to_vict = "повредило вам грудь, свалив вас с ног";
-			break;
-		case 5:	// chest damaged, waits 1, speed/2
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			to_char = "повредило $N2 туловище";
-			to_vict = "повредило вам туловище";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 6:	// shield damaged, chest damaged, speed/2
-			alt_equip(victim, WEAR_SHIELD, 100, 100);
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
-			to_char = "повредило $N2 туловище";
-			to_vict = "повредило вам туловище";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 7:	// srmor damaged, chest damaged, speed/2, HR-2
-			alt_equip(victim, WEAR_BODY, 100, 100);
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 5);
-			to_char = "повредило $N2 туловище";
-			to_vict = "повредило вам туловище";
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_HITROLL;
-			af[0].modifier = -2;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 8:	// chest damaged, no speed, no attack
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 5);
-			to_char = "вывело $N3 из строя";
-			to_vict = "повредило вам туловище";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			af[1].type = SPELL_BATTLE;
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 20);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 9:	// chest damaged, speed/2, HR-2
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
-			to_char = "заставило $N3 ослабить натиск";
-			to_vict = "сломало вам ребра";
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_HITROLL;
-			af[0].modifier = -2;
-			af[1].type = SPELL_BATTLE;
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 20);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 10:	// chest damaged, no speed, no attack
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
-			to_char = "вывело $N3 из строя";
-			to_vict = "сломало вам ребра";
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			af[1].type = SPELL_BATTLE;
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 40);
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		case 11:	// chest crushed, hits 0
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
-			haemorragia(victim, 50);
-			to_char = "вывело $N3 из строя";
-			to_vict = "разорвало вам грудь";
-			break;
-		default:	// chest crushed, killing
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
-			haemorragia(victim, 60);
-			to_char = "вывело $N3 из строя";
-			to_vict = "размозжило вам грудь";
-			break;
-		}
-		break;
-	case 8:
-	case 9:		// HANDS
-		switch (dam_critic)
-		{
-		case 1:
-		case 2:
-		case 3:
-			return;
-		case 4:	// hands damaged, weapon/shield putdown
-			to_char = "ослабило натиск $N1";
-			to_vict = "ранило вам руку";
-			if (GET_EQ(victim, WEAR_BOTHS))
-				unequip_pos = WEAR_BOTHS;
-			else if (GET_EQ(victim, WEAR_WIELD))
-				unequip_pos = WEAR_WIELD;
-			else if (GET_EQ(victim, WEAR_HOLD))
-				unequip_pos = WEAR_HOLD;
-			else if (GET_EQ(victim, WEAR_SHIELD))
-				unequip_pos = WEAR_SHIELD;
-			break;
-		case 5:	// hands damaged, shield damaged/weapon putdown
-			to_char = "ослабило натиск $N1";
-			to_vict = "ранило вас в руку";
-			if (GET_EQ(victim, WEAR_SHIELD))
-				alt_equip(victim, WEAR_SHIELD, 100, 100);
-			else if (GET_EQ(victim, WEAR_BOTHS))
-				unequip_pos = WEAR_BOTHS;
-			else if (GET_EQ(victim, WEAR_WIELD))
-				unequip_pos = WEAR_WIELD;
-			else if (GET_EQ(victim, WEAR_HOLD))
-				unequip_pos = WEAR_HOLD;
-			break;
+        case 5:    // abdomin damaged, waits 1, speed/2
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 8);
+          WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          to_char = "ранило $N3 в живот";
+          to_vict = "ранило вас в живот";
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 6:    // armor damaged else dam*3, waits 1d6
+          WAIT_STATE(victim, number(2, 6) * PULSE_VIOLENCE);
+          if (GET_EQ(victim, WEAR_WAIST))
+            alt_equip(victim, WEAR_WAIST, 100, 100);
+          else
+            dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
+          to_char = "повредило $N2 живот";
+          to_vict = "повредило вам живот";
+          break;
+        case 7:
+        case 8:    // abdomin damage, speed/2, HR-2
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
+          to_char = "ранило $N3 в живот";
+          to_vict = "ранило вас в живот";
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_HITROLL;
+          af[0].modifier = -2;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 9:    // armor damaged, abdomin damaged, speed/2, HR-2
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 5);
+          alt_equip(victim, WEAR_BODY, 100, 100);
+          to_char = "ранило $N3 в живот";
+          to_vict = "ранило вас в живот";
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_HITROLL;
+          af[0].modifier = -2;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 20);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 10:    // abdomin damaged, no speed, no attack
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
+          to_char = "повредило $N2 живот";
+          to_vict = "повредило вам живот";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          af[1].type = SPELL_BATTLE;
+          af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 20);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 11:    // abdomin damaged, no speed, no attack
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 3);
+          to_char = "разорвало $N2 живот";
+          to_vict = "разорвало вам живот";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          af[1].type = SPELL_BATTLE;
+          af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 40);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        default:    // abdomin damaged, hits = 0
+          dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
+          to_char = "размозжило $N2 живот";
+          to_vict = "размозжило вам живот";
+          haemorragia(victim, 60);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+      }
+      break;
+    case 6:
+    case 7:        // CHEST
+      switch (dam_critic) {
+        case 1:
+        case 2:
+        case 3:
+          // nothing
+          return;
+        case 4:    // waits 1d4, bashed
+          WAIT_STATE(victim, number(2, 5) * PULSE_VIOLENCE);
+          if (GET_POS(victim) > POS_SITTING)
+            GET_POS(victim) = POS_SITTING;
+          to_char = "повредило $N2 грудь, свалив $S с ног";
+          to_vict = "повредило вам грудь, свалив вас с ног";
+          break;
+        case 5:    // chest damaged, waits 1, speed/2
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
+          WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          to_char = "повредило $N2 туловище";
+          to_vict = "повредило вам туловище";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 6:    // shield damaged, chest damaged, speed/2
+          alt_equip(victim, WEAR_SHIELD, 100, 100);
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
+          to_char = "повредило $N2 туловище";
+          to_vict = "повредило вам туловище";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 7:    // srmor damaged, chest damaged, speed/2, HR-2
+          alt_equip(victim, WEAR_BODY, 100, 100);
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 5);
+          to_char = "повредило $N2 туловище";
+          to_vict = "повредило вам туловище";
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_HITROLL;
+          af[0].modifier = -2;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 8:    // chest damaged, no speed, no attack
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 5);
+          to_char = "вывело $N3 из строя";
+          to_vict = "повредило вам туловище";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          af[1].type = SPELL_BATTLE;
+          af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 20);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 9:    // chest damaged, speed/2, HR-2
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
+          to_char = "заставило $N3 ослабить натиск";
+          to_vict = "сломало вам ребра";
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_HITROLL;
+          af[0].modifier = -2;
+          af[1].type = SPELL_BATTLE;
+          af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 20);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 10:    // chest damaged, no speed, no attack
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
+          to_char = "вывело $N3 из строя";
+          to_vict = "сломало вам ребра";
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          af[1].type = SPELL_BATTLE;
+          af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 40);
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+        case 11:    // chest crushed, hits 0
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
+          haemorragia(victim, 50);
+          to_char = "вывело $N3 из строя";
+          to_vict = "разорвало вам грудь";
+          break;
+        default:    // chest crushed, killing
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
+          haemorragia(victim, 60);
+          to_char = "вывело $N3 из строя";
+          to_vict = "размозжило вам грудь";
+          break;
+      }
+      break;
+    case 8:
+    case 9:        // HANDS
+      switch (dam_critic) {
+        case 1:
+        case 2:
+        case 3: return;
+        case 4:    // hands damaged, weapon/shield putdown
+          to_char = "ослабило натиск $N1";
+          to_vict = "ранило вам руку";
+          if (GET_EQ(victim, WEAR_BOTHS))
+            unequip_pos = WEAR_BOTHS;
+          else if (GET_EQ(victim, WEAR_WIELD))
+            unequip_pos = WEAR_WIELD;
+          else if (GET_EQ(victim, WEAR_HOLD))
+            unequip_pos = WEAR_HOLD;
+          else if (GET_EQ(victim, WEAR_SHIELD))
+            unequip_pos = WEAR_SHIELD;
+          break;
+        case 5:    // hands damaged, shield damaged/weapon putdown
+          to_char = "ослабило натиск $N1";
+          to_vict = "ранило вас в руку";
+          if (GET_EQ(victim, WEAR_SHIELD))
+            alt_equip(victim, WEAR_SHIELD, 100, 100);
+          else if (GET_EQ(victim, WEAR_BOTHS))
+            unequip_pos = WEAR_BOTHS;
+          else if (GET_EQ(victim, WEAR_WIELD))
+            unequip_pos = WEAR_WIELD;
+          else if (GET_EQ(victim, WEAR_HOLD))
+            unequip_pos = WEAR_HOLD;
+          break;
 
-		case 6:	// hands damaged, HR-2, shield putdown
-			to_char = "ослабило натиск $N1";
-			to_vict = "сломало вам руку";
-			if (GET_EQ(victim, WEAR_SHIELD))
-				unequip_pos = WEAR_SHIELD;
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_HITROLL;
-			af[0].modifier = -2;
-			break;
-		case 7:	// armor damaged, hand damaged if no armour
-			if (GET_EQ(victim, WEAR_ARMS))
-				alt_equip(victim, WEAR_ARMS, 100, 100);
-			else
-				alt_equip(victim, WEAR_HANDS, 100, 100);
-			if (!GET_EQ(victim, WEAR_ARMS) && !GET_EQ(victim, WEAR_HANDS))
-				dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
-			to_char = "ослабило атаку $N1";
-			to_vict = "повредило вам руку";
-			break;
-		case 8:	// shield damaged, hands damaged, waits 1
-			alt_equip(victim, WEAR_SHIELD, 100, 100);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
-			to_char = "придержало $N3";
-			to_vict = "повредило вам руку";
-			break;
-		case 9:	// weapon putdown, hands damaged, waits 1d4
-			WAIT_STATE(victim, number(2, 4) * PULSE_VIOLENCE);
-			if (GET_EQ(victim, WEAR_BOTHS))
-				unequip_pos = WEAR_BOTHS;
-			else if (GET_EQ(victim, WEAR_WIELD))
-				unequip_pos = WEAR_WIELD;
-			else if (GET_EQ(victim, WEAR_HOLD))
-				unequip_pos = WEAR_HOLD;
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
-			to_char = "придержало $N3";
-			to_vict = "повредило вам руку";
-			break;
-		case 10:	// hand damaged, no attack this
-			if (!AFF_FLAGGED(victim, EAffectFlag::AFF_STOPRIGHT))
-			{
-				to_char = "ослабило атаку $N1";
-				to_vict = "изуродовало вам правую руку";
-				af[0].type = SPELL_BATTLE;
-				af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPRIGHT);
-				af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-				af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			}
-			else if (!AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT))
-			{
-				to_char = "ослабило атаку $N1";
-				to_vict = "изуродовало вам левую руку";
-				af[0].type = SPELL_BATTLE;
-				af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPLEFT);
-				af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-				af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			}
-			else
-			{
-				to_char = "вывело $N3 из строя";
-				to_vict = "вывело вас из строя";
-				af[0].type = SPELL_BATTLE;
-				af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-				af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-				af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			}
-			haemorragia(victim, 20);
-			break;
-		default:	// no hand attack, no speed, dam*2 if >= 13
-			if (!AFF_FLAGGED(victim, EAffectFlag::AFF_STOPRIGHT))
-			{
-				to_char = "ослабило натиск $N1";
-				to_vict = "изуродовало вам правую руку";
-				af[0].type = SPELL_BATTLE;
-				af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPRIGHT);
-				af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-				af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			}
-			else if (!AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT))
-			{
-				to_char = "ослабило натиск $N1";
-				to_vict = "изуродовало вам левую руку";
-				af[0].type = SPELL_BATTLE;
-				af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPLEFT);
-				af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-				af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			}
-			else
-			{
-				to_char = "вывело $N3 из строя";
-				to_vict = "вывело вас из строя";
-				af[0].type = SPELL_BATTLE;
-				af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-				af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-				af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			}
-			af[1].type = SPELL_BATTLE;
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			haemorragia(victim, 30);
-			if (dam_critic >= 13)
-				dam *= ch->get_skill(SKILL_PUNCTUAL) / 5;
-			SET_AF_BATTLE(victim, EAF_SLOW);
-			break;
-		}
-		break;
-	default:		// HEAD
-		switch (dam_critic)
-		{
-		case 1:
-		case 2:
-		case 3:
-			// nothing
-			return;
-		case 4:	// waits 1d6
-			WAIT_STATE(victim, number(2, 6) * PULSE_VIOLENCE);
-			to_char = "помутило $N2 сознание";
-			to_vict = "помутило ваше сознание";
-			break;
+        case 6:    // hands damaged, HR-2, shield putdown
+          to_char = "ослабило натиск $N1";
+          to_vict = "сломало вам руку";
+          if (GET_EQ(victim, WEAR_SHIELD))
+            unequip_pos = WEAR_SHIELD;
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_HITROLL;
+          af[0].modifier = -2;
+          break;
+        case 7:    // armor damaged, hand damaged if no armour
+          if (GET_EQ(victim, WEAR_ARMS))
+            alt_equip(victim, WEAR_ARMS, 100, 100);
+          else
+            alt_equip(victim, WEAR_HANDS, 100, 100);
+          if (!GET_EQ(victim, WEAR_ARMS) && !GET_EQ(victim, WEAR_HANDS))
+            dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
+          to_char = "ослабило атаку $N1";
+          to_vict = "повредило вам руку";
+          break;
+        case 8:    // shield damaged, hands damaged, waits 1
+          alt_equip(victim, WEAR_SHIELD, 100, 100);
+          WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 7);
+          to_char = "придержало $N3";
+          to_vict = "повредило вам руку";
+          break;
+        case 9:    // weapon putdown, hands damaged, waits 1d4
+          WAIT_STATE(victim, number(2, 4) * PULSE_VIOLENCE);
+          if (GET_EQ(victim, WEAR_BOTHS))
+            unequip_pos = WEAR_BOTHS;
+          else if (GET_EQ(victim, WEAR_WIELD))
+            unequip_pos = WEAR_WIELD;
+          else if (GET_EQ(victim, WEAR_HOLD))
+            unequip_pos = WEAR_HOLD;
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 6);
+          to_char = "придержало $N3";
+          to_vict = "повредило вам руку";
+          break;
+        case 10:    // hand damaged, no attack this
+          if (!AFF_FLAGGED(victim, EAffectFlag::AFF_STOPRIGHT)) {
+            to_char = "ослабило атаку $N1";
+            to_vict = "изуродовало вам правую руку";
+            af[0].type = SPELL_BATTLE;
+            af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPRIGHT);
+            af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+            af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          } else if (!AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT)) {
+            to_char = "ослабило атаку $N1";
+            to_vict = "изуродовало вам левую руку";
+            af[0].type = SPELL_BATTLE;
+            af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPLEFT);
+            af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+            af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          } else {
+            to_char = "вывело $N3 из строя";
+            to_vict = "вывело вас из строя";
+            af[0].type = SPELL_BATTLE;
+            af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+            af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+            af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          }
+          haemorragia(victim, 20);
+          break;
+        default:    // no hand attack, no speed, dam*2 if >= 13
+          if (!AFF_FLAGGED(victim, EAffectFlag::AFF_STOPRIGHT)) {
+            to_char = "ослабило натиск $N1";
+            to_vict = "изуродовало вам правую руку";
+            af[0].type = SPELL_BATTLE;
+            af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPRIGHT);
+            af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+            af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          } else if (!AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT)) {
+            to_char = "ослабило натиск $N1";
+            to_vict = "изуродовало вам левую руку";
+            af[0].type = SPELL_BATTLE;
+            af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPLEFT);
+            af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+            af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          } else {
+            to_char = "вывело $N3 из строя";
+            to_vict = "вывело вас из строя";
+            af[0].type = SPELL_BATTLE;
+            af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+            af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+            af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          }
+          af[1].type = SPELL_BATTLE;
+          af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          haemorragia(victim, 30);
+          if (dam_critic >= 13)
+            dam *= ch->get_skill(SKILL_PUNCTUAL) / 5;
+          SET_AF_BATTLE(victim, EAF_SLOW);
+          break;
+      }
+      break;
+    default:        // HEAD
+      switch (dam_critic) {
+        case 1:
+        case 2:
+        case 3:
+          // nothing
+          return;
+        case 4:    // waits 1d6
+          WAIT_STATE(victim, number(2, 6) * PULSE_VIOLENCE);
+          to_char = "помутило $N2 сознание";
+          to_vict = "помутило ваше сознание";
+          break;
 
-		case 5:	// head damaged, cap putdown, waits 1, HR-2 if no cap
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			if (GET_EQ(victim, WEAR_HEAD))
-				unequip_pos = WEAR_HEAD;
-			else
-			{
-				af[0].type = SPELL_BATTLE;
-				af[0].location = APPLY_HITROLL;
-				af[0].modifier = -2;
-			}
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
-			to_char = "повредило $N2 голову";
-			to_vict = "повредило вам голову";
-			break;
-		case 6:	// head damaged
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_HITROLL;
-			af[0].modifier = -2;
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
-			to_char = "повредило $N2 голову";
-			to_vict = "повредило вам голову";
-			break;
-		case 7:	// cap damaged, waits 1d6, speed/2, HR-4
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			alt_equip(victim, WEAR_HEAD, 100, 100);
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_HITROLL;
-			af[0].modifier = -4;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-			to_char = "ранило $N3 в голову";
-			to_vict = "ранило вас в голову";
-			break;
-		case 8:	// cap damaged, hits 0
-			WAIT_STATE(victim, 4 * PULSE_VIOLENCE);
-			alt_equip(victim, WEAR_HEAD, 100, 100);
-			//dam = GET_HIT(victim);
-			dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
-			to_char = "отбило у $N1 сознание";
-			to_vict = "отбило у вас сознание";
-			haemorragia(victim, 20);
-			break;
-		case 9:	// head damaged, no speed, no attack
-			af[0].type = SPELL_BATTLE;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			haemorragia(victim, 30);
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 3);
-			to_char = "повергло $N3 в оцепенение";
-			to_vict = "повергло вас в оцепенение";
-			break;
-		case 10:	// head damaged, -1 INT/WIS/CHA
-			dam *= (ch->get_skill(SKILL_PUNCTUAL) / 2);
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_INT;
-			af[0].modifier = -1;
-			af[0].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[0].battleflag = AF_DEADKEEP;
-			af[1].type = SPELL_BATTLE;
-			af[1].location = APPLY_WIS;
-			af[1].modifier = -1;
-			af[1].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[1].battleflag = AF_DEADKEEP;
-			af[2].type = SPELL_BATTLE;
-			af[2].location = APPLY_CHA;
-			af[2].modifier = -1;
-			af[2].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[2].battleflag = AF_DEADKEEP;
-			af[3].type = SPELL_BATTLE;
-			af[3].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af[3].duration = pc_duration(victim, 30, 0, 0, 0, 0);
-			af[3].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			haemorragia(victim, 50);
-			to_char = "сорвало у $N1 крышу";
-			to_vict = "сорвало у вас крышу";
-			break;
-		case 11:	// hits 0, WIS/2, INT/2, CHA/2
-			dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_INT;
-			af[0].modifier = -victim->get_int() / 2;
-			af[0].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[0].battleflag = AF_DEADKEEP;
-			af[1].type = SPELL_BATTLE;
-			af[1].location = APPLY_WIS;
-			af[1].modifier = -victim->get_wis() / 2;
-			af[1].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[1].battleflag = AF_DEADKEEP;
-			af[2].type = SPELL_BATTLE;
-			af[2].location = APPLY_CHA;
-			af[2].modifier = -victim->get_cha() / 2;
-			af[2].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[2].battleflag = AF_DEADKEEP;
-			haemorragia(victim, 60);
-			to_char = "сорвало у $N1 крышу";
-			to_vict = "сорвало у вас крышу";
-			break;
-		default:	// killed
-			af[0].type = SPELL_BATTLE;
-			af[0].location = APPLY_INT;
-			af[0].modifier = -victim->get_int() / 2;
-			af[0].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[0].battleflag = AF_DEADKEEP;
-			af[1].type = SPELL_BATTLE;
-			af[1].location = APPLY_WIS;
-			af[1].modifier = -victim->get_wis() / 2;
-			af[1].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[1].battleflag = AF_DEADKEEP;
-			af[2].type = SPELL_BATTLE;
-			af[2].location = APPLY_CHA;
-			af[2].modifier = -victim->get_cha() / 2;
-			af[2].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
-			af[2].battleflag = AF_DEADKEEP;
-			dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
-			to_char = "размозжило $N2 голову";
-			to_vict = "размозжило вам голову";
-			haemorragia(victim, 90);
-			break;
-		}
-		break;
-	}
-	if (to_char)
-	{
-		sprintf(buf, "&G&qВаше точное попадание %s.&Q&n", to_char);
-		act(buf, FALSE, ch, 0, victim, TO_CHAR);
-		sprintf(buf, "Точное попадание $n1 %s.", to_char);
-		act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-	}
+        case 5:    // head damaged, cap putdown, waits 1, HR-2 if no cap
+          WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          if (GET_EQ(victim, WEAR_HEAD))
+            unequip_pos = WEAR_HEAD;
+          else {
+            af[0].type = SPELL_BATTLE;
+            af[0].location = APPLY_HITROLL;
+            af[0].modifier = -2;
+          }
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
+          to_char = "повредило $N2 голову";
+          to_vict = "повредило вам голову";
+          break;
+        case 6:    // head damaged
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_HITROLL;
+          af[0].modifier = -2;
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 4);
+          to_char = "повредило $N2 голову";
+          to_vict = "повредило вам голову";
+          break;
+        case 7:    // cap damaged, waits 1d6, speed/2, HR-4
+          WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          alt_equip(victim, WEAR_HEAD, 100, 100);
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_HITROLL;
+          af[0].modifier = -4;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+          to_char = "ранило $N3 в голову";
+          to_vict = "ранило вас в голову";
+          break;
+        case 8:    // cap damaged, hits 0
+          WAIT_STATE(victim, 4 * PULSE_VIOLENCE);
+          alt_equip(victim, WEAR_HEAD, 100, 100);
+          //dam = GET_HIT(victim);
+          dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
+          to_char = "отбило у $N1 сознание";
+          to_vict = "отбило у вас сознание";
+          haemorragia(victim, 20);
+          break;
+        case 9:    // head damaged, no speed, no attack
+          af[0].type = SPELL_BATTLE;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[0].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          haemorragia(victim, 30);
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 3);
+          to_char = "повергло $N3 в оцепенение";
+          to_vict = "повергло вас в оцепенение";
+          break;
+        case 10:    // head damaged, -1 INT/WIS/CHA
+          dam *= (ch->get_skill(SKILL_PUNCTUAL) / 2);
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_INT;
+          af[0].modifier = -1;
+          af[0].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[0].battleflag = AF_DEADKEEP;
+          af[1].type = SPELL_BATTLE;
+          af[1].location = APPLY_WIS;
+          af[1].modifier = -1;
+          af[1].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[1].battleflag = AF_DEADKEEP;
+          af[2].type = SPELL_BATTLE;
+          af[2].location = APPLY_CHA;
+          af[2].modifier = -1;
+          af[2].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[2].battleflag = AF_DEADKEEP;
+          af[3].type = SPELL_BATTLE;
+          af[3].bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+          af[3].duration = pc_duration(victim, 30, 0, 0, 0, 0);
+          af[3].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          haemorragia(victim, 50);
+          to_char = "сорвало у $N1 крышу";
+          to_vict = "сорвало у вас крышу";
+          break;
+        case 11:    // hits 0, WIS/2, INT/2, CHA/2
+          dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_INT;
+          af[0].modifier = -victim->get_int() / 2;
+          af[0].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[0].battleflag = AF_DEADKEEP;
+          af[1].type = SPELL_BATTLE;
+          af[1].location = APPLY_WIS;
+          af[1].modifier = -victim->get_wis() / 2;
+          af[1].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[1].battleflag = AF_DEADKEEP;
+          af[2].type = SPELL_BATTLE;
+          af[2].location = APPLY_CHA;
+          af[2].modifier = -victim->get_cha() / 2;
+          af[2].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[2].battleflag = AF_DEADKEEP;
+          haemorragia(victim, 60);
+          to_char = "сорвало у $N1 крышу";
+          to_vict = "сорвало у вас крышу";
+          break;
+        default:    // killed
+          af[0].type = SPELL_BATTLE;
+          af[0].location = APPLY_INT;
+          af[0].modifier = -victim->get_int() / 2;
+          af[0].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[0].battleflag = AF_DEADKEEP;
+          af[1].type = SPELL_BATTLE;
+          af[1].location = APPLY_WIS;
+          af[1].modifier = -victim->get_wis() / 2;
+          af[1].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[1].battleflag = AF_DEADKEEP;
+          af[2].type = SPELL_BATTLE;
+          af[2].location = APPLY_CHA;
+          af[2].modifier = -victim->get_cha() / 2;
+          af[2].duration = pc_duration(victim, number(1, 6) * 24, 0, 0, 0, 0);
+          af[2].battleflag = AF_DEADKEEP;
+          dam *= ch->get_skill(SKILL_PUNCTUAL) / 2;
+          to_char = "размозжило $N2 голову";
+          to_vict = "размозжило вам голову";
+          haemorragia(victim, 90);
+          break;
+      }
+      break;
+  }
+  if (to_char) {
+    sprintf(buf, "&G&qВаше точное попадание %s.&Q&n", to_char);
+    act(buf, FALSE, ch, 0, victim, TO_CHAR);
+    sprintf(buf, "Точное попадание $n1 %s.", to_char);
+    act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+  }
 
-	if (to_vict)
-	{
-		sprintf(buf, "&R&qМеткое попадание $n1 %s.&Q&n", to_vict);
-		act(buf, FALSE, ch, 0, victim, TO_VICT);
-	}
-	if (unequip_pos && GET_EQ(victim, unequip_pos))
-	{
-		obj = unequip_char(victim, unequip_pos);
-		switch (unequip_pos)
-		{
-			case 6:		//WEAR_HEAD
-				sprintf(buf, "%s слетел%s с вашей головы.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
-				act(buf, FALSE, ch, 0, victim, TO_VICT);
-				sprintf(buf, "%s слетел%s с головы $N1.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
-				act(buf, FALSE, ch, 0, victim, TO_CHAR);
-				act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-				break;
+  if (to_vict) {
+    sprintf(buf, "&R&qМеткое попадание $n1 %s.&Q&n", to_vict);
+    act(buf, FALSE, ch, 0, victim, TO_VICT);
+  }
+  if (unequip_pos && GET_EQ(victim, unequip_pos)) {
+    obj = unequip_char(victim, unequip_pos);
+    switch (unequip_pos) {
+      case 6:        //WEAR_HEAD
+        sprintf(buf, "%s слетел%s с вашей головы.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
+        act(buf, FALSE, ch, 0, victim, TO_VICT);
+        sprintf(buf, "%s слетел%s с головы $N1.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
+        act(buf, FALSE, ch, 0, victim, TO_CHAR);
+        act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+        break;
 
-			case 11:	//WEAR_SHIELD
-				sprintf(buf, "%s слетел%s с вашей руки.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
-				act(buf, FALSE, ch, 0, victim, TO_VICT);
-				sprintf(buf, "%s слетел%s с руки $N1.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
-				act(buf, FALSE, ch, 0, victim, TO_CHAR);
-				act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-				break;
+      case 11:    //WEAR_SHIELD
+        sprintf(buf, "%s слетел%s с вашей руки.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
+        act(buf, FALSE, ch, 0, victim, TO_VICT);
+        sprintf(buf, "%s слетел%s с руки $N1.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
+        act(buf, FALSE, ch, 0, victim, TO_CHAR);
+        act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+        break;
 
-			case 16:	//WEAR_WIELD
-			case 17:	//WEAR_HOLD
-				sprintf(buf, "%s выпал%s из вашей руки.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
-				act(buf, FALSE, ch, 0, victim, TO_VICT);
-				sprintf(buf, "%s выпал%s из руки $N1.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
-				act(buf, FALSE, ch, 0, victim, TO_CHAR);
-				act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-				break;
+      case 16:    //WEAR_WIELD
+      case 17:    //WEAR_HOLD
+        sprintf(buf, "%s выпал%s из вашей руки.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
+        act(buf, FALSE, ch, 0, victim, TO_VICT);
+        sprintf(buf, "%s выпал%s из руки $N1.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
+        act(buf, FALSE, ch, 0, victim, TO_CHAR);
+        act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+        break;
 
-			case 18:	//WEAR_BOTHS
-				sprintf(buf, "%s выпал%s из ваших рук.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
-				act(buf, FALSE, ch, 0, victim, TO_VICT);
-				sprintf(buf, "%s выпал%s из рук $N1.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
-				act(buf, FALSE, ch, 0, victim, TO_CHAR);
-				act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-				break;
-		}
-		if (!IS_NPC(victim) && ROOM_FLAGGED(IN_ROOM(victim), ROOM_ARENA))
-			obj_to_char(obj, victim);
-		else
-			obj_to_room(obj, IN_ROOM(victim));
-		obj_decay(obj);
-	}
-	if (!IS_NPC(victim)) {
-		dam /= 5;
-	}
-	dam = calculate_resistance_coeff(victim, VITALITY_RESISTANCE, dam);
-	for (int i = 0; i < 4; i++) {
-		if (af[i].type) {
-			if (af[i].bitvector == to_underlying(EAffectFlag::AFF_STOPFIGHT)
-				|| af[i].bitvector == to_underlying(EAffectFlag::AFF_STOPRIGHT)
-				|| af[i].bitvector == to_underlying(EAffectFlag::AFF_STOPLEFT)) {
-				if (victim->get_role(MOB_ROLE_BOSS)) {
-					af[i].duration /= 5;
-					// вес оружия тоже влияет на длит точки, офф проходит реже, берем вес прайма.
-					sh_int extra_duration = 0;
-					OBJ_DATA* both = GET_EQ(ch, WEAR_BOTHS);
-					OBJ_DATA* wield = GET_EQ(ch, WEAR_WIELD);
-					if (both) {
-						extra_duration = GET_OBJ_WEIGHT(both) / 5;
-					}
-					else if (wield) {
-						extra_duration = GET_OBJ_WEIGHT(wield) / 5;
-					}
-					af[i].duration += pc_duration(victim, GET_REMORT(ch)/2 + extra_duration, 0, 0, 0, 0);
-				}
-			}
-			affect_join(victim, af[i], TRUE, FALSE, TRUE, FALSE);
-		}
-	}
+      case 18:    //WEAR_BOTHS
+        sprintf(buf, "%s выпал%s из ваших рук.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
+        act(buf, FALSE, ch, 0, victim, TO_VICT);
+        sprintf(buf, "%s выпал%s из рук $N1.", obj->get_PName(0).c_str(), GET_OBJ_SUF_1(obj));
+        act(buf, FALSE, ch, 0, victim, TO_CHAR);
+        act(buf, TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+        break;
+    }
+    if (!IS_NPC(victim) && ROOM_FLAGGED(IN_ROOM(victim), ROOM_ARENA))
+      obj_to_char(obj, victim);
+    else
+      obj_to_room(obj, IN_ROOM(victim));
+    obj_decay(obj);
+  }
+  if (!IS_NPC(victim)) {
+    dam /= 5;
+  }
+  dam = calculate_resistance_coeff(victim, VITALITY_RESISTANCE, dam);
+  for (int i = 0; i < 4; i++) {
+    if (af[i].type) {
+      if (af[i].bitvector == to_underlying(EAffectFlag::AFF_STOPFIGHT)
+          || af[i].bitvector == to_underlying(EAffectFlag::AFF_STOPRIGHT)
+          || af[i].bitvector == to_underlying(EAffectFlag::AFF_STOPLEFT)) {
+        if (victim->get_role(MOB_ROLE_BOSS)) {
+          af[i].duration /= 5;
+          // вес оружия тоже влияет на длит точки, офф проходит реже, берем вес прайма.
+          sh_int extra_duration = 0;
+          OBJ_DATA *both = GET_EQ(ch, WEAR_BOTHS);
+          OBJ_DATA *wield = GET_EQ(ch, WEAR_WIELD);
+          if (both) {
+            extra_duration = GET_OBJ_WEIGHT(both) / 5;
+          } else if (wield) {
+            extra_duration = GET_OBJ_WEIGHT(wield) / 5;
+          }
+          af[i].duration += pc_duration(victim, GET_REMORT(ch) / 2 + extra_duration, 0, 0, 0, 0);
+        }
+      }
+      affect_join(victim, af[i], TRUE, FALSE, TRUE, FALSE);
+    }
+  }
 }
 
 /**
@@ -819,88 +779,79 @@ void HitData::compute_critical(CHAR_DATA * ch, CHAR_DATA * victim)
 * распределением 62.5% на силу и 37.5% на уровни + штрафы до 5 ремов.
 * Способность не плюсуется при железном ветре и оглушении.
 */
-int calculate_strconc_damage(CHAR_DATA * ch, OBJ_DATA* /*wielded*/, int damage)
-{
-	if (IS_NPC(ch)
-		|| GET_REAL_STR(ch) <= 25
-		|| !can_use_feat(ch, STRENGTH_CONCETRATION_FEAT)
-		|| GET_AF_BATTLE(ch, EAF_IRON_WIND)
-		|| GET_AF_BATTLE(ch, EAF_STUPOR))
-	{
-		return damage;
-	}
-	float str_mod = (GET_REAL_STR(ch) - 25) * 0.4;
-	float lvl_mod = GET_LEVEL(ch) * 0.2;
-	float rmt_mod = MIN(5, GET_REMORT(ch)) / 5.0;
-	float res_mod = 1 + (str_mod + lvl_mod) / 10.0 * rmt_mod;
+int calculate_strconc_damage(CHAR_DATA *ch, OBJ_DATA * /*wielded*/, int damage) {
+  if (IS_NPC(ch)
+      || GET_REAL_STR(ch) <= 25
+      || !can_use_feat(ch, STRENGTH_CONCETRATION_FEAT)
+      || GET_AF_BATTLE(ch, EAF_IRON_WIND)
+      || GET_AF_BATTLE(ch, EAF_STUPOR)) {
+    return damage;
+  }
+  float str_mod = (GET_REAL_STR(ch) - 25) * 0.4;
+  float lvl_mod = GET_LEVEL(ch) * 0.2;
+  float rmt_mod = MIN(5, GET_REMORT(ch)) / 5.0;
+  float res_mod = 1 + (str_mod + lvl_mod) / 10.0 * rmt_mod;
 
-	return static_cast<int>(damage * res_mod);
+  return static_cast<int>(damage * res_mod);
 }
 
 /**
 * Расчет прибавки дамаги со скрытого стиля.
 * (скилл/5 + реморты*3) * (среднее/(10 + среднее/2)) * (левел/30)
 */
-int calculate_noparryhit_dmg(CHAR_DATA * ch, OBJ_DATA * wielded)
-{
-	if (!ch->get_skill(SKILL_NOPARRYHIT)) return 0;
+int calculate_noparryhit_dmg(CHAR_DATA *ch, OBJ_DATA *wielded) {
+  if (!ch->get_skill(SKILL_NOPARRYHIT)) return 0;
 
-	float weap_dmg = (((GET_OBJ_VAL(wielded, 2) + 1) / 2.0) * GET_OBJ_VAL(wielded, 1));
-	float weap_mod = weap_dmg / (10 + weap_dmg / 2);
-	float level_mod = static_cast<float>(GET_LEVEL(ch)) / 30;
-	float skill_mod = static_cast<float>(ch->get_skill(SKILL_NOPARRYHIT)) / 5;
+  float weap_dmg = (((GET_OBJ_VAL(wielded, 2) + 1) / 2.0) * GET_OBJ_VAL(wielded, 1));
+  float weap_mod = weap_dmg / (10 + weap_dmg / 2);
+  float level_mod = static_cast<float>(GET_LEVEL(ch)) / 30;
+  float skill_mod = static_cast<float>(ch->get_skill(SKILL_NOPARRYHIT)) / 5;
 
-	return static_cast<int>((skill_mod + GET_REMORT(ch) * 3) * weap_mod * level_mod);
+  return static_cast<int>((skill_mod + GET_REMORT(ch) * 3) * weap_mod * level_mod);
 }
 
-void might_hit_bash(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	if (MOB_FLAGGED(victim, MOB_NOBASH) || !GET_MOB_HOLD(victim))
-	{
-		return;
-	}
+void might_hit_bash(CHAR_DATA *ch, CHAR_DATA *victim) {
+  if (MOB_FLAGGED(victim, MOB_NOBASH) || !GET_MOB_HOLD(victim)) {
+    return;
+  }
 
-	act("$n обреченно повалил$u на землю.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-	WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
+  act("$n обреченно повалил$u на землю.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
 
-	if (GET_POS(victim) > POS_SITTING)
-	{
-		GET_POS(victim) = POS_SITTING;
-		send_to_char(victim, "&R&qБогатырский удар %s сбил вас с ног.&Q&n\r\n", PERS(ch, victim, 1));
-	}
+  if (GET_POS(victim) > POS_SITTING) {
+    GET_POS(victim) = POS_SITTING;
+    send_to_char(victim, "&R&qБогатырский удар %s сбил вас с ног.&Q&n\r\n", PERS(ch, victim, 1));
+  }
 }
 
-bool check_mighthit_weapon(CHAR_DATA *ch)
-{
-	if (!GET_EQ(ch, WEAR_BOTHS)
-		&& !GET_EQ(ch, WEAR_WIELD)
-		&& !GET_EQ(ch, WEAR_HOLD)
-		&& !GET_EQ(ch, WEAR_LIGHT)
-		&& !GET_EQ(ch, WEAR_SHIELD))
-	{
-			return true;
-	}
-	return false;
+bool check_mighthit_weapon(CHAR_DATA *ch) {
+  if (!GET_EQ(ch, WEAR_BOTHS)
+      && !GET_EQ(ch, WEAR_WIELD)
+      && !GET_EQ(ch, WEAR_HOLD)
+      && !GET_EQ(ch, WEAR_LIGHT)
+      && !GET_EQ(ch, WEAR_SHIELD)) {
+    return true;
+  }
+  return false;
 }
 
 // * При надуве выше х 1.5 в пк есть 1% того, что весь надув слетит одним ударом.
-void try_remove_extrahits(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	if (((!IS_NPC(ch) && ch != victim)
-			|| (ch->has_master()
-				&& !IS_NPC(ch->get_master())
-				&& ch->get_master() != victim))
-		&& !IS_NPC(victim)
-		&& GET_POS(victim) != POS_DEAD
-		&& GET_HIT(victim) > GET_REAL_MAX_HIT(victim) * 1.5
-		&& number(1, 100) == 5)// пусть будет 5, а то 1 по субъективным ощущениям выпадает как-то часто
-	{
-		GET_HIT(victim) = GET_REAL_MAX_HIT(victim);
-		send_to_char(victim, "%s'Будь%s тощ%s аки прежде' - мелькнула чужая мысль в вашей голове.%s\r\n",
-				CCWHT(victim, C_NRM), GET_CH_POLY_1(victim), GET_CH_EXSUF_1(victim), CCNRM(victim, C_NRM));
-		act("Вы прервали золотистую нить, питающую $N3 жизнью.", FALSE, ch, 0, victim, TO_CHAR);
-		act("$n прервал$g золотистую нить, питающую $N3 жизнью.", FALSE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-	}
+void try_remove_extrahits(CHAR_DATA *ch, CHAR_DATA *victim) {
+  if (((!IS_NPC(ch) && ch != victim)
+      || (ch->has_master()
+          && !IS_NPC(ch->get_master())
+          && ch->get_master() != victim))
+      && !IS_NPC(victim)
+      && GET_POS(victim) != POS_DEAD
+      && GET_HIT(victim) > GET_REAL_MAX_HIT(victim) * 1.5
+      && number(1, 100) == 5)// пусть будет 5, а то 1 по субъективным ощущениям выпадает как-то часто
+  {
+    GET_HIT(victim) = GET_REAL_MAX_HIT(victim);
+    send_to_char(victim, "%s'Будь%s тощ%s аки прежде' - мелькнула чужая мысль в вашей голове.%s\r\n",
+                 CCWHT(victim, C_NRM), GET_CH_POLY_1(victim), GET_CH_EXSUF_1(victim), CCNRM(victim, C_NRM));
+    act("Вы прервали золотистую нить, питающую $N3 жизнью.", FALSE, ch, 0, victim, TO_CHAR);
+    act("$n прервал$g золотистую нить, питающую $N3 жизнью.", FALSE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+  }
 }
 
 /**
@@ -910,329 +861,259 @@ void try_remove_extrahits(CHAR_DATA *ch, CHAR_DATA *victim)
 * На заднице 70% от итоговых процентов.
 * У чармисов 100% и 60% без остальных допов.
 */
-void addshot_damage(CHAR_DATA * ch, ESkill type, FightSystem::AttType weapon)
-{
-	int prob = train_skill(ch, SKILL_ADDSHOT, skill_info[SKILL_ADDSHOT].max_percent, ch->get_fighting());
+void addshot_damage(CHAR_DATA *ch, ESkill type, FightSystem::AttType weapon) {
+  int prob = calculate_skill(ch, SKILL_ADDSHOT, ch->get_fighting());
+  train_skill(ch, SKILL_ADDSHOT, true, ch->get_fighting());
+  // ловка роляет только выше 21 (стартовый максимум охота) и до 50
+  // поставим кап в 50 ловки для допвыстрела
+  float dex_mod = static_cast<float>(MAX(MIN(GET_REAL_DEX(ch), 50) - 21, 0)) / 29 * 2;
+  // штраф на 4й и 5й выстрелы для чаров ниже 5 мортов, по 20% за морт
+  float remort_mod = static_cast<float>(GET_REMORT(ch)) / 5;
+  if (remort_mod > 1) {
+    remort_mod = 1;
+  }
+  // на жопе процентовка снижается на 70% от текущего максимума каждого допа
+  float sit_mod = (GET_POS(ch) >= POS_FIGHTING) ? 1 : 0.7;
 
-	// ловка роляет только выше 21 (стартовый максимум охота) и до 50
-	float dex_mod = static_cast<float>(MAX(MIN(GET_REAL_DEX(ch), 50) - 21, 0)) / 29 * 2;  //поставим кап в 50 ловки для допвыстрела
-	// штраф на 4й и 5й выстрелы для чаров ниже 5 мортов, по 20% за морт
-	float remort_mod = static_cast<float>(GET_REMORT(ch)) / 5;
-	if (remort_mod > 1) remort_mod = 1;
-	// на жопе процентовка снижается на 70% от текущего максимума каждого допа
-	float sit_mod = (GET_POS(ch) >= POS_FIGHTING) ? 1 : 0.7;
+  // у чармисов никаких плюшек от 100+ скилла и максимум 2 доп атаки
+  if (IS_CHARMICE(ch)) {
+    prob = MIN(100, prob);
+    dex_mod = 0;
+    remort_mod = 0;
+  }
 
-	// у чармисов никаких плюшек от 100+ скилла и максимум 2 доп атаки
-	if (IS_CHARMICE(ch))
-	{
-		prob = MIN(100, prob);
-		dex_mod = 0;
-		remort_mod = 0;
-	}
+  // выше 100% идет другая формула
+  // скилл выше 100 добавляет равный ловке процент в максимуме
+  // а для скилла до сотни все остается как было
+  prob = MIN(100, prob);
 
-	// выше 100% идет другая формула
-	// скилл выше 100 добавляет равный ловке процент в максимуме
-	// а для скилла до сотни все остается как было
-	prob = MIN(100, prob);
-
-	int percent = number(1, skill_info[SKILL_ADDSHOT].max_percent);
-	// 1й доп - не более 100% при скилее 100+
-	if (prob * sit_mod >= percent / 2)
-		hit(ch, ch->get_fighting(), type, weapon);
-
-	percent = number(1, skill_info[SKILL_ADDSHOT].max_percent);
-	// 2й доп - 60% при скилле 100, до 100% при максимуме скилла и дексы
-	if ((prob * 3 + dex_mod * 100) * sit_mod > percent * 5 / 2 && ch->get_fighting())
-		hit(ch, ch->get_fighting(), type, weapon);
-
-	percent = number(1, skill_info[SKILL_ADDSHOT].max_percent);
-	// 3й доп - 30% при скилле 100, до 70% при максимуме скилла и дексы (при 5+ мортов)
-	if ((prob * 3 + dex_mod * 200) * remort_mod * sit_mod > percent * 5 && ch->get_fighting())
-		hit(ch, ch->get_fighting(), type, weapon);
-
-	percent = number(1, skill_info[SKILL_ADDSHOT].max_percent);
-	// 4й доп - 20% при скилле 100, до 60% при максимуме скилла и дексы (при 5+ мортов)
-	if ((prob + dex_mod * 100) * remort_mod * sit_mod > percent * 5 / 2 && ch->get_fighting())
-		hit(ch, ch->get_fighting(), type, weapon);
+  int percent = number(1, skill_info[SKILL_ADDSHOT].max_percent);
+  // 1й доп - не более 100% при скилее 100+
+  if (prob * sit_mod >= percent / 2)
+    hit(ch, ch->get_fighting(), type, weapon);
+  percent = number(1, skill_info[SKILL_ADDSHOT].max_percent);
+  // 2й доп - 60% при скилле 100, до 100% при максимуме скилла и дексы
+  if ((prob * 3 + dex_mod * 100) * sit_mod > percent * 5 / 2 && ch->get_fighting())
+    hit(ch, ch->get_fighting(), type, weapon);
+  percent = number(1, skill_info[SKILL_ADDSHOT].max_percent);
+  // 3й доп - 30% при скилле 100, до 70% при максимуме скилла и дексы (при 5+ мортов)
+  if ((prob * 3 + dex_mod * 200) * remort_mod * sit_mod > percent * 5 && ch->get_fighting())
+    hit(ch, ch->get_fighting(), type, weapon);
+  percent = number(1, skill_info[SKILL_ADDSHOT].max_percent);
+  // 4й доп - 20% при скилле 100, до 60% при максимуме скилла и дексы (при 5+ мортов)
+  if ((prob + dex_mod * 100) * remort_mod * sit_mod > percent * 5 / 2 && ch->get_fighting())
+    hit(ch, ch->get_fighting(), type, weapon);
 }
 
 // бонусы/штрафы классам за юзание определенных видов оружия
-void apply_weapon_bonus(int ch_class, const ESkill skill, int *damroll, int *hitroll)
-{
-	int dam = *damroll;
-	int calc_thaco = *hitroll;
+void apply_weapon_bonus(int ch_class, const ESkill skill, int *damroll, int *hitroll) {
+  int dam = *damroll;
+  int calc_thaco = *hitroll;
 
-	switch (ch_class)
-	{
-	case CLASS_CLERIC:
-		switch (skill)
-		{
-		case SKILL_CLUBS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_AXES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_LONGS:
-			calc_thaco += 2;
-			dam -= 1;
-			break;
-		case SKILL_SHORTS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_NONSTANDART:
-			calc_thaco += 1;
-			dam -= 2;
-			break;
-		case SKILL_BOTHHANDS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_PICK:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_SPADES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOWS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
+  switch (ch_class) {
+    case CLASS_CLERIC:
+      switch (skill) {
+        case SKILL_CLUBS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_AXES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_LONGS: calc_thaco += 2;
+          dam -= 1;
+          break;
+        case SKILL_SHORTS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_NONSTANDART: calc_thaco += 1;
+          dam -= 2;
+          break;
+        case SKILL_BOTHHANDS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_PICK: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_SPADES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOWS: calc_thaco -= 0;
+          dam += 0;
+          break;
 
-		default:
-			break;
-		}
-		break;
+        default: break;
+      }
+      break;
 
-	case CLASS_BATTLEMAGE:
-	case CLASS_DEFENDERMAGE:
-	case CLASS_CHARMMAGE:
-	case CLASS_NECROMANCER:
-		switch (skill)
-		{
-		case SKILL_CLUBS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_AXES:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_LONGS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_SHORTS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_NONSTANDART:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOTHHANDS:
-			calc_thaco += 1;
-			dam -= 3;
-			break;
-		case SKILL_PICK:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_SPADES:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_BOWS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		default:
-			break;
-		}
-		break;
+    case CLASS_BATTLEMAGE:
+    case CLASS_DEFENDERMAGE:
+    case CLASS_CHARMMAGE:
+    case CLASS_NECROMANCER:
+      switch (skill) {
+        case SKILL_CLUBS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_AXES: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_LONGS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_SHORTS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_NONSTANDART: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOTHHANDS: calc_thaco += 1;
+          dam -= 3;
+          break;
+        case SKILL_PICK: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_SPADES: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_BOWS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        default: break;
+      }
+      break;
 
-	case CLASS_WARRIOR:
-		switch (skill)
-		{
-		case SKILL_CLUBS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_AXES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_LONGS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_SHORTS:
-			calc_thaco += 2;
-			dam += 0;
-			break;
-		case SKILL_NONSTANDART:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOTHHANDS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_PICK:
-			calc_thaco += 2;
-			dam += 0;
-			break;
-		case SKILL_SPADES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOWS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		default:
-			break;
-		}
-		break;
+    case CLASS_WARRIOR:
+      switch (skill) {
+        case SKILL_CLUBS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_AXES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_LONGS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_SHORTS: calc_thaco += 2;
+          dam += 0;
+          break;
+        case SKILL_NONSTANDART: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOTHHANDS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_PICK: calc_thaco += 2;
+          dam += 0;
+          break;
+        case SKILL_SPADES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOWS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        default: break;
+      }
+      break;
 
-	case CLASS_RANGER:
-		switch (skill)
-		{
-		case SKILL_CLUBS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_AXES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_LONGS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_SHORTS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_NONSTANDART:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOTHHANDS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_PICK:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_SPADES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOWS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		default:
-			break;
-		}
-		break;
+    case CLASS_RANGER:
+      switch (skill) {
+        case SKILL_CLUBS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_AXES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_LONGS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_SHORTS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_NONSTANDART: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOTHHANDS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_PICK: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_SPADES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOWS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        default: break;
+      }
+      break;
 
-	case CLASS_GUARD:
-	case CLASS_THIEF:
-		switch (skill)
-		{
-		case SKILL_CLUBS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_AXES:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_LONGS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_SHORTS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_NONSTANDART:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOTHHANDS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_PICK:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_SPADES:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_BOWS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		default:
-			break;
-		}
-		break;
+    case CLASS_GUARD:
+    case CLASS_THIEF:
+      switch (skill) {
+        case SKILL_CLUBS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_AXES: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_LONGS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_SHORTS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_NONSTANDART: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOTHHANDS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_PICK: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_SPADES: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_BOWS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        default: break;
+      }
+      break;
 
-	case CLASS_ASSASINE:
-		switch (skill)
-		{
-		case SKILL_CLUBS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_AXES:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_LONGS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_SHORTS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_NONSTANDART:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOTHHANDS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_PICK:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_SPADES:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_BOWS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		default:
-			break;
-		}
-		break;
-		/*	case CLASS_PALADINE:
+    case CLASS_ASSASINE:
+      switch (skill) {
+        case SKILL_CLUBS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_AXES: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_LONGS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_SHORTS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_NONSTANDART: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOTHHANDS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_PICK: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_SPADES: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_BOWS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        default: break;
+      }
+      break;
+      /*	case CLASS_PALADINE:
 			case CLASS_SMITH:
 				switch (skill) {
 					case SKILL_CLUBS:	calc_thaco -= 0; dam += 0; break;
@@ -1246,785 +1127,663 @@ void apply_weapon_bonus(int ch_class, const ESkill skill, int *damroll, int *hit
 					case SKILL_BOWS:	calc_thaco -= 0; dam += 0; break;
 				}
 				break; */
-	case CLASS_MERCHANT:
-		switch (skill)
-		{
-		case SKILL_CLUBS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_AXES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_LONGS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_SHORTS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_NONSTANDART:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOTHHANDS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_PICK:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_SPADES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOWS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		default:
-			break;
-		}
-		break;
+    case CLASS_MERCHANT:
+      switch (skill) {
+        case SKILL_CLUBS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_AXES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_LONGS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_SHORTS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_NONSTANDART: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOTHHANDS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_PICK: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_SPADES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOWS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        default: break;
+      }
+      break;
 
-	case CLASS_DRUID:
-		switch (skill)
-		{
-		case SKILL_CLUBS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_AXES:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_LONGS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_SHORTS:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_NONSTANDART:
-			calc_thaco -= 0;
-			dam += 0;
-			break;
-		case SKILL_BOTHHANDS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		case SKILL_PICK:
-			calc_thaco += 0;
-			dam += 0;
-			break;
-		case SKILL_SPADES:
-			calc_thaco += 0;
-			dam += 0;
-			break;
-		case SKILL_BOWS:
-			calc_thaco += 1;
-			dam += 0;
-			break;
-		default:
-			break;
-		}
-		break;
-	}
+    case CLASS_DRUID:
+      switch (skill) {
+        case SKILL_CLUBS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_AXES: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_LONGS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_SHORTS: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_NONSTANDART: calc_thaco -= 0;
+          dam += 0;
+          break;
+        case SKILL_BOTHHANDS: calc_thaco += 1;
+          dam += 0;
+          break;
+        case SKILL_PICK: calc_thaco += 0;
+          dam += 0;
+          break;
+        case SKILL_SPADES: calc_thaco += 0;
+          dam += 0;
+          break;
+        case SKILL_BOWS: calc_thaco += 1;
+          dam += 0;
+          break;
+        default: break;
+      }
+      break;
+  }
 
-	*damroll = dam;
-	*hitroll = calc_thaco;
+  *damroll = dam;
+  *hitroll = calc_thaco;
 }
 
-int do_punctual(CHAR_DATA *ch, CHAR_DATA* /*victim*/, OBJ_DATA *wielded)
-{
-	int dam_critic = 0, wapp = 0;
+int do_punctual(CHAR_DATA *ch, CHAR_DATA * /*victim*/, OBJ_DATA *wielded) {
+  int dam_critic = 0, wapp = 0;
 
-	if (wielded)
-	{
-		wapp = (int)(GET_OBJ_SKILL(wielded) == SKILL_BOWS) ?
-		   GET_OBJ_WEIGHT(wielded) * 1 / 3 : GET_OBJ_WEIGHT(wielded);
-	}
+  if (wielded) {
+    wapp = (int) (GET_OBJ_SKILL(wielded) == SKILL_BOWS) ?
+           GET_OBJ_WEIGHT(wielded) * 1 / 3 : GET_OBJ_WEIGHT(wielded);
+  }
 
-	if (wapp < 10)
-		dam_critic = dice(1, 6);
-	else if (wapp < 19)
-		dam_critic = dice(2, 5);
-	else if (wapp < 27)
-		dam_critic = dice(3, 4);
-	else if (wapp < 36)
-		dam_critic = dice(3, 5);
-	else if (wapp < 44)
-		dam_critic = dice(3, 6);
-	else
-		dam_critic = dice(4, 5);
+  if (wapp < 10)
+    dam_critic = dice(1, 6);
+  else if (wapp < 19)
+    dam_critic = dice(2, 5);
+  else if (wapp < 27)
+    dam_critic = dice(3, 4);
+  else if (wapp < 36)
+    dam_critic = dice(3, 5);
+  else if (wapp < 44)
+    dam_critic = dice(3, 6);
+  else
+    dam_critic = dice(4, 5);
 
-	const int skill = 1 + ch->get_skill(SKILL_PUNCTUAL) / 6;
-	dam_critic = MIN(number(4, skill), dam_critic);
+  const int skill = 1 + ch->get_skill(SKILL_PUNCTUAL) / 6;
+  dam_critic = MIN(number(4, skill), dam_critic);
 
-	return dam_critic;
+  return dam_critic;
 }
 
 // * Умножение дамаги при стабе.
-int backstab_mult(int level)
-{
-	if (level <= 0)
-		return 1;	// level 0 //
-	else if (level <= 5)
-		return 2;	// level 1 - 5 //
-	else if (level <= 10)
-		return 3;	// level 6 - 10 //
-	else if (level <= 15)
-		return 4;	// level 11 - 15 //
-	else if (level <= 20)
-		return 5;	// level 16 - 20 //
-	else if (level <= 25)
-		return 6;	// level 21 - 25 //
-	else if (level <= 30)
-		return 7;	// level 26 - 30 //
-	else
-		return 10;
+int backstab_mult(int level) {
+  if (level <= 0)
+    return 1;    // level 0 //
+  else if (level <= 5)
+    return 2;    // level 1 - 5 //
+  else if (level <= 10)
+    return 3;    // level 6 - 10 //
+  else if (level <= 15)
+    return 4;    // level 11 - 15 //
+  else if (level <= 20)
+    return 5;    // level 16 - 20 //
+  else if (level <= 25)
+    return 6;    // level 21 - 25 //
+  else if (level <= 30)
+    return 7;    // level 26 - 30 //
+  else
+    return 10;
 }
 
 /**
 * Процент прохождения крит.стаба = скилл/11 + (декса-20)/(декса/30)
 * Влияение по 50% от скилла и дексы, максимум 36,18%.
 */
-int calculate_crit_backstab_percent(CHAR_DATA *ch)
-{
-	return static_cast<int>(ch->get_skill(SKILL_BACKSTAB)/11.0 + (GET_REAL_DEX(ch) - 20) / (GET_REAL_DEX(ch) / 30.0));
+int calculate_crit_backstab_percent(CHAR_DATA *ch) {
+  return static_cast<int>(ch->get_skill(SKILL_BACKSTAB) / 11.0 + (GET_REAL_DEX(ch) - 20) / (GET_REAL_DEX(ch) / 30.0));
 }
 
 // * Расчет множителя крит.стаба (по игрокам только для татей).
-double HitData::crit_backstab_multiplier(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	double bs_coeff = 1.0;
-	if (IS_NPC(victim))
-	{
-		if (can_use_feat(ch, THIEVES_STRIKE_FEAT))
-		{
-			bs_coeff *= ch->get_skill(SKILL_BACKSTAB) / 20.0;
-		}
-		else
-		{
-			bs_coeff *= ch->get_skill(SKILL_BACKSTAB) / 25.0;
-		}
+double HitData::crit_backstab_multiplier(CHAR_DATA *ch, CHAR_DATA *victim) {
+  double bs_coeff = 1.0;
+  if (IS_NPC(victim)) {
+    if (can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
+      bs_coeff *= ch->get_skill(SKILL_BACKSTAB) / 20.0;
+    } else {
+      bs_coeff *= ch->get_skill(SKILL_BACKSTAB) / 25.0;
+    }
 
-		// Читаем справку по скрытому: Если нанести такой удар в спину противника (ака стаб), то почти
-		// всегда для жертвы такой удар будет смертельным. Однако, в коде скрытый нигде не дает
-		// бонусов для стаба. Решил это исправить
-		// Проверяем, наем ли наш игрок
-		if (can_use_feat(ch, SHADOW_STRIKE_FEAT)
-			&& (ch->get_skill(SKILL_NOPARRYHIT)))
-		{
-			bs_coeff *= (1 + (ch->get_skill(SKILL_NOPARRYHIT) * 0.00125));
-		}
-	}
-	else if (can_use_feat(ch, THIEVES_STRIKE_FEAT))
-	{
-		if (victim->get_fighting()) //если враг в бою коэфф 1.125
-		{
-			bs_coeff *= (1.0 + (ch->get_skill(SKILL_BACKSTAB) * 0.00125));
-			// если стоит 1.25
-		}
-		else
-		{
-			bs_coeff *= (1.0 + (ch->get_skill(SKILL_BACKSTAB) * 0.00250));
-		}
-		// санку и призму при крите игнорим,
-		// чтобы дамаг был более-менее предсказуемым
-		set_flag(FightSystem::IGNORE_SANCT);
-		set_flag(FightSystem::IGNORE_PRISM);
-	}
+    // Читаем справку по скрытому: Если нанести такой удар в спину противника (ака стаб), то почти
+    // всегда для жертвы такой удар будет смертельным. Однако, в коде скрытый нигде не дает
+    // бонусов для стаба. Решил это исправить
+    // Проверяем, наем ли наш игрок
+    if (can_use_feat(ch, SHADOW_STRIKE_FEAT)
+        && (ch->get_skill(SKILL_NOPARRYHIT))) {
+      bs_coeff *= (1 + (ch->get_skill(SKILL_NOPARRYHIT) * 0.00125));
+    }
+  } else if (can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
+    if (victim->get_fighting()) //если враг в бою коэфф 1.125
+    {
+      bs_coeff *= (1.0 + (ch->get_skill(SKILL_BACKSTAB) * 0.00125));
+      // если стоит 1.25
+    } else {
+      bs_coeff *= (1.0 + (ch->get_skill(SKILL_BACKSTAB) * 0.00250));
+    }
+    // санку и призму при крите игнорим,
+    // чтобы дамаг был более-менее предсказуемым
+    set_flag(FightSystem::IGNORE_SANCT);
+    set_flag(FightSystem::IGNORE_PRISM);
+  }
 
-	if (bs_coeff < 1.0)
-	{
-		bs_coeff = 1.0;
-	}
+  if (bs_coeff < 1.0) {
+    bs_coeff = 1.0;
+  }
 
-	return bs_coeff;
+  return bs_coeff;
 }
 
 // * Может ли персонаж блокировать атаки автоматом (вообще в данный момент, без учета лагов).
-bool can_auto_block(CHAR_DATA *ch)
-{
-	if (GET_EQ(ch, WEAR_SHIELD) && GET_AF_BATTLE(ch, EAF_AWAKE) && GET_AF_BATTLE(ch, EAF_AUTOBLOCK))
-		return true;
-	else
-		return false;
+bool can_auto_block(CHAR_DATA *ch) {
+  if (GET_EQ(ch, WEAR_SHIELD) && GET_AF_BATTLE(ch, EAF_AWAKE) && GET_AF_BATTLE(ch, EAF_AUTOBLOCK))
+    return true;
+  else
+    return false;
 }
 
-
 // * Проверка на фит "любимое оружие".
-void HitData::check_weap_feats(const CHAR_DATA* ch, int weap_skill, int& calc_thaco, int& dam)
-{
-	switch (weap_skill)
-	{
-	case SKILL_PUNCH:
-		if (HAVE_FEAT(ch, PUNCH_FOCUS_FEAT))
-		{
-			calc_thaco -= 2;
-			dam += 2;
-		}
-		break;
-	case SKILL_CLUBS:
-		if (HAVE_FEAT(ch, CLUB_FOCUS_FEAT))
-		{
-			calc_thaco -= 2;
-			dam += 2;
-		}
-		break;
-	case SKILL_AXES:
-		if (HAVE_FEAT(ch, AXES_FOCUS_FEAT))
-		{
-			calc_thaco -= 1;
-			dam += 2;
-		}
-		break;
-	case SKILL_LONGS:
-		if (HAVE_FEAT(ch, LONGS_FOCUS_FEAT))
-		{
-			calc_thaco -= 1;
-			dam += 2;
-		}
-		break;
-	case SKILL_SHORTS:
-		if (HAVE_FEAT(ch, SHORTS_FOCUS_FEAT))
-		{
-			calc_thaco -= 2;
-			dam += 3;
-		}
-		break;
-	case SKILL_NONSTANDART:
-		if (HAVE_FEAT(ch, NONSTANDART_FOCUS_FEAT))
-		{
-			calc_thaco -= 1;
-			dam += 3;
-		}
-		break;
-	case SKILL_BOTHHANDS:
-		if (HAVE_FEAT(ch, BOTHHANDS_FOCUS_FEAT))
-		{
-			calc_thaco -= 1;
-			dam += 3;
-		}
-		break;
-	case SKILL_PICK:
-		if (HAVE_FEAT(ch, PICK_FOCUS_FEAT))
-		{
-			calc_thaco -= 2;
-			dam += 3;
-		}
-		break;
-	case SKILL_SPADES:
-		if (HAVE_FEAT(ch, SPADES_FOCUS_FEAT))
-		{
-			calc_thaco -= 1;
-			dam += 2;
-		}
-		break;
-	case SKILL_BOWS:
-		if (HAVE_FEAT(ch, BOWS_FOCUS_FEAT))
-		{
-			calc_thaco -= 7;
-			dam += 4;
-		}
-		break;
-	default:
-		break;
-	}
+void HitData::check_weap_feats(const CHAR_DATA *ch, int weap_skill, int &calc_thaco, int &dam) {
+  switch (weap_skill) {
+    case SKILL_PUNCH:
+      if (HAVE_FEAT(ch, PUNCH_FOCUS_FEAT)) {
+        calc_thaco -= 2;
+        dam += 2;
+      }
+      break;
+    case SKILL_CLUBS:
+      if (HAVE_FEAT(ch, CLUB_FOCUS_FEAT)) {
+        calc_thaco -= 2;
+        dam += 2;
+      }
+      break;
+    case SKILL_AXES:
+      if (HAVE_FEAT(ch, AXES_FOCUS_FEAT)) {
+        calc_thaco -= 1;
+        dam += 2;
+      }
+      break;
+    case SKILL_LONGS:
+      if (HAVE_FEAT(ch, LONGS_FOCUS_FEAT)) {
+        calc_thaco -= 1;
+        dam += 2;
+      }
+      break;
+    case SKILL_SHORTS:
+      if (HAVE_FEAT(ch, SHORTS_FOCUS_FEAT)) {
+        calc_thaco -= 2;
+        dam += 3;
+      }
+      break;
+    case SKILL_NONSTANDART:
+      if (HAVE_FEAT(ch, NONSTANDART_FOCUS_FEAT)) {
+        calc_thaco -= 1;
+        dam += 3;
+      }
+      break;
+    case SKILL_BOTHHANDS:
+      if (HAVE_FEAT(ch, BOTHHANDS_FOCUS_FEAT)) {
+        calc_thaco -= 1;
+        dam += 3;
+      }
+      break;
+    case SKILL_PICK:
+      if (HAVE_FEAT(ch, PICK_FOCUS_FEAT)) {
+        calc_thaco -= 2;
+        dam += 3;
+      }
+      break;
+    case SKILL_SPADES:
+      if (HAVE_FEAT(ch, SPADES_FOCUS_FEAT)) {
+        calc_thaco -= 1;
+        dam += 2;
+      }
+      break;
+    case SKILL_BOWS:
+      if (HAVE_FEAT(ch, BOWS_FOCUS_FEAT)) {
+        calc_thaco -= 7;
+        dam += 4;
+      }
+      break;
+    default: break;
+  }
 }
 
 // * Захват.
-void hit_touching(CHAR_DATA *ch, CHAR_DATA *vict, int *dam)
-{
-	if (vict->get_touching() == ch
-		&& !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPFIGHT)
-		&& !AFF_FLAGGED(vict, EAffectFlag::AFF_MAGICSTOPFIGHT)
-		&& !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPRIGHT)
-		&& GET_WAIT(vict) <= 0
-		&& !GET_MOB_HOLD(vict)
-		&& (IS_IMMORTAL(vict) || IS_NPC(vict)
-			|| !(GET_EQ(vict, WEAR_WIELD) || GET_EQ(vict, WEAR_BOTHS)))
-		&& GET_POS(vict) > POS_SLEEPING)
-	{
-		int percent = number(1, skill_info[SKILL_TOUCH].max_percent);
-		int prob = train_skill(vict, SKILL_TOUCH, skill_info[SKILL_TOUCH].max_percent, ch);
-		if (IS_IMMORTAL(vict) || GET_GOD_FLAG(vict, GF_GODSLIKE))
-		{
-			percent = prob;
-		}
-		if (GET_GOD_FLAG(vict, GF_GODSCURSE))
-		{
-			percent = 0;
-		}
-		CLR_AF_BATTLE(vict, EAF_TOUCH);
-		SET_AF_BATTLE(vict, EAF_USEDRIGHT);
-		vict->set_touching(0);
-		if (prob < percent)
-		{
-			act("Вы не смогли перехватить атаку $N1.", FALSE, vict, 0, ch, TO_CHAR);
-			act("$N не смог$Q перехватить вашу атаку.", FALSE, ch, 0, vict, TO_CHAR);
-			act("$n не смог$q перехватить атаку $N1.", TRUE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			prob = 2;
-		}
-		else
-		{
-			act("Вы перехватили атаку $N1.", FALSE, vict, 0, ch, TO_CHAR);
-			act("$N перехватил$G вашу атаку.", FALSE, ch, 0, vict, TO_CHAR);
-			act("$n перехватил$g атаку $N1.", TRUE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			*dam = -1;
-			prob = 1;
-		}
-		if (!WAITLESS(vict))
-		{
-			WAIT_STATE(vict, prob * PULSE_VIOLENCE);
-		}
-	}
+void hit_touching(CHAR_DATA *ch, CHAR_DATA *vict, int *dam) {
+  if (vict->get_touching() == ch
+      && !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPFIGHT)
+      && !AFF_FLAGGED(vict, EAffectFlag::AFF_MAGICSTOPFIGHT)
+      && !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPRIGHT)
+      && GET_WAIT(vict) <= 0
+      && !GET_MOB_HOLD(vict)
+      && (IS_IMMORTAL(vict) || IS_NPC(vict)
+          || !(GET_EQ(vict, WEAR_WIELD) || GET_EQ(vict, WEAR_BOTHS)))
+      && GET_POS(vict) > POS_SLEEPING) {
+    int percent = number(1, skill_info[SKILL_TOUCH].max_percent);
+    int prob = calculate_skill(vict, SKILL_TOUCH, ch);
+    train_skill(vict, SKILL_TOUCH, prob >= percent, ch);
+    if (IS_IMMORTAL(vict) || GET_GOD_FLAG(vict, GF_GODSLIKE)) {
+      percent = prob;
+    }
+    if (GET_GOD_FLAG(vict, GF_GODSCURSE)) {
+      percent = 0;
+    }
+    CLR_AF_BATTLE(vict, EAF_TOUCH);
+    SET_AF_BATTLE(vict, EAF_USEDRIGHT);
+    vict->set_touching(0);
+    if (prob < percent) {
+      act("Вы не смогли перехватить атаку $N1.", FALSE, vict, 0, ch, TO_CHAR);
+      act("$N не смог$Q перехватить вашу атаку.", FALSE, ch, 0, vict, TO_CHAR);
+      act("$n не смог$q перехватить атаку $N1.", TRUE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      prob = 2;
+    } else {
+      act("Вы перехватили атаку $N1.", FALSE, vict, 0, ch, TO_CHAR);
+      act("$N перехватил$G вашу атаку.", FALSE, ch, 0, vict, TO_CHAR);
+      act("$n перехватил$g атаку $N1.", TRUE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      *dam = -1;
+      prob = 1;
+    }
+    if (!WAITLESS(vict)) {
+      WAIT_STATE(vict, prob * PULSE_VIOLENCE);
+    }
+  }
 }
 
-void hit_deviate(CHAR_DATA *ch, CHAR_DATA *victim, int *dam)
-{
-	int range = number(1, skill_info[SKILL_DEVIATE].max_percent);
-	int prob = train_skill(victim, SKILL_DEVIATE, skill_info[SKILL_DEVIATE].max_percent, ch);
-	if (GET_GOD_FLAG(victim, GF_GODSCURSE))
-	{
-		prob = 0;
-	}
-	prob = prob * 100 / range;
-	if (check_spell_on_player(victim, SPELL_WEB))
-	{
-		prob /= 3;
-	}
-	if (prob < 60)
-	{
-		act("Вы не смогли уклониться от атаки $N1", FALSE, victim, 0, ch, TO_CHAR);
-		act("$N не сумел$G уклониться от вашей атаки", FALSE, ch, 0, victim, TO_CHAR);
-		act("$n не сумел$g уклониться от атаки $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-                SET_AF_BATTLE(victim, EAF_DEVIATE);
-}
-	else if (prob < 100)
-	{
-		act("Вы немного уклонились от атаки $N1", FALSE, victim, 0, ch, TO_CHAR);
-		act("$N немного уклонил$U от вашей атаки", FALSE, ch, 0, victim, TO_CHAR);
-		act("$n немного уклонил$u от атаки $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-		*dam = *dam * 10 / 15;
-                SET_AF_BATTLE(victim, EAF_DEVIATE);
-	}
-	else if (prob < 200)
-	{
-		act("Вы частично уклонились от атаки $N1", FALSE, victim, 0, ch, TO_CHAR);
-		act("$N частично уклонил$U от вашей атаки", FALSE, ch, 0, victim, TO_CHAR);
-		act("$n частично уклонил$u от атаки $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-		*dam = *dam / 2;
-                SET_AF_BATTLE(victim, EAF_DEVIATE);
-	}
-	else
-	{
-		act("Вы уклонились от атаки $N1", FALSE, victim, 0, ch, TO_CHAR);
-		act("$N уклонил$U от вашей атаки", FALSE, ch, 0, victim, TO_CHAR);
-		act("$n уклонил$u от атаки $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-		*dam = -1;
-                SET_AF_BATTLE(victim, EAF_DEVIATE);
-	}
-	BATTLECNTR(victim)++;
+void hit_deviate(CHAR_DATA *ch, CHAR_DATA *victim, int *dam) {
+  int range = number(1, skill_info[SKILL_DEVIATE].max_percent);
+  int prob = calculate_skill(victim, SKILL_DEVIATE, ch);
+  if (GET_GOD_FLAG(victim, GF_GODSCURSE)) {
+    prob = 0;
+  }
+  prob = prob * 100 / range;
+  if (check_spell_on_player(victim, SPELL_WEB)) {
+    prob /= 3;
+  }
+  train_skill(victim, SKILL_DEVIATE, prob < 100, ch);
+  if (prob < 60) {
+    act("Вы не смогли уклониться от атаки $N1", FALSE, victim, 0, ch, TO_CHAR);
+    act("$N не сумел$G уклониться от вашей атаки", FALSE, ch, 0, victim, TO_CHAR);
+    act("$n не сумел$g уклониться от атаки $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+    SET_AF_BATTLE(victim, EAF_DEVIATE);
+  } else if (prob < 100) {
+    act("Вы немного уклонились от атаки $N1", FALSE, victim, 0, ch, TO_CHAR);
+    act("$N немного уклонил$U от вашей атаки", FALSE, ch, 0, victim, TO_CHAR);
+    act("$n немного уклонил$u от атаки $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+    *dam = *dam * 10 / 15;
+    SET_AF_BATTLE(victim, EAF_DEVIATE);
+  } else if (prob < 200) {
+    act("Вы частично уклонились от атаки $N1", FALSE, victim, 0, ch, TO_CHAR);
+    act("$N частично уклонил$U от вашей атаки", FALSE, ch, 0, victim, TO_CHAR);
+    act("$n частично уклонил$u от атаки $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+    *dam = *dam / 2;
+    SET_AF_BATTLE(victim, EAF_DEVIATE);
+  } else {
+    act("Вы уклонились от атаки $N1", FALSE, victim, 0, ch, TO_CHAR);
+    act("$N уклонил$U от вашей атаки", FALSE, ch, 0, victim, TO_CHAR);
+    act("$n уклонил$u от атаки $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+    *dam = -1;
+    SET_AF_BATTLE(victim, EAF_DEVIATE);
+  }
+  BATTLECNTR(victim)++;
 }
 
-void hit_parry(CHAR_DATA *ch, CHAR_DATA *victim, int skill, int hit_type, int *dam)
-{
-	if (!((GET_EQ(victim, WEAR_WIELD)
-			&& GET_OBJ_TYPE(GET_EQ(victim, WEAR_WIELD)) == OBJ_DATA::ITEM_WEAPON
-			&& GET_EQ(victim, WEAR_HOLD)
-			&& GET_OBJ_TYPE(GET_EQ(victim, WEAR_HOLD)) == OBJ_DATA::ITEM_WEAPON)
-		|| IS_NPC(victim)
-		|| IS_IMMORTAL(victim)))
-	{
-		send_to_char("У вас нечем отклонить атаку противника\r\n", victim);
-		CLR_AF_BATTLE(victim, EAF_PARRY);
-	}
-	else
-	{
-		int range = number(1, skill_info[SKILL_PARRY].max_percent);
-		int prob = train_skill(victim, SKILL_PARRY,
-				skill_info[SKILL_PARRY].max_percent, ch);
-		prob = prob * 100 / range;
-
-		if (prob < 70
-			|| ((skill == SKILL_BOWS || hit_type == FightSystem::type_maul)
-				&& !IS_IMMORTAL(victim)
-				&& (!can_use_feat(victim, PARRY_ARROW_FEAT)
-				|| number(1, 1000) >= 20 * MIN(GET_REAL_DEX(victim), 35))))
-		{
-			act("Вы не смогли отбить атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N не сумел$G отбить вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n не сумел$g отбить атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			prob = 2;
-			SET_AF_BATTLE(victim, EAF_USEDLEFT);
-		}
-		else if (prob < 100)
-		{
-			act("Вы немного отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N немного отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n немного отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 10);
-			prob = 1;
-			*dam = *dam * 10 / 15;
-			SET_AF_BATTLE(victim, EAF_USEDLEFT);
-		}
-		else if (prob < 170)
-		{
-			act("Вы частично отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N частично отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n частично отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 15);
-			prob = 0;
-			*dam = *dam / 2;
-			SET_AF_BATTLE(victim, EAF_USEDLEFT);
-		}
-		else
-		{
-			act("Вы полностью отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N полностью отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n полностью отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 25);
-			prob = 0;
-			*dam = -1;
-		}
-		if (!WAITLESS(ch) && prob)
-		{
-			WAIT_STATE(victim, PULSE_VIOLENCE * prob);
-		}
-		CLR_AF_BATTLE(victim, EAF_PARRY);
-	}
+void hit_parry(CHAR_DATA *ch, CHAR_DATA *victim, int skill, int hit_type, int *dam) {
+  if (!((GET_EQ(victim, WEAR_WIELD)
+      && GET_OBJ_TYPE(GET_EQ(victim, WEAR_WIELD)) == OBJ_DATA::ITEM_WEAPON
+      && GET_EQ(victim, WEAR_HOLD)
+      && GET_OBJ_TYPE(GET_EQ(victim, WEAR_HOLD)) == OBJ_DATA::ITEM_WEAPON)
+      || IS_NPC(victim)
+      || IS_IMMORTAL(victim))) {
+    send_to_char("У вас нечем отклонить атаку противника\r\n", victim);
+    CLR_AF_BATTLE(victim, EAF_PARRY);
+  } else {
+    int range = number(1, skill_info[SKILL_PARRY].max_percent);
+    int prob = calculate_skill(victim, SKILL_PARRY, ch);
+    prob = prob * 100 / range;
+    train_skill(victim, SKILL_PARRY, prob < 100, ch);
+    if (prob < 70
+        || ((skill == SKILL_BOWS || hit_type == FightSystem::type_maul)
+            && !IS_IMMORTAL(victim)
+            && (!can_use_feat(victim, PARRY_ARROW_FEAT)
+                || number(1, 1000) >= 20 * MIN(GET_REAL_DEX(victim), 35)))) {
+      act("Вы не смогли отбить атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N не сумел$G отбить вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n не сумел$g отбить атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      prob = 2;
+      SET_AF_BATTLE(victim, EAF_USEDLEFT);
+    } else if (prob < 100) {
+      act("Вы немного отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N немного отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n немного отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 10);
+      prob = 1;
+      *dam = *dam * 10 / 15;
+      SET_AF_BATTLE(victim, EAF_USEDLEFT);
+    } else if (prob < 170) {
+      act("Вы частично отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N частично отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n частично отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 15);
+      prob = 0;
+      *dam = *dam / 2;
+      SET_AF_BATTLE(victim, EAF_USEDLEFT);
+    } else {
+      act("Вы полностью отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N полностью отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n полностью отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 25);
+      prob = 0;
+      *dam = -1;
+    }
+    if (!WAITLESS(ch) && prob) {
+      WAIT_STATE(victim, PULSE_VIOLENCE * prob);
+    }
+    CLR_AF_BATTLE(victim, EAF_PARRY);
+  }
 }
 
-void hit_multyparry(CHAR_DATA *ch, CHAR_DATA *victim, int skill, int hit_type, int *dam)
-{
-	if (!((GET_EQ(victim, WEAR_WIELD)
-			&& GET_OBJ_TYPE(GET_EQ(victim, WEAR_WIELD)) == OBJ_DATA::ITEM_WEAPON
-			&& GET_EQ(victim, WEAR_HOLD)
-			&& GET_OBJ_TYPE(GET_EQ(victim, WEAR_HOLD)) == OBJ_DATA::ITEM_WEAPON)
-		|| IS_NPC(victim)
-		|| IS_IMMORTAL(victim)))
-	{
-		send_to_char("У вас нечем отклонять атаки противников\r\n", victim);
-	}
-	else
-	{
-		int range = number(1,
-				skill_info[SKILL_MULTYPARRY].max_percent) + 15 * BATTLECNTR(victim);
-		int prob = train_skill(victim, SKILL_MULTYPARRY,
-				skill_info[SKILL_MULTYPARRY].max_percent + BATTLECNTR(ch) * 15, ch);
-		prob = prob * 100 / range;
+void hit_multyparry(CHAR_DATA *ch, CHAR_DATA *victim, int skill, int hit_type, int *dam) {
+  if (!((GET_EQ(victim, WEAR_WIELD)
+      && GET_OBJ_TYPE(GET_EQ(victim, WEAR_WIELD)) == OBJ_DATA::ITEM_WEAPON
+      && GET_EQ(victim, WEAR_HOLD)
+      && GET_OBJ_TYPE(GET_EQ(victim, WEAR_HOLD)) == OBJ_DATA::ITEM_WEAPON)
+      || IS_NPC(victim)
+      || IS_IMMORTAL(victim))) {
+    send_to_char("У вас нечем отклонять атаки противников\r\n", victim);
+  } else {
+    int range = number(1,
+                       skill_info[SKILL_MULTYPARRY].max_percent) + 15 * BATTLECNTR(victim);
+    int prob = calculate_skill(victim, SKILL_MULTYPARRY, ch);
+    prob = prob * 100 / range;
 
-		if ((skill == SKILL_BOWS || hit_type == FightSystem::type_maul)
-			&& !IS_IMMORTAL(victim)
-			&& (!can_use_feat(victim, PARRY_ARROW_FEAT)
-				|| number(1, 1000) >= 20 * MIN(GET_REAL_DEX(victim), 35)))
-		{
-			prob = 0;
-		}
-		else
-		{
-			BATTLECNTR(victim)++;
-		}
+    if ((skill == SKILL_BOWS || hit_type == FightSystem::type_maul)
+        && !IS_IMMORTAL(victim)
+        && (!can_use_feat(victim, PARRY_ARROW_FEAT)
+            || number(1, 1000) >= 20 * MIN(GET_REAL_DEX(victim), 35))) {
+      prob = 0;
+    } else {
+      BATTLECNTR(victim)++;
+    }
 
-		if (prob < 50)
-		{
-			act("Вы не смогли отбить атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N не сумел$G отбить вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n не сумел$g отбить атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-		}
-		else if (prob < 90)
-		{
-			act("Вы немного отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N немного отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n немного отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 10);
-			*dam = *dam * 10 / 15;
-		}
-		else if (prob < 180)
-		{
-			act("Вы частично отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N частично отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n частично отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 15);
-			*dam = *dam / 2;
-		}
-		else
-		{
-			act("Вы полностью отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N полностью отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n полностью отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 25);
-			*dam = -1;
-		}
-	}
+    train_skill(victim, SKILL_MULTYPARRY, prob >= 50, ch);
+    if (prob < 50) {
+      act("Вы не смогли отбить атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N не сумел$G отбить вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n не сумел$g отбить атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+    } else if (prob < 90) {
+      act("Вы немного отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N немного отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n немного отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 10);
+      *dam = *dam * 10 / 15;
+    } else if (prob < 180) {
+      act("Вы частично отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N частично отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n частично отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 15);
+      *dam = *dam / 2;
+    } else {
+      act("Вы полностью отклонили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N полностью отклонил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n полностью отклонил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, number(0, 2) ? WEAR_WIELD : WEAR_HOLD, *dam, 25);
+      *dam = -1;
+    }
+  }
 }
 
-void hit_block(CHAR_DATA *ch, CHAR_DATA *victim, int *dam)
-{
-	if (!(GET_EQ(victim, WEAR_SHIELD)
-		|| IS_NPC(victim)
-		|| IS_IMMORTAL(victim)))
-	{
-		send_to_char("У вас нечем отразить атаку противника\r\n", victim);
-	}
-	else
-	{
-		int range = number(1, skill_info[SKILL_BLOCK].max_percent);
-		int prob =
-			train_skill(victim, SKILL_BLOCK, skill_info[SKILL_BLOCK].max_percent, ch);
-		prob = prob * 100 / range;
-		BATTLECNTR(victim)++;
-		if (prob < 100)
-		{
-			act("Вы не смогли отразить атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N не сумел$G отразить вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n не сумел$g отразить атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-		}
-		else if (prob < 150)
-		{
-			act("Вы немного отразили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N немного отразил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n немного отразил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, WEAR_SHIELD, *dam, 10);
-			*dam = *dam * 10 / 15;
-		}
-		else if (prob < 250)
-		{
-			act("Вы частично отразили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N частично отразил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n частично отразил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, WEAR_SHIELD, *dam, 15);
-			*dam = *dam / 2;
-		}
-		else
-		{
-			act("Вы полностью отразили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
-			act("$N полностью отразил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
-			act("$n полностью отразил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-			alt_equip(victim, WEAR_SHIELD, *dam, 25);
-			*dam = -1;
-		}
-	}
+void hit_block(CHAR_DATA *ch, CHAR_DATA *victim, int *dam) {
+  if (!(GET_EQ(victim, WEAR_SHIELD)
+      || IS_NPC(victim)
+      || IS_IMMORTAL(victim))) {
+    send_to_char("У вас нечем отразить атаку противника\r\n", victim);
+  } else {
+    int range = number(1, skill_info[SKILL_BLOCK].max_percent);
+    int prob = calculate_skill(victim, SKILL_BLOCK, ch);
+    train_skill(victim, SKILL_BLOCK, prob > 99, ch);
+    prob = prob * 100 / range;
+    BATTLECNTR(victim)++;
+    if (prob < 100) {
+      act("Вы не смогли отразить атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N не сумел$G отразить вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n не сумел$g отразить атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+    } else if (prob < 150) {
+      act("Вы немного отразили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N немного отразил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n немного отразил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, WEAR_SHIELD, *dam, 10);
+      *dam = *dam * 10 / 15;
+    } else if (prob < 250) {
+      act("Вы частично отразили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N частично отразил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n частично отразил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, WEAR_SHIELD, *dam, 15);
+      *dam = *dam / 2;
+    } else {
+      act("Вы полностью отразили атаку $N1", FALSE, victim, 0, ch, TO_CHAR);
+      act("$N полностью отразил$G вашу атаку", FALSE, ch, 0, victim, TO_CHAR);
+      act("$n полностью отразил$g атаку $N1", TRUE, victim, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+      alt_equip(victim, WEAR_SHIELD, *dam, 25);
+      *dam = -1;
+    }
+  }
 }
 
-void appear(CHAR_DATA * ch)
-{
-	const bool appear_msg = AFF_FLAGGED(ch, EAffectFlag::AFF_INVISIBLE)
-		|| AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE)
-		|| AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE);
+void appear(CHAR_DATA *ch) {
+  const bool appear_msg = AFF_FLAGGED(ch, EAffectFlag::AFF_INVISIBLE)
+      || AFF_FLAGGED(ch, EAffectFlag::AFF_CAMOUFLAGE)
+      || AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE);
 
-	if (affected_by_spell(ch, SPELL_INVISIBLE))
-		affect_from_char(ch, SPELL_INVISIBLE);
-	if (affected_by_spell(ch, SPELL_HIDE))
-		affect_from_char(ch, SPELL_HIDE);
-	if (affected_by_spell(ch, SPELL_SNEAK))
-		affect_from_char(ch, SPELL_SNEAK);
-	if (affected_by_spell(ch, SPELL_CAMOUFLAGE))
-		affect_from_char(ch, SPELL_CAMOUFLAGE);
+  if (affected_by_spell(ch, SPELL_INVISIBLE))
+    affect_from_char(ch, SPELL_INVISIBLE);
+  if (affected_by_spell(ch, SPELL_HIDE))
+    affect_from_char(ch, SPELL_HIDE);
+  if (affected_by_spell(ch, SPELL_SNEAK))
+    affect_from_char(ch, SPELL_SNEAK);
+  if (affected_by_spell(ch, SPELL_CAMOUFLAGE))
+    affect_from_char(ch, SPELL_CAMOUFLAGE);
 
-	AFF_FLAGS(ch).unset(EAffectFlag::AFF_INVISIBLE);
-	AFF_FLAGS(ch).unset(EAffectFlag::AFF_HIDE);
-	AFF_FLAGS(ch).unset(EAffectFlag::AFF_SNEAK);
-	AFF_FLAGS(ch).unset(EAffectFlag::AFF_CAMOUFLAGE);
+  AFF_FLAGS(ch).unset(EAffectFlag::AFF_INVISIBLE);
+  AFF_FLAGS(ch).unset(EAffectFlag::AFF_HIDE);
+  AFF_FLAGS(ch).unset(EAffectFlag::AFF_SNEAK);
+  AFF_FLAGS(ch).unset(EAffectFlag::AFF_CAMOUFLAGE);
 
-	if (appear_msg)
-	{
-		if (IS_NPC(ch)
-			|| GET_LEVEL(ch) < LVL_IMMORT)
-		{
-			act("$n медленно появил$u из пустоты.", FALSE, ch, 0, 0, TO_ROOM);
-		}
-		else
-		{
-			act("Вы почувствовали странное присутствие $n1.", FALSE, ch, 0, 0, TO_ROOM);
-		}
-	}
+  if (appear_msg) {
+    if (IS_NPC(ch)
+        || GET_LEVEL(ch) < LVL_IMMORT) {
+      act("$n медленно появил$u из пустоты.", FALSE, ch, 0, 0, TO_ROOM);
+    } else {
+      act("Вы почувствовали странное присутствие $n1.", FALSE, ch, 0, 0, TO_ROOM);
+    }
+  }
 }
 
 // message for doing damage with a weapon
-void Damage::dam_message(CHAR_DATA* ch, CHAR_DATA* victim) const
-{
-	int dam_msgnum;
-	int w_type = msg_num;
+void Damage::dam_message(CHAR_DATA *ch, CHAR_DATA *victim) const {
+  int dam_msgnum;
+  int w_type = msg_num;
 
-	static const struct dam_weapon_type
-	{
-		const char *to_room;
-		const char *to_char;
-		const char *to_victim;
-	} dam_weapons[] =
-	{
+  static const struct dam_weapon_type {
+    const char *to_room;
+    const char *to_char;
+    const char *to_victim;
+  } dam_weapons[] =
+      {
 
-		// use #w for singular (i.e. "slash") and #W for plural (i.e. "slashes")
+          // use #w for singular (i.e. "slash") and #W for plural (i.e. "slashes")
 
-		{
-			"$n попытал$u #W $N3, но промахнул$u.",	// 0: 0      0 //
-			"Вы попытались #W $N3, но промахнулись.",
-			"$n попытал$u #W вас, но промахнул$u."
-		}, {
-			"$n легонько #w$g $N3.",	//  1..5 1 //
-			"Вы легонько #wи $N3.",
-			"$n легонько #w$g вас."
-		}, {
-			"$n слегка #w$g $N3.",	//  6..11  2 //
-			"Вы слегка #wи $N3.",
-			"$n слегка #w$g вас."
-		}, {
-			"$n #w$g $N3.",	//  12..18   3 //
-			"Вы #wи $N3.",
-			"$n #w$g вас."
-		}, {
-			"$n #w$g $N3.",	// 19..26  4 //
-			"Вы #wи $N3.",
-			"$n #w$g вас."
-		}, {
-			"$n сильно #w$g $N3.",	// 27..35  5 //
-			"Вы сильно #wи $N3.",
-			"$n сильно #w$g вас."
-		}, {
-			"$n очень сильно #w$g $N3.",	//  36..45 6  //
-			"Вы очень сильно #wи $N3.",
-			"$n очень сильно #w$g вас."
-		}, {
-			"$n чрезвычайно сильно #w$g $N3.",	//  46..55  7 //
-			"Вы чрезвычайно сильно #wи $N3.",
-			"$n чрезвычайно сильно #w$g вас."
-		}, {
-			"$n БОЛЬНО #w$g $N3.",	//  56..96   8 //
-			"Вы БОЛЬНО #wи $N3.",
-			"$n БОЛЬНО #w$g вас."
-		}, {
-			"$n ОЧЕНЬ БОЛЬНО #w$g $N3.",	//    97..136  9  //
-			"Вы ОЧЕНЬ БОЛЬНО #wи $N3.",
-			"$n ОЧЕНЬ БОЛЬНО #w$g вас."
-		}, {
-			"$n ЧРЕЗВЫЧАЙНО БОЛЬНО #w$g $N3.",	//   137..176  10 //
-			"Вы ЧРЕЗВЫЧАЙНО БОЛЬНО #wи $N3.",
-			"$n ЧРЕЗВЫЧАЙНО БОЛЬНО #w$g вас."
-		}, {
-			"$n НЕВЫНОСИМО БОЛЬНО #w$g $N3.",	//    177..216  11 //
-			"Вы НЕВЫНОСИМО БОЛЬНО #wи $N3.",
-			"$n НЕВЫНОСИМО БОЛЬНО #w$g вас."
-		}, {
-			"$n ЖЕСТОКО #w$g $N3.",	//    217..256  13 //
-			"Вы ЖЕСТОКО #wи $N3.",
-			"$n ЖЕСТОКО #w$g вас."
-		}, {
-			"$n УЖАСНО #w$g $N3.",	//    257..296  13 //
-			"Вы УЖАСНО #wи $N3.",
-			"$n УЖАСНО #w$g вас."
-		}, {
-			"$n УБИЙСТВЕННО #w$g $N3.",	//    297..400  15 //
-			"Вы УБИЙСТВЕННО #wи $N3.",
-			"$n УБИЙСТВЕННО #w$g вас."
-		}, {
-			"$n ИЗУВЕРСКИ #w$g $N3.",	//    297..400  15 //
-			"Вы ИЗУВЕРСКИ #wи $N3.",
-			"$n ИЗУВЕРСКИ #w$g вас."
-		}, {
-			"$n СМЕРТЕЛЬНО #w$g $N3.",	// 400+  16 //
-			"Вы СМЕРТЕЛЬНО #wи $N3.",
-			"$n СМЕРТЕЛЬНО #w$g вас."
-		}
-	};
+          {
+              "$n попытал$u #W $N3, но промахнул$u.",    // 0: 0      0 //
+              "Вы попытались #W $N3, но промахнулись.",
+              "$n попытал$u #W вас, но промахнул$u."
+          }, {
+              "$n легонько #w$g $N3.",    //  1..5 1 //
+              "Вы легонько #wи $N3.",
+              "$n легонько #w$g вас."
+          }, {
+              "$n слегка #w$g $N3.",    //  6..11  2 //
+              "Вы слегка #wи $N3.",
+              "$n слегка #w$g вас."
+          }, {
+              "$n #w$g $N3.",    //  12..18   3 //
+              "Вы #wи $N3.",
+              "$n #w$g вас."
+          }, {
+              "$n #w$g $N3.",    // 19..26  4 //
+              "Вы #wи $N3.",
+              "$n #w$g вас."
+          }, {
+              "$n сильно #w$g $N3.",    // 27..35  5 //
+              "Вы сильно #wи $N3.",
+              "$n сильно #w$g вас."
+          }, {
+              "$n очень сильно #w$g $N3.",    //  36..45 6  //
+              "Вы очень сильно #wи $N3.",
+              "$n очень сильно #w$g вас."
+          }, {
+              "$n чрезвычайно сильно #w$g $N3.",    //  46..55  7 //
+              "Вы чрезвычайно сильно #wи $N3.",
+              "$n чрезвычайно сильно #w$g вас."
+          }, {
+              "$n БОЛЬНО #w$g $N3.",    //  56..96   8 //
+              "Вы БОЛЬНО #wи $N3.",
+              "$n БОЛЬНО #w$g вас."
+          }, {
+              "$n ОЧЕНЬ БОЛЬНО #w$g $N3.",    //    97..136  9  //
+              "Вы ОЧЕНЬ БОЛЬНО #wи $N3.",
+              "$n ОЧЕНЬ БОЛЬНО #w$g вас."
+          }, {
+              "$n ЧРЕЗВЫЧАЙНО БОЛЬНО #w$g $N3.",    //   137..176  10 //
+              "Вы ЧРЕЗВЫЧАЙНО БОЛЬНО #wи $N3.",
+              "$n ЧРЕЗВЫЧАЙНО БОЛЬНО #w$g вас."
+          }, {
+              "$n НЕВЫНОСИМО БОЛЬНО #w$g $N3.",    //    177..216  11 //
+              "Вы НЕВЫНОСИМО БОЛЬНО #wи $N3.",
+              "$n НЕВЫНОСИМО БОЛЬНО #w$g вас."
+          }, {
+              "$n ЖЕСТОКО #w$g $N3.",    //    217..256  13 //
+              "Вы ЖЕСТОКО #wи $N3.",
+              "$n ЖЕСТОКО #w$g вас."
+          }, {
+              "$n УЖАСНО #w$g $N3.",    //    257..296  13 //
+              "Вы УЖАСНО #wи $N3.",
+              "$n УЖАСНО #w$g вас."
+          }, {
+              "$n УБИЙСТВЕННО #w$g $N3.",    //    297..400  15 //
+              "Вы УБИЙСТВЕННО #wи $N3.",
+              "$n УБИЙСТВЕННО #w$g вас."
+          }, {
+              "$n ИЗУВЕРСКИ #w$g $N3.",    //    297..400  15 //
+              "Вы ИЗУВЕРСКИ #wи $N3.",
+              "$n ИЗУВЕРСКИ #w$g вас."
+          }, {
+              "$n СМЕРТЕЛЬНО #w$g $N3.",    // 400+  16 //
+              "Вы СМЕРТЕЛЬНО #wи $N3.",
+              "$n СМЕРТЕЛЬНО #w$g вас."
+          }
+      };
 
-	if (w_type >= TYPE_HIT && w_type < TYPE_MAGIC)
-		w_type -= TYPE_HIT;	// Change to base of table with text //
-	else
-		w_type = TYPE_HIT;
+  if (w_type >= TYPE_HIT && w_type < TYPE_MAGIC)
+    w_type -= TYPE_HIT;    // Change to base of table with text //
+  else
+    w_type = TYPE_HIT;
 
-	if (dam == 0)
-		dam_msgnum = 0;
-	else if (dam <= 5)
-		dam_msgnum = 1;
-	else if (dam <= 11)
-		dam_msgnum = 2;
-	else if (dam <= 18)
-		dam_msgnum = 3;
-	else if (dam <= 26)
-		dam_msgnum = 4;
-	else if (dam <= 35)
-		dam_msgnum = 5;
-	else if (dam <= 45)
-		dam_msgnum = 6;
-	else if (dam <= 56)
-		dam_msgnum = 7;
-	else if (dam <= 96)
-		dam_msgnum = 8;
-	else if (dam <= 136)
-		dam_msgnum = 9;
-	else if (dam <= 176)
-		dam_msgnum = 10;
-	else if (dam <= 216)
-		dam_msgnum = 11;
-	else if (dam <= 256)
-		dam_msgnum = 12;
-	else if (dam <= 296)
-		dam_msgnum = 13;
-	else if (dam <= 400)
-		dam_msgnum = 14;
-	else if (dam <= 800)
-		dam_msgnum = 15;
-	else
-		dam_msgnum = 16;
-	// damage message to onlookers
-	char *buf_ptr = replace_string(dam_weapons[dam_msgnum].to_room,
-		attack_hit_text[w_type].singular, attack_hit_text[w_type].plural);
-	if (brief_shields_.empty())
-	{
-		act(buf_ptr, FALSE, ch, NULL, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-	}
-	else
-	{
-		char buf_[MAX_INPUT_LENGTH];
-		snprintf(buf_, sizeof(buf_), "%s%s", buf_ptr, brief_shields_.c_str());
-		act(buf_, FALSE, ch, NULL, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_BRIEF_SHIELDS);
-		act(buf_ptr, FALSE, ch, NULL, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
-	}
+  if (dam == 0)
+    dam_msgnum = 0;
+  else if (dam <= 5)
+    dam_msgnum = 1;
+  else if (dam <= 11)
+    dam_msgnum = 2;
+  else if (dam <= 18)
+    dam_msgnum = 3;
+  else if (dam <= 26)
+    dam_msgnum = 4;
+  else if (dam <= 35)
+    dam_msgnum = 5;
+  else if (dam <= 45)
+    dam_msgnum = 6;
+  else if (dam <= 56)
+    dam_msgnum = 7;
+  else if (dam <= 96)
+    dam_msgnum = 8;
+  else if (dam <= 136)
+    dam_msgnum = 9;
+  else if (dam <= 176)
+    dam_msgnum = 10;
+  else if (dam <= 216)
+    dam_msgnum = 11;
+  else if (dam <= 256)
+    dam_msgnum = 12;
+  else if (dam <= 296)
+    dam_msgnum = 13;
+  else if (dam <= 400)
+    dam_msgnum = 14;
+  else if (dam <= 800)
+    dam_msgnum = 15;
+  else
+    dam_msgnum = 16;
+  // damage message to onlookers
+  char *buf_ptr = replace_string(dam_weapons[dam_msgnum].to_room,
+                                 attack_hit_text[w_type].singular, attack_hit_text[w_type].plural);
+  if (brief_shields_.empty()) {
+    act(buf_ptr, FALSE, ch, NULL, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+  } else {
+    char buf_[MAX_INPUT_LENGTH];
+    snprintf(buf_, sizeof(buf_), "%s%s", buf_ptr, brief_shields_.c_str());
+    act(buf_, FALSE, ch, NULL, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_BRIEF_SHIELDS);
+    act(buf_ptr, FALSE, ch, NULL, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
+  }
 
-	// damage message to damager
-	send_to_char(ch, "%s", dam ? "&Y&q" : "&y&q");
-	if (!brief_shields_.empty() && PRF_FLAGGED(ch, PRF_BRIEF_SHIELDS))
-	{
-		char buf_[MAX_INPUT_LENGTH];
-		snprintf(buf_, sizeof(buf_), "%s%s",
-			replace_string(dam_weapons[dam_msgnum].to_char,
-				attack_hit_text[w_type].singular, attack_hit_text[w_type].plural),
-			brief_shields_.c_str());
-		act(buf_, FALSE, ch, NULL, victim, TO_CHAR);
-	}
-	else
-	{
-		buf_ptr = replace_string(dam_weapons[dam_msgnum].to_char,
-			attack_hit_text[w_type].singular, attack_hit_text[w_type].plural);
-		act(buf_ptr, FALSE, ch, NULL, victim, TO_CHAR);
-	}
-	send_to_char("&Q&n", ch);
+  // damage message to damager
+  send_to_char(ch, "%s", dam ? "&Y&q" : "&y&q");
+  if (!brief_shields_.empty() && PRF_FLAGGED(ch, PRF_BRIEF_SHIELDS)) {
+    char buf_[MAX_INPUT_LENGTH];
+    snprintf(buf_, sizeof(buf_), "%s%s",
+             replace_string(dam_weapons[dam_msgnum].to_char,
+                            attack_hit_text[w_type].singular, attack_hit_text[w_type].plural),
+             brief_shields_.c_str());
+    act(buf_, FALSE, ch, NULL, victim, TO_CHAR);
+  } else {
+    buf_ptr = replace_string(dam_weapons[dam_msgnum].to_char,
+                             attack_hit_text[w_type].singular, attack_hit_text[w_type].plural);
+    act(buf_ptr, FALSE, ch, NULL, victim, TO_CHAR);
+  }
+  send_to_char("&Q&n", ch);
 
-	// damage message to damagee
-	send_to_char("&R&q", victim);
-	if (!brief_shields_.empty() && PRF_FLAGGED(victim, PRF_BRIEF_SHIELDS))
-	{
-		char buf_[MAX_INPUT_LENGTH];
-		snprintf(buf_, sizeof(buf_), "%s%s",
-			replace_string(dam_weapons[dam_msgnum].to_victim,
-				attack_hit_text[w_type].singular, attack_hit_text[w_type].plural),
-			brief_shields_.c_str());
-		act(buf_, FALSE, ch, NULL, victim, TO_VICT | TO_SLEEP);
-	}
-	else
-	{
-		buf_ptr = replace_string(dam_weapons[dam_msgnum].to_victim,
-			attack_hit_text[w_type].singular, attack_hit_text[w_type].plural);
-		act(buf_ptr, FALSE, ch, NULL, victim, TO_VICT | TO_SLEEP);
-	}
-	send_to_char("&Q&n", victim);
+  // damage message to damagee
+  send_to_char("&R&q", victim);
+  if (!brief_shields_.empty() && PRF_FLAGGED(victim, PRF_BRIEF_SHIELDS)) {
+    char buf_[MAX_INPUT_LENGTH];
+    snprintf(buf_, sizeof(buf_), "%s%s",
+             replace_string(dam_weapons[dam_msgnum].to_victim,
+                            attack_hit_text[w_type].singular, attack_hit_text[w_type].plural),
+             brief_shields_.c_str());
+    act(buf_, FALSE, ch, NULL, victim, TO_VICT | TO_SLEEP);
+  } else {
+    buf_ptr = replace_string(dam_weapons[dam_msgnum].to_victim,
+                             attack_hit_text[w_type].singular, attack_hit_text[w_type].plural);
+    act(buf_ptr, FALSE, ch, NULL, victim, TO_VICT | TO_SLEEP);
+  }
+  send_to_char("&Q&n", victim);
 }
 
 // запоминание.
@@ -2032,191 +1791,161 @@ void Damage::dam_message(CHAR_DATA* ch, CHAR_DATA* victim) const
 // если бьют клоны (проверка на MOB_CLONE), тоже помнит всегда.
 // если бьют храны или чармис (все остальные под чармом), то только если
 // моб может видеть их хозяина.
-void update_mob_memory(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	// первое -- бьют моба, он запоминает обидчика
-	if (IS_NPC(victim) && MOB_FLAGGED(victim, MOB_MEMORY))
-	{
-		if (!IS_NPC(ch))
-		{
-			mobRemember(victim, ch);
-		}
-		else if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-			&& ch->has_master()
-			&& !IS_NPC(ch->get_master()))
-		{
-			if (MOB_FLAGGED(ch, MOB_CLONE))
-			{
-                mobRemember(victim, ch->get_master());
-			}
-			else if (IN_ROOM(ch->get_master()) == IN_ROOM(victim)
-				&& CAN_SEE(victim, ch->get_master()))
-			{
-				mobRemember(victim, ch->get_master());
-			}
-		}
-	}
+void update_mob_memory(CHAR_DATA *ch, CHAR_DATA *victim) {
+  // первое -- бьют моба, он запоминает обидчика
+  if (IS_NPC(victim) && MOB_FLAGGED(victim, MOB_MEMORY)) {
+    if (!IS_NPC(ch)) {
+      mobRemember(victim, ch);
+    } else if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+        && ch->has_master()
+        && !IS_NPC(ch->get_master())) {
+      if (MOB_FLAGGED(ch, MOB_CLONE)) {
+        mobRemember(victim, ch->get_master());
+      } else if (IN_ROOM(ch->get_master()) == IN_ROOM(victim)
+          && CAN_SEE(victim, ch->get_master())) {
+        mobRemember(victim, ch->get_master());
+      }
+    }
+  }
 
-	// второе -- бьет сам моб и запоминает, кого потом добивать :)
-	if (IS_NPC(ch) && MOB_FLAGGED(ch, MOB_MEMORY))
-	{
-		if (!IS_NPC(victim))
-		{
-			mobRemember(ch, victim);
-		}
-		else if (AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM)
-			&& victim->has_master()
-			&& !IS_NPC(victim->get_master()))
-		{
-			if (MOB_FLAGGED(victim, MOB_CLONE))
-			{
-				mobRemember(ch, victim->get_master());
-			}
-			else if (IN_ROOM(victim->get_master()) == ch->in_room
-				&& CAN_SEE(ch, victim->get_master()))
-			{
-				mobRemember(ch, victim->get_master());
-			}
-		}
-	}
+  // второе -- бьет сам моб и запоминает, кого потом добивать :)
+  if (IS_NPC(ch) && MOB_FLAGGED(ch, MOB_MEMORY)) {
+    if (!IS_NPC(victim)) {
+      mobRemember(ch, victim);
+    } else if (AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM)
+        && victim->has_master()
+        && !IS_NPC(victim->get_master())) {
+      if (MOB_FLAGGED(victim, MOB_CLONE)) {
+        mobRemember(ch, victim->get_master());
+      } else if (IN_ROOM(victim->get_master()) == ch->in_room
+          && CAN_SEE(ch, victim->get_master())) {
+        mobRemember(ch, victim->get_master());
+      }
+    }
+  }
 }
 
-bool Damage::magic_shields_dam(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	if (dam <= 0)
-	{
-		return false;
-	}
+bool Damage::magic_shields_dam(CHAR_DATA *ch, CHAR_DATA *victim) {
+  if (dam <= 0) {
+    return false;
+  }
 
-	// отражение части маг дамага от зеркала
-	if (AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICGLASS)
-		&& dmg_type == FightSystem::MAGE_DMG)
-	{
-		int pct = 6;
-		if (IS_NPC(victim) && !IS_CHARMICE(victim))
-		{
-			pct += 2;
-			if (victim->get_role(MOB_ROLE_BOSS))
-			{
-				pct += 2;
-			}
-		}
-		// дамаг обратки
-		const int mg_damage = dam * pct / 100;
-		if (mg_damage > 0
-			&& victim->get_fighting()
-			&& GET_POS(victim) > POS_STUNNED
-			&& IN_ROOM(victim) != NOWHERE)
-		{
-			flags.set(FightSystem::DRAW_BRIEF_MAG_MIRROR);
-			Damage dmg(SpellDmg(SPELL_MAGICGLASS), mg_damage, FightSystem::UNDEF_DMG);
-			dmg.flags.set(FightSystem::NO_FLEE_DMG);
-			dmg.flags.set(FightSystem::MAGIC_REFLECT);
-			dmg.process(victim, ch);
-		}
-	}
+  // отражение части маг дамага от зеркала
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICGLASS)
+      && dmg_type == FightSystem::MAGE_DMG) {
+    int pct = 6;
+    if (IS_NPC(victim) && !IS_CHARMICE(victim)) {
+      pct += 2;
+      if (victim->get_role(MOB_ROLE_BOSS)) {
+        pct += 2;
+      }
+    }
+    // дамаг обратки
+    const int mg_damage = dam * pct / 100;
+    if (mg_damage > 0
+        && victim->get_fighting()
+        && GET_POS(victim) > POS_STUNNED
+        && IN_ROOM(victim) != NOWHERE) {
+      flags.set(FightSystem::DRAW_BRIEF_MAG_MIRROR);
+      Damage dmg(SpellDmg(SPELL_MAGICGLASS), mg_damage, FightSystem::UNDEF_DMG);
+      dmg.flags.set(FightSystem::NO_FLEE_DMG);
+      dmg.flags.set(FightSystem::MAGIC_REFLECT);
+      dmg.process(victim, ch);
+    }
+  }
 
-	// обработка щитов, см Damage::post_init_shields()
-	if (flags[FightSystem::VICTIM_FIRE_SHIELD]
-		&& !flags[FightSystem::CRIT_HIT])
-	{
-		if (dmg_type == FightSystem::PHYS_DMG
-			&& !flags[FightSystem::IGNORE_FSHIELD])
-		{
-			int pct = 15;
-			if (IS_NPC(victim) && !IS_CHARMICE(victim))
-			{
-				pct += 5;
-				if (victim->get_role(MOB_ROLE_BOSS))
-				{
-					pct += 5;
-				}
-			}
-			fs_damage = dam * pct / 100;
-		}
-		else
-		{
-			act("Огненный щит вокруг $N1 ослабил вашу атаку.",
-				FALSE, ch, 0, victim, TO_CHAR | TO_NO_BRIEF_SHIELDS);
-			act("Огненный щит принял часть повреждений на себя.",
-				FALSE, ch, 0, victim, TO_VICT | TO_NO_BRIEF_SHIELDS);
-			act("Огненный щит вокруг $N1 ослабил атаку $n1.",
-				TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
-		}
-		flags.set(FightSystem::DRAW_BRIEF_FIRE_SHIELD);
-		dam -= (dam * number(30, 50) / 100);
-	}
-
-        // если критический удар (не точка и стаб) и есть щит - 95% шанс в молоко
-        // критическим считается любой удар который вложиля в определенные границы
-	if (dam
-		&& flags[FightSystem::CRIT_HIT] && flags[FightSystem::VICTIM_ICE_SHIELD]
-		&& !dam_critic
-		&& spell_num != SPELL_POISON
-                && number(0, 100)<94)
-	{
-            act("Ваше меткое попадания частично утонуло в ледяной пелене вокруг $N1.",
-			FALSE, ch, 0, victim, TO_CHAR | TO_NO_BRIEF_SHIELDS);
-            act("Меткое попадание частично утонуло в ледяной пелене щита.",
-			FALSE, ch, 0, victim, TO_VICT | TO_NO_BRIEF_SHIELDS);
-            act("Ледяной щит вокруг $N1 частично поглотил меткое попадание $n1.",
-			TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
-
-                   flags[FightSystem::CRIT_HIT] = false; //вот это место очень тщательно проверить
-		   if (dam > 0) dam -= (dam * number(30, 50) / 100);
+  // обработка щитов, см Damage::post_init_shields()
+  if (flags[FightSystem::VICTIM_FIRE_SHIELD]
+      && !flags[FightSystem::CRIT_HIT]) {
+    if (dmg_type == FightSystem::PHYS_DMG
+        && !flags[FightSystem::IGNORE_FSHIELD]) {
+      int pct = 15;
+      if (IS_NPC(victim) && !IS_CHARMICE(victim)) {
+        pct += 5;
+        if (victim->get_role(MOB_ROLE_BOSS)) {
+          pct += 5;
         }
+      }
+      fs_damage = dam * pct / 100;
+    } else {
+      act("Огненный щит вокруг $N1 ослабил вашу атаку.",
+          FALSE, ch, 0, victim, TO_CHAR | TO_NO_BRIEF_SHIELDS);
+      act("Огненный щит принял часть повреждений на себя.",
+          FALSE, ch, 0, victim, TO_VICT | TO_NO_BRIEF_SHIELDS);
+      act("Огненный щит вокруг $N1 ослабил атаку $n1.",
+          TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
+    }
+    flags.set(FightSystem::DRAW_BRIEF_FIRE_SHIELD);
+    dam -= (dam * number(30, 50) / 100);
+  }
+
+  // если критический удар (не точка и стаб) и есть щит - 95% шанс в молоко
+  // критическим считается любой удар который вложиля в определенные границы
+  if (dam
+      && flags[FightSystem::CRIT_HIT] && flags[FightSystem::VICTIM_ICE_SHIELD]
+      && !dam_critic
+      && spell_num != SPELL_POISON
+      && number(0, 100) < 94) {
+    act("Ваше меткое попадания частично утонуло в ледяной пелене вокруг $N1.",
+        FALSE, ch, 0, victim, TO_CHAR | TO_NO_BRIEF_SHIELDS);
+    act("Меткое попадание частично утонуло в ледяной пелене щита.",
+        FALSE, ch, 0, victim, TO_VICT | TO_NO_BRIEF_SHIELDS);
+    act("Ледяной щит вокруг $N1 частично поглотил меткое попадание $n1.",
+        TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
+
+    flags[FightSystem::CRIT_HIT] = false; //вот это место очень тщательно проверить
+    if (dam > 0) dam -= (dam * number(30, 50) / 100);
+  }
     //шоб небуло спама модернизировал условие
-	else if (dam > 0
-		&& flags[FightSystem::VICTIM_ICE_SHIELD]
-		&& !flags[FightSystem::CRIT_HIT])
-	{
-		flags.set(FightSystem::DRAW_BRIEF_ICE_SHIELD);
-		act("Ледяной щит вокруг $N1 смягчил ваш удар.",
-			FALSE, ch, 0, victim, TO_CHAR | TO_NO_BRIEF_SHIELDS);
-		act("Ледяной щит принял часть удара на себя.",
-			FALSE, ch, 0, victim, TO_VICT | TO_NO_BRIEF_SHIELDS);
-		act("Ледяной щит вокруг $N1 смягчил удар $n1.",
-			TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
-		dam -= (dam * number(30, 50) / 100);
-	}
+  else if (dam > 0
+      && flags[FightSystem::VICTIM_ICE_SHIELD]
+      && !flags[FightSystem::CRIT_HIT]) {
+    flags.set(FightSystem::DRAW_BRIEF_ICE_SHIELD);
+    act("Ледяной щит вокруг $N1 смягчил ваш удар.",
+        FALSE, ch, 0, victim, TO_CHAR | TO_NO_BRIEF_SHIELDS);
+    act("Ледяной щит принял часть удара на себя.",
+        FALSE, ch, 0, victim, TO_VICT | TO_NO_BRIEF_SHIELDS);
+    act("Ледяной щит вокруг $N1 смягчил удар $n1.",
+        TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
+    dam -= (dam * number(30, 50) / 100);
+  }
 
-	if (dam > 0
-		&& flags[FightSystem::VICTIM_AIR_SHIELD]
-		&& !flags[FightSystem::CRIT_HIT])
-	{
-		flags.set(FightSystem::DRAW_BRIEF_AIR_SHIELD);
-		act("Воздушный щит вокруг $N1 ослабил ваш удар.",
-			FALSE, ch, 0, victim, TO_CHAR | TO_NO_BRIEF_SHIELDS);
-		act("Воздушный щит смягчил удар $n1.",
-			FALSE, ch, 0, victim, TO_VICT | TO_NO_BRIEF_SHIELDS);
-		act("Воздушный щит вокруг $N1 ослабил удар $n1.",
-			TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
-		dam -= (dam * number(30, 50) / 100);
-	}
+  if (dam > 0
+      && flags[FightSystem::VICTIM_AIR_SHIELD]
+      && !flags[FightSystem::CRIT_HIT]) {
+    flags.set(FightSystem::DRAW_BRIEF_AIR_SHIELD);
+    act("Воздушный щит вокруг $N1 ослабил ваш удар.",
+        FALSE, ch, 0, victim, TO_CHAR | TO_NO_BRIEF_SHIELDS);
+    act("Воздушный щит смягчил удар $n1.",
+        FALSE, ch, 0, victim, TO_VICT | TO_NO_BRIEF_SHIELDS);
+    act("Воздушный щит вокруг $N1 ослабил удар $n1.",
+        TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
+    dam -= (dam * number(30, 50) / 100);
+  }
 
-	return false;
+  return false;
 }
 
 void Damage::armor_dam_reduce(CHAR_DATA *victim) {
-	// броня на физ дамаг
-	if (dam > 0 && dmg_type == FightSystem::PHYS_DMG) {
-		alt_equip(victim, NOWHERE, dam, 50);
-		if (!flags[FightSystem::CRIT_HIT] && !flags[FightSystem::IGNORE_ARMOR]) {
-			// 50 брони = 50% снижение дамага
-			int max_armour = 50;
-			if (can_use_feat(victim, IMPREGNABLE_FEAT) && PRF_FLAGS(victim).get(PRF_AWAKE)) {
-				// непробиваемый в осторожке - до 75 брони
-				max_armour = 75;
-			}
-			int tmp_dam = dam * MAX(0, MIN(max_armour, GET_ARMOUR(victim))) / 100;
-			// ополовинивание брони по флагу скила
-			if (tmp_dam >= 2 && flags[FightSystem::HALF_IGNORE_ARMOR]) {
-				tmp_dam /= 2;
-			}
-			dam -= tmp_dam;
-			// крит удар умножает дамаг, если жертва без призмы и без лед.щита
-		}
-	}
+  // броня на физ дамаг
+  if (dam > 0 && dmg_type == FightSystem::PHYS_DMG) {
+    alt_equip(victim, NOWHERE, dam, 50);
+    if (!flags[FightSystem::CRIT_HIT] && !flags[FightSystem::IGNORE_ARMOR]) {
+      // 50 брони = 50% снижение дамага
+      int max_armour = 50;
+      if (can_use_feat(victim, IMPREGNABLE_FEAT) && PRF_FLAGS(victim).get(PRF_AWAKE)) {
+        // непробиваемый в осторожке - до 75 брони
+        max_armour = 75;
+      }
+      int tmp_dam = dam * MAX(0, MIN(max_armour, GET_ARMOUR(victim))) / 100;
+      // ополовинивание брони по флагу скила
+      if (tmp_dam >= 2 && flags[FightSystem::HALF_IGNORE_ARMOR]) {
+        tmp_dam /= 2;
+      }
+      dam -= tmp_dam;
+      // крит удар умножает дамаг, если жертва без призмы и без лед.щита
+    }
+  }
 }
 
 /**
@@ -2224,1054 +1953,941 @@ void Damage::armor_dam_reduce(CHAR_DATA *victim) {
  * \return true - полное поглощение
  */
 bool Damage::dam_absorb(CHAR_DATA *ch, CHAR_DATA *victim) {
-	if (dmg_type == FightSystem::PHYS_DMG
-		&& skill_num < 0
-		&& spell_num < 0
-		&& dam > 0
-		&& GET_ABSORBE(victim) > 0) {
-		// шансы поглощения: непробиваемый в осторожке 15%, остальные 10%
-		int chance = 10 + GET_REMORT(victim) / 3;
-		if (can_use_feat(victim, IMPREGNABLE_FEAT)
-			&& PRF_FLAGS(victim).get(PRF_AWAKE)) {
-			chance += 5;
-		}
-		// физ урон - прямое вычитание из дамага
-		if (number(1, 100) <= chance) {
-			dam -= GET_ABSORBE(victim) / 2;
-			if (dam <= 0) {
-				act("Ваши доспехи полностью поглотили удар $n1.",
-					FALSE, ch, 0, victim, TO_VICT);
-				act("Доспехи $N1 полностью поглотили ваш удар.",
-					FALSE, ch, 0, victim, TO_CHAR);
-				act("Доспехи $N1 полностью поглотили удар $n1.",
-					TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-				return true;
-			}
-		}
-	}
-	return false;
+  if (dmg_type == FightSystem::PHYS_DMG
+      && skill_num < 0
+      && spell_num < 0
+      && dam > 0
+      && GET_ABSORBE(victim) > 0) {
+    // шансы поглощения: непробиваемый в осторожке 15%, остальные 10%
+    int chance = 10 + GET_REMORT(victim) / 3;
+    if (can_use_feat(victim, IMPREGNABLE_FEAT)
+        && PRF_FLAGS(victim).get(PRF_AWAKE)) {
+      chance += 5;
+    }
+    // физ урон - прямое вычитание из дамага
+    if (number(1, 100) <= chance) {
+      dam -= GET_ABSORBE(victim) / 2;
+      if (dam <= 0) {
+        act("Ваши доспехи полностью поглотили удар $n1.",
+            FALSE, ch, 0, victim, TO_VICT);
+        act("Доспехи $N1 полностью поглотили ваш удар.",
+            FALSE, ch, 0, victim, TO_CHAR);
+        act("Доспехи $N1 полностью поглотили удар $n1.",
+            TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
-void Damage::send_critical_message(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	// Блочить мессагу крита при ледяном щите вроде нелогично,
-	// так что добавил отдельные сообщения для ледяного щита (Купала)
-	if (!flags[FightSystem::VICTIM_ICE_SHIELD])
-	{
-		sprintf(buf, "&G&qВаше меткое попадание тяжело ранило %s.&Q&n\r\n",
-			PERS(victim, ch, 3));
-	}
-	else
-	{
-		sprintf(buf, "&B&qВаше меткое попадание утонуло в ледяной пелене щита %s.&Q&n\r\n",
-			PERS(victim, ch, 1));
-	}
+void Damage::send_critical_message(CHAR_DATA *ch, CHAR_DATA *victim) {
+  // Блочить мессагу крита при ледяном щите вроде нелогично,
+  // так что добавил отдельные сообщения для ледяного щита (Купала)
+  if (!flags[FightSystem::VICTIM_ICE_SHIELD]) {
+    sprintf(buf, "&G&qВаше меткое попадание тяжело ранило %s.&Q&n\r\n",
+            PERS(victim, ch, 3));
+  } else {
+    sprintf(buf, "&B&qВаше меткое попадание утонуло в ледяной пелене щита %s.&Q&n\r\n",
+            PERS(victim, ch, 1));
+  }
 
-	send_to_char(buf, ch);
+  send_to_char(buf, ch);
 
-	if (!flags[FightSystem::VICTIM_ICE_SHIELD])
-	{
-		sprintf(buf, "&r&qМеткое попадание %s тяжело ранило вас.&Q&n\r\n",
-			PERS(ch, victim, 1));
-	}
-	else
-	{
-		sprintf(buf, "&r&qМеткое попадание %s утонуло в ледяной пелене вашего щита.&Q&n\r\n",
-			PERS(ch, victim, 1));
-	}
+  if (!flags[FightSystem::VICTIM_ICE_SHIELD]) {
+    sprintf(buf, "&r&qМеткое попадание %s тяжело ранило вас.&Q&n\r\n",
+            PERS(ch, victim, 1));
+  } else {
+    sprintf(buf, "&r&qМеткое попадание %s утонуло в ледяной пелене вашего щита.&Q&n\r\n",
+            PERS(ch, victim, 1));
+  }
 
-	send_to_char(buf, victim);
-	// Закомментил чтобы не спамило, сделать потом в виде режима
-	//act("Меткое попадание $N1 заставило $n3 пошатнуться.", TRUE, victim, 0, ch, TO_NOTVICT);
+  send_to_char(buf, victim);
+  // Закомментил чтобы не спамило, сделать потом в виде режима
+  //act("Меткое попадание $N1 заставило $n3 пошатнуться.", TRUE, victim, 0, ch, TO_NOTVICT);
 }
 
-void update_dps_stats(CHAR_DATA *ch, int real_dam, int over_dam)
-{
-	if (!IS_NPC(ch))
-	{
-		ch->dps_add_dmg(DpsSystem::PERS_DPS, real_dam, over_dam);
-		log("DmetrLog. Name(player): %s, class: %d, remort:%d, level:%d, dmg: %d, over_dmg:%d", GET_NAME(ch), GET_CLASS(ch), GET_REMORT(ch), GET_LEVEL(ch), real_dam, over_dam);
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_GROUP))
-		{
-			CHAR_DATA *leader = ch->has_master() ? ch->get_master() : ch;
-			leader->dps_add_dmg(DpsSystem::GROUP_DPS, real_dam, over_dam, ch);
-		}
-	}
-	else if (IS_CHARMICE(ch)
-		&& ch->has_master())
-	{
-		ch->get_master()->dps_add_dmg(DpsSystem::PERS_CHARM_DPS, real_dam, over_dam, ch);
-		if (!IS_NPC(ch->get_master()))
-		{
-			log("DmetrLog. Name(charmice): %s, name(master): %s, class: %d, remort: %d, level: %d, dmg: %d, over_dmg:%d",
-				GET_NAME(ch), GET_NAME(ch->get_master()), GET_CLASS(ch->get_master()), GET_REMORT(ch->get_master()),
-				GET_LEVEL(ch->get_master()), real_dam, over_dam);
-		}
+void update_dps_stats(CHAR_DATA *ch, int real_dam, int over_dam) {
+  if (!IS_NPC(ch)) {
+    ch->dps_add_dmg(DpsSystem::PERS_DPS, real_dam, over_dam);
+    log("DmetrLog. Name(player): %s, class: %d, remort:%d, level:%d, dmg: %d, over_dmg:%d",
+        GET_NAME(ch),
+        GET_CLASS(ch),
+        GET_REMORT(ch),
+        GET_LEVEL(ch),
+        real_dam,
+        over_dam);
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_GROUP)) {
+      CHAR_DATA *leader = ch->has_master() ? ch->get_master() : ch;
+      leader->dps_add_dmg(DpsSystem::GROUP_DPS, real_dam, over_dam, ch);
+    }
+  } else if (IS_CHARMICE(ch)
+      && ch->has_master()) {
+    ch->get_master()->dps_add_dmg(DpsSystem::PERS_CHARM_DPS, real_dam, over_dam, ch);
+    if (!IS_NPC(ch->get_master())) {
+      log("DmetrLog. Name(charmice): %s, name(master): %s, class: %d, remort: %d, level: %d, dmg: %d, over_dmg:%d",
+          GET_NAME(ch), GET_NAME(ch->get_master()), GET_CLASS(ch->get_master()), GET_REMORT(ch->get_master()),
+          GET_LEVEL(ch->get_master()), real_dam, over_dam);
+    }
 
-		if (AFF_FLAGGED(ch->get_master(), EAffectFlag::AFF_GROUP))
-		{
-			CHAR_DATA *leader = ch->get_master()->has_master() ? ch->get_master()->get_master() : ch->get_master();
-			leader->dps_add_dmg(DpsSystem::GROUP_CHARM_DPS, real_dam, over_dam, ch);
-		}
-	}
+    if (AFF_FLAGGED(ch->get_master(), EAffectFlag::AFF_GROUP)) {
+      CHAR_DATA *leader = ch->get_master()->has_master() ? ch->get_master()->get_master() : ch->get_master();
+      leader->dps_add_dmg(DpsSystem::GROUP_CHARM_DPS, real_dam, over_dam, ch);
+    }
+  }
 }
 
-void try_angel_sacrifice(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	// если виктим в группе с кем-то с ангелом - вместо смерти виктима умирает ангел
-	if (GET_HIT(victim) <= 0
-		&& !IS_NPC(victim)
-		&& AFF_FLAGGED(victim, EAffectFlag::AFF_GROUP))
-	{
-		const auto people = world[IN_ROOM(victim)]->people;	// make copy of people because keeper might be removed from this list inside the loop
-		for (const auto keeper : people)
-		{
-			if (IS_NPC(keeper)
-				&& MOB_FLAGGED(keeper, MOB_ANGEL)
-				&& keeper->has_master()
-				&& AFF_FLAGGED(keeper->get_master(), EAffectFlag::AFF_GROUP))
-			{
-				CHAR_DATA *keeper_leader = keeper->get_master()->has_master()
-					? keeper->get_master()->get_master()
-					: keeper->get_master();
-				CHAR_DATA *victim_leader = victim->has_master()
-					? victim->get_master()
-					: victim;
+void try_angel_sacrifice(CHAR_DATA *ch, CHAR_DATA *victim) {
+  // если виктим в группе с кем-то с ангелом - вместо смерти виктима умирает ангел
+  if (GET_HIT(victim) <= 0
+      && !IS_NPC(victim)
+      && AFF_FLAGGED(victim, EAffectFlag::AFF_GROUP)) {
+    const auto people =
+        world[IN_ROOM(victim)]->people;    // make copy of people because keeper might be removed from this list inside the loop
+    for (const auto keeper : people) {
+      if (IS_NPC(keeper)
+          && MOB_FLAGGED(keeper, MOB_ANGEL)
+          && keeper->has_master()
+          && AFF_FLAGGED(keeper->get_master(), EAffectFlag::AFF_GROUP)) {
+        CHAR_DATA *keeper_leader = keeper->get_master()->has_master()
+                                   ? keeper->get_master()->get_master()
+                                   : keeper->get_master();
+        CHAR_DATA *victim_leader = victim->has_master()
+                                   ? victim->get_master()
+                                   : victim;
 
-				if ((keeper_leader == victim_leader) && (may_kill_here(keeper->get_master(), ch, NULL)))
-				{
-					if (!pk_agro_action(keeper->get_master(), ch))
-					{
-						return;
-					}
-					send_to_char(victim, "%s пожертвовал%s своей жизнью, вытаскивая вас с того света!\r\n",
-						GET_PAD(keeper, 0), GET_CH_SUF_1(keeper));
-					snprintf(buf, MAX_STRING_LENGTH, "%s пожертвовал%s своей жизнью, вытаскивая %s с того света!",
-						GET_PAD(keeper, 0), GET_CH_SUF_1(keeper), GET_PAD(victim, 3));
-					act(buf, FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        if ((keeper_leader == victim_leader) && (may_kill_here(keeper->get_master(), ch, NULL))) {
+          if (!pk_agro_action(keeper->get_master(), ch)) {
+            return;
+          }
+          send_to_char(victim, "%s пожертвовал%s своей жизнью, вытаскивая вас с того света!\r\n",
+                       GET_PAD(keeper, 0), GET_CH_SUF_1(keeper));
+          snprintf(buf, MAX_STRING_LENGTH, "%s пожертвовал%s своей жизнью, вытаскивая %s с того света!",
+                   GET_PAD(keeper, 0), GET_CH_SUF_1(keeper), GET_PAD(victim, 3));
+          act(buf, FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
 
-					extract_char(keeper, 0);
-					GET_HIT(victim) = MIN(300, GET_MAX_HIT(victim) / 2);
-				}
-			}
-		}
-	}
+          extract_char(keeper, 0);
+          GET_HIT(victim) = MIN(300, GET_MAX_HIT(victim) / 2);
+        }
+      }
+    }
+  }
 }
 
-void update_pk_logs(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	ClanPkLog::check(ch, victim);
-	sprintf(buf2, "%s killed by %s at %s [%d] ", GET_NAME(victim), GET_NAME(ch),
-		IN_ROOM(victim) != NOWHERE ? world[IN_ROOM(victim)]->name : "NOWHERE", GET_ROOM_VNUM(IN_ROOM(victim)));
-	log("%s",buf2);
+void update_pk_logs(CHAR_DATA *ch, CHAR_DATA *victim) {
+  ClanPkLog::check(ch, victim);
+  sprintf(buf2, "%s killed by %s at %s [%d] ", GET_NAME(victim), GET_NAME(ch),
+          IN_ROOM(victim) != NOWHERE ? world[IN_ROOM(victim)]->name : "NOWHERE", GET_ROOM_VNUM(IN_ROOM(victim)));
+  log("%s", buf2);
 
-	if ((!IS_NPC(ch)
-			|| (ch->has_master()
-				&& !IS_NPC(ch->get_master())))
-		&& RENTABLE(victim)
-		&& !ROOM_FLAGGED(IN_ROOM(victim), ROOM_ARENA))
-	{
-		mudlog(buf2, BRF, LVL_IMPL, SYSLOG, 0);
-		if (IS_NPC(ch)
-			&& (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) || IS_HORSE(ch))
-			&& ch->has_master()
-			&& !IS_NPC(ch->get_master()))
-		{
-			sprintf(buf2, "%s is following %s.", GET_NAME(ch), GET_PAD(ch->get_master(), 2));
-			mudlog(buf2, BRF, LVL_IMPL, SYSLOG, TRUE);
-		}
-	}
+  if ((!IS_NPC(ch)
+      || (ch->has_master()
+          && !IS_NPC(ch->get_master())))
+      && RENTABLE(victim)
+      && !ROOM_FLAGGED(IN_ROOM(victim), ROOM_ARENA)) {
+    mudlog(buf2, BRF, LVL_IMPL, SYSLOG, 0);
+    if (IS_NPC(ch)
+        && (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) || IS_HORSE(ch))
+        && ch->has_master()
+        && !IS_NPC(ch->get_master())) {
+      sprintf(buf2, "%s is following %s.", GET_NAME(ch), GET_PAD(ch->get_master(), 2));
+      mudlog(buf2, BRF, LVL_IMPL, SYSLOG, TRUE);
+    }
+  }
 }
 
-void Damage::process_death(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	CHAR_DATA *killer = NULL;
+void Damage::process_death(CHAR_DATA *ch, CHAR_DATA *victim) {
+  CHAR_DATA *killer = NULL;
 
-	if (IS_NPC(victim) || victim->desc)
-	{
-		if (victim == ch && IN_ROOM(victim) != NOWHERE)
-		{
-			if (spell_num == SPELL_POISON)
-			{
-				for (const auto poisoner : world[IN_ROOM(victim)]->people)
-				{
-					if (poisoner != victim
-						&& GET_ID(poisoner) == victim->Poisoner)
-					{
-						killer = poisoner;
-					}
-				}
-			}
-			else if (msg_num == TYPE_SUFFERING)
-			{
-				for (const auto attacker : world[IN_ROOM(victim)]->people)
-				{
-					if (attacker->get_fighting() == victim)
-					{
-						killer = attacker;
-					}
-				}
-			}
-		}
+  if (IS_NPC(victim) || victim->desc) {
+    if (victim == ch && IN_ROOM(victim) != NOWHERE) {
+      if (spell_num == SPELL_POISON) {
+        for (const auto poisoner : world[IN_ROOM(victim)]->people) {
+          if (poisoner != victim
+              && GET_ID(poisoner) == victim->Poisoner) {
+            killer = poisoner;
+          }
+        }
+      } else if (msg_num == TYPE_SUFFERING) {
+        for (const auto attacker : world[IN_ROOM(victim)]->people) {
+          if (attacker->get_fighting() == victim) {
+            killer = attacker;
+          }
+        }
+      }
+    }
 
-		if (ch != victim)
-		{
-			killer = ch;
-		}
-	}
+    if (ch != victim) {
+      killer = ch;
+    }
+  }
 
-	if (killer)
-	{
-		if (AFF_FLAGGED(killer, EAffectFlag::AFF_GROUP))
-		{
-			// т.к. помечен флагом AFF_GROUP - точно PC
-			group_gain(killer, victim);
-		}
-		else if ((AFF_FLAGGED(killer, EAffectFlag::AFF_CHARM)
-				|| MOB_FLAGGED(killer, MOB_ANGEL)
-				|| MOB_FLAGGED(killer, MOB_GHOST))
-			&& killer->has_master())
-			// killer - зачармленный NPC с хозяином
-		{
-			// по логике надо бы сделать, что если хозяина нет в клетке, но
-			// кто-то из группы хозяина в клетке, то опыт накинуть согруппам,
-			// которые рядом с убившим моба чармисом.
-			if (AFF_FLAGGED(killer->get_master(), EAffectFlag::AFF_GROUP)
-				&& IN_ROOM(killer) == IN_ROOM(killer->get_master()))
-			{
-				// Хозяин - PC в группе => опыт группе
-				group_gain(killer->get_master(), victim);
-			}
-			else if (IN_ROOM(killer) == IN_ROOM(killer->get_master()))
-				// Чармис и хозяин в одной комнате
-				// Опыт хозяину
-			{
-				perform_group_gain(killer->get_master(), victim, 1, 100);
-			}
-			// else
-			// А хозяина то рядом не оказалось, все чармису - убрано
-			// нефиг абьюзить чарм  perform_group_gain( killer, victim, 1, 100 );
-		}
-		else
-		{
-			// Просто NPC или PC сам по себе
-			perform_group_gain(killer, victim, 1, 100);
-		}
-	}
+  if (killer) {
+    if (AFF_FLAGGED(killer, EAffectFlag::AFF_GROUP)) {
+      // т.к. помечен флагом AFF_GROUP - точно PC
+      group_gain(killer, victim);
+    } else if ((AFF_FLAGGED(killer, EAffectFlag::AFF_CHARM)
+        || MOB_FLAGGED(killer, MOB_ANGEL)
+        || MOB_FLAGGED(killer, MOB_GHOST))
+        && killer->has_master())
+      // killer - зачармленный NPC с хозяином
+    {
+      // по логике надо бы сделать, что если хозяина нет в клетке, но
+      // кто-то из группы хозяина в клетке, то опыт накинуть согруппам,
+      // которые рядом с убившим моба чармисом.
+      if (AFF_FLAGGED(killer->get_master(), EAffectFlag::AFF_GROUP)
+          && IN_ROOM(killer) == IN_ROOM(killer->get_master())) {
+        // Хозяин - PC в группе => опыт группе
+        group_gain(killer->get_master(), victim);
+      } else if (IN_ROOM(killer) == IN_ROOM(killer->get_master()))
+        // Чармис и хозяин в одной комнате
+        // Опыт хозяину
+      {
+        perform_group_gain(killer->get_master(), victim, 1, 100);
+      }
+      // else
+      // А хозяина то рядом не оказалось, все чармису - убрано
+      // нефиг абьюзить чарм  perform_group_gain( killer, victim, 1, 100 );
+    } else {
+      // Просто NPC или PC сам по себе
+      perform_group_gain(killer, victim, 1, 100);
+    }
+  }
 
-	// в сислог иммам идут только смерти в пк (без арен)
-	// в файл пишутся все смерти чаров
-	// если чар убит палачем то тоже не спамим
+  // в сислог иммам идут только смерти в пк (без арен)
+  // в файл пишутся все смерти чаров
+  // если чар убит палачем то тоже не спамим
 
-	if (!IS_NPC(victim) && !(killer && PRF_FLAGGED(killer, PRF_EXECUTOR)))
-	{
-		update_pk_logs(ch, victim);
+  if (!IS_NPC(victim) && !(killer && PRF_FLAGGED(killer, PRF_EXECUTOR))) {
+    update_pk_logs(ch, victim);
 
-	for (const auto& ch_vict : world[ch->in_room]->people)
-	{
-		//Мобы все кто присутствовал при смерти игрока забывают
-		if (IS_IMMORTAL(ch_vict))
-			continue;
-		if (!HERE(ch_vict))
-			continue;
-		if (!IS_NPC(ch_vict))
-			continue;
-		if (MOB_FLAGGED(ch_vict, MOB_MEMORY))
-		{
-            mobForget(ch_vict, victim);
-		}
-	}
+    for (const auto &ch_vict : world[ch->in_room]->people) {
+      //Мобы все кто присутствовал при смерти игрока забывают
+      if (IS_IMMORTAL(ch_vict))
+        continue;
+      if (!HERE(ch_vict))
+        continue;
+      if (!IS_NPC(ch_vict))
+        continue;
+      if (MOB_FLAGGED(ch_vict, MOB_MEMORY)) {
+        mobForget(ch_vict, victim);
+      }
+    }
 
-	}
+  }
 
-	if (killer)
-	{
-		ch = killer;
-	}
+  if (killer) {
+    ch = killer;
+  }
 
-	die(victim, ch);
+  die(victim, ch);
 }
 
 // обработка щитов, зб, поглощения, сообщения для огн. щита НЕ ЗДЕСЬ
 // возвращает сделанный дамаг
-int Damage::process(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	post_init(ch, victim);
+int Damage::process(CHAR_DATA *ch, CHAR_DATA *victim) {
+  post_init(ch, victim);
 
-	if (!check_valid_chars(ch, victim, __FILE__, __LINE__))
-	{
-		return 0;
-	}
+  if (!check_valid_chars(ch, victim, __FILE__, __LINE__)) {
+    return 0;
+  }
 
-	if (IN_ROOM(victim) == NOWHERE
-		|| ch->in_room == NOWHERE
-		|| ch->in_room != IN_ROOM(victim))
-	{
-		log("SYSERR: Attempt to damage '%s' in room NOWHERE by '%s'.",
-			GET_NAME(victim), GET_NAME(ch));
-		return 0;
-	}
+  if (IN_ROOM(victim) == NOWHERE
+      || ch->in_room == NOWHERE
+      || ch->in_room != IN_ROOM(victim)) {
+    log("SYSERR: Attempt to damage '%s' in room NOWHERE by '%s'.",
+        GET_NAME(victim), GET_NAME(ch));
+    return 0;
+  }
 
-	if (GET_POS(victim) <= POS_DEAD)
-	{
-		log("SYSERR: Attempt to damage corpse '%s' in room #%d by '%s'.",
-			GET_NAME(victim), GET_ROOM_VNUM(IN_ROOM(victim)), GET_NAME(ch));
-		die(victim, NULL);
-		return 0;	// -je, 7/7/92
-	}
+  if (GET_POS(victim) <= POS_DEAD) {
+    log("SYSERR: Attempt to damage corpse '%s' in room #%d by '%s'.",
+        GET_NAME(victim), GET_ROOM_VNUM(IN_ROOM(victim)), GET_NAME(ch));
+    die(victim, NULL);
+    return 0;    // -je, 7/7/92
+  }
 
-	// первая такая проверка идет в hit перед ломанием пушек
-	if (dam >= 0 && damage_mtrigger(ch, victim))
-		return 0;
+  // первая такая проверка идет в hit перед ломанием пушек
+  if (dam >= 0 && damage_mtrigger(ch, victim))
+    return 0;
 
-	// No fight mobiles
-	if ((IS_NPC(ch) && MOB_FLAGGED(ch, MOB_NOFIGHT))
-		|| (IS_NPC(victim) && MOB_FLAGGED(victim, MOB_NOFIGHT)))
-	{
-		return 0;
-	}
+  // No fight mobiles
+  if ((IS_NPC(ch) && MOB_FLAGGED(ch, MOB_NOFIGHT))
+      || (IS_NPC(victim) && MOB_FLAGGED(victim, MOB_NOFIGHT))) {
+    return 0;
+  }
 
-	if (dam > 0)
-	{
-		// You can't damage an immortal!
-		if (IS_GOD(victim))
-			dam = 0;
-		else if (IS_IMMORTAL(victim) || GET_GOD_FLAG(victim, GF_GODSLIKE))
-			dam /= 4;
-		else if (GET_GOD_FLAG(victim, GF_GODSCURSE))
-			dam *= 2;
-	}
+  if (dam > 0) {
+    // You can't damage an immortal!
+    if (IS_GOD(victim))
+      dam = 0;
+    else if (IS_IMMORTAL(victim) || GET_GOD_FLAG(victim, GF_GODSLIKE))
+      dam /= 4;
+    else if (GET_GOD_FLAG(victim, GF_GODSCURSE))
+      dam *= 2;
+  }
 
-	// запоминание мобами обидчиков и жертв
-	update_mob_memory(ch, victim);
+  // запоминание мобами обидчиков и жертв
+  update_mob_memory(ch, victim);
 
-	// атакер и жертва становятся видимыми
-	appear(ch);
-	appear(victim);
+  // атакер и жертва становятся видимыми
+  appear(ch);
+  appear(victim);
 
-	// If you attack a pet, it hates your guts
-	if (!same_group(ch, victim))
-		check_agro_follower(ch, victim);
+  // If you attack a pet, it hates your guts
+  if (!same_group(ch, victim))
+    check_agro_follower(ch, victim);
 
-	if (victim != ch)  	// Start the attacker fighting the victim
-	{
-		if (GET_POS(ch) > POS_STUNNED && (ch->get_fighting() == NULL)) {
-			if (!pk_agro_action(ch, victim))
-				return (0);
-			set_fighting(ch, victim);
-			npc_groupbattle(ch);
-		}
-		// Start the victim fighting the attacker
-		if (GET_POS(victim) > POS_DEAD && (victim->get_fighting() == NULL))
-		{
-			set_fighting(victim, ch);
-			npc_groupbattle(victim);
-		}
+  if (victim != ch)    // Start the attacker fighting the victim
+  {
+    if (GET_POS(ch) > POS_STUNNED && (ch->get_fighting() == NULL)) {
+      if (!pk_agro_action(ch, victim))
+        return (0);
+      set_fighting(ch, victim);
+      npc_groupbattle(ch);
+    }
+    // Start the victim fighting the attacker
+    if (GET_POS(victim) > POS_DEAD && (victim->get_fighting() == NULL)) {
+      set_fighting(victim, ch);
+      npc_groupbattle(victim);
+    }
 
-		// лошадь сбрасывает седока при уроне
-		if (ch->ahorse() && ch->get_horse() == victim) {
-			victim->drop_from_horse();
-		}
-		else if (victim->ahorse() && victim->get_horse() == ch) {
-			ch->drop_from_horse();
-		}
-	}
+    // лошадь сбрасывает седока при уроне
+    if (ch->ahorse() && ch->get_horse() == victim) {
+      victim->drop_from_horse();
+    } else if (victim->ahorse() && victim->get_horse() == ch) {
+      ch->drop_from_horse();
+    }
+  }
 
-	// If negative damage - return
-	if (dam < 0
-		|| ch->in_room == NOWHERE
-		|| IN_ROOM(victim) == NOWHERE
-		|| ch->in_room != IN_ROOM(victim))
-	{
-		return (0);
-	}
+  // If negative damage - return
+  if (dam < 0
+      || ch->in_room == NOWHERE
+      || IN_ROOM(victim) == NOWHERE
+      || ch->in_room != IN_ROOM(victim)) {
+    return (0);
+  }
 
-	// нельзя драться в состоянии нестояния
-	if (GET_POS(ch) <= POS_INCAP)
-	{
-		return 0;
-	}
+  // нельзя драться в состоянии нестояния
+  if (GET_POS(ch) <= POS_INCAP) {
+    return 0;
+  }
 
-	// санка/призма для физ и маг урона
-	if (dam >= 2)
-	{
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_PRISMATICAURA) &&  !(skill_num == SKILL_BACKSTAB && can_use_feat(ch, THIEVES_STRIKE_FEAT)))
-		{
-			if (dmg_type == FightSystem::PHYS_DMG)
-			{
-				dam *= 2;
-			}
-			else if (dmg_type == FightSystem::MAGE_DMG)
-			{
-				dam /= 2;
-			}
-		}
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_SANCTUARY) &&  !(skill_num == SKILL_BACKSTAB && can_use_feat(ch, THIEVES_STRIKE_FEAT)))
-		{
-			if (dmg_type == FightSystem::PHYS_DMG)
-			{
-				dam /= 2;
-			}
-			else if (dmg_type == FightSystem::MAGE_DMG)
-			{
-				dam *= 2;
-			}
-		}
+  // санка/призма для физ и маг урона
+  if (dam >= 2) {
+    if (AFF_FLAGGED(victim, EAffectFlag::AFF_PRISMATICAURA)
+        && !(skill_num == SKILL_BACKSTAB && can_use_feat(ch, THIEVES_STRIKE_FEAT))) {
+      if (dmg_type == FightSystem::PHYS_DMG) {
+        dam *= 2;
+      } else if (dmg_type == FightSystem::MAGE_DMG) {
+        dam /= 2;
+      }
+    }
+    if (AFF_FLAGGED(victim, EAffectFlag::AFF_SANCTUARY)
+        && !(skill_num == SKILL_BACKSTAB && can_use_feat(ch, THIEVES_STRIKE_FEAT))) {
+      if (dmg_type == FightSystem::PHYS_DMG) {
+        dam /= 2;
+      } else if (dmg_type == FightSystem::MAGE_DMG) {
+        dam *= 2;
+      }
+    }
 
-		if (IS_NPC(victim) && Bonus::is_bonus(Bonus::BONUS_DAMAGE))
-		{
-			dam *= Bonus::get_mult_bonus();
-		}
-	}
+    if (IS_NPC(victim) && Bonus::is_bonus(Bonus::BONUS_DAMAGE)) {
+      dam *= Bonus::get_mult_bonus();
+    }
+  }
 
-	//учет резистов для магического урона
-	if (dmg_type == FightSystem::MAGE_DMG) {
-		if (spell_num > 0) {
-			dam = MAX(0, calculate_resistance_coeff(victim, get_resist_type(spell_num), dam));
-		} else {
-			dam = MAX(0, calculate_resistance_coeff(victim, getResisTypeWithSpellClass(magic_type) , dam));
-		};
-	};
+  //учет резистов для магического урона
+  if (dmg_type == FightSystem::MAGE_DMG) {
+    if (spell_num > 0) {
+      dam = MAX(0, calculate_resistance_coeff(victim, get_resist_type(spell_num), dam));
+    } else {
+      dam = MAX(0, calculate_resistance_coeff(victim, getResisTypeWithSpellClass(magic_type), dam));
+    };
+  };
 
-	// учет положения атакующего и жертвы
-	// Include a damage multiplier if victim isn't ready to fight:
-	// Position sitting  1.5 x normal
-	// Position resting  2.0 x normal
-	// Position sleeping 2.5 x normal
-	// Position stunned  3.0 x normal
-	// Position incap    3.5 x normal
-	// Position mortally 4.0 x normal
-	// Note, this is a hack because it depends on the particular
-	// values of the POSITION_XXX constants.
+  // учет положения атакующего и жертвы
+  // Include a damage multiplier if victim isn't ready to fight:
+  // Position sitting  1.5 x normal
+  // Position resting  2.0 x normal
+  // Position sleeping 2.5 x normal
+  // Position stunned  3.0 x normal
+  // Position incap    3.5 x normal
+  // Position mortally 4.0 x normal
+  // Note, this is a hack because it depends on the particular
+  // values of the POSITION_XXX constants.
 
-	// физ дамага атакера из сидячего положения
-	if (ch_start_pos < POS_FIGHTING
-		&& dmg_type == FightSystem::PHYS_DMG)
-	{
-		dam -= dam * (POS_FIGHTING - ch_start_pos) / 4;
-	}
+  // физ дамага атакера из сидячего положения
+  if (ch_start_pos < POS_FIGHTING
+      && dmg_type == FightSystem::PHYS_DMG) {
+    dam -= dam * (POS_FIGHTING - ch_start_pos) / 4;
+  }
 
-	// дамаг не увеличивается если:
-	// на жертве есть воздушный щит
-	// атака - каст моба (в mage_damage увеличение дамага от позиции было только у колдунов)
-	if (victim_start_pos < POS_FIGHTING
-		&& !flags[FightSystem::VICTIM_AIR_SHIELD]
-		&& !(dmg_type == FightSystem::MAGE_DMG
-			&& IS_NPC(ch)))
-	{
-		dam += dam * (POS_FIGHTING - victim_start_pos) / 4;
-	}
+  // дамаг не увеличивается если:
+  // на жертве есть воздушный щит
+  // атака - каст моба (в mage_damage увеличение дамага от позиции было только у колдунов)
+  if (victim_start_pos < POS_FIGHTING
+      && !flags[FightSystem::VICTIM_AIR_SHIELD]
+      && !(dmg_type == FightSystem::MAGE_DMG
+          && IS_NPC(ch))) {
+    dam += dam * (POS_FIGHTING - victim_start_pos) / 4;
+  }
 
-	// прочие множители
+  // прочие множители
 
-	// изменение физ урона по холду
-	if (GET_MOB_HOLD(victim)
-		&& dmg_type == FightSystem::PHYS_DMG)
-	{
-		if (IS_NPC(ch)
-			&& !IS_CHARMICE(ch))
-		{
-			dam = dam * 15 / 10;
-		}
-		else
-		{
-			dam = dam * 125 / 100;
-		}
-	}
+  // изменение физ урона по холду
+  if (GET_MOB_HOLD(victim)
+      && dmg_type == FightSystem::PHYS_DMG) {
+    if (IS_NPC(ch)
+        && !IS_CHARMICE(ch)) {
+      dam = dam * 15 / 10;
+    } else {
+      dam = dam * 125 / 100;
+    }
+  }
 
-	// тюнинг дамага чармисов по чарам
-	if (!IS_NPC(victim)
-		&& IS_CHARMICE(ch))
-	{
-		dam = dam * 8 / 10;
-	}
+  // тюнинг дамага чармисов по чарам
+  if (!IS_NPC(victim)
+      && IS_CHARMICE(ch)) {
+    dam = dam * 8 / 10;
+  }
 
-	// яд белены для физ урона
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_BELENA_POISON)
-		&& dmg_type == FightSystem::PHYS_DMG)
-	{
-		dam -= dam * GET_POISON(ch) / 100;
-	}
+  // яд белены для физ урона
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BELENA_POISON)
+      && dmg_type == FightSystem::PHYS_DMG) {
+    dam -= dam * GET_POISON(ch) / 100;
+  }
 
-	// added by WorM(Видолюб) поглощение физ.урона в %
-	//if(GET_PR(victim) && IS_NPC(victim)
-	if (GET_PR(victim) && dmg_type == FightSystem::PHYS_DMG)
-	{
-		int ResultDam = dam - (dam * GET_PR(victim) / 100);
-		ch->send_to_TC(false, true, false,
-			"&CУчет поглощения урона: %d начислено, %d применено.&n\r\n", dam, ResultDam);
-		victim->send_to_TC(false, true, false,
-			"&CУчет поглощения урона: %d начислено, %d применено.&n\r\n", dam, ResultDam);
-		dam = ResultDam;
-	}
+  // added by WorM(Видолюб) поглощение физ.урона в %
+  //if(GET_PR(victim) && IS_NPC(victim)
+  if (GET_PR(victim) && dmg_type == FightSystem::PHYS_DMG) {
+    int ResultDam = dam - (dam * GET_PR(victim) / 100);
+    ch->send_to_TC(false, true, false,
+                   "&CУчет поглощения урона: %d начислено, %d применено.&n\r\n", dam, ResultDam);
+    victim->send_to_TC(false, true, false,
+                       "&CУчет поглощения урона: %d начислено, %d применено.&n\r\n", dam, ResultDam);
+    dam = ResultDam;
+  }
 
-	// ЗБ
-	if (!IS_IMMORTAL(ch) && AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD))
-	{
-		if (skill_num == SKILL_BASH)
-		{
-			skill_message(dam, ch, victim, msg_num);
-		}
-		act("Магический кокон полностью поглотил удар $N1.", FALSE, victim, 0, ch, TO_CHAR);
-		act("Магический кокон вокруг $N1 полностью поглотил ваш удар.", FALSE, ch, 0, victim, TO_CHAR);
-		act("Магический кокон вокруг $N1 полностью поглотил удар $n1.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-		return 0;
-	}
-	// щиты, броня, поглощение
-	if (victim != ch) {
-		bool shield_full_absorb = magic_shields_dam(ch, victim);
-		// сначала броня
-		armor_dam_reduce(victim);
-		// потом абсорб
-		bool armor_full_absorb = dam_absorb(ch, victim);
-		if (flags[FightSystem::CRIT_HIT] && (GET_LEVEL(victim) >= 5 || !IS_NPC(ch)) && !AFF_FLAGGED(victim, EAffectFlag::AFF_PRISMATICAURA)
-			&& !flags[FightSystem::VICTIM_ICE_SHIELD]) {
-			dam = MAX(dam, MIN(GET_REAL_MAX_HIT(victim) / 8, dam * 2)); //крит
-		}
-		// полное поглощение
-		if (shield_full_absorb || armor_full_absorb) {
-			return 0;
-		}
-	}
+  // ЗБ
+  if (!IS_IMMORTAL(ch) && AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD)) {
+    if (skill_num == SKILL_BASH) {
+      skill_message(dam, ch, victim, msg_num);
+    }
+    act("Магический кокон полностью поглотил удар $N1.", FALSE, victim, 0, ch, TO_CHAR);
+    act("Магический кокон вокруг $N1 полностью поглотил ваш удар.", FALSE, ch, 0, victim, TO_CHAR);
+    act("Магический кокон вокруг $N1 полностью поглотил удар $n1.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+    return 0;
+  }
+  // щиты, броня, поглощение
+  if (victim != ch) {
+    bool shield_full_absorb = magic_shields_dam(ch, victim);
+    // сначала броня
+    armor_dam_reduce(victim);
+    // потом абсорб
+    bool armor_full_absorb = dam_absorb(ch, victim);
+    if (flags[FightSystem::CRIT_HIT] && (GET_LEVEL(victim) >= 5 || !IS_NPC(ch))
+        && !AFF_FLAGGED(victim, EAffectFlag::AFF_PRISMATICAURA)
+        && !flags[FightSystem::VICTIM_ICE_SHIELD]) {
+      dam = MAX(dam, MIN(GET_REAL_MAX_HIT(victim) / 8, dam * 2)); //крит
+    }
+    // полное поглощение
+    if (shield_full_absorb || armor_full_absorb) {
+      return 0;
+    }
+  }
 
-	// Внутри magic_shields_dam вызывается dmg::proccess, если чар там умрет, то будет креш
-	if (!(ch && victim) || (ch->purged() || victim->purged()))
-		return 0;
+  // Внутри magic_shields_dam вызывается dmg::proccess, если чар там умрет, то будет креш
+  if (!(ch && victim) || (ch->purged() || victim->purged()))
+    return 0;
 
-	// зб на мобе
-	if (MOB_FLAGGED(victim, MOB_PROTECT))
-	{
-		if (victim != ch)
-		{
-			act("$n находится под защитой Богов.", FALSE, victim, 0, 0, TO_ROOM);
-		}
-		return 0;
-	}
+  // зб на мобе
+  if (MOB_FLAGGED(victim, MOB_PROTECT)) {
+    if (victim != ch) {
+      act("$n находится под защитой Богов.", FALSE, victim, 0, 0, TO_ROOM);
+    }
+    return 0;
+  }
 
-	// яд скополии
-	if (skill_num != SKILL_BACKSTAB
-		&& AFF_FLAGGED(victim, EAffectFlag::AFF_SCOPOLIA_POISON))
-	{
-		dam += dam * GET_POISON(victim) / 100;
-	}
+  // яд скополии
+  if (skill_num != SKILL_BACKSTAB
+      && AFF_FLAGGED(victim, EAffectFlag::AFF_SCOPOLIA_POISON)) {
+    dam += dam * GET_POISON(victim) / 100;
+  }
 
-	// внутри есть !боевое везение!, для какого типа дамага - не знаю
-	DamageActorParameters params(ch, victim, dam);
-	handle_affects(params);
-	dam = params.damage;
-	DamageVictimParameters params1(ch, victim, dam);
-	handle_affects(params1);
-	dam = params1.damage;
+  // внутри есть !боевое везение!, для какого типа дамага - не знаю
+  DamageActorParameters params(ch, victim, dam);
+  handle_affects(params);
+  dam = params.damage;
+  DamageVictimParameters params1(ch, victim, dam);
+  handle_affects(params1);
+  dam = params1.damage;
 
-	// костыль для сетовых бонусов
-	if (dmg_type == FightSystem::PHYS_DMG)
-	{
-		dam += ch->obj_bonus().calc_phys_dmg(dam);
-	}
-	else if (dmg_type == FightSystem::MAGE_DMG)
-	{
-		dam += ch->obj_bonus().calc_mage_dmg(dam);
-	}
+  // костыль для сетовых бонусов
+  if (dmg_type == FightSystem::PHYS_DMG) {
+    dam += ch->obj_bonus().calc_phys_dmg(dam);
+  } else if (dmg_type == FightSystem::MAGE_DMG) {
+    dam += ch->obj_bonus().calc_mage_dmg(dam);
+  }
 
-	// обратка от зеркал/огненного щита
-	if (flags[FightSystem::MAGIC_REFLECT])
-	{
-		// ограничение для зеркал на 40% от макс хп кастера
-		dam = MIN(dam, GET_MAX_HIT(victim) * 4 / 10);
-		// чтобы не убивало обраткой
-		dam = MIN(dam, GET_HIT(victim) - 1);
-	}
+  // обратка от зеркал/огненного щита
+  if (flags[FightSystem::MAGIC_REFLECT]) {
+    // ограничение для зеркал на 40% от макс хп кастера
+    dam = MIN(dam, GET_MAX_HIT(victim) * 4 / 10);
+    // чтобы не убивало обраткой
+    dam = MIN(dam, GET_HIT(victim) - 1);
+  }
 
-	dam = MAX(0, MIN(dam, MAX_HITS));
+  dam = MAX(0, MIN(dam, MAX_HITS));
 
-	// расчет бэтл-экспы для чаров
-	gain_battle_exp(ch, victim, dam);
+  // расчет бэтл-экспы для чаров
+  gain_battle_exp(ch, victim, dam);
 
-	// real_dam так же идет в обратку от огн.щита
-	int real_dam = dam;
-	int over_dam = 0;
+  // real_dam так же идет в обратку от огн.щита
+  int real_dam = dam;
+  int over_dam = 0;
 
-	// собственно нанесение дамага
-	if (dam > GET_HIT(victim) + 11)
-	{
-		real_dam = GET_HIT(victim) + 11;
-		over_dam = dam - real_dam;
-	}
-	GET_HIT(victim) -= dam;
-	// если на чармисе вампир
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_VAMPIRE))
-	{
-		GET_HIT(ch) = MAX(GET_HIT(ch), MIN(GET_HIT(ch) + MAX(1, dam * 0.1), GET_REAL_MAX_HIT(ch)
-			+ GET_REAL_MAX_HIT(ch) * GET_LEVEL(ch) / 10));
-		// если есть родство душ, то чару отходит по 5% от дамаги к хп
-		if (ch->has_master())
-		{
-			if (can_use_feat(ch->get_master(), SOULLINK_FEAT))
-			{
-				GET_HIT(ch->get_master()) = MAX(GET_HIT(ch->get_master()),
-					MIN(GET_HIT(ch->get_master()) + MAX(1, dam * 0.05),
-						GET_REAL_MAX_HIT(ch->get_master())
-						+ GET_REAL_MAX_HIT(ch->get_master()) * GET_LEVEL(ch->get_master()) / 10));
-			}
-		}
-	}
+  // собственно нанесение дамага
+  if (dam > GET_HIT(victim) + 11) {
+    real_dam = GET_HIT(victim) + 11;
+    over_dam = dam - real_dam;
+  }
+  GET_HIT(victim) -= dam;
+  // если на чармисе вампир
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_VAMPIRE)) {
+    GET_HIT(ch) = MAX(GET_HIT(ch), MIN(GET_HIT(ch) + MAX(1, dam * 0.1), GET_REAL_MAX_HIT(ch)
+        + GET_REAL_MAX_HIT(ch) * GET_LEVEL(ch) / 10));
+    // если есть родство душ, то чару отходит по 5% от дамаги к хп
+    if (ch->has_master()) {
+      if (can_use_feat(ch->get_master(), SOULLINK_FEAT)) {
+        GET_HIT(ch->get_master()) = MAX(GET_HIT(ch->get_master()),
+                                        MIN(GET_HIT(ch->get_master()) + MAX(1, dam * 0.05),
+                                            GET_REAL_MAX_HIT(ch->get_master())
+                                                + GET_REAL_MAX_HIT(ch->get_master()) * GET_LEVEL(ch->get_master())
+                                                    / 10));
+      }
+    }
+  }
 
-	// запись в дметр фактического и овер дамага
-	update_dps_stats(ch, real_dam, over_dam);
-	// запись дамага в список атакеров
-	if (IS_NPC(victim))
-	{
-		victim->add_attacker(ch, ATTACKER_DAMAGE, real_dam);
-	}
+  // запись в дметр фактического и овер дамага
+  update_dps_stats(ch, real_dam, over_dam);
+  // запись дамага в список атакеров
+  if (IS_NPC(victim)) {
+    victim->add_attacker(ch, ATTACKER_DAMAGE, real_dam);
+  }
 
-	// попытка спасти жертву через ангела
-	try_angel_sacrifice(ch, victim);
+  // попытка спасти жертву через ангела
+  try_angel_sacrifice(ch, victim);
 
-	// обновление позиции после удара и ангела
-	update_pos(victim);
-	// если вдруг виктим сдох после этого, то произойдет креш, поэтому вставил тут проверочку
-	if (!(ch && victim) || (ch->purged() || victim->purged()))
-	{
-		log("Error in fight_hit, function process()\r\n");
-		return 0;
-	}
-	// если у чара есть жатва жизни
-	if (can_use_feat(victim, HARVESTLIFE_FEAT))
-	{
-		if (GET_POS(victim) == POS_DEAD)
-		{
-			int souls = victim->get_souls();
-			if (souls >= 10)
-			{
-				GET_HIT(victim) = 0 + souls * 10;
-				update_pos(victim);
-				send_to_char("&GДуши спасли вас от смерти!&n\r\n", victim);
-				victim->set_souls(0);
-			}
-		}
-	}
-	// сбивание надува черноков //
-	if (spell_num != SPELL_POISON
-		&& dam > 0
-		&& !flags[FightSystem::MAGIC_REFLECT])
-	{
-		try_remove_extrahits(ch, victim);
-	}
+  // обновление позиции после удара и ангела
+  update_pos(victim);
+  // если вдруг виктим сдох после этого, то произойдет креш, поэтому вставил тут проверочку
+  if (!(ch && victim) || (ch->purged() || victim->purged())) {
+    log("Error in fight_hit, function process()\r\n");
+    return 0;
+  }
+  // если у чара есть жатва жизни
+  if (can_use_feat(victim, HARVESTLIFE_FEAT)) {
+    if (GET_POS(victim) == POS_DEAD) {
+      int souls = victim->get_souls();
+      if (souls >= 10) {
+        GET_HIT(victim) = 0 + souls * 10;
+        update_pos(victim);
+        send_to_char("&GДуши спасли вас от смерти!&n\r\n", victim);
+        victim->set_souls(0);
+      }
+    }
+  }
+  // сбивание надува черноков //
+  if (spell_num != SPELL_POISON
+      && dam > 0
+      && !flags[FightSystem::MAGIC_REFLECT]) {
+    try_remove_extrahits(ch, victim);
+  }
 
-	// сообщения о крит ударах //
-	if (dam
-		&& flags[FightSystem::CRIT_HIT]
-		&& !dam_critic
-		&& spell_num != SPELL_POISON)
-	{
-		send_critical_message(ch, victim);
-	}
+  // сообщения о крит ударах //
+  if (dam
+      && flags[FightSystem::CRIT_HIT]
+      && !dam_critic
+      && spell_num != SPELL_POISON) {
+    send_critical_message(ch, victim);
+  }
 
-	//  skill_message sends a message from the messages file in lib/misc.
-	//  dam_message just sends a generic "You hit $n extremely hard.".
-	//  skill_message is preferable to dam_message because it is more
-	//  descriptive.
-	//
-	//  If we are _not_ attacking with a weapon (i.e. a spell), always use
-	//  skill_message. If we are attacking with a weapon: If this is a miss or a
-	//  death blow, send a skill_message if one exists; if not, default to a
-	//  dam_message. Otherwise, always send a dam_message.
-	// log("[DAMAGE] Attack message...");
+  //  skill_message sends a message from the messages file in lib/misc.
+  //  dam_message just sends a generic "You hit $n extremely hard.".
+  //  skill_message is preferable to dam_message because it is more
+  //  descriptive.
+  //
+  //  If we are _not_ attacking with a weapon (i.e. a spell), always use
+  //  skill_message. If we are attacking with a weapon: If this is a miss or a
+  //  death blow, send a skill_message if one exists; if not, default to a
+  //  dam_message. Otherwise, always send a dam_message.
+  // log("[DAMAGE] Attack message...");
 
-	// инит Damage::brief_shields_
-	if (flags.test(FightSystem::DRAW_BRIEF_FIRE_SHIELD)
-		|| flags.test(FightSystem::DRAW_BRIEF_AIR_SHIELD)
-		|| flags.test(FightSystem::DRAW_BRIEF_ICE_SHIELD)
-		|| flags.test(FightSystem::DRAW_BRIEF_MAG_MIRROR))
-	{
-		char buf_[MAX_INPUT_LENGTH];
-		snprintf(buf_, sizeof(buf_), "&n (%s%s%s%s)",
-			flags.test(FightSystem::DRAW_BRIEF_FIRE_SHIELD) ? "&R*&n" : "",
-			flags.test(FightSystem::DRAW_BRIEF_AIR_SHIELD) ? "&C*&n" : "",
-			flags.test(FightSystem::DRAW_BRIEF_ICE_SHIELD) ? "&W*&n" : "",
-			flags.test(FightSystem::DRAW_BRIEF_MAG_MIRROR) ? "&M*&n" : "");
-		brief_shields_ = buf_;
-	}
+  // инит Damage::brief_shields_
+  if (flags.test(FightSystem::DRAW_BRIEF_FIRE_SHIELD)
+      || flags.test(FightSystem::DRAW_BRIEF_AIR_SHIELD)
+      || flags.test(FightSystem::DRAW_BRIEF_ICE_SHIELD)
+      || flags.test(FightSystem::DRAW_BRIEF_MAG_MIRROR)) {
+    char buf_[MAX_INPUT_LENGTH];
+    snprintf(buf_, sizeof(buf_), "&n (%s%s%s%s)",
+             flags.test(FightSystem::DRAW_BRIEF_FIRE_SHIELD) ? "&R*&n" : "",
+             flags.test(FightSystem::DRAW_BRIEF_AIR_SHIELD) ? "&C*&n" : "",
+             flags.test(FightSystem::DRAW_BRIEF_ICE_SHIELD) ? "&W*&n" : "",
+             flags.test(FightSystem::DRAW_BRIEF_MAG_MIRROR) ? "&M*&n" : "");
+    brief_shields_ = buf_;
+  }
 
-	// сообщения об ударах //
-	if (skill_num >= 0 || spell_num >= 0 || hit_type < 0)
-	{
-		// скилл, спелл, необычный дамаг
-		skill_message(dam, ch, victim, msg_num, brief_shields_);
-	}
-	else
-	{
-		// простой удар рукой/оружием
-		if (GET_POS(victim) == POS_DEAD || dam == 0)
-		{
-			if (!skill_message(dam, ch, victim, msg_num,  brief_shields_))
-			{
-				dam_message(ch, victim);
-			}
-		}
-		else
-		{
-			dam_message(ch, victim);
-		}
-	}
+  // сообщения об ударах //
+  if (skill_num >= 0 || spell_num >= 0 || hit_type < 0) {
+    // скилл, спелл, необычный дамаг
+    skill_message(dam, ch, victim, msg_num, brief_shields_);
+  } else {
+    // простой удар рукой/оружием
+    if (GET_POS(victim) == POS_DEAD || dam == 0) {
+      if (!skill_message(dam, ch, victim, msg_num, brief_shields_)) {
+        dam_message(ch, victim);
+      }
+    } else {
+      dam_message(ch, victim);
+    }
+  }
 
-	/// Use send_to_char -- act() doesn't send message if you are DEAD.
-	char_dam_message(dam, ch, victim, flags[FightSystem::NO_FLEE_DMG]);
+  /// Use send_to_char -- act() doesn't send message if you are DEAD.
+  char_dam_message(dam, ch, victim, flags[FightSystem::NO_FLEE_DMG]);
 
-	victim->send_to_TC(false, true, true, "&MПолучен урон = %d&n\r\n", dam);
-	ch->send_to_TC(false, true, true, "&MПрименен урон = %d&n\r\n", dam);
+  victim->send_to_TC(false, true, true, "&MПолучен урон = %d&n\r\n", dam);
+  ch->send_to_TC(false, true, true, "&MПрименен урон = %d&n\r\n", dam);
 
-	// Проверить, что жертва все еще тут. Может уже сбежала по трусости.
-	// Думаю, простой проверки достаточно.
-	// Примечание, если сбежал в FIRESHIELD,
-	// то обратного повреждения по атакующему не будет
-	if (ch->in_room != IN_ROOM(victim))
-	{
-		return dam;
-	}
+  // Проверить, что жертва все еще тут. Может уже сбежала по трусости.
+  // Думаю, простой проверки достаточно.
+  // Примечание, если сбежал в FIRESHIELD,
+  // то обратного повреждения по атакующему не будет
+  if (ch->in_room != IN_ROOM(victim)) {
+    return dam;
+  }
 
-	// Stop someone from fighting if they're stunned or worse
-	/*if ((GET_POS(victim) <= POS_STUNNED)
+  // Stop someone from fighting if they're stunned or worse
+  /*if ((GET_POS(victim) <= POS_STUNNED)
 		&& (victim->get_fighting() != NULL))
 	{
 		stop_fighting(victim, GET_POS(victim) <= POS_DEAD);
 	} */
 
 
-	// жертва умирает //
-	if (GET_POS(victim) == POS_DEAD)
-	{
-		process_death(ch, victim);
-		return -1;
-	}
+  // жертва умирает //
+  if (GET_POS(victim) == POS_DEAD) {
+    process_death(ch, victim);
+    return -1;
+  }
 
-	// обратка от огненного щита
-	if (fs_damage > 0
-		&& victim->get_fighting()
-		&& GET_POS(victim) > POS_STUNNED
-		&& IN_ROOM(victim) != NOWHERE)
-	{
-		Damage dmg(SpellDmg(SPELL_FIRE_SHIELD), fs_damage, FightSystem::UNDEF_DMG);
-		dmg.flags.set(FightSystem::NO_FLEE_DMG);
-		dmg.flags.set(FightSystem::MAGIC_REFLECT);
-		dmg.process(victim, ch);
-	}
+  // обратка от огненного щита
+  if (fs_damage > 0
+      && victim->get_fighting()
+      && GET_POS(victim) > POS_STUNNED
+      && IN_ROOM(victim) != NOWHERE) {
+    Damage dmg(SpellDmg(SPELL_FIRE_SHIELD), fs_damage, FightSystem::UNDEF_DMG);
+    dmg.flags.set(FightSystem::NO_FLEE_DMG);
+    dmg.flags.set(FightSystem::MAGIC_REFLECT);
+    dmg.process(victim, ch);
+  }
 
-	return dam;
+  return dam;
 }
 
-void HitData::try_mighthit_dam(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	int percent = number(1, skill_info[SKILL_MIGHTHIT].max_percent);
-	int prob = train_skill(ch, SKILL_MIGHTHIT, skill_info[SKILL_MIGHTHIT].max_percent, victim);
-	int lag = 0, might = 0;
+void HitData::try_mighthit_dam(CHAR_DATA *ch, CHAR_DATA *victim) {
+  int percent = number(1, skill_info[SKILL_MIGHTHIT].max_percent);
+  int prob = calculate_skill(ch, SKILL_MIGHTHIT, victim);
+  train_skill(ch, SKILL_MIGHTHIT, percent <= prob, victim);
+  int lag = 0, might = 0;
 
-	if (GET_MOB_HOLD(victim)) {
-		percent = number(1, 25);
-	}
+  if (GET_MOB_HOLD(victim)) {
+    percent = number(1, 25);
+  }
 
-	if (IS_IMMORTAL(victim)) {
-		prob = 0;
-	}
+  if (IS_IMMORTAL(victim)) {
+    prob = 0;
+  }
 
-	if (percent > prob || dam == 0) {
-		sprintf(buf, "&c&qВаш богатырский удар пропал впустую.&Q&n\r\n");
-		send_to_char(buf, ch);
-		lag = 3;
-		dam = 0;
-	} else if (MOB_FLAGGED(victim, MOB_NOMIGHTHIT)) {
-		sprintf(buf, "&c&qНа других надо силу проверять!&Q&n\r\n");
-		send_to_char(buf, ch);
-		lag = 1;
-		dam = 0;
-	} else {
-		might = prob * 100 / percent;
-		if (might < 180) {
-			sprintf(buf, "&b&qВаш богатырский удар задел %s.&Q&n\r\n",
-				PERS(victim, ch, 3));
-			send_to_char(buf, ch);
-			lag = 1;
-			WAIT_STATE(victim, PULSE_VIOLENCE);
-			AFFECT_DATA<EApplyLocation> af;
-			af.type = SPELL_BATTLE;
-			af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af.location = APPLY_NONE;
-			af.modifier = 0;
-			af.duration = pc_duration(victim, 1, 0, 0, 0, 0);
-			af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			affect_join(victim, af, TRUE, FALSE, TRUE, FALSE);
-			sprintf(buf, "&R&qВаше сознание затуманилось после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
-			send_to_char(buf, victim);
-			act("$N содрогнул$U от богатырского удара $n1.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-			if (!number(0, 2)) {
-				might_hit_bash(ch, victim);
-			}
-		} else if (might < 800) {
-			sprintf(buf, "&g&qВаш богатырский удар пошатнул %s.&Q&n\r\n", PERS(victim, ch, 3));
-			send_to_char(buf, ch);
-			lag = 2;
-			dam += (dam / 1);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			AFFECT_DATA<EApplyLocation> af;
-			af.type = SPELL_BATTLE;
-			af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af.location = APPLY_NONE;
-			af.modifier = 0;
-			af.duration = pc_duration(victim, 2, 0, 0, 0, 0);
-			af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			affect_join(victim, af, TRUE, FALSE, TRUE, FALSE);
-			sprintf(buf, "&R&qВаше сознание помутилось после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
-			send_to_char(buf, victim);
-			act("$N пошатнул$U от богатырского удара $n1.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-			if (!number(0, 1)) {
-				might_hit_bash(ch, victim);
-			}
-		} else {
-			sprintf(buf, "&G&qВаш богатырский удар сотряс %s.&Q&n\r\n", PERS(victim, ch, 3));
-			send_to_char(buf, ch);
-			lag = 2;
-			dam *= 4;
-			WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
-			AFFECT_DATA<EApplyLocation> af;
-			af.type = SPELL_BATTLE;
-			af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-			af.location = APPLY_NONE;
-			af.modifier = 0;
-			af.duration = pc_duration(victim, 3, 0, 0, 0, 0);
-			af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			affect_join(victim, af, TRUE, FALSE, TRUE, FALSE);
-			sprintf(buf, "&R&qВаше сознание померкло после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
-			send_to_char(buf, victim);
-			act("$N зашатал$U от богатырского удара $n1.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-			might_hit_bash(ch, victim);
-		}
-	}
-	//set_wait(ch, lag, TRUE);
-	// Временный костыль, чтоб пофиксить лищний раунд КД
-	lag = MAX(1, lag - 1);
-	setSkillCooldown(ch, SKILL_MIGHTHIT, lag);
+  if (percent > prob || dam == 0) {
+    sprintf(buf, "&c&qВаш богатырский удар пропал впустую.&Q&n\r\n");
+    send_to_char(buf, ch);
+    lag = 3;
+    dam = 0;
+  } else if (MOB_FLAGGED(victim, MOB_NOMIGHTHIT)) {
+    sprintf(buf, "&c&qНа других надо силу проверять!&Q&n\r\n");
+    send_to_char(buf, ch);
+    lag = 1;
+    dam = 0;
+  } else {
+    might = prob * 100 / percent;
+    if (might < 180) {
+      sprintf(buf, "&b&qВаш богатырский удар задел %s.&Q&n\r\n",
+              PERS(victim, ch, 3));
+      send_to_char(buf, ch);
+      lag = 1;
+      WAIT_STATE(victim, PULSE_VIOLENCE);
+      AFFECT_DATA<EApplyLocation> af;
+      af.type = SPELL_BATTLE;
+      af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+      af.location = APPLY_NONE;
+      af.modifier = 0;
+      af.duration = pc_duration(victim, 1, 0, 0, 0, 0);
+      af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+      affect_join(victim, af, TRUE, FALSE, TRUE, FALSE);
+      sprintf(buf, "&R&qВаше сознание затуманилось после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
+      send_to_char(buf, victim);
+      act("$N содрогнул$U от богатырского удара $n1.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+      if (!number(0, 2)) {
+        might_hit_bash(ch, victim);
+      }
+    } else if (might < 800) {
+      sprintf(buf, "&g&qВаш богатырский удар пошатнул %s.&Q&n\r\n", PERS(victim, ch, 3));
+      send_to_char(buf, ch);
+      lag = 2;
+      dam += (dam / 1);
+      WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+      AFFECT_DATA<EApplyLocation> af;
+      af.type = SPELL_BATTLE;
+      af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+      af.location = APPLY_NONE;
+      af.modifier = 0;
+      af.duration = pc_duration(victim, 2, 0, 0, 0, 0);
+      af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+      affect_join(victim, af, TRUE, FALSE, TRUE, FALSE);
+      sprintf(buf, "&R&qВаше сознание помутилось после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
+      send_to_char(buf, victim);
+      act("$N пошатнул$U от богатырского удара $n1.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+      if (!number(0, 1)) {
+        might_hit_bash(ch, victim);
+      }
+    } else {
+      sprintf(buf, "&G&qВаш богатырский удар сотряс %s.&Q&n\r\n", PERS(victim, ch, 3));
+      send_to_char(buf, ch);
+      lag = 2;
+      dam *= 4;
+      WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
+      AFFECT_DATA<EApplyLocation> af;
+      af.type = SPELL_BATTLE;
+      af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+      af.location = APPLY_NONE;
+      af.modifier = 0;
+      af.duration = pc_duration(victim, 3, 0, 0, 0, 0);
+      af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+      affect_join(victim, af, TRUE, FALSE, TRUE, FALSE);
+      sprintf(buf, "&R&qВаше сознание померкло после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
+      send_to_char(buf, victim);
+      act("$N зашатал$U от богатырского удара $n1.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+      might_hit_bash(ch, victim);
+    }
+  }
+  //set_wait(ch, lag, TRUE);
+  // Временный костыль, чтоб пофиксить лищний раунд КД
+  lag = MAX(1, lag - 1);
+  setSkillCooldown(ch, SKILL_MIGHTHIT, lag);
 }
 
-void HitData::try_stupor_dam(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	int percent = number(1, skill_info[SKILL_STUPOR].max_percent);
-	int prob = train_skill(ch, SKILL_STUPOR, skill_info[SKILL_STUPOR].max_percent, victim);
-	int lag = 0;
+void HitData::try_stupor_dam(CHAR_DATA *ch, CHAR_DATA *victim) {
+  int percent = number(1, skill_info[SKILL_STUPOR].max_percent);
+  int prob = calculate_skill(ch, SKILL_STUPOR, victim);
+  train_skill(ch, SKILL_STUPOR, prob >= percent, victim);
+  int lag = 0;
 
-	if (GET_MOB_HOLD(victim)) {
-		prob = MAX(prob, percent * 150 / 100 + 1);
-	}
+  if (GET_MOB_HOLD(victim)) {
+    prob = MAX(prob, percent * 150 / 100 + 1);
+  }
 
-	if (IS_IMMORTAL(victim)) {
-		prob = 0;
-	}
+  if (IS_IMMORTAL(victim)) {
+    prob = 0;
+  }
 
-	if (prob < percent || dam == 0 || MOB_FLAGGED(victim, MOB_NOSTUPOR)) {
-		sprintf(buf, "&c&qВы попытались оглушить %s, но не смогли.&Q&n\r\n", PERS(victim, ch, 3));
-		send_to_char(buf, ch);
-		lag = 3;
-		dam = 0;
-	} else if (prob * 100 / percent < 300) {
-		sprintf(buf, "&g&qВаша мощная атака оглушила %s.&Q&n\r\n", PERS(victim, ch, 3));
-		send_to_char(buf, ch);
-		lag = 2;
-		int k = ch->get_skill(SKILL_STUPOR) / 30;
-		if (!IS_NPC(victim)) {
-			k = MIN(2, k);
-		}
-		dam *= MAX(2, number(1, k));
-		WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
-		sprintf(buf, "&R&qВаше сознание слегка помутилось после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
-		send_to_char(buf, victim);
-		act("$n оглушил$a $N3.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-	} else {
-		if (MOB_FLAGGED(victim, MOB_NOBASH)) {
-			sprintf(buf, "&G&qВаш мощнейший удар оглушил %s.&Q&n\r\n", PERS(victim, ch, 3));
-		} else {
-			sprintf(buf, "&G&qВаш мощнейший удар сбил %s с ног.&Q&n\r\n", PERS(victim, ch, 3));
-		}
-		send_to_char(buf, ch);
-		if (MOB_FLAGGED(victim, MOB_NOBASH)) {
-			act("$n мощным ударом оглушил$a $N3.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-		} else {
-			act("$n своим оглушающим ударом сбил$a $N3 с ног.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-		}
-		lag = 2;
-		int k = ch->get_skill(SKILL_STUPOR) / 20;
-		if (!IS_NPC(victim)) {
-			k = MIN(4, k);
-		}
-		dam *= MAX(3, number(1, k));
-		WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
-		if (GET_POS(victim) > POS_SITTING && !MOB_FLAGGED(victim, MOB_NOBASH)) {
-			GET_POS(victim) = POS_SITTING;
-			sprintf(buf, "&R&qОглушающий удар %s сбил вас с ног.&Q&n\r\n", PERS(ch, victim, 1));
-			send_to_char(buf, victim);
-		} else {
-			sprintf(buf, "&R&qВаше сознание слегка помутилось после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
-			send_to_char(buf, victim);
-		}
-	}
-	//set_wait(ch, lag, TRUE);
-	// Временный костыль, чтоб пофиксить лищний раунд КД
-	lag = MAX(1, lag - 1);
-	setSkillCooldown(ch, SKILL_STUPOR, lag);
+  if (prob < percent || dam == 0 || MOB_FLAGGED(victim, MOB_NOSTUPOR)) {
+    sprintf(buf, "&c&qВы попытались оглушить %s, но не смогли.&Q&n\r\n", PERS(victim, ch, 3));
+    send_to_char(buf, ch);
+    lag = 3;
+    dam = 0;
+  } else if (prob * 100 / percent < 300) {
+    sprintf(buf, "&g&qВаша мощная атака оглушила %s.&Q&n\r\n", PERS(victim, ch, 3));
+    send_to_char(buf, ch);
+    lag = 2;
+    int k = ch->get_skill(SKILL_STUPOR) / 30;
+    if (!IS_NPC(victim)) {
+      k = MIN(2, k);
+    }
+    dam *= MAX(2, number(1, k));
+    WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
+    sprintf(buf, "&R&qВаше сознание слегка помутилось после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
+    send_to_char(buf, victim);
+    act("$n оглушил$a $N3.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+  } else {
+    if (MOB_FLAGGED(victim, MOB_NOBASH)) {
+      sprintf(buf, "&G&qВаш мощнейший удар оглушил %s.&Q&n\r\n", PERS(victim, ch, 3));
+    } else {
+      sprintf(buf, "&G&qВаш мощнейший удар сбил %s с ног.&Q&n\r\n", PERS(victim, ch, 3));
+    }
+    send_to_char(buf, ch);
+    if (MOB_FLAGGED(victim, MOB_NOBASH)) {
+      act("$n мощным ударом оглушил$a $N3.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+    } else {
+      act("$n своим оглушающим ударом сбил$a $N3 с ног.", TRUE, ch, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+    }
+    lag = 2;
+    int k = ch->get_skill(SKILL_STUPOR) / 20;
+    if (!IS_NPC(victim)) {
+      k = MIN(4, k);
+    }
+    dam *= MAX(3, number(1, k));
+    WAIT_STATE(victim, 3 * PULSE_VIOLENCE);
+    if (GET_POS(victim) > POS_SITTING && !MOB_FLAGGED(victim, MOB_NOBASH)) {
+      GET_POS(victim) = POS_SITTING;
+      sprintf(buf, "&R&qОглушающий удар %s сбил вас с ног.&Q&n\r\n", PERS(ch, victim, 1));
+      send_to_char(buf, victim);
+    } else {
+      sprintf(buf, "&R&qВаше сознание слегка помутилось после удара %s.&Q&n\r\n", PERS(ch, victim, 1));
+      send_to_char(buf, victim);
+    }
+  }
+  //set_wait(ch, lag, TRUE);
+  // Временный костыль, чтоб пофиксить лищний раунд КД
+  lag = MAX(1, lag - 1);
+  setSkillCooldown(ch, SKILL_STUPOR, lag);
 }
 
-int HitData::extdamage(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	if (!check_valid_chars(ch, victim, __FILE__, __LINE__))
-	{
-		return 0;
-	}
+int HitData::extdamage(CHAR_DATA *ch, CHAR_DATA *victim) {
+  if (!check_valid_chars(ch, victim, __FILE__, __LINE__)) {
+    return 0;
+  }
 
-	const int mem_dam = dam;
+  const int mem_dam = dam;
 
-	if (dam < 0)
-	{
-		dam = 0;
-	}
+  if (dam < 0) {
+    dam = 0;
+  }
 
-	//* богатырский молот //
-	// в эти условия ничего добавлять не надо, иначе EAF_MIGHTHIT не снимется
-	// с моба по ходу боя, если он не может по каким-то причинам смолотить
-	if (GET_AF_BATTLE(ch, EAF_MIGHTHIT) && GET_WAIT(ch) <= 0) {
-		CLR_AF_BATTLE(ch, EAF_MIGHTHIT);
-		if (check_mighthit_weapon(ch) && !GET_AF_BATTLE(ch, EAF_TOUCH)) {
-			try_mighthit_dam(ch, victim);
-		}
-	}
-	//* оглушить //
-	// аналогично молоту, все доп условия добавляются внутри
-	else if (GET_AF_BATTLE(ch, EAF_STUPOR) && GET_WAIT(ch) <= 0) {
-		CLR_AF_BATTLE(ch, EAF_STUPOR);
-		if (IS_NPC(ch) || IS_IMMORTAL(ch)) {
-			try_stupor_dam(ch, victim);
-		} else if (wielded) {
-			if (GET_OBJ_SKILL(wielded) == SKILL_BOWS) {
-				send_to_char("Луком оглушить нельзя.\r\n", ch);
-			} else if (!GET_AF_BATTLE(ch, EAF_PARRY) && !GET_AF_BATTLE(ch, EAF_MULTYPARRY)) {
-				if (GET_OBJ_WEIGHT(wielded) > 18) {
-					try_stupor_dam(ch, victim);
-				} else {
-					send_to_char("&WВаше оружие слишком легкое, чтобы им можно было оглушить!&Q&n\r\n", ch);
-				}
-			}
-		} else {
-			sprintf(buf,"&c&qВы оказались без оружия, а пальцем оглушить нельзя.&Q&n\r\n");
-			send_to_char(buf, ch);
-			sprintf(buf,"&c&q%s оказался без оружия и не смог вас оглушить.&Q&n\r\n", GET_NAME(ch));
-			send_to_char(buf, victim);
-		}
-	}
-	//* яды со скила отравить //
-	else if (!MOB_FLAGGED(victim, MOB_PROTECT)
-		&& dam
-		&& wielded
-		&& wielded->has_timed_spell()
-		&& ch->get_skill(SKILL_POISONED))
-	{
-		try_weap_poison(ch, victim, wielded->timed_spell().is_spell_poisoned());
-	}
-	//* травящий ядом моб //
-	else if (dam
-		&& IS_NPC(ch)
-		&& NPC_FLAGGED(ch, NPC_POISON)
-		&& !AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-		&& GET_WAIT(ch) <= 0
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_POISON)
-		&& number(0, 100) < GET_LIKES(ch) + GET_LEVEL(ch) - GET_LEVEL(victim)
-		&& !general_savingthrow(ch, victim, SAVING_CRITICAL, - GET_REAL_CON(victim)))
-	{
-		poison_victim(ch, victim, MAX(1, GET_LEVEL(ch) - GET_LEVEL(victim)) * 10);
-	}
-	//* точный стиль //
-	else if (dam && get_flags()[FightSystem::CRIT_HIT] && dam_critic)
-	{
-		compute_critical(ch, victim);
-	}
+  //* богатырский молот //
+  // в эти условия ничего добавлять не надо, иначе EAF_MIGHTHIT не снимется
+  // с моба по ходу боя, если он не может по каким-то причинам смолотить
+  if (GET_AF_BATTLE(ch, EAF_MIGHTHIT) && GET_WAIT(ch) <= 0) {
+    CLR_AF_BATTLE(ch, EAF_MIGHTHIT);
+    if (check_mighthit_weapon(ch) && !GET_AF_BATTLE(ch, EAF_TOUCH)) {
+      try_mighthit_dam(ch, victim);
+    }
+  }
+    //* оглушить //
+    // аналогично молоту, все доп условия добавляются внутри
+  else if (GET_AF_BATTLE(ch, EAF_STUPOR) && GET_WAIT(ch) <= 0) {
+    CLR_AF_BATTLE(ch, EAF_STUPOR);
+    if (IS_NPC(ch) || IS_IMMORTAL(ch)) {
+      try_stupor_dam(ch, victim);
+    } else if (wielded) {
+      if (GET_OBJ_SKILL(wielded) == SKILL_BOWS) {
+        send_to_char("Луком оглушить нельзя.\r\n", ch);
+      } else if (!GET_AF_BATTLE(ch, EAF_PARRY) && !GET_AF_BATTLE(ch, EAF_MULTYPARRY)) {
+        if (GET_OBJ_WEIGHT(wielded) > 18) {
+          try_stupor_dam(ch, victim);
+        } else {
+          send_to_char("&WВаше оружие слишком легкое, чтобы им можно было оглушить!&Q&n\r\n", ch);
+        }
+      }
+    } else {
+      sprintf(buf, "&c&qВы оказались без оружия, а пальцем оглушить нельзя.&Q&n\r\n");
+      send_to_char(buf, ch);
+      sprintf(buf, "&c&q%s оказался без оружия и не смог вас оглушить.&Q&n\r\n", GET_NAME(ch));
+      send_to_char(buf, victim);
+    }
+  }
+    //* яды со скила отравить //
+  else if (!MOB_FLAGGED(victim, MOB_PROTECT)
+      && dam
+      && wielded
+      && wielded->has_timed_spell()
+      && ch->get_skill(SKILL_POISONED)) {
+    try_weap_poison(ch, victim, wielded->timed_spell().is_spell_poisoned());
+  }
+    //* травящий ядом моб //
+  else if (dam
+      && IS_NPC(ch)
+      && NPC_FLAGGED(ch, NPC_POISON)
+      && !AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+      && GET_WAIT(ch) <= 0
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_POISON)
+      && number(0, 100) < GET_LIKES(ch) + GET_LEVEL(ch) - GET_LEVEL(victim)
+      && !general_savingthrow(ch, victim, SAVING_CRITICAL, -GET_REAL_CON(victim))) {
+    poison_victim(ch, victim, MAX(1, GET_LEVEL(ch) - GET_LEVEL(victim)) * 10);
+  }
+    //* точный стиль //
+  else if (dam && get_flags()[FightSystem::CRIT_HIT] && dam_critic) {
+    compute_critical(ch, victim);
+  }
 
-	// Если удар парирован, необходимо все равно ввязаться в драку.
-	// Вызывается damage с отрицательным уроном
-	dam = mem_dam >= 0 ? dam : -1;
+  // Если удар парирован, необходимо все равно ввязаться в драку.
+  // Вызывается damage с отрицательным уроном
+  dam = mem_dam >= 0 ? dam : -1;
 
-	Damage dmg(SkillDmg(skill_num), dam, FightSystem::PHYS_DMG);
-	dmg.hit_type = hit_type;
-	dmg.dam_critic = dam_critic;
-	dmg.flags = get_flags();
-	dmg.ch_start_pos = ch_start_pos;
-	dmg.victim_start_pos = victim_start_pos;
+  Damage dmg(SkillDmg(skill_num), dam, FightSystem::PHYS_DMG);
+  dmg.hit_type = hit_type;
+  dmg.dam_critic = dam_critic;
+  dmg.flags = get_flags();
+  dmg.ch_start_pos = ch_start_pos;
+  dmg.victim_start_pos = victim_start_pos;
 
-	return dmg.process(ch, victim);
+  return dmg.process(ch, victim);
 }
 
 /**
  * Инициализация всех нужных первичных полей (отделены в хедере), после
  * этой функции уже начинаются подсчеты собсна хитролов/дамролов и прочего.
  */
-void HitData::init(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	// Find weapon for attack number weapon //
+void HitData::init(CHAR_DATA *ch, CHAR_DATA *victim) {
+  // Find weapon for attack number weapon //
 
-	if (weapon == FightSystem::AttType::MAIN_HAND)
-	{
-		if (!(wielded = GET_EQ(ch, WEAR_WIELD)))
-		{
-			wielded = GET_EQ(ch, WEAR_BOTHS);
-			weapon_pos = WEAR_BOTHS;
-		}
-	}
-	else if (weapon == FightSystem::AttType::OFFHAND)
-	{
-		wielded = GET_EQ(ch, WEAR_HOLD);
-		weapon_pos = WEAR_HOLD;
-	}
+  if (weapon == FightSystem::AttType::MAIN_HAND) {
+    if (!(wielded = GET_EQ(ch, WEAR_WIELD))) {
+      wielded = GET_EQ(ch, WEAR_BOTHS);
+      weapon_pos = WEAR_BOTHS;
+    }
+  } else if (weapon == FightSystem::AttType::OFFHAND) {
+    wielded = GET_EQ(ch, WEAR_HOLD);
+    weapon_pos = WEAR_HOLD;
+  }
 
-	if (wielded
-		&& GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON)
-	{
-		// для всех типов атак скилл берется из пушки, если она есть
-		weap_skill = static_cast<ESkill>(GET_OBJ_SKILL(wielded));
-	}
-	else
-	{
-		// удар голыми руками
-		weap_skill = SKILL_PUNCH;
-	}
-	weap_skill_is = train_skill(ch, weap_skill, skill_info[weap_skill].max_percent, victim);
+  if (wielded
+      && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON) {
+    // для всех типов атак скилл берется из пушки, если она есть
+    weap_skill = static_cast<ESkill>(GET_OBJ_SKILL(wielded));
+  } else {
+    // удар голыми руками
+    weap_skill = SKILL_PUNCH;
+  }
+  weap_skill_is = calculate_skill(ch, weap_skill, victim);
+  train_skill(ch, weap_skill, true, victim);
 
-	//* обработка SKILL_NOPARRYHIT //
-	if (skill_num == TYPE_UNDEFINED && ch->get_skill(SKILL_NOPARRYHIT))
-	{
-		int tmp_skill = train_skill(ch, SKILL_NOPARRYHIT, skill_info[SKILL_NOPARRYHIT].max_percent, victim);
-		// TODO: max_percent в данный момент 100 (хорошо бы не тупо 200, а с % фейла)
-		if (tmp_skill >= number(1, skill_info[SKILL_NOPARRYHIT].max_percent))
-		{
-			hit_no_parry = true;
-		}
-	}
+  //* обработка SKILL_NOPARRYHIT //
+  if (skill_num == TYPE_UNDEFINED && ch->get_skill(SKILL_NOPARRYHIT)) {
+    int tmp_skill = calculate_skill(ch, SKILL_NOPARRYHIT, victim);
+    bool success = tmp_skill >= number(1, skill_info[SKILL_NOPARRYHIT].max_percent);
+    train_skill(ch, SKILL_NOPARRYHIT, success, victim);
+    if (success) {
+      hit_no_parry = true;
+    }
+  }
 
-	if (GET_AF_BATTLE(ch, EAF_STUPOR) || GET_AF_BATTLE(ch, EAF_MIGHTHIT))
-	{
-		hit_no_parry = true;
-	}
+  if (GET_AF_BATTLE(ch, EAF_STUPOR) || GET_AF_BATTLE(ch, EAF_MIGHTHIT)) {
+    hit_no_parry = true;
+  }
 
-	if (wielded && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON)
-	{
-		hit_type = GET_OBJ_VAL(wielded, 3);
-	}
-	else
-	{
-		weapon_pos = 0;
-		if (IS_NPC(ch))
-		{
-			hit_type = ch->mob_specials.attack_type;
-		}
-	}
+  if (wielded && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON) {
+    hit_type = GET_OBJ_VAL(wielded, 3);
+  } else {
+    weapon_pos = 0;
+    if (IS_NPC(ch)) {
+      hit_type = ch->mob_specials.attack_type;
+    }
+  }
 
-	// позиции сражающихся до применения скилов и прочего, что может их изменить
-	ch_start_pos = GET_POS(ch);
-	victim_start_pos = GET_POS(victim);
+  // позиции сражающихся до применения скилов и прочего, что может их изменить
+  ch_start_pos = GET_POS(ch);
+  victim_start_pos = GET_POS(victim);
 }
 
 /**
@@ -3280,183 +2896,144 @@ void HitData::init(CHAR_DATA *ch, CHAR_DATA *victim)
  * Предполагается, что в итоге это пойдет в 'счет все' через что-то вроде
  * test_self_hitroll() в данный момент.
  */
-void HitData::calc_base_hr(CHAR_DATA *ch)
-{
-	if (skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB)
-	{
-		if (wielded
-			&& GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON
-			&& !IS_NPC(ch))
-		{
-			// Apply HR for light weapon
-			int percent = 0;
-			switch (weapon_pos)
-			{
-			case WEAR_WIELD:
-				percent = (str_bonus(GET_REAL_STR(ch), STR_WIELD_W) - GET_OBJ_WEIGHT(wielded) + 1) / 2;
-				break;
-			case WEAR_HOLD:
-				percent = (str_bonus(GET_REAL_STR(ch), STR_HOLD_W) - GET_OBJ_WEIGHT(wielded) + 1) / 2;
-				break;
-			case WEAR_BOTHS:
-				percent = (str_bonus(GET_REAL_STR(ch), STR_WIELD_W) +
-				   str_bonus(GET_REAL_STR(ch), STR_HOLD_W) - GET_OBJ_WEIGHT(wielded) + 1) / 2;
-				break;
-			}
-			calc_thaco -= MIN(3, MAX(percent, 0));
+void HitData::calc_base_hr(CHAR_DATA *ch) {
+  if (skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB) {
+    if (wielded
+        && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON
+        && !IS_NPC(ch)) {
+      // Apply HR for light weapon
+      int percent = 0;
+      switch (weapon_pos) {
+        case WEAR_WIELD: percent = (str_bonus(GET_REAL_STR(ch), STR_WIELD_W) - GET_OBJ_WEIGHT(wielded) + 1) / 2;
+          break;
+        case WEAR_HOLD: percent = (str_bonus(GET_REAL_STR(ch), STR_HOLD_W) - GET_OBJ_WEIGHT(wielded) + 1) / 2;
+          break;
+        case WEAR_BOTHS:
+          percent = (str_bonus(GET_REAL_STR(ch), STR_WIELD_W) +
+              str_bonus(GET_REAL_STR(ch), STR_HOLD_W) - GET_OBJ_WEIGHT(wielded) + 1) / 2;
+          break;
+      }
+      calc_thaco -= MIN(3, MAX(percent, 0));
 
-			// Penalty for unknown weapon type
-			// shapirus: старый штраф нифига не работает, тем более, что unknown_weapon_fault
-			// нигде не определяется. сделан новый на базе инты чара. плюс сделан штраф на дамролл.
-			// если скилл есть, то штраф не даем, а применяем бонусы/штрафы по профам
-			if (ch->get_skill(weap_skill) == 0)
-			{
-				calc_thaco += (50 - MIN(50, GET_REAL_INT(ch))) / 3;
-				dam -= (50 - MIN(50, GET_REAL_INT(ch))) / 6;
-			}
-			else
-			{
-				apply_weapon_bonus(GET_CLASS(ch), weap_skill, &dam, &calc_thaco);
-			}
-		}
-		else if (!IS_NPC(ch))
-		{
-			// кулаками у нас полагается бить только богатырям :)
-			if (!can_use_feat(ch, BULLY_FEAT))
-				calc_thaco += 4;
-			else	// а богатырям положен бонус за отсутствие оружия
-				calc_thaco -= 3;
-		}
-	}
+      // Penalty for unknown weapon type
+      // shapirus: старый штраф нифига не работает, тем более, что unknown_weapon_fault
+      // нигде не определяется. сделан новый на базе инты чара. плюс сделан штраф на дамролл.
+      // если скилл есть, то штраф не даем, а применяем бонусы/штрафы по профам
+      if (ch->get_skill(weap_skill) == 0) {
+        calc_thaco += (50 - MIN(50, GET_REAL_INT(ch))) / 3;
+        dam -= (50 - MIN(50, GET_REAL_INT(ch))) / 6;
+      } else {
+        apply_weapon_bonus(GET_CLASS(ch), weap_skill, &dam, &calc_thaco);
+      }
+    } else if (!IS_NPC(ch)) {
+      // кулаками у нас полагается бить только богатырям :)
+      if (!can_use_feat(ch, BULLY_FEAT))
+        calc_thaco += 4;
+      else    // а богатырям положен бонус за отсутствие оружия
+        calc_thaco -= 3;
+    }
+  }
 
-	check_weap_feats(ch, weap_skill, calc_thaco, dam);
+  check_weap_feats(ch, weap_skill, calc_thaco, dam);
 
-	if (GET_AF_BATTLE(ch, EAF_STUPOR) || GET_AF_BATTLE(ch, EAF_MIGHTHIT))
-	{
-		calc_thaco -= MAX(0, (ch->get_skill(weap_skill) - 70) / 8);
-	}
+  if (GET_AF_BATTLE(ch, EAF_STUPOR) || GET_AF_BATTLE(ch, EAF_MIGHTHIT)) {
+    calc_thaco -= MAX(0, (ch->get_skill(weap_skill) - 70) / 8);
+  }
 
-	//    AWAKE style - decrease hitroll
-	if (GET_AF_BATTLE(ch, EAF_AWAKE)
-		&& !can_use_feat(ch, SHADOW_STRIKE_FEAT)
-		&& skill_num != SKILL_THROW
-		&& skill_num != SKILL_BACKSTAB)
-	{
-		if (can_auto_block(ch))
-		{
-			// осторожка со щитом в руках у дружа с блоком - штрафы на хитролы (от 0 до 10)
-			calc_thaco += ch->get_skill(SKILL_AWAKE) * 5 / 100;
-		}
-		else
-		{
-			// здесь еще были штрафы на дамаг через деление, но положительного дамага
-			// на этом этапе еще нет, так что делили по сути нули
-			calc_thaco += ((ch->get_skill(SKILL_AWAKE) + 9) / 10) + 2;
-		}
-	}
+  //    AWAKE style - decrease hitroll
+  if (GET_AF_BATTLE(ch, EAF_AWAKE)
+      && !can_use_feat(ch, SHADOW_STRIKE_FEAT)
+      && skill_num != SKILL_THROW
+      && skill_num != SKILL_BACKSTAB) {
+    if (can_auto_block(ch)) {
+      // осторожка со щитом в руках у дружа с блоком - штрафы на хитролы (от 0 до 10)
+      calc_thaco += ch->get_skill(SKILL_AWAKE) * 5 / 100;
+    } else {
+      // здесь еще были штрафы на дамаг через деление, но положительного дамага
+      // на этом этапе еще нет, так что делили по сути нули
+      calc_thaco += ((ch->get_skill(SKILL_AWAKE) + 9) / 10) + 2;
+    }
+  }
 
-	if (!IS_NPC(ch) && skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB)
-	{
-		// Casters use weather, int and wisdom
-		if (IS_CASTER(ch))
-		{
-			/*	  calc_thaco +=
+  if (!IS_NPC(ch) && skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB) {
+    // Casters use weather, int and wisdom
+    if (IS_CASTER(ch)) {
+      /*	  calc_thaco +=
 				    (10 -
 				     complex_skill_modifier (ch, SKILL_INDEFINITE, GAPPLY_SKILL_SUCCESS,
 							     10));
 			*/
-			calc_thaco -= (int)((GET_REAL_INT(ch) - 13) / GET_LEVEL(ch));
-			calc_thaco -= (int)((GET_REAL_WIS(ch) - 13) / GET_LEVEL(ch));
-		}
-		// Skill level increase damage
-		if (ch->get_skill(weap_skill) >= 60)
-			dam += ((ch->get_skill(weap_skill) - 50) / 10);
-	}
+      calc_thaco -= (int) ((GET_REAL_INT(ch) - 13) / GET_LEVEL(ch));
+      calc_thaco -= (int) ((GET_REAL_WIS(ch) - 13) / GET_LEVEL(ch));
+    }
+    // Skill level increase damage
+    if (ch->get_skill(weap_skill) >= 60)
+      dam += ((ch->get_skill(weap_skill) - 50) / 10);
+  }
 
-	// bless
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLESS))
-	{
-		calc_thaco -= 4;
-	}
-	// curse
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_CURSE))
-	{
-		calc_thaco += 6;
-		dam -= 5;
-	}
+  // bless
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLESS)) {
+    calc_thaco -= 4;
+  }
+  // curse
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_CURSE)) {
+    calc_thaco += 6;
+    dam -= 5;
+  }
 
-	// Учет мощной и прицельной атаки
-	if (PRF_FLAGGED(ch, PRF_POWERATTACK) && can_use_feat(ch, POWER_ATTACK_FEAT))
-	{
-		calc_thaco += 2;
-		dam += 5;
-	}
-	else if (PRF_FLAGGED(ch, PRF_GREATPOWERATTACK) && can_use_feat(ch, GREAT_POWER_ATTACK_FEAT))
-	{
-		calc_thaco += 4;
-		dam += 10;
-	}
-	else if (PRF_FLAGGED(ch, PRF_AIMINGATTACK) && can_use_feat(ch, AIMING_ATTACK_FEAT))
-	{
-		calc_thaco -= 2;
-		dam -= 5;
-	}
-	else if (PRF_FLAGGED(ch, PRF_GREATAIMINGATTACK) && can_use_feat(ch, GREAT_AIMING_ATTACK_FEAT))
-	{
-		calc_thaco -= 4;
-		dam -= 10;
-	}
+  // Учет мощной и прицельной атаки
+  if (PRF_FLAGGED(ch, PRF_POWERATTACK) && can_use_feat(ch, POWER_ATTACK_FEAT)) {
+    calc_thaco += 2;
+    dam += 5;
+  } else if (PRF_FLAGGED(ch, PRF_GREATPOWERATTACK) && can_use_feat(ch, GREAT_POWER_ATTACK_FEAT)) {
+    calc_thaco += 4;
+    dam += 10;
+  } else if (PRF_FLAGGED(ch, PRF_AIMINGATTACK) && can_use_feat(ch, AIMING_ATTACK_FEAT)) {
+    calc_thaco -= 2;
+    dam -= 5;
+  } else if (PRF_FLAGGED(ch, PRF_GREATAIMINGATTACK) && can_use_feat(ch, GREAT_AIMING_ATTACK_FEAT)) {
+    calc_thaco -= 4;
+    dam -= 10;
+  }
 
-	// Calculate the THAC0 of the attacker
-	if (!IS_NPC(ch))
-	{
-		calc_thaco += thaco((int) GET_CLASS(ch), (int) GET_LEVEL(ch));
-	}
-	else
-	{
-		// штраф мобам по рекомендации Триглава
-		calc_thaco += (25 - GET_LEVEL(ch) / 3);
-	}
+  // Calculate the THAC0 of the attacker
+  if (!IS_NPC(ch)) {
+    calc_thaco += thaco((int) GET_CLASS(ch), (int) GET_LEVEL(ch));
+  } else {
+    // штраф мобам по рекомендации Триглава
+    calc_thaco += (25 - GET_LEVEL(ch) / 3);
+  }
 
-	//Вычисляем штраф за голод
-	float p_hitroll = ch->get_cond_penalty(P_HITROLL);
+  //Вычисляем штраф за голод
+  float p_hitroll = ch->get_cond_penalty(P_HITROLL);
 
-	calc_thaco -= GET_REAL_HR(ch) * p_hitroll;
+  calc_thaco -= GET_REAL_HR(ch) * p_hitroll;
 
 
-	// Использование ловкости вместо силы для попадания
-	if (can_use_feat(ch, WEAPON_FINESSE_FEAT))
-	{
-		calc_thaco -= str_bonus(GET_REAL_STR(ch), STR_TO_HIT) * p_hitroll;
-	}
-	else
-	{
-		calc_thaco -= str_bonus(GET_REAL_DEX(ch), STR_TO_HIT) * p_hitroll;
-	}
-	if ((skill_num == SKILL_THROW
-			|| skill_num == SKILL_BACKSTAB)
-		&& wielded
-		&& GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON)
-	{
-		if (skill_num == SKILL_BACKSTAB)
-		{
-			calc_thaco -= MAX(0, (ch->get_skill(SKILL_SNEAK) + ch->get_skill(SKILL_HIDE) - 100) / 30);
-		}
-	}
-	else
-	{
-		// тюнинг оверности делается тут :)
-		calc_thaco += 4;
-	}
+  // Использование ловкости вместо силы для попадания
+  if (can_use_feat(ch, WEAPON_FINESSE_FEAT)) {
+    calc_thaco -= str_bonus(GET_REAL_STR(ch), STR_TO_HIT) * p_hitroll;
+  } else {
+    calc_thaco -= str_bonus(GET_REAL_DEX(ch), STR_TO_HIT) * p_hitroll;
+  }
+  if ((skill_num == SKILL_THROW
+      || skill_num == SKILL_BACKSTAB)
+      && wielded
+      && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON) {
+    if (skill_num == SKILL_BACKSTAB) {
+      calc_thaco -= MAX(0, (ch->get_skill(SKILL_SNEAK) + ch->get_skill(SKILL_HIDE) - 100) / 30);
+    }
+  } else {
+    // тюнинг оверности делается тут :)
+    calc_thaco += 4;
+  }
 
-	//dzMUDiST Обработка !исступления! +Gorrah
-	if (affected_by_spell(ch, SPELL_BERSERK))
-	{
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_BERSERK))
-		{
-			calc_thaco -= (12 * ((GET_REAL_MAX_HIT(ch) / 2) - GET_HIT(ch)) / GET_REAL_MAX_HIT(ch));
-		}
-	}
+  //dzMUDiST Обработка !исступления! +Gorrah
+  if (affected_by_spell(ch, SPELL_BERSERK)) {
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_BERSERK)) {
+      calc_thaco -= (12 * ((GET_REAL_MAX_HIT(ch) / 2) - GET_HIT(ch)) / GET_REAL_MAX_HIT(ch));
+    }
+  }
 
 }
 
@@ -3465,246 +3042,217 @@ void HitData::calc_base_hr(CHAR_DATA *ch)
  * Все, что меняется от раза к разу или при разных противниках
  * При любом изменении содержимого нужно поддерживать адекватность calc_stat_hr()
  */
-void HitData::calc_rand_hr(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	//считаем штраф за голод
-	float p_hitroll = ch->get_cond_penalty(P_HITROLL);
-	// штраф в размере 1 хитролла за каждые
-	// недокачанные 10% скилла "удар левой рукой"
+void HitData::calc_rand_hr(CHAR_DATA *ch, CHAR_DATA *victim) {
+  //считаем штраф за голод
+  float p_hitroll = ch->get_cond_penalty(P_HITROLL);
+  // штраф в размере 1 хитролла за каждые
+  // недокачанные 10% скилла "удар левой рукой"
 
-	if (weapon == FightSystem::AttType::OFFHAND
-		&& skill_num != SKILL_THROW
-		&& skill_num != SKILL_BACKSTAB
-		&& !(wielded && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON)
-		&& !IS_NPC(ch))
-	{
-		calc_thaco += (skill_info[SKILL_SHIT].max_percent -
-		   train_skill(ch, SKILL_SHIT, skill_info[SKILL_SHIT].max_percent, victim)) / 10;
-	}
+  if (weapon == FightSystem::AttType::OFFHAND
+      && skill_num != SKILL_THROW
+      && skill_num != SKILL_BACKSTAB
+      && !(wielded && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON)
+      && !IS_NPC(ch)) {
+    calc_thaco += (skill_info[SKILL_SHIT].max_percent - calculate_skill(ch, SKILL_SHIT, victim) / 10);
+    train_skill(ch, SKILL_SHIT, true, victim);
+  }
 
-	// courage
-	if (affected_by_spell(ch, SPELL_COURAGE))
-	{
-		int range = number(1, skill_info[SKILL_COURAGE].max_percent + GET_REAL_MAX_HIT(ch) - GET_HIT(ch));
-		int prob = train_skill(ch, SKILL_COURAGE, skill_info[SKILL_COURAGE].max_percent, victim);
-		if (prob > range)
-		{
-			dam += ((ch->get_skill(SKILL_COURAGE) + 19) / 20);
-			calc_thaco -= ((ch->get_skill(SKILL_COURAGE) + 9) / 20) * p_hitroll;
-		}
-	}
+  // courage
+  if (affected_by_spell(ch, SPELL_COURAGE)) {
+    int range = number(1, skill_info[SKILL_COURAGE].max_percent + GET_REAL_MAX_HIT(ch) - GET_HIT(ch));
+    int prob = calculate_skill(ch, SKILL_COURAGE, victim);
+    train_skill(ch, SKILL_COURAGE, prob > range, victim);
+    if (prob > range) {
+      dam += ((ch->get_skill(SKILL_COURAGE) + 19) / 20);
+      calc_thaco -= ((ch->get_skill(SKILL_COURAGE) + 9) / 20) * p_hitroll;
+    }
+  }
 
-	// Horse modifier for attacker
-	if (!IS_NPC(ch) && skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB && ch->ahorse())
-	{
-		train_skill(ch, SKILL_HORSE, skill_info[SKILL_HORSE].max_percent, victim);
-//		dam += ((prob + 19) / 10);
-//		int range = number(1, skill_info[SKILL_HORSE].max_percent);
-//		if (range > prob)
-//			calc_thaco += ((range - prob) + 19 / 20);
-//		else
-//			calc_thaco -= ((prob - range) + 19 / 20);
-		calc_thaco += 10 - GET_SKILL(ch, SKILL_HORSE) / 20;
-	}
+  // Horse modifier for attacker
+  if (!IS_NPC(ch) && skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB && ch->ahorse()) {
+    train_skill(ch, SKILL_HORSE, true, victim);
+    calc_thaco += 10 - GET_SKILL(ch, SKILL_HORSE) / 20;
+  }
 
-	// not can see (blind, dark, etc)
-	if (!CAN_SEE(ch, victim))
-		calc_thaco += (can_use_feat(ch, BLIND_FIGHT_FEAT) ? 2 : IS_NPC(ch) ? 6 : 10);
-	if (!CAN_SEE(victim, ch))
-		calc_thaco -= (can_use_feat(victim, BLIND_FIGHT_FEAT) ? 2 : 8);
+  // not can see (blind, dark, etc)
+  if (!CAN_SEE(ch, victim))
+    calc_thaco += (can_use_feat(ch, BLIND_FIGHT_FEAT) ? 2 : IS_NPC(ch) ? 6 : 10);
+  if (!CAN_SEE(victim, ch))
+    calc_thaco -= (can_use_feat(victim, BLIND_FIGHT_FEAT) ? 2 : 8);
 
-	// some protects
-	if (AFF_FLAGGED(victim, EAffectFlag::AFF_PROTECT_EVIL) && IS_EVIL(ch))
-		calc_thaco += 2;
-	if (AFF_FLAGGED(victim, EAffectFlag::AFF_PROTECT_GOOD) && IS_GOOD(ch))
-		calc_thaco += 2;
+  // some protects
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_PROTECT_EVIL) && IS_EVIL(ch))
+    calc_thaco += 2;
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_PROTECT_GOOD) && IS_GOOD(ch))
+    calc_thaco += 2;
 
-	// "Dirty" methods for battle
-	if (skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB)
-	{
-		int prob = (ch->get_skill(weap_skill) + cha_app[GET_REAL_CHA(ch)].illusive) -
-			   (victim->get_skill(weap_skill) + int_app[GET_REAL_INT(victim)].observation);
-		if (prob >= 30 && !GET_AF_BATTLE(victim, EAF_AWAKE)
-				&& (IS_NPC(ch) || !GET_AF_BATTLE(ch, EAF_PUNCTUAL)))
-		{
-			calc_thaco -= (ch->get_skill(weap_skill) - victim->get_skill(weap_skill) > 60 ? 2 : 1) * p_hitroll;
-			if (!IS_NPC(victim))
-				dam += (prob >= 70 ? 3 : (prob >= 50 ? 2 : 1));
-		}
-	}
+  // "Dirty" methods for battle
+  if (skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB) {
+    int prob = (ch->get_skill(weap_skill) + cha_app[GET_REAL_CHA(ch)].illusive) -
+        (victim->get_skill(weap_skill) + int_app[GET_REAL_INT(victim)].observation);
+    if (prob >= 30 && !GET_AF_BATTLE(victim, EAF_AWAKE)
+        && (IS_NPC(ch) || !GET_AF_BATTLE(ch, EAF_PUNCTUAL))) {
+      calc_thaco -= (ch->get_skill(weap_skill) - victim->get_skill(weap_skill) > 60 ? 2 : 1) * p_hitroll;
+      if (!IS_NPC(victim))
+        dam += (prob >= 70 ? 3 : (prob >= 50 ? 2 : 1));
+    }
+  }
 
-	// AWAKE style for victim
-	if (GET_AF_BATTLE(victim, EAF_AWAKE)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
-		&& !GET_MOB_HOLD(victim)
-		&& train_skill(victim, SKILL_AWAKE, skill_info[SKILL_AWAKE].max_percent,
-			ch) >= number(1, skill_info[SKILL_AWAKE].max_percent))
-	{
-		// > и зачем так? кто балансом занимается поправте.
-		// воткнул мин. разницу, чтобы анализаторы не ругались
-		dam -= IS_NPC(ch) ? 5 : 4;
-		calc_thaco += IS_NPC(ch) ? 4 : 2;
-	}
+  // AWAKE style for victim
+  if (GET_AF_BATTLE(victim, EAF_AWAKE)
+      && AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
+      && !GET_MOB_HOLD(victim)) {
+    bool success = calculate_skill(ch, SKILL_AWAKE, victim)
+        >= number(1, skill_info[SKILL_AWAKE].max_percent);
+    if (success) {
+      // > и зачем так? кто балансом занимается поправте.
+      // воткнул мин. разницу, чтобы анализаторы не ругались
+      dam -= IS_NPC(ch) ? 5 : 4;
+      calc_thaco += IS_NPC(ch) ? 4 : 2;
+    }
+    train_skill(victim, SKILL_AWAKE, success, ch);
+  }
 
-	// скилл владения пушкой или голыми руками
-	if (weap_skill_is <= 80)
-		calc_thaco -= (weap_skill_is / 20) * p_hitroll;
-	else if (weap_skill_is <= 160)
-		calc_thaco -= (4 + (weap_skill_is - 80) / 10) * p_hitroll;
-	else
-		calc_thaco -= (4 + 8 + (weap_skill_is - 160) / 5) * p_hitroll;
+  // скилл владения пушкой или голыми руками
+  if (weap_skill_is <= 80)
+    calc_thaco -= (weap_skill_is / 20) * p_hitroll;
+  else if (weap_skill_is <= 160)
+    calc_thaco -= (4 + (weap_skill_is - 80) / 10) * p_hitroll;
+  else
+    calc_thaco -= (4 + 8 + (weap_skill_is - 160) / 5) * p_hitroll;
 }
 
 // * Версия calc_rand_hr для показа по 'счет', без рандомов и статов жертвы.
-void HitData::calc_stat_hr(CHAR_DATA *ch)
-{
-	//считаем штраф за голод
-	float p_hitroll = ch->get_cond_penalty(P_HITROLL);
-	// штраф в размере 1 хитролла за каждые
-	// недокачанные 10% скилла "удар левой рукой"
-	if (weapon == FightSystem::AttType::OFFHAND
-		&& skill_num != SKILL_THROW
-		&& skill_num != SKILL_BACKSTAB
-		&& !(wielded && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON)
-		&& !IS_NPC(ch))
-	{
-		calc_thaco += (skill_info[SKILL_SHIT].max_percent - ch->get_skill(SKILL_SHIT)) / 10;
-	}
+void HitData::calc_stat_hr(CHAR_DATA *ch) {
+  //считаем штраф за голод
+  float p_hitroll = ch->get_cond_penalty(P_HITROLL);
+  // штраф в размере 1 хитролла за каждые
+  // недокачанные 10% скилла "удар левой рукой"
+  if (weapon == FightSystem::AttType::OFFHAND
+      && skill_num != SKILL_THROW
+      && skill_num != SKILL_BACKSTAB
+      && !(wielded && GET_OBJ_TYPE(wielded) == OBJ_DATA::ITEM_WEAPON)
+      && !IS_NPC(ch)) {
+    calc_thaco += (skill_info[SKILL_SHIT].max_percent - ch->get_skill(SKILL_SHIT)) / 10;
+  }
 
-	// courage
-	if (affected_by_spell(ch, SPELL_COURAGE))
-	{
-		dam += ((ch->get_skill(SKILL_COURAGE) + 19) / 20);
-		calc_thaco -= ((ch->get_skill(SKILL_COURAGE) + 9) / 20) * p_hitroll;
-	}
+  // courage
+  if (affected_by_spell(ch, SPELL_COURAGE)) {
+    dam += ((ch->get_skill(SKILL_COURAGE) + 19) / 20);
+    calc_thaco -= ((ch->get_skill(SKILL_COURAGE) + 9) / 20) * p_hitroll;
+  }
 
-	// Horse modifier for attacker
-	if (!IS_NPC(ch) && skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB && ch->ahorse())
-	{
-		int prob = ch->get_skill(SKILL_HORSE);
-		int range = skill_info[SKILL_HORSE].max_percent / 2;
+  // Horse modifier for attacker
+  if (!IS_NPC(ch) && skill_num != SKILL_THROW && skill_num != SKILL_BACKSTAB && ch->ahorse()) {
+    int prob = ch->get_skill(SKILL_HORSE);
+    int range = skill_info[SKILL_HORSE].max_percent / 2;
 
-		dam += ((prob + 19) / 10);
+    dam += ((prob + 19) / 10);
 
-		if (range > prob)
-			calc_thaco += ((range - prob) + 19 / 20);
-		else
-			calc_thaco -= ((prob - range) + 19 / 20);
-	}
+    if (range > prob)
+      calc_thaco += ((range - prob) + 19 / 20);
+    else
+      calc_thaco -= ((prob - range) + 19 / 20);
+  }
 
-	// скилл владения пушкой или голыми руками
-	if (ch->get_skill(weap_skill) <= 80)
-		calc_thaco -= (ch->get_skill(weap_skill) / 20)*p_hitroll;
-	else if (ch->get_skill(weap_skill) <= 160)
-		calc_thaco -= (4 + (ch->get_skill(weap_skill) - 80) / 10)*p_hitroll;
-	else
-		calc_thaco -= (4 + 8 + (ch->get_skill(weap_skill) - 160) / 5)*p_hitroll;
+  // скилл владения пушкой или голыми руками
+  if (ch->get_skill(weap_skill) <= 80)
+    calc_thaco -= (ch->get_skill(weap_skill) / 20) * p_hitroll;
+  else if (ch->get_skill(weap_skill) <= 160)
+    calc_thaco -= (4 + (ch->get_skill(weap_skill) - 80) / 10) * p_hitroll;
+  else
+    calc_thaco -= (4 + 8 + (ch->get_skill(weap_skill) - 160) / 5) * p_hitroll;
 }
 
 // * Подсчет армор класса жертвы.
-void HitData::calc_ac(CHAR_DATA *victim)
-{
+void HitData::calc_ac(CHAR_DATA *victim) {
 
 
-	// Calculate the raw armor including magic armor.  Lower AC is better.
-	victim_ac += compute_armor_class(victim);
-	victim_ac /= 10;
-	//считаем штраф за голод
-	if (!IS_NPC(victim) && victim_ac<5) { //для голодных
-		int p_ac = (1 - victim->get_cond_penalty(P_AC))*40;
-		if (p_ac)  {
-			if (victim_ac+p_ac>5) {
-				victim_ac = 5;
-			} else {
-				victim_ac+=p_ac;
-			}
-		}
-	}
+  // Calculate the raw armor including magic armor.  Lower AC is better.
+  victim_ac += compute_armor_class(victim);
+  victim_ac /= 10;
+  //считаем штраф за голод
+  if (!IS_NPC(victim) && victim_ac < 5) { //для голодных
+    int p_ac = (1 - victim->get_cond_penalty(P_AC)) * 40;
+    if (p_ac) {
+      if (victim_ac + p_ac > 5) {
+        victim_ac = 5;
+      } else {
+        victim_ac += p_ac;
+      }
+    }
+  }
 
-	if (GET_POS(victim) < POS_FIGHTING)
-		victim_ac += 4;
-	if (GET_POS(victim) < POS_RESTING)
-		victim_ac += 3;
-	if (AFF_FLAGGED(victim, EAffectFlag::AFF_HOLD))
-		victim_ac += 4;
-	if (AFF_FLAGGED(victim, EAffectFlag::AFF_CRYING))
-		victim_ac += 4;
+  if (GET_POS(victim) < POS_FIGHTING)
+    victim_ac += 4;
+  if (GET_POS(victim) < POS_RESTING)
+    victim_ac += 3;
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_HOLD))
+    victim_ac += 4;
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_CRYING))
+    victim_ac += 4;
 }
 
 // * Обработка защитных скиллов: захват, уклон, веер, блок.
-void HitData::check_defense_skills(CHAR_DATA *ch, CHAR_DATA *victim)
-{
-	if (!hit_no_parry)
-	{
-		// обработаем ситуацию ЗАХВАТ
-		const auto& people = world[ch->in_room]->people;
-		for (const auto vict : people)
-		{
-			if (dam < 0)
-			{
-				break;
-			}
+void HitData::check_defense_skills(CHAR_DATA *ch, CHAR_DATA *victim) {
+  if (!hit_no_parry) {
+    // обработаем ситуацию ЗАХВАТ
+    const auto &people = world[ch->in_room]->people;
+    for (const auto vict : people) {
+      if (dam < 0) {
+        break;
+      }
 
-			hit_touching(ch, vict, &dam);
-		}
-	}
+      hit_touching(ch, vict, &dam);
+    }
+  }
 
-	if (dam > 0
-		&& !hit_no_parry
-		&& GET_AF_BATTLE(victim, EAF_DEVIATE)
-		&& GET_WAIT(victim) <= 0
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
-		&& GET_MOB_HOLD(victim) == 0
-		&& BATTLECNTR(victim) < (GET_LEVEL(victim) + 7) / 8)
-	{
-		// Обработаем команду   УКЛОНИТЬСЯ
-		hit_deviate(ch, victim, &dam);
-	}
-	else
-	if (dam > 0
-		&& !hit_no_parry
-		&& GET_AF_BATTLE(victim, EAF_PARRY)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPRIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT)
-		&& GET_WAIT(victim) <= 0
-		&& GET_MOB_HOLD(victim) == 0)
-	{
-		// обработаем команду  ПАРИРОВАТЬ
-		hit_parry(ch, victim, weap_skill, hit_type, &dam);
-	}
-	else
-	if (dam > 0
-		&& !hit_no_parry
-		&& GET_AF_BATTLE(victim, EAF_MULTYPARRY)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPRIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT)
-		&& BATTLECNTR(victim) < (GET_LEVEL(victim) + 4) / 5
-		&& GET_WAIT(victim) <= 0
-		&& GET_MOB_HOLD(victim) == 0)
-	{
-		// обработаем команду  ВЕЕРНАЯ ЗАЩИТА
-		hit_multyparry(ch, victim, weap_skill, hit_type, &dam);
-	}
-	else
-	if (dam > 0
-		&& !hit_no_parry
-		&& ((GET_AF_BATTLE(victim, EAF_BLOCK) || can_auto_block(victim)) && GET_POS(victim) > POS_SITTING)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
-		&& !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT)
-		&& GET_WAIT(victim) <= 0
-		&& GET_MOB_HOLD(victim) == 0
-		&& BATTLECNTR(victim) < (GET_LEVEL(victim) + 8) / 9)
-	{
-		// Обработаем команду   БЛОКИРОВАТЬ
-		hit_block(ch, victim, &dam);
-	}
+  if (dam > 0
+      && !hit_no_parry
+      && GET_AF_BATTLE(victim, EAF_DEVIATE)
+      && GET_WAIT(victim) <= 0
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
+      && GET_MOB_HOLD(victim) == 0
+      && BATTLECNTR(victim) < (GET_LEVEL(victim) + 7) / 8) {
+    // Обработаем команду   УКЛОНИТЬСЯ
+    hit_deviate(ch, victim, &dam);
+  } else if (dam > 0
+      && !hit_no_parry
+      && GET_AF_BATTLE(victim, EAF_PARRY)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPRIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT)
+      && GET_WAIT(victim) <= 0
+      && GET_MOB_HOLD(victim) == 0) {
+    // обработаем команду  ПАРИРОВАТЬ
+    hit_parry(ch, victim, weap_skill, hit_type, &dam);
+  } else if (dam > 0
+      && !hit_no_parry
+      && GET_AF_BATTLE(victim, EAF_MULTYPARRY)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPRIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT)
+      && BATTLECNTR(victim) < (GET_LEVEL(victim) + 4) / 5
+      && GET_WAIT(victim) <= 0
+      && GET_MOB_HOLD(victim) == 0) {
+    // обработаем команду  ВЕЕРНАЯ ЗАЩИТА
+    hit_multyparry(ch, victim, weap_skill, hit_type, &dam);
+  } else if (dam > 0
+      && !hit_no_parry
+      && ((GET_AF_BATTLE(victim, EAF_BLOCK) || can_auto_block(victim)) && GET_POS(victim) > POS_SITTING)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT)
+      && !AFF_FLAGGED(victim, EAffectFlag::AFF_STOPLEFT)
+      && GET_WAIT(victim) <= 0
+      && GET_MOB_HOLD(victim) == 0
+      && BATTLECNTR(victim) < (GET_LEVEL(victim) + 8) / 9) {
+    // Обработаем команду   БЛОКИРОВАТЬ
+    hit_block(ch, victim, &dam);
+  }
 }
 
 /**
@@ -3712,482 +3260,468 @@ void HitData::check_defense_skills(CHAR_DATA *ch, CHAR_DATA *victim)
  * добавление дамролов с пушек
  * добавление дамага от концентрации силы
  */
-void HitData::add_weapon_damage(CHAR_DATA *ch)
-{
-	int damroll = dice(GET_OBJ_VAL(wielded, 1),
-		GET_OBJ_VAL(wielded, 2));
+void HitData::add_weapon_damage(CHAR_DATA *ch) {
+  int damroll = dice(GET_OBJ_VAL(wielded, 1),
+                     GET_OBJ_VAL(wielded, 2));
 
-	if (IS_NPC(ch)
-		&& !AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-		&& !(MOB_FLAGGED(ch, MOB_ANGEL)|| MOB_FLAGGED(ch, MOB_GHOST)))
-	{
-		damroll *= MOB_DAMAGE_MULT;
-	}
-	else
-	{
-		damroll = MIN(damroll,
-			damroll * GET_OBJ_CUR(wielded) / MAX(1, GET_OBJ_MAX(wielded)));
-	}
+  if (IS_NPC(ch)
+      && !AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+      && !(MOB_FLAGGED(ch, MOB_ANGEL) || MOB_FLAGGED(ch, MOB_GHOST))) {
+    damroll *= MOB_DAMAGE_MULT;
+  } else {
+    damroll = MIN(damroll,
+                  damroll * GET_OBJ_CUR(wielded) / MAX(1, GET_OBJ_MAX(wielded)));
+  }
 
-	damroll = calculate_strconc_damage(ch, wielded, damroll);
-	dam += MAX(1, damroll);
+  damroll = calculate_strconc_damage(ch, wielded, damroll);
+  dam += MAX(1, damroll);
 }
 
 // * Добавление дамага от голых рук и молота.
-void HitData::add_hand_damage(CHAR_DATA *ch)
-{
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_STONEHAND))
-		dam += dice(2, 3);
-	else
-		dam += number(1, 3);
+void HitData::add_hand_damage(CHAR_DATA *ch) {
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_STONEHAND))
+    dam += dice(2, 3);
+  else
+    dam += number(1, 3);
 
-	if (can_use_feat(ch, BULLY_FEAT))
-	{
-		dam += GET_LEVEL(ch) / 5;
-		dam += MAX(0, GET_REAL_STR(ch) - 25);
-	}
+  if (can_use_feat(ch, BULLY_FEAT)) {
+    dam += GET_LEVEL(ch) / 5;
+    dam += MAX(0, GET_REAL_STR(ch) - 25);
+  }
 
-	// Мультипликатор повреждений без оружия и в перчатках (линейная интерполяция)
-	// <вес перчаток> <увеличение>
-	// 0  50%
-	// 5 100%
-	// 10 150%
-	// 15 200%
-	// НА МОЛОТ НЕ ВЛИЯЕТ
-	if (!GET_AF_BATTLE(ch, EAF_MIGHTHIT)
-		|| get_flags()[FightSystem::CRIT_HIT]) //в метком молоте идет учет перчаток
-	{
-		int modi = 10 * (5 + (GET_EQ(ch, WEAR_HANDS) ? MIN(GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HANDS)), 18) : 0)); //вес перчаток больше 18 не учитывается
-		if (IS_NPC(ch) || can_use_feat(ch, BULLY_FEAT))
-		{
-			modi = MAX(100, modi);
-		}
-		dam *= modi / 100;
-	}
+  // Мультипликатор повреждений без оружия и в перчатках (линейная интерполяция)
+  // <вес перчаток> <увеличение>
+  // 0  50%
+  // 5 100%
+  // 10 150%
+  // 15 200%
+  // НА МОЛОТ НЕ ВЛИЯЕТ
+  if (!GET_AF_BATTLE(ch, EAF_MIGHTHIT)
+      || get_flags()[FightSystem::CRIT_HIT]) //в метком молоте идет учет перчаток
+  {
+    int modi = 10 * (5 + (GET_EQ(ch, WEAR_HANDS) ? MIN(GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HANDS)), 18)
+                                                 : 0)); //вес перчаток больше 18 не учитывается
+    if (IS_NPC(ch) || can_use_feat(ch, BULLY_FEAT)) {
+      modi = MAX(100, modi);
+    }
+    dam *= modi / 100;
+  }
 }
 
 // * Расчет шанса на критический удар (не точкой).
-void HitData::calc_crit_chance(CHAR_DATA *ch)
-{
-	dam_critic = 0;
-	int calc_critic = 0;
+void HitData::calc_crit_chance(CHAR_DATA *ch) {
+  dam_critic = 0;
+  int calc_critic = 0;
 
-	// Маги, волхвы и не-купеческие чармисы не умеют критать //
-	if ((!IS_NPC(ch) && !IS_MAGIC_USER(ch) && !IS_DRUID(ch))
-		|| (IS_NPC(ch) && (!AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) && !AFF_FLAGGED(ch, EAffectFlag::AFF_HELPER))))
-	{
-		calc_critic = MIN(ch->get_skill(weap_skill), 70);
-		// Мастерские фиты по оружию удваивают шанс критического попадания //
-		for (int i = PUNCH_MASTER_FEAT; i <= BOWS_MASTER_FEAT; i++)
-		{
-			if ((ubyte) feat_info[i].affected[0].location == weap_skill && can_use_feat(ch, i))
-			{
-				calc_critic += MAX(0, ch->get_skill(weap_skill) -  70);
-				break;
-			}
-		}
-		if (can_use_feat(ch, THIEVES_STRIKE_FEAT))
-		{
-			calc_critic += ch->get_skill(SKILL_BACKSTAB);
-		}
-		//Нафига тут проверять класс?
-		//Скиллы уникальные, другим классам все равно недоступны.
-		//А чтоб мобы не лютовали -- есть проверка на игрока.
-		if (!IS_NPC(ch))
-		{
-			calc_critic += (int)(ch->get_skill(SKILL_PUNCTUAL) / 2);
-			calc_critic += (int)(ch->get_skill(SKILL_NOPARRYHIT) / 3);
-		}
-		if (IS_NPC(ch) && !AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM))
-		{
-			calc_critic += GET_LEVEL(ch);
-		}
-	}
-	else
-	{
-		//Polud не должны - так пусть и не критают
-		reset_flag(FightSystem::CRIT_HIT);
-	}
+  // Маги, волхвы и не-купеческие чармисы не умеют критать //
+  if ((!IS_NPC(ch) && !IS_MAGIC_USER(ch) && !IS_DRUID(ch))
+      || (IS_NPC(ch) && (!AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) && !AFF_FLAGGED(ch, EAffectFlag::AFF_HELPER)))) {
+    calc_critic = MIN(ch->get_skill(weap_skill), 70);
+    // Мастерские фиты по оружию удваивают шанс критического попадания //
+    for (int i = PUNCH_MASTER_FEAT; i <= BOWS_MASTER_FEAT; i++) {
+      if ((ubyte) feat_info[i].affected[0].location == weap_skill && can_use_feat(ch, i)) {
+        calc_critic += MAX(0, ch->get_skill(weap_skill) - 70);
+        break;
+      }
+    }
+    if (can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
+      calc_critic += ch->get_skill(SKILL_BACKSTAB);
+    }
+    //Нафига тут проверять класс?
+    //Скиллы уникальные, другим классам все равно недоступны.
+    //А чтоб мобы не лютовали -- есть проверка на игрока.
+    if (!IS_NPC(ch)) {
+      calc_critic += (int) (ch->get_skill(SKILL_PUNCTUAL) / 2);
+      calc_critic += (int) (ch->get_skill(SKILL_NOPARRYHIT) / 3);
+    }
+    if (IS_NPC(ch) && !AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)) {
+      calc_critic += GET_LEVEL(ch);
+    }
+  } else {
+    //Polud не должны - так пусть и не критают
+    reset_flag(FightSystem::CRIT_HIT);
+  }
 
-	//critical hit ignore magic_shields and armour
-	if (number(0, 2000) < calc_critic)
-	{
-		set_flag(FightSystem::CRIT_HIT);
-	}
-	else
-	{
-		reset_flag(FightSystem::CRIT_HIT);
-	}
+  //critical hit ignore magic_shields and armour
+  if (number(0, 2000) < calc_critic) {
+    set_flag(FightSystem::CRIT_HIT);
+  } else {
+    reset_flag(FightSystem::CRIT_HIT);
+  }
 }
 
-ESpell breathFlag2Spellnum (CHAR_DATA *ch)
-{
-	ESpell t = SPELL_NO_SPELL;
-	// наркоманский код с объездом в двух циклах битвекторов флагов заменил на читаемый код
-	// извините..
-	if (MOB_FLAGGED(ch, (MOB_FIREBREATH)))
-		t = ESpell::SPELL_FIRE_BREATH;
-	if (MOB_FLAGGED(ch, (MOB_GASBREATH)))
-		t = ESpell::SPELL_GAS_BREATH;
-	if (MOB_FLAGGED(ch, (MOB_FROSTBREATH)))
-		t = ESpell::SPELL_FROST_BREATH;
-	if (MOB_FLAGGED(ch, (MOB_ACIDBREATH)))
-		t = ESpell::SPELL_ACID_BREATH;
-	if (MOB_FLAGGED(ch, (MOB_LIGHTBREATH)))
-		t = ESpell::SPELL_LIGHTNING_BREATH;
-	return t;
+ESpell breathFlag2Spellnum(CHAR_DATA *ch) {
+  ESpell t = SPELL_NO_SPELL;
+  // наркоманский код с объездом в двух циклах битвекторов флагов заменил на читаемый код
+  // извините..
+  if (MOB_FLAGGED(ch, (MOB_FIREBREATH)))
+    t = ESpell::SPELL_FIRE_BREATH;
+  if (MOB_FLAGGED(ch, (MOB_GASBREATH)))
+    t = ESpell::SPELL_GAS_BREATH;
+  if (MOB_FLAGGED(ch, (MOB_FROSTBREATH)))
+    t = ESpell::SPELL_FROST_BREATH;
+  if (MOB_FLAGGED(ch, (MOB_ACIDBREATH)))
+    t = ESpell::SPELL_ACID_BREATH;
+  if (MOB_FLAGGED(ch, (MOB_LIGHTBREATH)))
+    t = ESpell::SPELL_LIGHTNING_BREATH;
+  return t;
 }
 
 /**
 * обработка ударов оружием, санка, призма, стили, итд.
 */
-void hit(CHAR_DATA *ch, CHAR_DATA *victim, ESkill type, FightSystem::AttType weapon)
-{
-	if (!victim)
-	{
-		return;
-	}
-	if (!ch || ch->purged() || victim->purged())
-	{
-		log("SYSERROR: ch = %s, victim = %s (%s:%d)",
-			ch ? (ch->purged() ? "purged" : "true") : "false",
-			victim->purged() ? "purged" : "true", __FILE__, __LINE__);
-		return;
-	}
-	// Do some sanity checking, in case someone flees, etc.
-	if (ch->in_room != IN_ROOM(victim) || ch->in_room == NOWHERE) {
-		if (ch->get_fighting() && ch->get_fighting() == victim) {
-			stop_fighting(ch, TRUE);
-		}
-		return;
-	}
-	// Stand awarness mobs
-	if (CAN_SEE(victim, ch)
-		&& !victim->get_fighting()
-		&& ((IS_NPC(victim) && (GET_HIT(victim) < GET_MAX_HIT(victim)
-			|| MOB_FLAGGED(victim, MOB_AWARE)))
-			|| AFF_FLAGGED(victim, EAffectFlag::AFF_AWARNESS))
-		&& !GET_MOB_HOLD(victim) && GET_WAIT(victim) <= 0) {
-		set_battle_pos(victim);
-	}
+void hit(CHAR_DATA *ch, CHAR_DATA *victim, ESkill type, FightSystem::AttType weapon) {
+  if (!victim) {
+    return;
+  }
+  if (!ch || ch->purged() || victim->purged()) {
+    log("SYSERROR: ch = %s, victim = %s (%s:%d)",
+        ch ? (ch->purged() ? "purged" : "true") : "false",
+        victim->purged() ? "purged" : "true", __FILE__, __LINE__);
+    return;
+  }
+  // Do some sanity checking, in case someone flees, etc.
+  if (ch->in_room != IN_ROOM(victim) || ch->in_room == NOWHERE) {
+    if (ch->get_fighting() && ch->get_fighting() == victim) {
+      stop_fighting(ch, TRUE);
+    }
+    return;
+  }
+  // Stand awarness mobs
+  if (CAN_SEE(victim, ch)
+      && !victim->get_fighting()
+      && ((IS_NPC(victim) && (GET_HIT(victim) < GET_MAX_HIT(victim)
+          || MOB_FLAGGED(victim, MOB_AWARE)))
+          || AFF_FLAGGED(victim, EAffectFlag::AFF_AWARNESS))
+      && !GET_MOB_HOLD(victim) && GET_WAIT(victim) <= 0) {
+    set_battle_pos(victim);
+  }
 
-	// дышащий моб может оглушить, и нанесёт физ.дамаг!!
-	if (type == ESkill::SKILL_UNDEF) {
-		ESpell spellnum;
-		spellnum = breathFlag2Spellnum (ch);
-        if (spellnum != ESpell::SPELL_NO_SPELL) // защита от падения
-        {
-            if (!ch->get_fighting())
-                set_fighting(ch, victim);
-            if (!victim->get_fighting())
-                set_fighting(victim, ch);
-            // AOE атаки всегда магические. Раздаём каждому игроку и уходим.
-            if (MOB_FLAGGED(ch, MOB_AREA_ATTACK)) {
-                const auto people = world[ch->in_room]->people;	// make copy because inside loop this list might be changed.
-                for (const auto& tch : people) {
-                    if (IS_IMMORTAL(tch) || ch->in_room == NOWHERE || IN_ROOM(tch) == NOWHERE)
-                        continue;
-                    if (tch != ch && !same_group(ch, tch)) {
-                            mag_damage(GET_LEVEL(ch), ch, tch, spellnum, SAVING_STABILITY);
-                        }
-                    }
-                return;
-            }
-            // а теперь просто дышащие
-            mag_damage(GET_LEVEL(ch), ch, victim, spellnum, SAVING_STABILITY);
-            return;
-		}
-	}
+  // дышащий моб может оглушить, и нанесёт физ.дамаг!!
+  if (type == ESkill::SKILL_UNDEF) {
+    ESpell spellnum;
+    spellnum = breathFlag2Spellnum(ch);
+    if (spellnum != ESpell::SPELL_NO_SPELL) // защита от падения
+    {
+      if (!ch->get_fighting())
+        set_fighting(ch, victim);
+      if (!victim->get_fighting())
+        set_fighting(victim, ch);
+      // AOE атаки всегда магические. Раздаём каждому игроку и уходим.
+      if (MOB_FLAGGED(ch, MOB_AREA_ATTACK)) {
+        const auto people = world[ch->in_room]->people;    // make copy because inside loop this list might be changed.
+        for (const auto &tch : people) {
+          if (IS_IMMORTAL(tch) || ch->in_room == NOWHERE || IN_ROOM(tch) == NOWHERE)
+            continue;
+          if (tch != ch && !same_group(ch, tch)) {
+            mag_damage(GET_LEVEL(ch), ch, tch, spellnum, SAVING_STABILITY);
+          }
+        }
+        return;
+      }
+      // а теперь просто дышащие
+      mag_damage(GET_LEVEL(ch), ch, victim, spellnum, SAVING_STABILITY);
+      return;
+    }
+  }
 
-	//go_autoassist(ch);
+  //go_autoassist(ch);
 
-	// старт инициализации полей для удара
-	HitData hit_params;
-	//конвертация скиллов, которые предполагают вызов hit()
-	//c тип_андеф, в тип_андеф.
-	hit_params.skill_num = type != SKILL_STUPOR && type != SKILL_MIGHTHIT ? type : SKILL_UNDEF;
-	hit_params.weapon = weapon;
-	hit_params.init(ch, victim);
+  // старт инициализации полей для удара
+  HitData hit_params;
+  //конвертация скиллов, которые предполагают вызов hit()
+  //c тип_андеф, в тип_андеф.
+  hit_params.skill_num = type != SKILL_STUPOR && type != SKILL_MIGHTHIT ? type : SKILL_UNDEF;
+  hit_params.weapon = weapon;
+  hit_params.init(ch, victim);
 
-	//  дополнительный маг. дамаг независимо от попадания физ. атаки
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_CLOUD_OF_ARROWS)
-		&& hit_params.skill_num == ESkill::SKILL_UNDEF
-		&& (ch->get_fighting()
-		|| (!GET_AF_BATTLE(ch, EAF_MIGHTHIT) && !GET_AF_BATTLE(ch, EAF_STUPOR)))) {
-		// здесь можно получить спурженного victim, но ch не умрет от зеркала
-		mag_damage(1, ch, victim, SPELL_MAGIC_MISSILE, SAVING_REFLEX);
-		if (ch->purged() || victim->purged()) {
-			return;
-		}
-		auto skillnum = get_magic_skill_number_by_spell(SPELL_CLOUD_OF_ARROWS);
-		train_skill(ch, skillnum, skill_info[skillnum].max_percent, victim);
-	}
+  //  дополнительный маг. дамаг независимо от попадания физ. атаки
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_CLOUD_OF_ARROWS)
+      && hit_params.skill_num == ESkill::SKILL_UNDEF
+      && (ch->get_fighting()
+          || (!GET_AF_BATTLE(ch, EAF_MIGHTHIT) && !GET_AF_BATTLE(ch, EAF_STUPOR)))) {
+    // здесь можно получить спурженного victim, но ch не умрет от зеркала
+    mag_damage(GET_LEVEL(ch), ch, victim, SPELL_MAGIC_MISSILE, SAVING_REFLEX);
+    if (ch->purged() || victim->purged()) {
+      return;
+    }
+    auto skillnum = get_magic_skill_number_by_spell(SPELL_CLOUD_OF_ARROWS);
+    train_skill(ch, skillnum, true, victim);
+  }
 
-	// вычисление хитролов/ац
-	hit_params.calc_base_hr(ch);
-	hit_params.calc_rand_hr(ch, victim);
-	hit_params.calc_ac(victim);
+  // вычисление хитролов/ац
+  hit_params.calc_base_hr(ch);
+  hit_params.calc_rand_hr(ch, victim);
+  hit_params.calc_ac(victim);
 
-	const int victim_lvl_miss = victim->get_level() + victim->get_remort();
-	const int ch_lvl_miss = ch->get_level() + ch->get_remort();
+  const int victim_lvl_miss = victim->get_level() + victim->get_remort();
+  const int ch_lvl_miss = ch->get_level() + ch->get_remort();
 
-	// собсно выяснение попали или нет
-	if (victim_lvl_miss - ch_lvl_miss <= 5 || (!IS_NPC(ch) && !IS_NPC(victim))) {
-		// 5% шанс промазать, если цель в пределах 5 уровней или пвп случай
-		if ((number(1, 100) <= 5)) {
-			hit_params.dam = 0;
-			hit_params.extdamage(ch, victim);
-			hitprcnt_mtrigger(victim);
-			return;
-		}
-	} else {
-		// шанс промазать = разнице уровней и мортов
-		const int diff = victim_lvl_miss - ch_lvl_miss;
-		if (number(1, 100) <= diff) {
-			hit_params.dam = 0;
-			hit_params.extdamage(ch, victim);
-			hitprcnt_mtrigger(victim);
-			return;
-		}
-	}
-	// всегда есть 5% вероятность попасть (diceroll == 20)
-	if ((hit_params.diceroll < 20 && AWAKE(victim))
-		&& hit_params.calc_thaco - hit_params.diceroll > hit_params.victim_ac) {
-		hit_params.dam = 0;
-		hit_params.extdamage(ch, victim);
-		hitprcnt_mtrigger(victim);
-		return;
-	}
-	// даже в случае попадания можно уклониться мигалкой
-	if (AFF_FLAGGED(victim, EAffectFlag::AFF_BLINK) || victim->add_abils.percent_spell_blink > 0) {
+  // собсно выяснение попали или нет
+  if (victim_lvl_miss - ch_lvl_miss <= 5 || (!IS_NPC(ch) && !IS_NPC(victim))) {
+    // 5% шанс промазать, если цель в пределах 5 уровней или пвп случай
+    if ((number(1, 100) <= 5)) {
+      hit_params.dam = 0;
+      hit_params.extdamage(ch, victim);
+      hitprcnt_mtrigger(victim);
+      return;
+    }
+  } else {
+    // шанс промазать = разнице уровней и мортов
+    const int diff = victim_lvl_miss - ch_lvl_miss;
+    if (number(1, 100) <= diff) {
+      hit_params.dam = 0;
+      hit_params.extdamage(ch, victim);
+      hitprcnt_mtrigger(victim);
+      return;
+    }
+  }
+  // всегда есть 5% вероятность попасть (diceroll == 20)
+  if ((hit_params.diceroll < 20 && AWAKE(victim))
+      && hit_params.calc_thaco - hit_params.diceroll > hit_params.victim_ac) {
+    hit_params.dam = 0;
+    hit_params.extdamage(ch, victim);
+    hitprcnt_mtrigger(victim);
+    return;
+  }
+  // даже в случае попадания можно уклониться мигалкой
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_BLINK) || victim->add_abils.percent_spell_blink > 0) {
 
-		if (!GET_AF_BATTLE(ch, EAF_MIGHTHIT) && !GET_AF_BATTLE(ch, EAF_STUPOR)
-				&& (!(hit_params.skill_num == SKILL_BACKSTAB && can_use_feat(ch, THIEVES_STRIKE_FEAT)))) {
-			ubyte blink;
-			if (victim->is_npc())
-				blink = 25;
-			else
-				blink = 5;
-			if (can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
-				blink = 10 + GET_REMORT(ch) * 2 / 3;
-			}
-			else if (victim->add_abils.percent_spell_blink > 0) { //мигалка спеллом а не аффектом с шмотки
-				blink = victim->add_abils.percent_spell_blink;
-				ch->send_to_TC(false, true, false, "Шанс мигалки равен == %d процентов.\r\n", blink);
-				victim->send_to_TC(false, true, false, "Шанс мигалки равен == %d процентов.\r\n", blink);
-			}
-			if (blink >= number(1, 100)) {
-				sprintf(buf, "%sНа мгновение вы исчезли из поля зрения противника.%s\r\n",
-					CCINRM(victim, C_NRM), CCNRM(victim, C_NRM));
-				send_to_char(buf, victim);
-				hit_params.dam = 0;
-				hit_params.extdamage(ch, victim);
-				return;
-			}
-		}
-	}
-	// обработка по факту попадания
-	hit_params.dam += get_real_dr(ch);
-	if (can_use_feat(ch, SHOT_FINESSE_FEAT))
-		hit_params.dam += str_bonus(GET_REAL_DEX(ch), STR_TO_DAM);
-	else
-		hit_params.dam += str_bonus(GET_REAL_STR(ch), STR_TO_DAM);
+    if (!GET_AF_BATTLE(ch, EAF_MIGHTHIT) && !GET_AF_BATTLE(ch, EAF_STUPOR)
+        && (!(hit_params.skill_num == SKILL_BACKSTAB && can_use_feat(ch, THIEVES_STRIKE_FEAT)))) {
+      ubyte blink;
+      if (victim->is_npc())
+        blink = 25;
+      else
+        blink = 5;
+      if (can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
+        blink = 10 + GET_REMORT(ch) * 2 / 3;
+      } else if (victim->add_abils.percent_spell_blink > 0) { //мигалка спеллом а не аффектом с шмотки
+        blink = victim->add_abils.percent_spell_blink;
+        ch->send_to_TC(false, true, false, "Шанс мигалки равен == %d процентов.\r\n", blink);
+        victim->send_to_TC(false, true, false, "Шанс мигалки равен == %d процентов.\r\n", blink);
+      }
+      if (blink >= number(1, 100)) {
+        sprintf(buf, "%sНа мгновение вы исчезли из поля зрения противника.%s\r\n",
+                CCINRM(victim, C_NRM), CCNRM(victim, C_NRM));
+        send_to_char(buf, victim);
+        hit_params.dam = 0;
+        hit_params.extdamage(ch, victim);
+        return;
+      }
+    }
+  }
+  // обработка по факту попадания
+  hit_params.dam += get_real_dr(ch);
+  if (can_use_feat(ch, SHOT_FINESSE_FEAT))
+    hit_params.dam += str_bonus(GET_REAL_DEX(ch), STR_TO_DAM);
+  else
+    hit_params.dam += str_bonus(GET_REAL_STR(ch), STR_TO_DAM);
 
-	// рандом разброс базового дамага
-	if (hit_params.dam > 0)
-	{
-		int min_rnd = hit_params.dam - hit_params.dam / 4;
-		int max_rnd = hit_params.dam + hit_params.dam / 4;
-		hit_params.dam = MAX(1, number(min_rnd, max_rnd));
-	}
+  // рандом разброс базового дамага
+  if (hit_params.dam > 0) {
+    int min_rnd = hit_params.dam - hit_params.dam / 4;
+    int max_rnd = hit_params.dam + hit_params.dam / 4;
+    hit_params.dam = MAX(1, number(min_rnd, max_rnd));
+  }
 
-	if (GET_EQ(ch, WEAR_BOTHS) && hit_params.weap_skill != SKILL_BOWS)
-		hit_params.dam *= 2;
+  if (GET_EQ(ch, WEAR_BOTHS) && hit_params.weap_skill != SKILL_BOWS)
+    hit_params.dam *= 2;
 
-	if (IS_NPC(ch)) {
-		hit_params.dam += dice(ch->mob_specials.damnodice, ch->mob_specials.damsizedice);
-	}
+  if (IS_NPC(ch)) {
+    hit_params.dam += dice(ch->mob_specials.damnodice, ch->mob_specials.damsizedice);
+  }
 
-	// расчет критических ударов
-	hit_params.calc_crit_chance(ch);
+  // расчет критических ударов
+  hit_params.calc_crit_chance(ch);
 
-	// оружие/руки и модификаторы урона скилов, с ними связанных
-	if (hit_params.wielded
-		&& GET_OBJ_TYPE(hit_params.wielded) == OBJ_DATA::ITEM_WEAPON)
-	{
-		hit_params.add_weapon_damage(ch);
-		// скрытый удар
-		int tmp_dam = calculate_noparryhit_dmg(ch, hit_params.wielded);
-		if (tmp_dam > 0)
-		{
-			// 0 раунд и стаб = 70% скрытого, дальше раунд * 0.4 (до 5 раунда)
-			int round_dam = tmp_dam * 7 / 10;
-			if (can_use_feat(ch, SNEAKRAGE_FEAT)) {
-				if (ROUND_COUNTER(ch) >= 1 && ROUND_COUNTER(ch) <= 3) {
-					hit_params.dam *= ROUND_COUNTER(ch);
-				}
-			}
-			if (hit_params.skill_num == SKILL_BACKSTAB || ROUND_COUNTER(ch) <= 0) {
-				hit_params.dam += round_dam;
-			} else {
-				hit_params.dam += round_dam * MIN(3, ROUND_COUNTER(ch));
-			}
-		}
-	} else {
-		hit_params.add_hand_damage(ch);
-	}
-	if (ch->add_abils.percent_dam_add > 0)
-		hit_params.dam += hit_params.dam * (number(1, ch->add_abils.percent_dam_add) / 100.0);
-	if (GET_AF_BATTLE(ch, EAF_IRON_WIND))
-		hit_params.dam += ch->get_skill(SKILL_IRON_WIND) / 2;
+  // оружие/руки и модификаторы урона скилов, с ними связанных
+  if (hit_params.wielded
+      && GET_OBJ_TYPE(hit_params.wielded) == OBJ_DATA::ITEM_WEAPON) {
+    hit_params.add_weapon_damage(ch);
+    // скрытый удар
+    int tmp_dam = calculate_noparryhit_dmg(ch, hit_params.wielded);
+    if (tmp_dam > 0) {
+      // 0 раунд и стаб = 70% скрытого, дальше раунд * 0.4 (до 5 раунда)
+      int round_dam = tmp_dam * 7 / 10;
+      if (can_use_feat(ch, SNEAKRAGE_FEAT)) {
+        if (ROUND_COUNTER(ch) >= 1 && ROUND_COUNTER(ch) <= 3) {
+          hit_params.dam *= ROUND_COUNTER(ch);
+        }
+      }
+      if (hit_params.skill_num == SKILL_BACKSTAB || ROUND_COUNTER(ch) <= 0) {
+        hit_params.dam += round_dam;
+      } else {
+        hit_params.dam += round_dam * MIN(3, ROUND_COUNTER(ch));
+      }
+    }
+  } else {
+    hit_params.add_hand_damage(ch);
+  }
+  if (ch->add_abils.percent_dam_add > 0)
+    hit_params.dam += hit_params.dam * (number(1, ch->add_abils.percent_dam_add) / 100.0);
+  if (GET_AF_BATTLE(ch, EAF_IRON_WIND))
+    hit_params.dam += ch->get_skill(SKILL_IRON_WIND) / 2;
 
-	if (affected_by_spell(ch, SPELL_BERSERK)) {
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_BERSERK)) {
-			hit_params.dam = (hit_params.dam * MAX(150, 150 + GET_LEVEL(ch) + dice(0, GET_REMORT(ch)) * 2)) / 100;
-		}
-	}
+  if (affected_by_spell(ch, SPELL_BERSERK)) {
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_BERSERK)) {
+      hit_params.dam = (hit_params.dam * MAX(150, 150 + GET_LEVEL(ch) + dice(0, GET_REMORT(ch)) * 2)) / 100;
+    }
+  }
 
-	// at least 1 hp damage min per hit
-	hit_params.dam = MAX(1, hit_params.dam);
-	if (GET_SKILL(ch, SKILL_HORSE) > 100 && ch->ahorse()) {
-		hit_params.dam *= 1 + (GET_SKILL(ch, SKILL_HORSE) - 100) / 500.0; // на лошадке до +20%
-	}
+  // at least 1 hp damage min per hit
+  hit_params.dam = MAX(1, hit_params.dam);
+  if (GET_SKILL(ch, SKILL_HORSE) > 100 && ch->ahorse()) {
+    hit_params.dam *= 1 + (GET_SKILL(ch, SKILL_HORSE) - 100) / 500.0; // на лошадке до +20%
+  }
 
-	// зовется до alt_equip, чтобы не абузить повреждение пушек
-	if (damage_mtrigger(ch, victim)) {
-		return;
-	}
+  // зовется до alt_equip, чтобы не абузить повреждение пушек
+  if (damage_mtrigger(ch, victim)) {
+    return;
+  }
 
-	if (hit_params.weapon_pos) {
-		alt_equip(ch, hit_params.weapon_pos, hit_params.dam, 10);
-	}
+  if (hit_params.weapon_pos) {
+    alt_equip(ch, hit_params.weapon_pos, hit_params.dam, 10);
+  }
 
-	if (hit_params.skill_num == SKILL_BACKSTAB) {
-		hit_params.reset_flag(FightSystem::CRIT_HIT);
-		hit_params.set_flag(FightSystem::IGNORE_FSHIELD);
-		if (can_use_feat(ch, THIEVES_STRIKE_FEAT) || can_use_feat(ch, SHADOW_STRIKE_FEAT)) {
-			// тати игнорят броню полностью
-			// и наемы тоже!
-			hit_params.set_flag(FightSystem::IGNORE_ARMOR);
-		} else {
-			//мобы игнорят вполовину
-			hit_params.set_flag(FightSystem::HALF_IGNORE_ARMOR);
-		}
-		// Наемы фигачат больше
-		if (can_use_feat(ch, SHADOW_STRIKE_FEAT) && IS_NPC(victim)) {
-			hit_params.dam *= backstab_mult(GET_LEVEL(ch)) * (1.0 + ch->get_skill(SKILL_NOPARRYHIT) / 200.0);
-		} else if (can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
-			if (victim->get_fighting()) {
-				hit_params.dam *= backstab_mult(GET_LEVEL(ch));
-			} else {
-				hit_params.dam *= backstab_mult(GET_LEVEL(ch)) * 1.3;
-			}
-		} else {
-			hit_params.dam *= backstab_mult(GET_LEVEL(ch));
-		}
+  if (hit_params.skill_num == SKILL_BACKSTAB) {
+    hit_params.reset_flag(FightSystem::CRIT_HIT);
+    hit_params.set_flag(FightSystem::IGNORE_FSHIELD);
+    if (can_use_feat(ch, THIEVES_STRIKE_FEAT) || can_use_feat(ch, SHADOW_STRIKE_FEAT)) {
+      // тати игнорят броню полностью
+      // и наемы тоже!
+      hit_params.set_flag(FightSystem::IGNORE_ARMOR);
+    } else {
+      //мобы игнорят вполовину
+      hit_params.set_flag(FightSystem::HALF_IGNORE_ARMOR);
+    }
+    // Наемы фигачат больше
+    if (can_use_feat(ch, SHADOW_STRIKE_FEAT) && IS_NPC(victim)) {
+      hit_params.dam *= backstab_mult(GET_LEVEL(ch)) * (1.0 + ch->get_skill(SKILL_NOPARRYHIT) / 200.0);
+    } else if (can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
+      if (victim->get_fighting()) {
+        hit_params.dam *= backstab_mult(GET_LEVEL(ch));
+      } else {
+        hit_params.dam *= backstab_mult(GET_LEVEL(ch)) * 1.3;
+      }
+    } else {
+      hit_params.dam *= backstab_mult(GET_LEVEL(ch));
+    }
 
-		if (can_use_feat(ch, SHADOW_STRIKE_FEAT)
-			&& IS_NPC(victim)
-			&& !(AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD)
-				&& !(MOB_FLAGGED(victim, MOB_PROTECT)))
-			&& (number(1,100) <= 6 * ch->get_cond_penalty(P_HITROLL)) //голодный наем снижаем скрытый удар
-			&& IS_NPC(victim)
-			&& !victim->get_role(MOB_ROLE_BOSS)) {
-			    GET_HIT(victim) = 1;
-			    hit_params.dam = 2000; // для надежности
-			    send_to_char(ch, "&GПрямо в сердце, насмерть!&n\r\n");
-			    hit_params.extdamage(ch, victim);
-			    return;
-		}
+    if (can_use_feat(ch, SHADOW_STRIKE_FEAT)
+        && IS_NPC(victim)
+        && !(AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD)
+            && !(MOB_FLAGGED(victim, MOB_PROTECT)))
+        && (number(1, 100) <= 6 * ch->get_cond_penalty(P_HITROLL)) //голодный наем снижаем скрытый удар
+        && IS_NPC(victim)
+        && !victim->get_role(MOB_ROLE_BOSS)) {
+      GET_HIT(victim) = 1;
+      hit_params.dam = 2000; // для надежности
+      send_to_char(ch, "&GПрямо в сердце, насмерть!&n\r\n");
+      hit_params.extdamage(ch, victim);
+      return;
+    }
 
-		if (number(1, 100) < calculate_crit_backstab_percent(ch) * ch->get_cond_penalty(P_HITROLL)
-			&& !general_savingthrow(ch, victim, SAVING_REFLEX, dex_bonus(GET_REAL_DEX(ch))))
-		{
-			hit_params.dam = static_cast<int>(hit_params.dam * hit_params.crit_backstab_multiplier(ch, victim));
-			if ((hit_params.dam > 0)
-				&& !AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD)
-				&& !(MOB_FLAGGED(victim, MOB_PROTECT)))
-			{
-				send_to_char("&GПрямо в сердце!&n\r\n", ch);
-			}
-		}
+    if (number(1, 100) < calculate_crit_backstab_percent(ch) * ch->get_cond_penalty(P_HITROLL)
+        && !general_savingthrow(ch, victim, SAVING_REFLEX, dex_bonus(GET_REAL_DEX(ch)))) {
+      hit_params.dam = static_cast<int>(hit_params.dam * hit_params.crit_backstab_multiplier(ch, victim));
+      if ((hit_params.dam > 0)
+          && !AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD)
+          && !(MOB_FLAGGED(victim, MOB_PROTECT))) {
+        send_to_char("&GПрямо в сердце!&n\r\n", ch);
+      }
+    }
 
-		int initial_dam = hit_params.dam;
-		//Adept: учитываем резисты от крит. повреждений
-		hit_params.dam = calculate_resistance_coeff(victim, VITALITY_RESISTANCE, hit_params.dam);
-		// выводим временно влияние живучести
-		ch->send_to_TC(false, true, true,
-			"&CДамага стаба до учета живучести = %d, живучесть = %d, коэфициент разницы = %g количество хитов врага = %d&n\r\n", initial_dam, GET_RESIST(victim, VITALITY_RESISTANCE), float(hit_params.dam) / initial_dam, GET_MAX_HIT(victim));
-		victim->send_to_TC(false, true, true,
-			"&CДамага стаба до учета живучести = %d, живучесть = %d, коэфициент разницы = %g количество хитов врага = %d&n\r\n", initial_dam, GET_RESIST(victim, VITALITY_RESISTANCE), float(hit_params.dam) / initial_dam, GET_MAX_HIT(victim));
+    int initial_dam = hit_params.dam;
+    //Adept: учитываем резисты от крит. повреждений
+    hit_params.dam = calculate_resistance_coeff(victim, VITALITY_RESISTANCE, hit_params.dam);
+    // выводим временно влияние живучести
+    ch->send_to_TC(false,
+                   true,
+                   true,
+                   "&CДамага стаба до учета живучести = %d, живучесть = %d, коэфициент разницы = %g количество хитов врага = %d&n\r\n",
+                   initial_dam,
+                   GET_RESIST(victim, VITALITY_RESISTANCE),
+                   float(hit_params.dam) / initial_dam,
+                   GET_MAX_HIT(victim));
+    victim->send_to_TC(false,
+                       true,
+                       true,
+                       "&CДамага стаба до учета живучести = %d, живучесть = %d, коэфициент разницы = %g количество хитов врага = %d&n\r\n",
+                       initial_dam,
+                       GET_RESIST(victim, VITALITY_RESISTANCE),
+                       float(hit_params.dam) / initial_dam,
+                       GET_MAX_HIT(victim));
 
-		// режем стаб
-		if (can_use_feat(ch, SHADOW_STRIKE_FEAT) && !IS_NPC(ch)) {
-			hit_params.dam = MIN(8000 + GET_REMORT(ch) * 20 * GET_LEVEL(ch), hit_params.dam);
-		}
+    // режем стаб
+    if (can_use_feat(ch, SHADOW_STRIKE_FEAT) && !IS_NPC(ch)) {
+      hit_params.dam = MIN(8000 + GET_REMORT(ch) * 20 * GET_LEVEL(ch), hit_params.dam);
+    }
 
-		ch->send_to_TC(false, true, false, "&CДамага стаба равна = %d&n\r\n", hit_params.dam);
-		victim->send_to_TC(false, true, false, "&RДамага стаба  равна = %d&n\r\n", hit_params.dam);
-		hit_params.extdamage(ch, victim);
-		return;
-	}
+    ch->send_to_TC(false, true, false, "&CДамага стаба равна = %d&n\r\n", hit_params.dam);
+    victim->send_to_TC(false, true, false, "&RДамага стаба  равна = %d&n\r\n", hit_params.dam);
+    hit_params.extdamage(ch, victim);
+    return;
+  }
 
-	if (hit_params.skill_num == SKILL_THROW) {
-		hit_params.set_flag(FightSystem::IGNORE_FSHIELD);
-		hit_params.dam *= (calculate_skill(ch, SKILL_THROW, victim) + 10) / 10;
-		if (IS_NPC(ch)) {
-			hit_params.dam = MIN(300, hit_params.dam);
-		}
-		hit_params.dam = calculate_resistance_coeff(victim, VITALITY_RESISTANCE, hit_params.dam);
-		hit_params.extdamage(ch, victim);
-		return;
-	}
+  if (hit_params.skill_num == SKILL_THROW) {
+    hit_params.set_flag(FightSystem::IGNORE_FSHIELD);
+    hit_params.dam *= (calculate_skill(ch, SKILL_THROW, victim) + 10) / 10;
+    if (IS_NPC(ch)) {
+      hit_params.dam = MIN(300, hit_params.dam);
+    }
+    hit_params.dam = calculate_resistance_coeff(victim, VITALITY_RESISTANCE, hit_params.dam);
+    hit_params.extdamage(ch, victim);
+    return;
+  }
 
-	if (GET_AF_BATTLE(ch, EAF_PUNCTUAL) && GET_PUNCTUAL_WAIT(ch) <= 0 && GET_WAIT(ch) <= 0
-		&& (hit_params.diceroll >= 18 - GET_MOB_HOLD(victim))) {
-		int percent = train_skill(ch, SKILL_PUNCTUAL, skill_info[SKILL_PUNCTUAL].max_percent, victim);
-		if (!PUNCTUAL_WAITLESS(ch)) {
-			PUNCTUAL_WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
-		}
-		if (percent >= number(1, skill_info[SKILL_PUNCTUAL].max_percent)
-			&& (hit_params.calc_thaco - hit_params.diceroll < hit_params.victim_ac - 5
-				|| percent >= skill_info[SKILL_PUNCTUAL].max_percent)) {
-			if (!MOB_FLAGGED(victim, MOB_NOTKILLPUNCTUAL)) {
-				hit_params.set_flag(FightSystem::CRIT_HIT);
-				// CRIT_HIT и так щиты игнорит, но для порядку
-				hit_params.set_flag(FightSystem::IGNORE_FSHIELD);
-				hit_params.dam_critic = do_punctual(ch, victim, hit_params.wielded);
-				ch->send_to_TC(false, true, false, "&CДамага точки равна = %d&n\r\n", hit_params.dam_critic);
-				victim->send_to_TC(false, true, false, "&CДамага точки равна = %d&n\r\n", hit_params.dam_critic);
-				if (!PUNCTUAL_WAITLESS(ch)) {
-					PUNCTUAL_WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
-				}
-			}
-            call_magic(ch, victim, nullptr, nullptr, ESpell::SPELL_PALADINE_INSPIRATION, ch->get_level());
-		}
-	}
+  if (GET_AF_BATTLE(ch, EAF_PUNCTUAL) && GET_PUNCTUAL_WAIT(ch) <= 0 && GET_WAIT(ch) <= 0
+      && (hit_params.diceroll >= 18 - GET_MOB_HOLD(victim))) {
+    int percent = calculate_skill(ch, SKILL_PUNCTUAL, victim);
+    bool success = percent >= number(1, skill_info[SKILL_PUNCTUAL].max_percent);
+    train_skill(ch, SKILL_PUNCTUAL, success, victim);
+    if (!PUNCTUAL_WAITLESS(ch)) {
+      PUNCTUAL_WAIT_STATE(ch, 1 * PULSE_VIOLENCE);
+    }
+    if (success
+        && (hit_params.calc_thaco - hit_params.diceroll < hit_params.victim_ac - 5
+            || percent >= skill_info[SKILL_PUNCTUAL].max_percent)) {
+      if (!MOB_FLAGGED(victim, MOB_NOTKILLPUNCTUAL)) {
+        hit_params.set_flag(FightSystem::CRIT_HIT);
+        // CRIT_HIT и так щиты игнорит, но для порядку
+        hit_params.set_flag(FightSystem::IGNORE_FSHIELD);
+        hit_params.dam_critic = do_punctual(ch, victim, hit_params.wielded);
+        ch->send_to_TC(false, true, false, "&CДамага точки равна = %d&n\r\n", hit_params.dam_critic);
+        victim->send_to_TC(false, true, false, "&CДамага точки равна = %d&n\r\n", hit_params.dam_critic);
+        if (!PUNCTUAL_WAITLESS(ch)) {
+          PUNCTUAL_WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
+        }
+      }
+      call_magic(ch, victim, nullptr, nullptr, ESpell::SPELL_PALADINE_INSPIRATION, ch->get_level());
+    }
+  }
 
-	ch->send_to_TC(false, true, true, "&CНанёс: Регуляр дамаг = %d&n\r\n", hit_params.dam);
-	victim->send_to_TC(false, true, true, "&CПолучил: Регуляр дамаг = %d&n\r\n", hit_params.dam);
+  ch->send_to_TC(false, true, true, "&CНанёс: Регуляр дамаг = %d&n\r\n", hit_params.dam);
+  victim->send_to_TC(false, true, true, "&CПолучил: Регуляр дамаг = %d&n\r\n", hit_params.dam);
 
-	// обнуляем флаги, если у нападающего есть лаг
-	if ((GET_AF_BATTLE(ch, EAF_STUPOR) || GET_AF_BATTLE(ch, EAF_MIGHTHIT)) && GET_WAIT(ch) > 0) {
-		CLR_AF_BATTLE(ch, EAF_STUPOR);
-		CLR_AF_BATTLE(ch, EAF_MIGHTHIT);
-	}
+  // обнуляем флаги, если у нападающего есть лаг
+  if ((GET_AF_BATTLE(ch, EAF_STUPOR) || GET_AF_BATTLE(ch, EAF_MIGHTHIT)) && GET_WAIT(ch) > 0) {
+    CLR_AF_BATTLE(ch, EAF_STUPOR);
+    CLR_AF_BATTLE(ch, EAF_MIGHTHIT);
+  }
 
-	// обработка защитных скилов (захват, уклон, парир, веер, блок)
-	hit_params.check_defense_skills(ch, victim);
+  // обработка защитных скилов (захват, уклон, парир, веер, блок)
+  hit_params.check_defense_skills(ch, victim);
 
-	//режем дамаг от голода
-	if (hit_params.dam)
-		hit_params.dam *= ch->get_cond_penalty(P_DAMROLL);
-	// итоговый дамаг
-	int made_dam = hit_params.extdamage(ch, victim);
+  //режем дамаг от голода
+  if (hit_params.dam)
+    hit_params.dam *= ch->get_cond_penalty(P_DAMROLL);
+  // итоговый дамаг
+  int made_dam = hit_params.extdamage(ch, victim);
 
-	//Обнуление лага, когда виктим убит с применением
-	//оглушить или молотить. Чтобы все это было похоже на
-	//действие скиллов экстраатак(пнуть, сбить и т.д.)
+  //Обнуление лага, когда виктим убит с применением
+  //оглушить или молотить. Чтобы все это было похоже на
+  //действие скиллов экстраатак(пнуть, сбить и т.д.)
 /*
 	if (CHECK_WAIT(ch)
 		&& made_dam == -1
@@ -4196,109 +3730,96 @@ void hit(CHAR_DATA *ch, CHAR_DATA *victim, ESkill type, FightSystem::AttType wea
 	{
 		ch->set_wait(0u);
 	} */
-	if (made_dam == -1) {
-		if (type == SKILL_STUPOR) {
-			ch->setSkillCooldown(SKILL_STUPOR, 0u);
-		} else if (type == SKILL_MIGHTHIT) {
-			ch->setSkillCooldown(SKILL_MIGHTHIT, 0u);
-		}
-	}
+  if (made_dam == -1) {
+    if (type == SKILL_STUPOR) {
+      ch->setSkillCooldown(SKILL_STUPOR, 0u);
+    } else if (type == SKILL_MIGHTHIT) {
+      ch->setSkillCooldown(SKILL_MIGHTHIT, 0u);
+    }
+  }
 
-	// check if the victim has a hitprcnt trigger
-	if (made_dam != -1) {
-		// victim is not dead after hit
-		hitprcnt_mtrigger(victim);
-	}
+  // check if the victim has a hitprcnt trigger
+  if (made_dam != -1) {
+    // victim is not dead after hit
+    hitprcnt_mtrigger(victim);
+  }
 }
 
 // реализация скилла "железный ветер"
-void performIronWindAttacks(CHAR_DATA *ch, FightSystem::AttType weapon)
-{
-	int percent = 0, prob = 0, div = 0, moves = 0;
-	/*
+void performIronWindAttacks(CHAR_DATA *ch, FightSystem::AttType weapon) {
+  int percent = 0, prob = 0, div = 0, moves = 0;
+  /*
 	первая дополнительная атака правой наносится 100%
 	вторая дополнительная атака правой начинает наноситься с 80%+ скилла, но не более чем с 80% вероятностью
 	первая дополнительная атака левой начинает наноситься сразу, но не более чем с 80% вероятностью
 	вторая дополнительная атака левей начинает наноситься с 170%+ скилла, но не более чем с 30% вероятности
 	*/
-	if (PRF_FLAGS(ch).get(PRF_IRON_WIND))
-	{
-		percent = ch->get_skill(SKILL_IRON_WIND);
-		moves = GET_MAX_MOVE(ch) / (6 + MAX(10, percent) / 10);
-		prob = GET_AF_BATTLE(ch, EAF_IRON_WIND);
-		if (prob && !check_moves(ch, moves)) {
-			CLR_AF_BATTLE(ch, EAF_IRON_WIND);
-		}
-		else if (!prob && (GET_MOVE(ch) > moves)) {
-			SET_AF_BATTLE(ch, EAF_IRON_WIND);
-		};
-	};
-	if (GET_AF_BATTLE(ch, EAF_IRON_WIND)) {
-		(void) train_skill(ch, SKILL_IRON_WIND, skill_info[SKILL_IRON_WIND].max_percent, ch->get_fighting());
-		if (weapon == FightSystem::MAIN_HAND){
-			div = 100 + MIN(80, MAX(1, percent - 80));
-			prob = 100;
-		}
-		else {
-			div = MIN(80, percent + 10);
-			prob = 80 - MIN(30, MAX(0, percent - 170));
-		};
-		while (div > 0) {
-			if (number(1, 100) < div)
-				hit(ch, ch->get_fighting(), ESkill::SKILL_UNDEF, weapon);
-			div -= prob;
-		};
-	};
+  if (PRF_FLAGS(ch).get(PRF_IRON_WIND)) {
+    percent = ch->get_skill(SKILL_IRON_WIND);
+    moves = GET_MAX_MOVE(ch) / (6 + MAX(10, percent) / 10);
+    prob = GET_AF_BATTLE(ch, EAF_IRON_WIND);
+    if (prob && !check_moves(ch, moves)) {
+      CLR_AF_BATTLE(ch, EAF_IRON_WIND);
+    } else if (!prob && (GET_MOVE(ch) > moves)) {
+      SET_AF_BATTLE(ch, EAF_IRON_WIND);
+    };
+  };
+  if (GET_AF_BATTLE(ch, EAF_IRON_WIND)) {
+    train_skill(ch, SKILL_IRON_WIND, true, ch->get_fighting());
+    if (weapon == FightSystem::MAIN_HAND) {
+      div = 100 + MIN(80, MAX(1, percent - 80));
+      prob = 100;
+    } else {
+      div = MIN(80, percent + 10);
+      prob = 80 - MIN(30, MAX(0, percent - 170));
+    };
+    while (div > 0) {
+      if (number(1, 100) < div)
+        hit(ch, ch->get_fighting(), ESkill::SKILL_UNDEF, weapon);
+      div -= prob;
+    };
+  };
 
 }
 
+OBJ_DATA *GetUsedWeapon(CHAR_DATA *ch, FightSystem::AttType AttackType) {
+  OBJ_DATA *UsedWeapon = nullptr;
 
-OBJ_DATA *GetUsedWeapon(CHAR_DATA *ch, FightSystem::AttType AttackType)
-{
-	OBJ_DATA *UsedWeapon = nullptr;
+  if (AttackType == FightSystem::AttType::MAIN_HAND) {
+    if (!(UsedWeapon = GET_EQ(ch, WEAR_WIELD)))
+      UsedWeapon = GET_EQ(ch, WEAR_BOTHS);
+  } else if (AttackType == FightSystem::AttType::OFFHAND)
+    UsedWeapon = GET_EQ(ch, WEAR_HOLD);
 
-	if (AttackType == FightSystem::AttType::MAIN_HAND)
-	{
-		if (!(UsedWeapon = GET_EQ(ch, WEAR_WIELD)))
-			UsedWeapon = GET_EQ(ch, WEAR_BOTHS);
-	}
-	else if (AttackType == FightSystem::AttType::OFFHAND)
-		UsedWeapon = GET_EQ(ch, WEAR_HOLD);
-
-    return UsedWeapon;
+  return UsedWeapon;
 }
 
 // Обработка доп.атак
-void exthit(CHAR_DATA * ch, ESkill type, FightSystem::AttType weapon)
-{
-	if (!ch || ch->purged()){
-		log("SYSERROR: ch = %s (%s:%d)", ch ? (ch->purged() ? "purged" : "true") : "false", __FILE__, __LINE__);
-		return;
-	}
-	// обрабатываем доп.атаки от железного ветра
-	performIronWindAttacks (ch, weapon);
+void exthit(CHAR_DATA *ch, ESkill type, FightSystem::AttType weapon) {
+  if (!ch || ch->purged()) {
+    log("SYSERROR: ch = %s (%s:%d)", ch ? (ch->purged() ? "purged" : "true") : "false", __FILE__, __LINE__);
+    return;
+  }
+  // обрабатываем доп.атаки от железного ветра
+  performIronWindAttacks(ch, weapon);
 
-	OBJ_DATA *wielded = NULL;
+  OBJ_DATA *wielded = NULL;
 
-	wielded = GetUsedWeapon(ch, weapon);
-	if (wielded
-			&& !GET_EQ(ch, WEAR_SHIELD)
-			&& GET_OBJ_SKILL(wielded) == SKILL_BOWS
-			&& GET_EQ(ch, WEAR_BOTHS))
-	{
-		// Лук в обеих руках - юзаем доп. или двойной выстрел
-		if (can_use_feat(ch, DOUBLESHOT_FEAT) && !ch->get_skill(SKILL_ADDSHOT)
-				&& MIN(850, 200 + ch->get_skill(SKILL_BOWS) * 4 + GET_REAL_DEX(ch) * 5) >= number(1, 1000))
-		{
-			hit(ch, ch->get_fighting(), type, weapon);
-		}
-		else if (ch->get_skill(SKILL_ADDSHOT) > 0)
-		{
-			addshot_damage(ch, type, weapon);
-		}
-	}
+  wielded = GetUsedWeapon(ch, weapon);
+  if (wielded
+      && !GET_EQ(ch, WEAR_SHIELD)
+      && GET_OBJ_SKILL(wielded) == SKILL_BOWS
+      && GET_EQ(ch, WEAR_BOTHS)) {
+    // Лук в обеих руках - юзаем доп. или двойной выстрел
+    if (can_use_feat(ch, DOUBLESHOT_FEAT) && !ch->get_skill(SKILL_ADDSHOT)
+        && MIN(850, 200 + ch->get_skill(SKILL_BOWS) * 4 + GET_REAL_DEX(ch) * 5) >= number(1, 1000)) {
+      hit(ch, ch->get_fighting(), type, weapon);
+    } else if (ch->get_skill(SKILL_ADDSHOT) > 0) {
+      addshot_damage(ch, type, weapon);
+    }
+  }
 
-	hit(ch, ch->get_fighting(), type, weapon);
+  hit(ch, ch->get_fighting(), type, weapon);
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/fightsystem/fight_stuff.cpp
+++ b/src/fightsystem/fight_stuff.cpp
@@ -253,7 +253,7 @@ void update_leadership(CHAR_DATA *ch, CHAR_DATA *killer)
 			&& killer->get_master()->get_skill(SKILL_LEADERSHIP) > 0
 			&& IN_ROOM(killer) == IN_ROOM(killer->get_master()))
 		{
-			improve_skill(killer->get_master(), SKILL_LEADERSHIP, number(0, 1), ch);
+          ImproveSkill(killer->get_master(), SKILL_LEADERSHIP, number(0, 1), ch);
 		}
 		else if (IS_NPC(killer) // Убил чармис загрупленного чара
 			&& IS_CHARMICE(killer)
@@ -265,7 +265,7 @@ void update_leadership(CHAR_DATA *ch, CHAR_DATA *killer)
 				&& IN_ROOM(killer) == IN_ROOM(killer->get_master())
 				&& IN_ROOM(killer) == IN_ROOM(killer->get_master()->get_master()))
 			{
-				improve_skill(killer->get_master()->get_master(), SKILL_LEADERSHIP, number(0, 1), ch);
+              ImproveSkill(killer->get_master()->get_master(), SKILL_LEADERSHIP, number(0, 1), ch);
 			}
 		}
 	}

--- a/src/fightsystem/mobact.cpp
+++ b/src/fightsystem/mobact.cpp
@@ -1325,7 +1325,7 @@ void mobile_activity(int activity_level, int missed_pulses)
 
 		if (GET_POS(ch) == POS_STANDING && NPC_FLAGGED(ch, NPC_SNEAK))
 		{
-			if (calculate_skill(ch.get(), SKILL_SNEAK, 0) >= number(0, 100))
+			if (CalcCurrentSkill(ch.get(), SKILL_SNEAK, 0) >= number(0, 100))
 			{
 				ch->set_affect(EAffectFlag::AFF_SNEAK);
 			}
@@ -1338,7 +1338,7 @@ void mobile_activity(int activity_level, int missed_pulses)
 
 		if (GET_POS(ch) == POS_STANDING && NPC_FLAGGED(ch, NPC_CAMOUFLAGE))
 		{
-			if (calculate_skill(ch.get(), SKILL_CAMOUFLAGE, 0) >= number(0, 100))
+			if (CalcCurrentSkill(ch.get(), SKILL_CAMOUFLAGE, 0) >= number(0, 100))
 			{
 				ch->set_affect(EAffectFlag::AFF_CAMOUFLAGE);
 			}

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -171,12 +171,12 @@ int find_first_step(room_rnum src, room_rnum target, CHAR_DATA * ch)
 
 int go_sense(CHAR_DATA * ch, CHAR_DATA * victim)
 {
-	int percent, dir, skill = calculate_skill(ch, SKILL_SENSE, victim);
+	int percent, dir, skill = CalcCurrentSkill(ch, SKILL_SENSE, victim);
 
 	skill = skill - MAX(1, (GET_REMORT(victim) - GET_REMORT(ch)) * 5); // разница в ремортах *5 вычитается из текущего умения
 	skill = skill - MAX(1, (GET_LEVEL(victim) - GET_LEVEL(ch)) * 5);
 	skill = MAX(0, skill);
-	percent = number(0, skill_info[SKILL_SENSE].max_percent);
+	percent = number(0, skill_info[SKILL_SENSE].fail_percent);
 	if (percent > skill)
 	{
 		int tries = 10;
@@ -250,7 +250,7 @@ void do_sense(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
 		strcpy(buf, "Ваши чувства молчат.");
 		break;
 	default:		// Success!
-		improve_skill(ch, SKILL_SENSE, TRUE, vict);
+      ImproveSkill(ch, SKILL_SENSE, TRUE, vict);
 		sprintf(buf, "Чувство подсказало вам : \"Ступай %s.\"\r\n", DirsTo[dir]);
 		break;
 	}

--- a/src/im.cpp
+++ b/src/im.cpp
@@ -34,12 +34,13 @@
 
 #include <vector>
 
-#define		VAR_CHAR	'@'
+#define        VAR_CHAR    '@'
+#define imlog(lvl, str)    mudlog(str, lvl, LVL_BUILDER, IMLOG, TRUE)
 
-#define imlog(lvl,str)	mudlog(str, lvl, LVL_BUILDER, IMLOG, TRUE)
+const short kMaxRecipeLevel = 200;
 
 // из spec_proc.c
-char *how_good(CHAR_DATA * ch, int percent);
+char *how_good(int skill_level, int skill_cap);
 
 extern CHAR_DATA *mob_proto;
 extern INDEX_DATA *mob_index;
@@ -49,165 +50,147 @@ void do_recipes(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_cook(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_imlist(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 
-im_type *imtypes = NULL;	// Список зарегестрированных ТИПОВ/МЕТАТИПОВ
-int top_imtypes = -1;		// Последний номер типа ИМ
+im_type *imtypes = NULL;    // Список зарегестрированных ТИПОВ/МЕТАТИПОВ
+int top_imtypes = -1;        // Последний номер типа ИМ
 
-im_recipe *imrecipes = NULL;	// Список зарегестрированных рецептов
-int top_imrecipes = -1;		// Последний номер рецепта ИМ
+im_recipe *imrecipes = NULL;    // Список зарегестрированных рецептов
+int top_imrecipes = -1;        // Последний номер рецепта ИМ
 
 // Поиск типа по имени name. mode=0-только элементарные,1-все подряд
-int im_get_type_by_name(char *name, int mode)
-{
-	int i;
-	for (i = 0; i <= top_imtypes; ++i)
-	{
-		if (mode == 0 && imtypes[i].proto_vnum == -1)
-			continue;
-		if (!strn_cmp(name, imtypes[i].name, strlen(imtypes[i].name)))
-			return i;
-	}
-	return -1;
+int im_get_type_by_name(char *name, int mode) {
+  int i;
+  for (i = 0; i <= top_imtypes; ++i) {
+    if (mode == 0 && imtypes[i].proto_vnum == -1)
+      continue;
+    if (!strn_cmp(name, imtypes[i].name, strlen(imtypes[i].name)))
+      return i;
+  }
+  return -1;
 }
 //Поиск index по номеру ТИПА
 
-int im_get_idx_by_type(int type)
-{
-	int i;
-	for (i = 0; i <= top_imtypes; ++i)
-	{
-		if (imtypes[i].id == type)
-		return i;
-	}
-	return -1;
+int im_get_idx_by_type(int type) {
+  int i;
+  for (i = 0; i <= top_imtypes; ++i) {
+    if (imtypes[i].id == type)
+      return i;
+  }
+  return -1;
 }
 
 // Поиск rid по id
-int im_get_recipe(int id)
-{
-	int rid;
-	for (rid = top_imrecipes; rid >= 0; --rid)
-		if (imrecipes[rid].id == id)
-			break;
-	return rid;
+int im_get_recipe(int id) {
+  int rid;
+  for (rid = top_imrecipes; rid >= 0; --rid)
+    if (imrecipes[rid].id == id)
+      break;
+  return rid;
 }
 
 // Поиск rid по имени
-int im_get_recipe_by_name(char *name)
-{
-	int rid;
-	int ok;
-	char *temp, *temp2;
-	char first[256], first2[256];
+int im_get_recipe_by_name(char *name) {
+  int rid;
+  int ok;
+  char *temp, *temp2;
+  char first[256], first2[256];
 
-	if (*name == 0)
-		return -1;
+  if (*name == 0)
+    return -1;
 
-	for (rid = top_imrecipes; rid >= 0; --rid)
-	{
-		if (is_abbrev(name, imrecipes[rid].name))
-			break;
+  for (rid = top_imrecipes; rid >= 0; --rid) {
+    if (is_abbrev(name, imrecipes[rid].name))
+      break;
 
-		ok = TRUE;
-		temp = any_one_arg(imrecipes[rid].name, first);
-		temp2 = any_one_arg(name, first2);
-		while (*first && *first2 && ok)
-		{
-			if (!is_abbrev(first2, first))
-				ok = FALSE;
-			temp = any_one_arg(temp, first);
-			temp2 = any_one_arg(temp2, first2);
-		}
-		if (ok && !*first2)
-			break;
-	}
-	return rid;
+    ok = TRUE;
+    temp = any_one_arg(imrecipes[rid].name, first);
+    temp2 = any_one_arg(name, first2);
+    while (*first && *first2 && ok) {
+      if (!is_abbrev(first2, first))
+        ok = FALSE;
+      temp = any_one_arg(temp, first);
+      temp2 = any_one_arg(temp2, first2);
+    }
+    if (ok && !*first2)
+      break;
+  }
+  return rid;
 }
 
-im_rskill *im_get_char_rskill(CHAR_DATA * ch, int rid)
-{
-	im_rskill *rs;
-	for (rs = GET_RSKILL(ch); rs; rs = rs->link)
-		if (rs->rid == rid)
-			break;
-	return rs;
+im_rskill *im_get_char_rskill(CHAR_DATA *ch, int rid) {
+  im_rskill *rs;
+  for (rs = GET_RSKILL(ch); rs; rs = rs->link)
+    if (rs->rid == rid)
+      break;
+  return rs;
 }
 
-int im_get_char_rskill_count(CHAR_DATA * ch)
-{
-	int cnt;
-	im_rskill *rs;
-	for (cnt = 0, rs = GET_RSKILL(ch); rs; rs = rs->link, ++cnt);
-	return cnt;
+int im_get_char_rskill_count(CHAR_DATA *ch) {
+  int cnt;
+  im_rskill *rs;
+  for (cnt = 0, rs = GET_RSKILL(ch); rs; rs = rs->link, ++cnt);
+  return cnt;
 }
 
 // Расширяет хранилище битов, до указанного размера (в случае необходимости)
-void TypeListAllocate(im_tlist * tl, int size)
-{
-	if (tl->size < size)
-	{
-		long *ptr;
-		CREATE(ptr, size);
-		if (tl->size)
-		{
-			memcpy(ptr, tl->types, size * 4);
-			free(tl->types);
-		}
-		tl->size = size;
-		tl->types = ptr;
-	}
+void TypeListAllocate(im_tlist *tl, int size) {
+  if (tl->size < size) {
+    long *ptr;
+    CREATE(ptr, size);
+    if (tl->size) {
+      memcpy(ptr, tl->types, size * 4);
+      free(tl->types);
+    }
+    tl->size = size;
+    tl->types = ptr;
+  }
 }
 
 // устанавливает в битовой маске списка типов tl бит номер index
-void TypeListSetSingle(im_tlist * tl, int index)
-{
-	TypeListAllocate(tl, (index >> 8) + 1);
-	tl->types[index >> 8] |= (1 << (index & 31));
+void TypeListSetSingle(im_tlist *tl, int index) {
+  TypeListAllocate(tl, (index >> 8) + 1);
+  tl->types[index >> 8] |= (1 << (index & 31));
 }
 
 // устанавливает в битовой маске списка типов tl все биты списка src
-void TypeListSet(im_tlist * tl, im_tlist * src)
-{
-	int i;
-	TypeListAllocate(tl, src->size);
-	for (i = 0; i < src->size; ++i)
-		tl->types[i] |= src->types[i];
+void TypeListSet(im_tlist *tl, im_tlist *src) {
+  int i;
+  TypeListAllocate(tl, src->size);
+  for (i = 0; i < src->size; ++i)
+    tl->types[i] |= src->types[i];
 }
 
 // проверяет в битовой маске списка типов tl бит index
-int TypeListCheck(im_tlist * tl, int index)
-{
-	TypeListAllocate(tl, (index >> 8) + 1);
-	return tl->types[index >> 8] & (1 << (index & 31));
+int TypeListCheck(im_tlist *tl, int index) {
+  TypeListAllocate(tl, (index >> 8) + 1);
+  return tl->types[index >> 8] & (1 << (index & 31));
 }
-
 
 // Рассчет силы ингредиента, при погрузке на землю
 const int def_probs[] =
-{
-	20,			// 20%    - 1
-	35,			// 15%    - 2
-	45,			// 10%    - 3
-	53,			//  8%    - 4
-	60,			//  7%    - 5
-	66,			//  6%    - 6
-	71,			//  5%    - 7
-	76,			//  5%    - 8
-	80,			//  4%    - 9
-	84,			//  4%    - 10
-	88,			//  4%    - 11
-	91,			//  3%    - 12
-	94,			//  3%    - 13
-	96,			//  2%    - 14
-	98,			//  2%    - 15
-	99,			//  1%    - 16
-	100			//  1%    - 17
-	// старше 17 вообще не погрузятся
-};
-int im_calc_power(void)
-{
-	int j, i = number(1, 100);
-	for (j = 0; i > def_probs[j++];);
-	return j;
+    {
+        20,            // 20%    - 1
+        35,            // 15%    - 2
+        45,            // 10%    - 3
+        53,            //  8%    - 4
+        60,            //  7%    - 5
+        66,            //  6%    - 6
+        71,            //  5%    - 7
+        76,            //  5%    - 8
+        80,            //  4%    - 9
+        84,            //  4%    - 10
+        88,            //  4%    - 11
+        91,            //  3%    - 12
+        94,            //  3%    - 13
+        96,            //  2%    - 14
+        98,            //  2%    - 15
+        99,            //  1%    - 16
+        100            //  1%    - 17
+        // старше 17 вообще не погрузятся
+    };
+int im_calc_power(void) {
+  int j, i = number(1, 100);
+  for (j = 0; i > def_probs[j++];);
+  return j;
 }
 
 
@@ -218,90 +201,77 @@ int im_calc_power(void)
 */
 
 // Поиск алиаса
-char * get_im_alias(im_memb * s, const char *name)
-{
-	char **al;
-	for (al = s->aliases; al[0]; al += 2)
-		if (!str_cmp(al[0], name))
-			break;
-	return al[1];
+char *get_im_alias(im_memb *s, const char *name) {
+  char **al;
+  for (al = s->aliases; al[0]; al += 2)
+    if (!str_cmp(al[0], name))
+      break;
+  return al[1];
 }
 
 // Функция заменяет alias в названиях ингредиентов
-const char* replace_alias(const char *ptr, im_memb * sample, int rnum, const char *std)
-{
-	char *dst, *al;
-	char aname[16];
+const char *replace_alias(const char *ptr, im_memb *sample, int rnum, const char *std) {
+  char *dst, *al;
+  char aname[16];
 
-	if (!sample && rnum == -1)
-		return ptr;
+  if (!sample && rnum == -1)
+    return ptr;
 
-	// Строю соответствуюжую строку в buf
-	if (sample)
-	{
-		// поиск в образце
-		if (std && (al = get_im_alias(sample, std)) != NULL)
-		{
-			ptr = al;
-		}
-		else
-		{
-			// Посимвольный разбор строки
-			dst = buf;
-			do
-			{
-				if (*ptr == VAR_CHAR)
-				{
-					int k;
-					++ptr;
-					for (k = 0; (*ptr) && a_isalnum(*ptr); aname[k++] = *ptr++);
-					aname[k] = 0;
-					al = get_im_alias(sample, aname);
-					strcpy(dst, al ? al : aname);
-					while (*dst != 0)
-						++dst;
-				}
-			}
-			while ((*dst++ = *ptr++) != 0);
-			ptr = buf;
-		}
-	}
-	else
-	{
-		// поиск в мобе (только p0-p5)
-		// Посимвольный разбор строки
-		for (dst = buf; (*dst++ = *ptr++) != 0;)
-		{
-			int k;
-			if (*ptr != VAR_CHAR)
-				continue;
-			sscanf(ptr + 1, "p%d", &k);
-			if (k < 0 || k > 5)
-				continue;
-			ptr += 3;
-			strcpy(dst, GET_PAD(mob_proto + rnum, k));
-			while (*dst != 0)
-				++dst;
-		}
-		ptr = buf;
-	}
+  // Строю соответствуюжую строку в buf
+  if (sample) {
+    // поиск в образце
+    if (std && (al = get_im_alias(sample, std)) != NULL) {
+      ptr = al;
+    } else {
+      // Посимвольный разбор строки
+      dst = buf;
+      do {
+        if (*ptr == VAR_CHAR) {
+          int k;
+          ++ptr;
+          for (k = 0; (*ptr) && a_isalnum(*ptr); aname[k++] = *ptr++);
+          aname[k] = 0;
+          al = get_im_alias(sample, aname);
+          strcpy(dst, al ? al : aname);
+          while (*dst != 0)
+            ++dst;
+        }
+      } while ((*dst++ = *ptr++) != 0);
+      ptr = buf;
+    }
+  } else {
+    // поиск в мобе (только p0-p5)
+    // Посимвольный разбор строки
+    for (dst = buf; (*dst++ = *ptr++) != 0;) {
+      int k;
+      if (*ptr != VAR_CHAR)
+        continue;
+      sscanf(ptr + 1, "p%d", &k);
+      if (k < 0 || k > 5)
+        continue;
+      ptr += 3;
+      strcpy(dst, GET_PAD(mob_proto + rnum, k));
+      while (*dst != 0)
+        ++dst;
+    }
+    ptr = buf;
+  }
 
-	return ptr;
+  return ptr;
 }
 
-int im_type_rnum(int vnum)
-{
-	int rind;
-	for (rind = top_imtypes; rind >= 0; --rind)
-		if (imtypes[rind].id == vnum)
-			break;
-	return rind;
+int im_type_rnum(int vnum) {
+  int rind;
+  for (rind = top_imtypes; rind >= 0; --rind)
+    if (imtypes[rind].id == vnum)
+      break;
+  return rind;
 }
 
-const char *def_alias[] = { "n0", "n1", "n2", "n3", "n4", "n5" };
+const char *def_alias[] = {"n0", "n1", "n2", "n3", "n4", "n5"};
 
 // Указание силы ингредиента
-int im_assign_power(OBJ_DATA * obj)
+int im_assign_power(OBJ_DATA *obj)
 /*
    obj - загруженный ингредиент
 
@@ -312,58 +282,56 @@ int im_assign_power(OBJ_DATA * obj)
    GET_OBJ_VAL(obj,IM_POWER_SLOT) = lev    - уровень ингредиента
 */
 {
-	int rind, onum;
-	int rnum = -1;
-	im_memb *sample, *p;
-	int j;
+  int rind, onum;
+  int rnum = -1;
+  im_memb *sample, *p;
+  int j;
 
-	// Перевод номера index в rnum
-	rind = im_type_rnum(GET_OBJ_VAL(obj, IM_TYPE_SLOT));
-	if (rind == -1)
-		return 1;	// неверный номер ТИПА ингредиента
+  // Перевод номера index в rnum
+  rind = im_type_rnum(GET_OBJ_VAL(obj, IM_TYPE_SLOT));
+  if (rind == -1)
+    return 1;    // неверный номер ТИПА ингредиента
 
 // Поиск образца или моба
 // Если используется живь, получить уровень из моба
-	onum = real_object(imtypes[rind].proto_vnum);
-	if (onum < 0)
-		return 4;
-	if (GET_OBJ_VAL(obj_proto[onum], 3) == IM_CLASS_JIV)
-	{
-		if (GET_OBJ_VAL(obj, IM_INDEX_SLOT) == -1)
-			return 3;
-		rnum = real_mobile(GET_OBJ_VAL(obj, IM_INDEX_SLOT));
-		if (rnum < 0)
-			return 3;	// неверный VNUM базового моба
-		obj->set_val(IM_POWER_SLOT, (GET_LEVEL(mob_proto + rnum) + 3) * 3 / 4);
-	}
-	// Попробовать найти описатель ВИДА
-	for (p = imtypes[rind].head, sample = NULL; p && p->power <= GET_OBJ_VAL(obj, IM_POWER_SLOT); sample = p, p = p->next);
+  onum = real_object(imtypes[rind].proto_vnum);
+  if (onum < 0)
+    return 4;
+  if (GET_OBJ_VAL(obj_proto[onum], 3) == IM_CLASS_JIV) {
+    if (GET_OBJ_VAL(obj, IM_INDEX_SLOT) == -1)
+      return 3;
+    rnum = real_mobile(GET_OBJ_VAL(obj, IM_INDEX_SLOT));
+    if (rnum < 0)
+      return 3;    // неверный VNUM базового моба
+    obj->set_val(IM_POWER_SLOT, (GET_LEVEL(mob_proto + rnum) + 3) * 3 / 4);
+  }
+  // Попробовать найти описатель ВИДА
+  for (p = imtypes[rind].head, sample = NULL; p && p->power <= GET_OBJ_VAL(obj, IM_POWER_SLOT);
+       sample = p, p = p->next);
 
-	if (sample)
-	{
-		obj->set_sex(sample->sex);
-	}
+  if (sample) {
+    obj->set_sex(sample->sex);
+  }
 
-	// Замена описаний
-	// Падежи, описание, alias
-	for (j = 0; j < 6; ++j)
-	{
-		const char* ptr = obj_proto[GET_OBJ_RNUM(obj)]->get_PName(j).c_str();
-		obj->set_PName(j, replace_alias(ptr, sample, rnum, def_alias[j]));
-	}
-	const char* ptr = obj_proto[GET_OBJ_RNUM(obj)]->get_description().c_str();
-	obj->set_description(replace_alias(ptr, sample, rnum, "s"));
+  // Замена описаний
+  // Падежи, описание, alias
+  for (j = 0; j < 6; ++j) {
+    const char *ptr = obj_proto[GET_OBJ_RNUM(obj)]->get_PName(j).c_str();
+    obj->set_PName(j, replace_alias(ptr, sample, rnum, def_alias[j]));
+  }
+  const char *ptr = obj_proto[GET_OBJ_RNUM(obj)]->get_description().c_str();
+  obj->set_description(replace_alias(ptr, sample, rnum, "s"));
 
-	ptr = obj_proto[GET_OBJ_RNUM(obj)]->get_short_description().c_str();
-	obj->set_short_description(replace_alias(ptr, sample, rnum, def_alias[0]));
+  ptr = obj_proto[GET_OBJ_RNUM(obj)]->get_short_description().c_str();
+  obj->set_short_description(replace_alias(ptr, sample, rnum, def_alias[0]));
 
-	ptr = obj_proto[GET_OBJ_RNUM(obj)]->get_aliases().c_str();
-	obj->set_aliases(replace_alias(ptr, sample, rnum, "m"));
+  ptr = obj_proto[GET_OBJ_RNUM(obj)]->get_aliases().c_str();
+  obj->set_aliases(replace_alias(ptr, sample, rnum, "m"));
 
-	// Обработка других полей объекта
-	// -- пока не сделано --
+  // Обработка других полей объекта
+  // -- пока не сделано --
 
-	return 0;
+  return 0;
 }
 
 // Загрузка магического ингредиента
@@ -374,577 +342,485 @@ OBJ_DATA *load_ingredient(int index, int power, int rnum)
    rnum  - VNUM моба, в который грузится ингредиент
 */
 {
-	int err;
+  int err;
 
-	while (1)
-	{
-		if (imtypes[index].proto_vnum < 0)
-		{
-			sprintf(buf, "IM METATYPE ingredient loading %d", imtypes[index].id);
-			break;
-		}
+  while (1) {
+    if (imtypes[index].proto_vnum < 0) {
+      sprintf(buf, "IM METATYPE ingredient loading %d", imtypes[index].id);
+      break;
+    }
 
-		const auto ing = world_objects.create_from_prototype_by_vnum(imtypes[index].proto_vnum);
-		if (!ing)
-		{
-			sprintf(buf, "IM ingredient prototype %d not found", imtypes[index].proto_vnum);
-			break;
-		}
+    const auto ing = world_objects.create_from_prototype_by_vnum(imtypes[index].proto_vnum);
+    if (!ing) {
+      sprintf(buf, "IM ingredient prototype %d not found", imtypes[index].proto_vnum);
+      break;
+    }
 
-		ing->set_val(IM_INDEX_SLOT, rnum);
-		ing->set_val(IM_POWER_SLOT, power);
-		ing->set_val(IM_TYPE_SLOT, imtypes[index].id);
+    ing->set_val(IM_INDEX_SLOT, rnum);
+    ing->set_val(IM_POWER_SLOT, power);
+    ing->set_val(IM_TYPE_SLOT, imtypes[index].id);
 
-		err = im_assign_power(ing.get());
-		if (err != 0)
-		{
-			extract_obj(ing.get());
-			sprintf(buf, "IM power assignment error %d", err);
-			break;
-		}
+    err = im_assign_power(ing.get());
+    if (err != 0) {
+      extract_obj(ing.get());
+      sprintf(buf, "IM power assignment error %d", err);
+      break;
+    }
 
-		return ing.get();
-	}
+    return ing.get();
+  }
 
-	imlog(CMP, buf);
-	return nullptr;
+  imlog(CMP, buf);
+  return nullptr;
 }
 
-void im_translate_rskill_to_id(void)
-{
-	im_rskill *rs;
-	for (const auto ch : character_list)
-	{
-		if (IS_NPC(ch))
-		{
-			continue;
-		}
+void im_translate_rskill_to_id(void) {
+  im_rskill *rs;
+  for (const auto ch : character_list) {
+    if (IS_NPC(ch)) {
+      continue;
+    }
 
-		for (rs = GET_RSKILL(ch); rs; rs = rs->link)
-		{
-			rs->rid = imrecipes[rs->rid].id;
-		}
-	}
+    for (rs = GET_RSKILL(ch); rs; rs = rs->link) {
+      rs->rid = imrecipes[rs->rid].id;
+    }
+  }
 }
 
-void im_translate_rskill_to_rid(void)
-{
-	im_rskill *rs, **prs;
-	int rid;
-	for (const auto ch : character_list)
-	{
-		if (IS_NPC(ch))
-			continue;
-		prs = &GET_RSKILL(ch);
-		while ((rs = *prs) != NULL)
-		{
-			rid = im_get_recipe(rs->rid);
-			if (rid >= 0)
-			{
-				rs->rid = rid;
-				prs = &rs->link;
-				continue;
-			}
-			else
-			{
-				*prs = rs->link;
-				free(rs);
-			}
-		}
-	}
+void im_translate_rskill_to_rid(void) {
+  im_rskill *rs, **prs;
+  int rid;
+  for (const auto ch : character_list) {
+    if (IS_NPC(ch))
+      continue;
+    prs = &GET_RSKILL(ch);
+    while ((rs = *prs) != NULL) {
+      rid = im_get_recipe(rs->rid);
+      if (rid >= 0) {
+        rs->rid = rid;
+        prs = &rs->link;
+        continue;
+      } else {
+        *prs = rs->link;
+        free(rs);
+      }
+    }
+  }
 }
 
-void im_cleanup_type(im_type * t)
-{
-	free(t->name);
-	if (t->tlst.size != 0)
-	{
-		free(t->tlst.types);
-		t->tlst.size = 0;
-	}
+void im_cleanup_type(im_type *t) {
+  free(t->name);
+  if (t->tlst.size != 0) {
+    free(t->tlst.types);
+    t->tlst.size = 0;
+  }
 }
 
-void im_cleanup_recipe(im_recipe * r)
-{
-	im_addon *a;
-	free(r->name);
-	free(r->require);
-	free(r->msg_char[0]);
-	free(r->msg_char[1]);
-	free(r->msg_char[2]);
-	free(r->msg_room[0]);
-	free(r->msg_room[1]);
-	free(r->msg_room[2]);
-	while ((a = r->addon) != NULL)
-	{
-		r->addon = a->link;
-		free(a);
-	}
+void im_cleanup_recipe(im_recipe *r) {
+  im_addon *a;
+  free(r->name);
+  free(r->require);
+  free(r->msg_char[0]);
+  free(r->msg_char[1]);
+  free(r->msg_char[2]);
+  free(r->msg_room[0]);
+  free(r->msg_room[1]);
+  free(r->msg_room[2]);
+  while ((a = r->addon) != NULL) {
+    r->addon = a->link;
+    free(a);
+  }
 }
 
 // Инициализация подсистемы ингредиентной магии
-void init_im(void)
-{
-	FILE *im_file;
-	char tmp[1024], tlist[1024], line1[256], line2[256], name[256];
-	im_memb *mbs, *mptr;
-	int i, j, rcpt;
-	int k[5];
+void init_im(void) {
+  FILE *im_file;
+  char tmp[1024], tlist[1024], line1[256], line2[256], name[256];
+  im_memb *mbs, *mptr;
+  int i, j, rcpt;
+  int k[5];
 
-	im_file = fopen(LIB_MISC "im.lst", "r");
-	if (!im_file)
-	{
-		imlog(BRF, "Can not open im.lst");
-		return;
-	}
-	// Очистка всего, что есть, на случай reset
-	// Преобразование rid у игроков
-	im_translate_rskill_to_id();
-	for (i = 0; i <= top_imtypes; ++i)
-		im_cleanup_type(imtypes + i);
-	for (i = 0; i <= top_imrecipes; ++i)
-		im_cleanup_recipe(imrecipes + i);
-	if (imtypes)
-		free(imtypes);
-	imtypes = NULL;
-	top_imtypes = -1;
-	if (imrecipes)
-		free(imrecipes);
-	imrecipes = NULL;
-	top_imrecipes = -1;
+  im_file = fopen(LIB_MISC "im.lst", "r");
+  if (!im_file) {
+    imlog(BRF, "Can not open im.lst");
+    return;
+  }
+  // Очистка всего, что есть, на случай reset
+  // Преобразование rid у игроков
+  im_translate_rskill_to_id();
+  for (i = 0; i <= top_imtypes; ++i)
+    im_cleanup_type(imtypes + i);
+  for (i = 0; i <= top_imrecipes; ++i)
+    im_cleanup_recipe(imrecipes + i);
+  if (imtypes)
+    free(imtypes);
+  imtypes = NULL;
+  top_imtypes = -1;
+  if (imrecipes)
+    free(imrecipes);
+  imrecipes = NULL;
+  top_imrecipes = -1;
 
+  mbs = mptr = NULL;
 
+  // ПРОХОД 1
+  // Определение количества ТИПОВ/МЕТАТИПОВ
+  // Получение описателей
+  while (get_line(im_file, tmp)) {
+    if (!strn_cmp(tmp, "ТИП", 3) || !strn_cmp(tmp, "МЕТАТИП", 7))
+      ++top_imtypes;
+    if (!strn_cmp(tmp, "РЕЦЕПТ", 6))
+      ++top_imrecipes;
+    if (!strn_cmp(tmp, "ВИД", 3)) {
+      if (mbs == NULL) {
+        CREATE(mbs, 1);
+        mptr = mbs;
+      } else {
+        CREATE(mptr->next, 1);
+        mptr = mptr->next;
+      }
+      // Количество пар alias
+      mptr->power = 0;
+      while (get_line(im_file, tmp)) {
+        if (*tmp == '~')
+          break;
+        mptr->power++;
+      }
+    }
+  }
 
-	mbs = mptr = NULL;
+  // Выделение памяти для imtypes и заполнение массива
+  CREATE(imtypes, top_imtypes + 1);
+  top_imtypes = -1;
 
-	// ПРОХОД 1
-	// Определение количества ТИПОВ/МЕТАТИПОВ
-	// Получение описателей
-	while (get_line(im_file, tmp))
-	{
-		if (!strn_cmp(tmp, "ТИП", 3) || !strn_cmp(tmp, "МЕТАТИП", 7))
-			++top_imtypes;
-		if (!strn_cmp(tmp, "РЕЦЕПТ", 6))
-			++top_imrecipes;
-		if (!strn_cmp(tmp, "ВИД", 3))
-		{
-			if (mbs == NULL)
-			{
-				CREATE(mbs, 1);
-				mptr = mbs;
-			}
-			else
-			{
-				CREATE(mptr->next, 1);
-				mptr = mptr->next;
-			}
-			// Количество пар alias
-			mptr->power = 0;
-			while (get_line(im_file, tmp))
-			{
-				if (*tmp == '~')
-					break;
-				mptr->power++;
-			}
-		}
-	}
+  // Выделение пямяти для imrecipes и заполнение массива
+  CREATE(imrecipes, top_imrecipes + 1);
+  top_imrecipes = -1;
 
-	// Выделение памяти для imtypes и заполнение массива
-	CREATE(imtypes, top_imtypes + 1);
-	top_imtypes = -1;
+  // ПРОХОД 2
+  rewind(im_file);
+  while (get_line(im_file, tmp)) {
+    int id, vnum;
+    char dummy[128], name[128], text[1024];
 
-	// Выделение пямяти для imrecipes и заполнение массива
-	CREATE(imrecipes, top_imrecipes + 1);
-	top_imrecipes = -1;
+    if (!strn_cmp(tmp, "ТИП", 3))    // Описание типа
+    {
+      if (sscanf(tmp, "%s %d %s %d", dummy, &id, name, &vnum) == 4) {
+        ++top_imtypes;
+        imtypes[top_imtypes].id = id;
+        imtypes[top_imtypes].name = str_dup(name);
+        imtypes[top_imtypes].proto_vnum = vnum;
+        imtypes[top_imtypes].head = NULL;
+        imtypes[top_imtypes].tlst.size = 0;
+        TypeListSetSingle(&imtypes[top_imtypes].tlst, top_imtypes);
+        continue;
+      }
+      sprintf(text, "[IM] Invalid type : '%s'", tmp);
+      imlog(NRM, text);
+    } else if (!strn_cmp(tmp, "МЕТАТИП", 7)) {
+      if (sscanf(tmp, "%s %d %s %s", dummy, &id, name, tlist) == 4) {
+        char *p;
+        ++top_imtypes;
+        imtypes[top_imtypes].id = id;
+        imtypes[top_imtypes].name = str_dup(name);
+        imtypes[top_imtypes].proto_vnum = -1;
+        imtypes[top_imtypes].head = NULL;
+        imtypes[top_imtypes].tlst.size = 0;
+        for (p = strtok(tlist, ","); p; p = strtok(NULL, ",")) {
+          int i = im_get_type_by_name(p, 1);    // поиск любого типа
+          if (i == -1) {
+            sprintf(text, "[IM] Invalid type name : '%s'", p);
+            imlog(NRM, text);
+            continue;
+          }
+          TypeListSet(&imtypes[top_imtypes].tlst, &imtypes[i].tlst);
+        }
+        continue;
+      }
+      sprintf(text, "[IM] Invalid metatype : %s", tmp);
+      imlog(NRM, text);
+    } else if (!strn_cmp(tmp, "ВИД", 3)) {
+      int power, sex;
+      mptr = mbs;
+      mbs = mbs->next;
+      if (sscanf(tmp, "%s %s %d %d", dummy, name, &power, &sex) == 4) {
+        int i = im_get_type_by_name(name, 0);    // поиск элементарного типа
+        if (i != -1) {
+          char **p;
+          im_memb *ins_after, *ins_before;
+          CREATE(mptr->aliases, 2 * (mptr->power + 1));
+          mptr->power = power;
+          mptr->sex = static_cast<ESex>(sex);
+          p = mptr->aliases;
+          while (get_line(im_file, tmp)) {
+            if (*tmp == '~')
+              break;
+            sscanf(tmp, "%s %s", name, text);
+            *p++ = str_dup(name);
+            *p++ = str_dup(text);
+          }
+          p[0] = p[1] = NULL;
+          // Добавляю в структуру типа согласно силе
+          ins_after = NULL;
+          ins_before = imtypes[i].head;
+          while (ins_before && ins_before->power < mptr->power) {
+            ins_after = ins_before;
+            ins_before = ins_before->next;
+          }
+          if (ins_after == NULL)
+            imtypes[i].head = mptr;
+          else
+            ins_after->next = mptr;
+          mptr->next = ins_before;
+          continue;
+        }
+        sprintf(text, "[IM] Can not find type : '%s'", name);
+        imlog(NRM, text);
+      }
+      free(mptr);
+      while (get_line(im_file, tmp))
+        if (*tmp == '~')
+          break;
+      if (*tmp != '~') {
+        sprintf(text, "[IM] Invalid inrgedient : '%s'", tmp);
+        imlog(NRM, text);
+      }
+    } else if (!strn_cmp(tmp, "РЕЦЕПТ", 6)) {
+      char *p;
+      // Описание рецепта
+      if (sscanf(tmp, "%s %d %s", dummy, &id, name) == 3) {
+        for (p = name; *p; ++p)
+          if (*p == '_')
+            *p = ' ';
+        ++top_imrecipes;
+        imrecipes[top_imrecipes].id = id;
+        imrecipes[top_imrecipes].name = str_dup(name);
+        imrecipes[top_imrecipes].k_improve = 1000;
+        while (get_line(im_file, tmp)) {
+          if (*tmp == '~')
+            break;
+          if (!strn_cmp(tmp, "OBJ", 3)) {
+            if (sscanf(tmp, "%s %d", dummy, &imrecipes[top_imrecipes].result) != 2) {
+              log("[IM] Invalid OBJ recipe string (%2d) '%s'!\n"
+                  "Format : OBJ <vnum (%%d)>",
+                  imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              sprintf(text, "[IM] Invalid OBJ recipe string (%2d) '%s' !",
+                      imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              imlog(NRM, text);
+              break;
+            }
+          } else if (!strn_cmp(tmp, "IMP", 3)) {
+            if (sscanf
+                (tmp, "%s %d", dummy, &imrecipes[top_imrecipes].k_improve) != 2) {
+              log("[IM] Invalid IMP recipe string (%2d) '%s'!\n",
+                  imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              sprintf(text, "[IM] Invalid IMP recipe string (%2d) '%s' !",
+                      imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              imlog(NRM, text);
+              break;
+            }
+          } else if (!strn_cmp(tmp, "CON", 3)) {
+            if (sscanf(tmp, "%s %f %f %f %f",
+                       dummy,
+                       &imrecipes[top_imrecipes].k[0],
+                       &imrecipes[top_imrecipes].k[1],
+                       &imrecipes[top_imrecipes].k[2],
+                       &imrecipes[top_imrecipes].kp) != 5) {
+              log("[IM] Invalid CON recipe string (%2d) '%s'!\n"
+                  "Format : CON <k1 (%%d)> <k2 (%%f)> <k3 (%%d)> <kp (%%d)>",
+                  imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              sprintf(text, "[IM] Invalid CON recipe string (%2d) '%s' !",
+                      imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              imlog(NRM, text);
+              break;
+            }
+          } else if (!strn_cmp(tmp, "MC1", 3)) {
+            p = tmp + 3;
+            skip_spaces(&p);
+            if (imrecipes[top_imrecipes].msg_char[0])
+              free(imrecipes[top_imrecipes].msg_char[0]);
+            imrecipes[top_imrecipes].msg_char[0] = str_dup(p);
+          } else if (!strn_cmp(tmp, "MR1", 3)) {
+            p = tmp + 3;
+            skip_spaces(&p);
+            if (imrecipes[top_imrecipes].msg_room[0])
+              free(imrecipes[top_imrecipes].msg_room[0]);
+            imrecipes[top_imrecipes].msg_room[0] = str_dup(p);
+          } else if (!strn_cmp(tmp, "MC2", 3)) {
+            p = tmp + 3;
+            skip_spaces(&p);
+            if (imrecipes[top_imrecipes].msg_char[1])
+              free(imrecipes[top_imrecipes].msg_char[1]);
+            imrecipes[top_imrecipes].msg_char[1] = str_dup(p);
+          } else if (!strn_cmp(tmp, "MR2", 3)) {
+            p = tmp + 3;
+            skip_spaces(&p);
+            if (imrecipes[top_imrecipes].msg_room[1])
+              free(imrecipes[top_imrecipes].msg_room[1]);
+            imrecipes[top_imrecipes].msg_room[1] = str_dup(p);
+          } else if (!strn_cmp(tmp, "MC3", 3)) {
+            p = tmp + 3;
+            skip_spaces(&p);
+            if (imrecipes[top_imrecipes].msg_char[2])
+              free(imrecipes[top_imrecipes].msg_char[2]);
+            imrecipes[top_imrecipes].msg_char[2] = str_dup(p);
+          } else if (!strn_cmp(tmp, "MR3", 3)) {
+            p = tmp + 3;
+            skip_spaces(&p);
+            if (imrecipes[top_imrecipes].msg_room[2])
+              free(imrecipes[top_imrecipes].msg_room[2]);
+            imrecipes[top_imrecipes].msg_room[2] = str_dup(p);
+          } else if (!strn_cmp(tmp, "DAM", 3)) {
+            if (sscanf(tmp, "%s %dd%d",
+                       dummy,
+                       &imrecipes[top_imrecipes].x,
+                       &imrecipes[top_imrecipes].y) != 3) {
+              log("[IM] Invalid DAM recipe string (%2d) '%s'!\n"
+                  "Format : DAM <x (%%d)>d<y (%%d)>",
+                  imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              sprintf(text, "[IM] Invalid DAM recipe string (%2d) '%s' !",
+                      imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              imlog(NRM, text);
+              break;
+            }
+          } else if (!strn_cmp(tmp, "REQ", 3)) {
+            im_parse(&imrecipes[top_imrecipes].require, tmp + 3);
+          } else if (!strn_cmp(tmp, "ADD", 3)) {
+            im_addon *adi;
+            int n, k0, k1, k2, id;
+            if (sscanf(tmp, "%s %d %s %d %d %d",
+                       dummy, &n, name, &k0, &k1, &k2) != 6) {
+              log("[IM] Invalid ADD recipe string (%2d) '%s'!\n"
+                  "Format : ADD <Nmax (%%d)> <type (%%s)> <n1 (%%d)> <n2 (%%d)> <n3 (%%d)>",
+                  imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              sprintf(text, "[IM] Invalid ADD recipe string (%2d) '%s' !",
+                      imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
+              imlog(NRM, text);
+              break;
+            }
+            id = im_get_type_by_name(name, 1);
+            if (id < 0)
+              break;
+            while (n--) {
+              CREATE(adi, 1);
+              adi->id = id;
+              adi->k0 = k0;
+              adi->k1 = k1;
+              adi->k2 = k2;
+              adi->obj = NULL;
+              adi->link = imrecipes[top_imrecipes].addon;
+              imrecipes[top_imrecipes].addon = adi;
+            }
+          }
+        }
+        if (*tmp == '~')
+          continue;
+      }
+      sprintf(text, "[IM] Invalid recipe : '%s'", tmp);
+      imlog(NRM, text);
+    } else {
+      if (*tmp) {
+        sprintf(text, "[IM] Unrecognized command : '%s'", tmp);
+        imlog(NRM, text);
+      }
+    }
+  }
 
-	// ПРОХОД 2
-	rewind(im_file);
-	while (get_line(im_file, tmp))
-	{
-		int id, vnum;
-		char dummy[128], name[128], text[1024];
+  fclose(im_file);
 
-		if (!strn_cmp(tmp, "ТИП", 3))  	// Описание типа
-		{
-			if (sscanf(tmp, "%s %d %s %d", dummy, &id, name, &vnum) == 4)
-			{
-				++top_imtypes;
-				imtypes[top_imtypes].id = id;
-				imtypes[top_imtypes].name = str_dup(name);
-				imtypes[top_imtypes].proto_vnum = vnum;
-				imtypes[top_imtypes].head = NULL;
-				imtypes[top_imtypes].tlst.size = 0;
-				TypeListSetSingle(&imtypes[top_imtypes].tlst, top_imtypes);
-				continue;
-			}
-			sprintf(text, "[IM] Invalid type : '%s'", tmp);
-			imlog(NRM, text);
-		}
-		else if (!strn_cmp(tmp, "МЕТАТИП", 7))
-		{
-			if (sscanf(tmp, "%s %d %s %s", dummy, &id, name, tlist) == 4)
-			{
-				char *p;
-				++top_imtypes;
-				imtypes[top_imtypes].id = id;
-				imtypes[top_imtypes].name = str_dup(name);
-				imtypes[top_imtypes].proto_vnum = -1;
-				imtypes[top_imtypes].head = NULL;
-				imtypes[top_imtypes].tlst.size = 0;
-				for (p = strtok(tlist, ","); p; p = strtok(NULL, ","))
-				{
-					int i = im_get_type_by_name(p, 1);	// поиск любого типа
-					if (i == -1)
-					{
-						sprintf(text, "[IM] Invalid type name : '%s'", p);
-						imlog(NRM, text);
-						continue;
-					}
-					TypeListSet(&imtypes[top_imtypes].tlst, &imtypes[i].tlst);
-				}
-				continue;
-			}
-			sprintf(text, "[IM] Invalid metatype : %s", tmp);
-			imlog(NRM, text);
-		}
-		else if (!strn_cmp(tmp, "ВИД", 3))
-		{
-			int power, sex;
-			mptr = mbs;
-			mbs = mbs->next;
-			if (sscanf(tmp, "%s %s %d %d", dummy, name, &power, &sex) == 4)
-			{
-				int i = im_get_type_by_name(name, 0);	// поиск элементарного типа
-				if (i != -1)
-				{
-					char **p;
-					im_memb *ins_after, *ins_before;
-					CREATE(mptr->aliases, 2 * (mptr->power + 1));
-					mptr->power = power;
-					mptr->sex = static_cast<ESex>(sex);
-					p = mptr->aliases;
-					while (get_line(im_file, tmp))
-					{
-						if (*tmp == '~')
-							break;
-						sscanf(tmp, "%s %s", name, text);
-						*p++ = str_dup(name);
-						*p++ = str_dup(text);
-					}
-					p[0] = p[1] = NULL;
-					// Добавляю в структуру типа согласно силе
-					ins_after = NULL;
-					ins_before = imtypes[i].head;
-					while (ins_before && ins_before->power < mptr->power)
-					{
-						ins_after = ins_before;
-						ins_before = ins_before->next;
-					}
-					if (ins_after == NULL)
-						imtypes[i].head = mptr;
-					else
-						ins_after->next = mptr;
-					mptr->next = ins_before;
-					continue;
-				}
-				sprintf(text, "[IM] Can not find type : '%s'", name);
-				imlog(NRM, text);
-			}
-			free(mptr);
-			while (get_line(im_file, tmp))
-				if (*tmp == '~')
-					break;
-			if (*tmp != '~')
-			{
-				sprintf(text, "[IM] Invalid inrgedient : '%s'", tmp);
-				imlog(NRM, text);
-			}
-		}
-		else if (!strn_cmp(tmp, "РЕЦЕПТ", 6))
-		{
-			char *p;
-			// Описание рецепта
-			if (sscanf(tmp, "%s %d %s", dummy, &id, name) == 3)
-			{
-				for (p = name; *p; ++p)
-					if (*p == '_')
-						*p = ' ';
-				++top_imrecipes;
-				imrecipes[top_imrecipes].id = id;
-				imrecipes[top_imrecipes].name = str_dup(name);
-				imrecipes[top_imrecipes].k_improve = 1000;
-				while (get_line(im_file, tmp))
-				{
-					if (*tmp == '~')
-						break;
-					if (!strn_cmp(tmp, "OBJ", 3))
-					{
-						if (sscanf(tmp, "%s %d", dummy, &imrecipes[top_imrecipes].result) != 2)
-						{
-							log("[IM] Invalid OBJ recipe string (%2d) '%s'!\n"
-								"Format : OBJ <vnum (%%d)>",
-								imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							sprintf(text, "[IM] Invalid OBJ recipe string (%2d) '%s' !",
-									imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							imlog(NRM, text);
-							break;
-						}
-					}
-					else if (!strn_cmp(tmp, "IMP", 3))
-					{
-						if (sscanf
-								(tmp, "%s %d", dummy, &imrecipes[top_imrecipes].k_improve) != 2)
-						{
-							log("[IM] Invalid IMP recipe string (%2d) '%s'!\n",
-								imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							sprintf(text, "[IM] Invalid IMP recipe string (%2d) '%s' !",
-									imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							imlog(NRM, text);
-							break;
-						}
-					}
-					else if (!strn_cmp(tmp, "CON", 3))
-					{
-						if (sscanf(tmp, "%s %f %f %f %f",
-								   dummy,
-								   &imrecipes[top_imrecipes].k[0],
-								   &imrecipes[top_imrecipes].k[1],
-								   &imrecipes[top_imrecipes].k[2],
-								   &imrecipes[top_imrecipes].kp) != 5)
-						{
-							log("[IM] Invalid CON recipe string (%2d) '%s'!\n"
-								"Format : CON <k1 (%%d)> <k2 (%%f)> <k3 (%%d)> <kp (%%d)>",
-								imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							sprintf(text, "[IM] Invalid CON recipe string (%2d) '%s' !",
-									imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							imlog(NRM, text);
-							break;
-						}
-					}
-					else if (!strn_cmp(tmp, "MC1", 3))
-					{
-						p = tmp + 3;
-						skip_spaces(&p);
-						if (imrecipes[top_imrecipes].msg_char[0])
-							free(imrecipes[top_imrecipes].msg_char[0]);
-						imrecipes[top_imrecipes].msg_char[0] = str_dup(p);
-					}
-					else if (!strn_cmp(tmp, "MR1", 3))
-					{
-						p = tmp + 3;
-						skip_spaces(&p);
-						if (imrecipes[top_imrecipes].msg_room[0])
-							free(imrecipes[top_imrecipes].msg_room[0]);
-						imrecipes[top_imrecipes].msg_room[0] = str_dup(p);
-					}
-					else if (!strn_cmp(tmp, "MC2", 3))
-					{
-						p = tmp + 3;
-						skip_spaces(&p);
-						if (imrecipes[top_imrecipes].msg_char[1])
-							free(imrecipes[top_imrecipes].msg_char[1]);
-						imrecipes[top_imrecipes].msg_char[1] = str_dup(p);
-					}
-					else if (!strn_cmp(tmp, "MR2", 3))
-					{
-						p = tmp + 3;
-						skip_spaces(&p);
-						if (imrecipes[top_imrecipes].msg_room[1])
-							free(imrecipes[top_imrecipes].msg_room[1]);
-						imrecipes[top_imrecipes].msg_room[1] = str_dup(p);
-					}
-					else if (!strn_cmp(tmp, "MC3", 3))
-					{
-						p = tmp + 3;
-						skip_spaces(&p);
-						if (imrecipes[top_imrecipes].msg_char[2])
-							free(imrecipes[top_imrecipes].msg_char[2]);
-						imrecipes[top_imrecipes].msg_char[2] = str_dup(p);
-					}
-					else if (!strn_cmp(tmp, "MR3", 3))
-					{
-						p = tmp + 3;
-						skip_spaces(&p);
-						if (imrecipes[top_imrecipes].msg_room[2])
-							free(imrecipes[top_imrecipes].msg_room[2]);
-						imrecipes[top_imrecipes].msg_room[2] = str_dup(p);
-					}
-					else if (!strn_cmp(tmp, "DAM", 3))
-					{
-						if (sscanf(tmp, "%s %dd%d",
-								   dummy,
-								   &imrecipes[top_imrecipes].x,
-								   &imrecipes[top_imrecipes].y) != 3)
-						{
-							log("[IM] Invalid DAM recipe string (%2d) '%s'!\n"
-								"Format : DAM <x (%%d)>d<y (%%d)>",
-								imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							sprintf(text, "[IM] Invalid DAM recipe string (%2d) '%s' !",
-									imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							imlog(NRM, text);
-							break;
-						}
-					}
-					else if (!strn_cmp(tmp, "REQ", 3))
-					{
-						im_parse(&imrecipes[top_imrecipes].require, tmp + 3);
-					}
-					else if (!strn_cmp(tmp, "ADD", 3))
-					{
-						im_addon *adi;
-						int n, k0, k1, k2, id;
-						if (sscanf(tmp, "%s %d %s %d %d %d",
-								   dummy, &n, name, &k0, &k1, &k2) != 6)
-						{
-							log("[IM] Invalid ADD recipe string (%2d) '%s'!\n"
-								"Format : ADD <Nmax (%%d)> <type (%%s)> <n1 (%%d)> <n2 (%%d)> <n3 (%%d)>",
-								imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							sprintf(text, "[IM] Invalid ADD recipe string (%2d) '%s' !",
-									imrecipes[top_imrecipes].id, imrecipes[top_imrecipes].name);
-							imlog(NRM, text);
-							break;
-						}
-						id = im_get_type_by_name(name, 1);
-						if (id < 0)
-							break;
-						while (n--)
-						{
-							CREATE(adi, 1);
-							adi->id = id;
-							adi->k0 = k0;
-							adi->k1 = k1;
-							adi->k2 = k2;
-							adi->obj = NULL;
-							adi->link = imrecipes[top_imrecipes].addon;
-							imrecipes[top_imrecipes].addon = adi;
-						}
-					}
-				}
-				if (*tmp == '~')
-					continue;
-			}
-			sprintf(text, "[IM] Invalid recipe : '%s'", tmp);
-			imlog(NRM, text);
-		}
-		else
-		{
-			if (*tmp)
-			{
-				sprintf(text, "[IM] Unrecognized command : '%s'", tmp);
-				imlog(NRM, text);
-			}
-		}
-	}
+  // Перестройка принадлежности элементарных типов
+  for (i = 0; i <= top_imtypes; ++i) {
+    if (imtypes[i].proto_vnum == -1)
+      continue;
+    for (j = 0; j <= top_imtypes; ++j)
+      if (i != j && imtypes[j].proto_vnum == -1 && TypeListCheck(&imtypes[j].tlst, i))
+        TypeListSetSingle(&imtypes[i].tlst, j);
+  }
+  // Удаление списков для составных типов
+  for (i = 0; i <= top_imtypes; ++i) {
+    if (imtypes[i].proto_vnum != -1)
+      continue;
+    imtypes[i].tlst.size = 0;
+    free(imtypes[i].tlst.types);
+  }
 
-	fclose(im_file);
+  // Прописываем для зарегестрированных рецептов всем классам KNOW_SKILL,
+  // но уровни и реморты равные -1, т.о. если файл classrecipe.lst поврежден,
+  // рецепты не будут обнулятся, просто станут недоступны для изучения
+  for (i = 0; i <= top_imrecipes; i++) {
+    for (j = 0; j < NUM_PLAYER_CLASSES; j++)
+      imrecipes[i].classknow[j] = KNOW_RECIPE;
+    imrecipes[i].level = -1;
+    imrecipes[i].remort = -1;
+  }
 
-	// Перестройка принадлежности элементарных типов
-	for (i = 0; i <= top_imtypes; ++i)
-	{
-		if (imtypes[i].proto_vnum == -1)
-			continue;
-		for (j = 0; j <= top_imtypes; ++j)
-			if (i != j && imtypes[j].proto_vnum == -1 && TypeListCheck(&imtypes[j].tlst, i))
-				TypeListSetSingle(&imtypes[i].tlst, j);
-	}
-	// Удаление списков для составных типов
-	for (i = 0; i <= top_imtypes; ++i)
-	{
-		if (imtypes[i].proto_vnum != -1)
-			continue;
-		imtypes[i].tlst.size = 0;
-		free(imtypes[i].tlst.types);
-	}
+  im_file = fopen(LIB_MISC "class.recipes.lst", "r");
+  if (!im_file) {
+    imlog(BRF, "Can not open classrecipe.lst. All recipes unavailable now");
+    return;
+  }
+  while (get_line(im_file, name)) {
+    if (!name[0] || name[0] == ';')
+      continue;
+    if (sscanf(name, "%d %s %s %d %d", k, line1, line2, k + 1, k + 2) != 5) {
+      log("Bad format for recipe string, recipe unavailable now!\r\n"
+          "Format : <recipe number (%%d)> <races (%%s)> <classes (%%s)> <level (%%d)> <remort (%%d)>");
+      continue;
+    }
+    rcpt = im_get_recipe(k[0]);
 
-	// Прописываем для зарегестрированных рецептов всем классам KNOW_SKILL,
-	// но уровни и реморты равные -1, т.о. если файл classrecipe.lst поврежден,
-	// рецепты не будут обнулятся, просто станут недоступны для изучения
-	for (i = 0; i <= top_imrecipes; i++)
-	{
-		for (j = 0; j < NUM_PLAYER_CLASSES; j++)
-			imrecipes[i].classknow[j] = KNOW_RECIPE;
-		imrecipes[i].level = -1;
-		imrecipes[i].remort = -1;
-	}
+    if (rcpt < 0) {
+      log("Invalid recipe (%d)", k[0]);
+      continue;
+    }
 
-	im_file = fopen(LIB_MISC "class.recipes.lst", "r");
-	if (!im_file)
-	{
-		imlog(BRF, "Can not open classrecipe.lst. All recipes unavailable now");
-		return;
-	}
-	while (get_line(im_file, name))
-	{
-		if (!name[0] || name[0] == ';')
-			continue;
-		if (sscanf(name, "%d %s %s %d %d", k, line1, line2, k + 1, k + 2) != 5)
-		{
-			log("Bad format for recipe string, recipe unavailable now!\r\n"
-				"Format : <recipe number (%%d)> <races (%%s)> <classes (%%s)> <level (%%d)> <remort (%%d)>");
-			continue;
-		}
-		rcpt = im_get_recipe(k[0]);
+    if (k[1] < 0 || k[1] >= 31) {
+      log("Bad level type for recipe (%d '%s'), set level to -1 (unavailable)", k[0], imrecipes[rcpt].name);
+      imrecipes[rcpt].level = 0;
+      continue;
+    }
 
-		if (rcpt < 0)
-		{
-			log("Invalid recipe (%d)", k[0]);
-			continue;
-		}
+    if (k[2] < 0 || k[2] >= MAX_REMORT) {
+      log("Bad remort type for recipe (%d '%s'), set remort to -1 (unavailable)", k[0], imrecipes[rcpt].name);
+      imrecipes[rcpt].remort = 0;
+      continue;
+    }
 
-		if (k[1] < 0 || k[1] >= 31)
-		{
-			log("Bad level type for recipe (%d '%s'), set level to -1 (unavailable)", k[0], imrecipes[rcpt].name);
-			imrecipes[rcpt].level = 0;
-			continue;
-		}
+    imrecipes[rcpt].level = k[1];
+    log("Set recipe (%d '%s') remort %d", k[0], imrecipes[rcpt].name, k[1]);
 
-		if (k[2] < 0 || k[2] >= MAX_REMORT)
-		{
-			log("Bad remort type for recipe (%d '%s'), set remort to -1 (unavailable)", k[0], imrecipes[rcpt].name);
-			imrecipes[rcpt].remort = 0;
-			continue;
-		}
-
-		imrecipes[rcpt].level = k[1];
-		log("Set recipe (%d '%s') remort %d", k[0], imrecipes[rcpt].name, k[1]);
-
-		imrecipes[rcpt].remort = k[2];
-		log("Set recipe (%d '%s') remort %d", k[0], imrecipes[rcpt].name, k[2]);
+    imrecipes[rcpt].remort = k[2];
+    log("Set recipe (%d '%s') remort %d", k[0], imrecipes[rcpt].name, k[2]);
 
 // line1 - ограничения для рас еще не реализованы
 
-		for (j = 0; line2[j] && j < NUM_PLAYER_CLASSES; j++)
-		{
-			if (!strchr("1xX!", line2[j]))
-			{
-				imrecipes[rcpt].classknow[j] = 0;
-			}
-			else
-			{
-				imrecipes[rcpt].classknow[j] = KNOW_RECIPE;
-				log("Set recipe (%d '%s') classes %d is Know", k[0], imrecipes[rcpt].name, j);
-			}
-		}
-	}
-	fclose(im_file);
+    for (j = 0; line2[j] && j < NUM_PLAYER_CLASSES; j++) {
+      if (!strchr("1xX!", line2[j])) {
+        imrecipes[rcpt].classknow[j] = 0;
+      } else {
+        imrecipes[rcpt].classknow[j] = KNOW_RECIPE;
+        log("Set recipe (%d '%s') classes %d is Know", k[0], imrecipes[rcpt].name, j);
+      }
+    }
+  }
+  fclose(im_file);
 
-
-	im_translate_rskill_to_rid();
+  im_translate_rskill_to_rid();
 
 #if 0
-	log(NRM, "IM types dump");
-	for (i = 0; i <= top_imtypes; ++i)
-	{
-		int j;
-		log("RNUM=%d,ID=%d,NAME: %s", i, imtypes[i].id, imtypes[i].name);
-		for (j = 0; j < imtypes[i].tlst.size; ++j)
-			log("%08lX", imtypes[i].tlst.types[j]);
-	}
-	log("IM recipes dump");
-	for (i = 0; i <= top_imrecipes; ++i)
-	{
-		log("RNUM=%d,ID=%d,NAME: %s", i, imrecipes[i].id, imrecipes[i].name);
-	}
+  log(NRM, "IM types dump");
+  for (i = 0; i <= top_imtypes; ++i)
+  {
+      int j;
+      log("RNUM=%d,ID=%d,NAME: %s", i, imtypes[i].id, imtypes[i].name);
+      for (j = 0; j < imtypes[i].tlst.size; ++j)
+          log("%08lX", imtypes[i].tlst.types[j]);
+  }
+  log("IM recipes dump");
+  for (i = 0; i <= top_imrecipes; ++i)
+  {
+      log("RNUM=%d,ID=%d,NAME: %s", i, imrecipes[i].id, imrecipes[i].name);
+  }
 #endif
 
 }
@@ -952,1053 +828,918 @@ void init_im(void)
 // Просматривает строку line и добавляет загружаемые ингрединенты
 // Формат строки: <номер>:<вер-ть>
 // Не используется, т.к. ингредиенты перенесены в конфиг зон и мобов в misc
-void im_parse(int **ing_list, char *line)
-{
-	int local_count = 0;
-	int count = 0;
-	int *local_list = NULL;
-	int *res;
-	int n, l, p, *ptr;
+void im_parse(int **ing_list, char *line) {
+  int local_count = 0;
+  int count = 0;
+  int *local_list = NULL;
+  int *res;
+  int n, l, p, *ptr;
 
-	while (1)
-	{
-		skip_spaces(&line);
-		if (*line == 0)
-			break;
-		if (a_isdigit(*line))
-		{
-			n = strtol(line, &line, 10);
-			n = im_type_rnum(n);
-		}
-		else
-		{
-			n = im_get_type_by_name(line, 1);
-			if (n >= 0)
-				line += strlen(imtypes[n].name);
-		}
-		if (n < 0)
-			break;
-		l = 0xFFFF;
-		if (*line == ',')
-		{
-			++line;
-			l = strtol(line, &line, 10);
-		}
-		if (*line++ != ':')
-		{
-			break;
-		}
+  while (1) {
+    skip_spaces(&line);
+    if (*line == 0)
+      break;
+    if (a_isdigit(*line)) {
+      n = strtol(line, &line, 10);
+      n = im_type_rnum(n);
+    } else {
+      n = im_get_type_by_name(line, 1);
+      if (n >= 0)
+        line += strlen(imtypes[n].name);
+    }
+    if (n < 0)
+      break;
+    l = 0xFFFF;
+    if (*line == ',') {
+      ++line;
+      l = strtol(line, &line, 10);
+    }
+    if (*line++ != ':') {
+      break;
+    }
 
-		p = strtol(line, &line, 10);
-		if (!p)
-		{
-			break;
-		}
+    p = strtol(line, &line, 10);
+    if (!p) {
+      break;
+    }
 
-		if (!local_count)
-		{
-			CREATE(local_list, 2);
-		}
-		else
-		{
-			RECREATE(local_list, local_count + 2);
-		}
+    if (!local_count) {
+      CREATE(local_list, 2);
+    } else {
+      RECREATE(local_list, local_count + 2);
+    }
 
-		local_list[local_count++] = n;
-		local_list[local_count++] = (l << 16) | p;
-	}
-	if (*ing_list)
-	{
-		for (ptr = *ing_list; (*ptr++ != -1););
-		count = ptr - *ing_list - 1;
-	}
-	CREATE(res, local_count + count + 1);
-	if (count)
-	{
-		memcpy(res, *ing_list, count * sizeof(int));
-	}
-	memcpy(res + count, local_list, local_count * sizeof(int));
-	res[count + local_count] = -1;
-	if (*ing_list)
-	{
-		free(*ing_list);
-	}
-	free(local_list);
-	*ing_list = res;
+    local_list[local_count++] = n;
+    local_list[local_count++] = (l << 16) | p;
+  }
+  if (*ing_list) {
+    for (ptr = *ing_list; (*ptr++ != -1););
+    count = ptr - *ing_list - 1;
+  }
+  CREATE(res, local_count + count + 1);
+  if (count) {
+    memcpy(res, *ing_list, count * sizeof(int));
+  }
+  memcpy(res + count, local_list, local_count * sizeof(int));
+  res[count + local_count] = -1;
+  if (*ing_list) {
+    free(*ing_list);
+  }
+  free(local_list);
+  *ing_list = res;
 }
 
-void im_reset_room(ROOM_DATA * room, int level, int type)
-{
-	OBJ_DATA *o, *next;
-	int i, indx;
-	im_memb *after, *before;
-	int pow, lev = level;
-	// 40 * level / MAX_ZONE_LEVEL;
+void im_reset_room(ROOM_DATA *room, int level, int type) {
+  OBJ_DATA *o, *next;
+  int i, indx;
+  im_memb *after, *before;
+  int pow, lev = level;
+  // 40 * level / MAX_ZONE_LEVEL;
 
-	for (o = room->contents; o; o = next)
-	{
-		next = o->get_next_content();
-		if (GET_OBJ_TYPE(o) == OBJ_DATA::ITEM_MING)
-		{
-			extract_obj(o);
-		}
-	}
-	if (!zone_types[type].ingr_qty
-		|| room->get_flag(ROOM_DEATH))
-	{
-		return;
-	}
-	for (i = 0; i < zone_types[type].ingr_qty; i++)
-	{
-		//	3% - 1-17
-		//	2% - 18-34
-		//	1% - 35-50
-		//		if (number(1, 100) <= 3 - 3 * (level - 1) / MAX_ZONE_LEVEL)
-		if (number(1, 1000) <= (4 - level / 10) * 10)
-		{
-			indx = im_type_rnum(zone_types[type].ingr_types[i]);
-			if (indx == -1)
-			{
-				log("SYSERR: WRONG INGREDIENT TYPE ID %d IN ZTYPES.LST", zone_types[type].ingr_types[i]);
-				continue;
-			}
-			after = NULL;
-			before = imtypes[indx].head;
-			while (before && before->power < lev)
-			{
-				after = before;
-				before = before->next;
-			}
-			if (after == NULL && before == NULL)
-			{
-				log("SYSERR: NO INGREDIENTS OF TYPE %d AVAILABLE NOW", indx);
-				continue;
-			}
-			else if (after == NULL)
-				pow = before->power;
-			else if (before == NULL)
-				pow = after->power;
-			else
-				pow = lev - after->power < before->power - lev ? after->power : before->power;
-			o = load_ingredient(indx, pow, -1);
-			if (o)
-				obj_to_room(o, real_room(room->number));
-		}
-	}
+  for (o = room->contents; o; o = next) {
+    next = o->get_next_content();
+    if (GET_OBJ_TYPE(o) == OBJ_DATA::ITEM_MING) {
+      extract_obj(o);
+    }
+  }
+  if (!zone_types[type].ingr_qty
+      || room->get_flag(ROOM_DEATH)) {
+    return;
+  }
+  for (i = 0; i < zone_types[type].ingr_qty; i++) {
+    //	3% - 1-17
+    //	2% - 18-34
+    //	1% - 35-50
+    //		if (number(1, 100) <= 3 - 3 * (level - 1) / MAX_ZONE_LEVEL)
+    if (number(1, 1000) <= (4 - level / 10) * 10) {
+      indx = im_type_rnum(zone_types[type].ingr_types[i]);
+      if (indx == -1) {
+        log("SYSERR: WRONG INGREDIENT TYPE ID %d IN ZTYPES.LST", zone_types[type].ingr_types[i]);
+        continue;
+      }
+      after = NULL;
+      before = imtypes[indx].head;
+      while (before && before->power < lev) {
+        after = before;
+        before = before->next;
+      }
+      if (after == NULL && before == NULL) {
+        log("SYSERR: NO INGREDIENTS OF TYPE %d AVAILABLE NOW", indx);
+        continue;
+      } else if (after == NULL)
+        pow = before->power;
+      else if (before == NULL)
+        pow = after->power;
+      else
+        pow = lev - after->power < before->power - lev ? after->power : before->power;
+      o = load_ingredient(indx, pow, -1);
+      if (o)
+        obj_to_room(o, real_room(room->number));
+    }
+  }
 }
 
 extern MobRaceListType mobraces_list;
 
-OBJ_DATA* try_make_ingr(int *ing_list, int vnum, int max_prob)
-{
-	for (int indx = 0; ing_list[indx] != -1; indx += 2)
-	{
-		int power;
-		if (number(1, max_prob) >= (ing_list[indx + 1] & 0xFFFF))
-		{
-			continue;
-		}
-		power = (ing_list[indx + 1] >> 16) & 0xFFFF;
-		if (power == 0xFFFF)
-		{
-			power = im_calc_power();
-		}
-		return load_ingredient(ing_list[indx], power, vnum);
-	}
-	return NULL;
+OBJ_DATA *try_make_ingr(int *ing_list, int vnum, int max_prob) {
+  for (int indx = 0; ing_list[indx] != -1; indx += 2) {
+    int power;
+    if (number(1, max_prob) >= (ing_list[indx + 1] & 0xFFFF)) {
+      continue;
+    }
+    power = (ing_list[indx + 1] >> 16) & 0xFFFF;
+    if (power == 0xFFFF) {
+      power = im_calc_power();
+    }
+    return load_ingredient(ing_list[indx], power, vnum);
+  }
+  return NULL;
 }
 
-OBJ_DATA* try_make_ingr(CHAR_DATA* mob, int prob_default, int prob_special)
-{
-	MobRaceListType::iterator it = mobraces_list.find(GET_RACE(mob));
-	const int vnum = GET_MOB_VNUM(mob);
-	if (it != mobraces_list.end())
-	{
-		size_t num_inrgs = it->second->ingrlist.size();
-		int* ingr_to_load_list = NULL;
-		CREATE(ingr_to_load_list, num_inrgs * 2 + 1);
-		size_t j = 0;
-		const int level_mob = GET_LEVEL(mob) > 0 ? GET_LEVEL(mob) : 1;
-		for (; j < num_inrgs; j++)
-		{
-			ingr_to_load_list[2*j] = im_get_idx_by_type(it->second->ingrlist[j].imtype);
-			ingr_to_load_list[2*j+1] = it->second->ingrlist[j].prob.at(level_mob - 1);
-			ingr_to_load_list[2*j+1] |= (level_mob << 16);
-		}
-		ingr_to_load_list[2*j] = -1;
-		return try_make_ingr(ingr_to_load_list, vnum, prob_default);
-	}
+OBJ_DATA *try_make_ingr(CHAR_DATA *mob, int prob_default, int prob_special) {
+  MobRaceListType::iterator it = mobraces_list.find(GET_RACE(mob));
+  const int vnum = GET_MOB_VNUM(mob);
+  if (it != mobraces_list.end()) {
+    size_t num_inrgs = it->second->ingrlist.size();
+    int *ingr_to_load_list = NULL;
+    CREATE(ingr_to_load_list, num_inrgs * 2 + 1);
+    size_t j = 0;
+    const int level_mob = GET_LEVEL(mob) > 0 ? GET_LEVEL(mob) : 1;
+    for (; j < num_inrgs; j++) {
+      ingr_to_load_list[2 * j] = im_get_idx_by_type(it->second->ingrlist[j].imtype);
+      ingr_to_load_list[2 * j + 1] = it->second->ingrlist[j].prob.at(level_mob - 1);
+      ingr_to_load_list[2 * j + 1] |= (level_mob << 16);
+    }
+    ingr_to_load_list[2 * j] = -1;
+    return try_make_ingr(ingr_to_load_list, vnum, prob_default);
+  }
 
-	return NULL;
+  return NULL;
 }
 
-void list_recipes(CHAR_DATA * ch, bool all_recipes)
-{
-	int i = 0, sortpos;
+void list_recipes(CHAR_DATA *ch, bool all_recipes) {
+  int i = 0, sortpos;
 // +newbook.patch (Alisher)
-	im_rskill *rs;
+  im_rskill *rs;
 // -newbook.patch (Alisher)
 
-	if (all_recipes)
-	{
-		if (clr(ch, C_NRM))
-		{
-			sprintf(buf, " Список доступных рецептов.\r\n"
-				" Зеленым цветом выделены уже изученные рецепты.\r\n"
-				" Красным цветом выделены рецепты, недоступные вам в настоящий момент.\r\n"
-				"\r\n     Рецепт                Уровень (реморт)\r\n"
-				"------------------------------------------------\r\n");
-		}
-		else
-		{
-			sprintf(buf, " Список доступных рецептов.\r\n"
-				" Пометкой [И] выделены уже изученные рецепты.\r\n"
-				" Пометкой [Д] выделены доступные для изучения рецепты.\r\n"
-				" Пометкой [Н] выделены рецепты, недоступные вам в настоящий момент.\r\n"
-				"\r\n     Рецепт                Уровень (реморт)\r\n"
-				"------------------------------------------------\r\n");
-		}
-		strcpy(buf1, buf);
-		for (sortpos = 0, i = 0; sortpos <= top_imrecipes; sortpos++)
-		{
-			if (!imrecipes[sortpos].classknow[(int) GET_CLASS(ch)])
-			{
-				continue;
-			}
+  if (all_recipes) {
+    if (clr(ch, C_NRM)) {
+      sprintf(buf, " Список доступных рецептов.\r\n"
+                   " Зеленым цветом выделены уже изученные рецепты.\r\n"
+                   " Красным цветом выделены рецепты, недоступные вам в настоящий момент.\r\n"
+                   "\r\n     Рецепт                Уровень (реморт)\r\n"
+                   "------------------------------------------------\r\n");
+    } else {
+      sprintf(buf, " Список доступных рецептов.\r\n"
+                   " Пометкой [И] выделены уже изученные рецепты.\r\n"
+                   " Пометкой [Д] выделены доступные для изучения рецепты.\r\n"
+                   " Пометкой [Н] выделены рецепты, недоступные вам в настоящий момент.\r\n"
+                   "\r\n     Рецепт                Уровень (реморт)\r\n"
+                   "------------------------------------------------\r\n");
+    }
+    strcpy(buf1, buf);
+    for (sortpos = 0, i = 0; sortpos <= top_imrecipes; sortpos++) {
+      if (!imrecipes[sortpos].classknow[(int) GET_CLASS(ch)]) {
+        continue;
+      }
 
-			if (strlen(buf1) >= MAX_STRING_LENGTH - 60)
-			{
-				strcat(buf1, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-				break;
-			}
-			rs = im_get_char_rskill(ch, sortpos);
-			if (clr(ch, C_NRM))
-				sprintf(buf, "     %s%-30s%s %2d (%2d)%s\r\n",
-					(imrecipes[sortpos].level < 0 || imrecipes[sortpos].level > GET_LEVEL(ch) ||
-					 imrecipes[sortpos].remort < 0 || imrecipes[sortpos].remort > GET_REMORT(ch)) ?
-					KRED : rs ? KGRN : KNRM,	imrecipes[sortpos].name, KCYN,
-					imrecipes[sortpos].level, imrecipes[sortpos].remort, KNRM);
-			else
-				sprintf(buf, " %s %-30s %2d (%2d)\r\n",
-					(imrecipes[sortpos].level < 0 || imrecipes[sortpos].level > GET_LEVEL(ch) ||
-					 imrecipes[sortpos].remort < 0 || imrecipes[sortpos].remort > GET_REMORT(ch)) ?
-					"[Н]" : rs ? "[И]" : "[Д]",	imrecipes[sortpos].name,
-					imrecipes[sortpos].level, imrecipes[sortpos].remort);
-			strcat(buf1, buf);
-			++i;
-		}
-		if (!i)
-			sprintf(buf1 + strlen(buf1), "Нет рецептов.\r\n");
-		page_string(ch->desc, buf1, 1);
-		return;
-	}
+      if (strlen(buf1) >= MAX_STRING_LENGTH - 60) {
+        strcat(buf1, "***ПЕРЕПОЛНЕНИЕ***\r\n");
+        break;
+      }
+      rs = im_get_char_rskill(ch, sortpos);
+      if (clr(ch, C_NRM))
+        sprintf(buf, "     %s%-30s%s %2d (%2d)%s\r\n",
+                (imrecipes[sortpos].level<0 || imrecipes[sortpos].level>GET_LEVEL(ch) ||
+                    imrecipes[sortpos].remort<0 || imrecipes[sortpos].remort>GET_REMORT(ch)) ?
+                KRED : rs ? KGRN : KNRM, imrecipes[sortpos].name, KCYN,
+                imrecipes[sortpos].level, imrecipes[sortpos].remort, KNRM);
+      else
+        sprintf(buf, " %s %-30s %2d (%2d)\r\n",
+                (imrecipes[sortpos].level<0 || imrecipes[sortpos].level>GET_LEVEL(ch) ||
+                    imrecipes[sortpos].remort<0 || imrecipes[sortpos].remort>GET_REMORT(ch)) ?
+                "[Н]" : rs ? "[И]" : "[Д]", imrecipes[sortpos].name,
+                imrecipes[sortpos].level, imrecipes[sortpos].remort);
+      strcat(buf1, buf);
+      ++i;
+    }
+    if (!i)
+      sprintf(buf1 + strlen(buf1), "Нет рецептов.\r\n");
+    page_string(ch->desc, buf1, 1);
+    return;
+  }
 
-	sprintf(buf, "Вы владеете следующими рецептами :\r\n");
+  sprintf(buf, "Вы владеете следующими рецептами :\r\n");
 
-	strcpy(buf2, buf);
+  strcpy(buf2, buf);
 
-// newbook.patch ТУТ БЫЛ БЕСКОНЕЧНЫЙ ЦИКЛ
-	for (rs = GET_RSKILL(ch), i = 0; rs; rs = rs->link)
-	{
-// -newbook.patch (Alisher)
-		if (strlen(buf2) >= MAX_STRING_LENGTH - 60)
-		{
-			strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-			break;
-		}
-		if (rs->perc <= 0)
-			continue;
-		sprintf(buf, "%-30s %s\r\n", imrecipes[rs->rid].name, how_good(ch, rs->perc));
-		strcat(buf2, buf);
-		++i;
-	}
+  for (rs = GET_RSKILL(ch), i = 0; rs; rs = rs->link) {
+    if (strlen(buf2) >= MAX_STRING_LENGTH - 60) {
+      strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
+      break;
+    }
+    if (rs->perc <= 0)
+      continue;
+    sprintf(buf, "%-30s %s%s\r\n", imrecipes[rs->rid].name, how_good(rs->perc, kMaxRecipeLevel), KIDRK);
+    strcat(buf2, buf);
+    ++i;
+  }
 
-	if (!i)
-		sprintf(buf2 + strlen(buf2), "Нет рецептов.\r\n");
+  if (!i)
+    sprintf(buf2 + strlen(buf2), "Нет рецептов.\r\n");
 
-	page_string(ch->desc, buf2, 1);
+  page_string(ch->desc, buf2, 1);
 }
 
-void do_recipes(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	if (IS_NPC(ch))
-		return;
-	skip_spaces(&argument);
-	if (is_abbrev(argument, "все") || is_abbrev(argument, "all"))
-		list_recipes(ch, TRUE);
-	else
-		list_recipes(ch, FALSE);
+void do_recipes(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  if (IS_NPC(ch))
+    return;
+  skip_spaces(&argument);
+  if (is_abbrev(argument, "все") || is_abbrev(argument, "all"))
+    list_recipes(ch, TRUE);
+  else
+    list_recipes(ch, FALSE);
 }
 
-void do_rset(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	CHAR_DATA *vict;
-	char name[MAX_INPUT_LENGTH], buf2[128];
-	char buf[MAX_INPUT_LENGTH], help[MAX_STRING_LENGTH];
-	int rcpt = -1, value, i, qend;
-	im_rskill *rs;
+void do_rset(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *vict;
+  char name[MAX_INPUT_LENGTH], buf2[128];
+  char buf[MAX_INPUT_LENGTH], help[MAX_STRING_LENGTH];
+  int rcpt = -1, value, i, qend;
+  im_rskill *rs;
 
-	argument = one_argument(argument, name);
+  argument = one_argument(argument, name);
 
-	// * No arguments. print an informative text.
-	if (!*name)
-	{
-		send_to_char("Формат: rset <игрок> '<рецепт>' <значение>\r\n", ch);
-		strcpy(help, "Зарегистрированные рецепты:\r\n");
-		for (qend = 0, i = 0; i <= top_imrecipes; i++)
-		{
-			sprintf(help + strlen(help), "%30s", imrecipes[i].name);
-			if (qend++ % 2 == 1)
-			{
-				strcat(help, "\r\n");
-				send_to_char(help, ch);
-				*help = '\0';
-			}
-		}
-		if (*help)
-			send_to_char(help, ch);
-		send_to_char("\r\n", ch);
-		return;
-	}
+  // * No arguments. print an informative text.
+  if (!*name) {
+    send_to_char("Формат: rset <игрок> '<рецепт>' <значение>\r\n", ch);
+    strcpy(help, "Зарегистрированные рецепты:\r\n");
+    for (qend = 0, i = 0; i <= top_imrecipes; i++) {
+      sprintf(help + strlen(help), "%30s", imrecipes[i].name);
+      if (qend++ % 2 == 1) {
+        strcat(help, "\r\n");
+        send_to_char(help, ch);
+        *help = '\0';
+      }
+    }
+    if (*help)
+      send_to_char(help, ch);
+    send_to_char("\r\n", ch);
+    return;
+  }
 
-	if (!(vict = get_char_vis(ch, name, FIND_CHAR_WORLD)))
-	{
-		send_to_char(NOPERSON, ch);
-		return;
-	}
-	skip_spaces(&argument);
+  if (!(vict = get_char_vis(ch, name, FIND_CHAR_WORLD))) {
+    send_to_char(NOPERSON, ch);
+    return;
+  }
+  skip_spaces(&argument);
 
-	// If there is no chars in argument
-	if (!*argument)
-	{
-		send_to_char("Пропущено название рецепта.\r\n", ch);
-		return;
-	}
-	if (*argument != '\'')
-	{
-		send_to_char("Рецепт надо заключить в символы : ''\r\n", ch);
-		return;
-	}
-	// Locate the last quote and lowercase the magic words (if any)
+  // If there is no chars in argument
+  if (!*argument) {
+    send_to_char("Пропущено название рецепта.\r\n", ch);
+    return;
+  }
+  if (*argument != '\'') {
+    send_to_char("Рецепт надо заключить в символы : ''\r\n", ch);
+    return;
+  }
+  // Locate the last quote and lowercase the magic words (if any)
 
-	for (qend = 1; argument[qend] && argument[qend] != '\''; qend++)
-		argument[qend] = LOWER(argument[qend]);
+  for (qend = 1; argument[qend] && argument[qend] != '\''; qend++)
+    argument[qend] = LOWER(argument[qend]);
 
-	if (argument[qend] != '\'')
-	{
-		send_to_char("Рецепт должен быть заключен в символы : ''\r\n", ch);
-		return;
-	}
-	strcpy(help, (argument + 1));
-	help[qend - 1] = '\0';
+  if (argument[qend] != '\'') {
+    send_to_char("Рецепт должен быть заключен в символы : ''\r\n", ch);
+    return;
+  }
+  strcpy(help, (argument + 1));
+  help[qend - 1] = '\0';
 
-	rcpt = im_get_recipe_by_name(help);
+  rcpt = im_get_recipe_by_name(help);
 
-	if (rcpt < 0)
-	{
-		send_to_char("Неизвестный рецепт.\r\n", ch);
-		return;
-	}
-	argument += qend + 1;	// skip to next parameter
-	argument = one_argument(argument, buf);
+  if (rcpt < 0) {
+    send_to_char("Неизвестный рецепт.\r\n", ch);
+    return;
+  }
+  argument += qend + 1;    // skip to next parameter
+  argument = one_argument(argument, buf);
 
-	if (!*buf)
-	{
-		send_to_char("Пропущен уровень рецепта.\r\n", ch);
-		return;
-	}
-	value = atoi(buf);
-	if (value < 0)
-	{
-		send_to_char("Минимальное значение рецепта 0.\r\n", ch);
-		return;
-	}
-	if (value > 200)
-	{
-		send_to_char("Максимальное значение рецепта 200.\r\n", ch);
-		return;
-	}
-	if (IS_NPC(vict))
-	{
-		send_to_char("Вы не можете добавить рецепт для мобов.\r\n", ch);
-		return;
-	}
-	// Задача - найти рецепт rcpt и установить его в value
-	rs = im_get_char_rskill(vict, rcpt);
-	if (!rs)
-	{
-		CREATE(rs, 1);
-		rs->rid = rcpt;
-		rs->link = GET_RSKILL(vict);
-		GET_RSKILL(vict) = rs;
-	}
-	rs->perc = value;
+  if (!*buf) {
+    send_to_char("Пропущен уровень рецепта.\r\n", ch);
+    return;
+  }
+  value = atoi(buf);
+  if (value < 0) {
+    send_to_char("Минимальное значение рецепта 0.\r\n", ch);
+    return;
+  }
+  if (value > kMaxRecipeLevel) {
+    send_to_char("Превышено максимальное значение рецепта.\r\n", ch);
+    value = kMaxRecipeLevel;
+  }
+  if (IS_NPC(vict)) {
+    send_to_char("Вы не можете добавить рецепт для мобов.\r\n", ch);
+    return;
+  }
+  // Задача - найти рецепт rcpt и установить его в value
+  rs = im_get_char_rskill(vict, rcpt);
+  if (!rs) {
+    CREATE(rs, 1);
+    rs->rid = rcpt;
+    rs->link = GET_RSKILL(vict);
+    GET_RSKILL(vict) = rs;
+  }
+  rs->perc = value;
 
-	sprintf(buf2, "%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict), imrecipes[rcpt].name, value);
-	mudlog(buf2, BRF, -1, SYSLOG, TRUE);
-	imm_log("%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict), imrecipes[rcpt].name, value);
-	send_to_char(buf2, ch);
+  sprintf(buf2, "%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict), imrecipes[rcpt].name, value);
+  mudlog(buf2, BRF, -1, SYSLOG, TRUE);
+  imm_log("%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict), imrecipes[rcpt].name, value);
+  send_to_char(buf2, ch);
 }
 
-void im_improve_recipe(CHAR_DATA * ch, im_rskill * rs, int success) {
-	int prob, div, diff;
+void im_improve_recipe(CHAR_DATA *ch, im_rskill *rs, int success) {
+  int prob, div, diff;
 
-	if (IS_NPC(ch) || (rs->perc >=200))
-		return;
+  if (IS_NPC(ch) || (rs->perc >= kMaxRecipeLevel))
+    return;
 
-	if (ch->in_room != NOWHERE && (max_upgradable_skill(ch) - rs->perc > 0)) {
-		int n = ch->get_skills_count();
-		n = (n + 1) >> 1;
-		n += im_get_char_rskill_count(ch);
-		prob = success ? 20000 : 15000;
-		div = int_app[GET_REAL_INT(ch)].improve;
-		div += imrecipes[rs->rid].k_improve / 100;
-		prob /= (MAX(1, div));
-		diff = n - wis_bonus(GET_REAL_WIS(ch), WIS_MAX_SKILLS);
-		if (diff < 0)
-			prob += (5 * diff);
-		else
-			prob += (10 * diff);
-		prob += number(1, rs->perc * 5);
-		if (number(1, MAX(1, prob)) <= GET_REAL_INT(ch)) {
-			if (success)
-				sprintf(buf,
-						"%sВы постигли тонкости приготовления рецепта \"%s\".%s\r\n",
-						CCICYN(ch, C_NRM), imrecipes[rs->rid].name, CCNRM(ch, C_NRM));
-			else
-				sprintf(buf,
-						"%sНеудача позволила вам осознать тонкости приготовления рецепта \"%s\".%s\r\n",
-						CCICYN(ch, C_NRM), imrecipes[rs->rid].name, CCNRM(ch, C_NRM));
-			send_to_char(buf, ch);
-			rs->perc += number(1, 2);
-			if (!IS_IMMORTAL(ch))
-				rs->perc = MIN(MAX_EXP_PERCENT + GET_REMORT(ch) * 5, rs->perc);
-		}
-	}
+  if (ch->in_room != NOWHERE && (CalcSkillSoftCap(ch) - rs->perc > 0)) {
+    int n = ch->get_skills_count();
+    n = (n + 1) >> 1;
+    n += im_get_char_rskill_count(ch);
+    prob = success ? 20000 : 15000;
+    div = int_app[GET_REAL_INT(ch)].improve;
+    div += imrecipes[rs->rid].k_improve / 100;
+    prob /= (MAX(1, div));
+    diff = n - wis_bonus(GET_REAL_WIS(ch), WIS_MAX_SKILLS);
+    if (diff < 0)
+      prob += (5 * diff);
+    else
+      prob += (10 * diff);
+    prob += number(1, rs->perc * 5);
+    if (number(1, MAX(1, prob)) <= GET_REAL_INT(ch)) {
+      if (success)
+        sprintf(buf,
+                "%sВы постигли тонкости приготовления рецепта \"%s\".%s\r\n",
+                CCICYN(ch, C_NRM), imrecipes[rs->rid].name, CCNRM(ch, C_NRM));
+      else
+        sprintf(buf,
+                "%sНеудача позволила вам осознать тонкости приготовления рецепта \"%s\".%s\r\n",
+                CCICYN(ch, C_NRM), imrecipes[rs->rid].name, CCNRM(ch, C_NRM));
+      send_to_char(buf, ch);
+      rs->perc += number(1, 2);
+      if (!IS_IMMORTAL(ch))
+        rs->perc = MIN(kSkillCapOnZeroRemort + GET_REMORT(ch) * 5, rs->perc);
+    }
+  }
 }
 
-OBJ_DATA **im_obtain_ingredients(CHAR_DATA * ch, char *argument, int *count)
-{
-	char name[MAX_STRING_LENGTH], buf[128];
-	OBJ_DATA **array = NULL;
-	OBJ_DATA *o;
-	int i, n = 0;
+OBJ_DATA **im_obtain_ingredients(CHAR_DATA *ch, char *argument, int *count) {
+  char name[MAX_STRING_LENGTH], buf[128];
+  OBJ_DATA **array = NULL;
+  OBJ_DATA *o;
+  int i, n = 0;
 
-	while (1)
-	{
-		argument = one_argument(argument, name);
-		if (!*name)
-		{
-			if (!n)
-			{
-				send_to_char("Укажите магические ингредиенты для рецепта.\r\n", ch);
-			}
-			count[0] = n;
-			return array;
-		}
-		o = get_obj_in_list_vis(ch, name, ch->carrying);
-		if (!o)
-		{
-			sprintf(buf, "У вас нет %s.\r\n", name);
-			break;
-		}
-		if (GET_OBJ_TYPE(o) != OBJ_DATA::ITEM_MING)
-		{
-			sprintf(buf, "Вы должны использовать только магические ингредиенты.\r\n");
-			break;
-		}
-		if (im_type_rnum(GET_OBJ_VAL(o, IM_TYPE_SLOT)) < 0)
-		{
-			sprintf(buf, "Магическая сила %s утеряна, похоже, безвозвратно.\r\n", o->get_PName(1).c_str());
-			break;
-		}
-		for (i = 0; i < n; ++i)
-		{
-			if (array[i] != o)
-				continue;
-			sprintf(buf, "Один и тот же ингредиент нельзя использовать дважды.\r\n");
-			break;
-		}
-		if (i != n)
-		{
-			break;
-		}
-		if (!array)
-		{
-			CREATE(array, 1);
-		}
-		else
-		{
-			RECREATE(array, n + 1);
-		}
-		array[n++] = o;
-	}
-	if (array)
-		free(array);
-	imlog(NRM, buf);
-	send_to_char(buf, ch);
-	return NULL;
+  while (1) {
+    argument = one_argument(argument, name);
+    if (!*name) {
+      if (!n) {
+        send_to_char("Укажите магические ингредиенты для рецепта.\r\n", ch);
+      }
+      count[0] = n;
+      return array;
+    }
+    o = get_obj_in_list_vis(ch, name, ch->carrying);
+    if (!o) {
+      sprintf(buf, "У вас нет %s.\r\n", name);
+      break;
+    }
+    if (GET_OBJ_TYPE(o) != OBJ_DATA::ITEM_MING) {
+      sprintf(buf, "Вы должны использовать только магические ингредиенты.\r\n");
+      break;
+    }
+    if (im_type_rnum(GET_OBJ_VAL(o, IM_TYPE_SLOT)) < 0) {
+      sprintf(buf, "Магическая сила %s утеряна, похоже, безвозвратно.\r\n", o->get_PName(1).c_str());
+      break;
+    }
+    for (i = 0; i < n; ++i) {
+      if (array[i] != o)
+        continue;
+      sprintf(buf, "Один и тот же ингредиент нельзя использовать дважды.\r\n");
+      break;
+    }
+    if (i != n) {
+      break;
+    }
+    if (!array) {
+      CREATE(array, 1);
+    } else {
+      RECREATE(array, n + 1);
+    }
+    array[n++] = o;
+  }
+  if (array)
+    free(array);
+  imlog(NRM, buf);
+  send_to_char(buf, ch);
+  return NULL;
 }
 
-#define		IS_RECIPE_DELIM(c)		(((c)=='\'')||((c)=='*')||((c)=='!'))
+#define        IS_RECIPE_DELIM(c)        (((c)=='\'')||((c)=='*')||((c)=='!'))
 
 // Применение рецепта
 // варить 'рецепт' <ингредиенты>
-void do_cook(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	char name[MAX_STRING_LENGTH];
-	int rcpt = -1, qend, mres;
-	im_rskill *rs;
-	OBJ_DATA **objs;
-	int tgt;
-	int i, num, add_start;
-	int *req;
-	float W1, W2, osr, prob;
-	float param[IM_NPARAM];
-	int val[IM_NPARAM];
-	im_addon *addon;
+void do_cook(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  char name[MAX_STRING_LENGTH];
+  int rcpt = -1, qend, mres;
+  im_rskill *rs;
+  OBJ_DATA **objs;
+  int tgt;
+  int i, num, add_start;
+  int *req;
+  float W1, W2, osr, prob;
+  float param[IM_NPARAM];
+  int val[IM_NPARAM];
+  im_addon *addon;
 
-	// Определяем, что за рецепт пытаемся варить
-	skip_spaces(&argument);
-	if (!*argument)
-	{
-		send_to_char("Пропущено название рецепта.\r\n", ch);
-		return;
-	}
-	if (!IS_RECIPE_DELIM(*argument))
-	{
-		send_to_char("Рецепт надо заключить в символы : ' * или !\r\n", ch);
-		return;
-	}
-	for (qend = 1; argument[qend] && !IS_RECIPE_DELIM(argument[qend]); qend++)
-		argument[qend] = LOWER(argument[qend]);
-	if (!IS_RECIPE_DELIM(argument[qend]))
-	{
-		send_to_char("Рецепт должен быть заключен в символы : ' * или !\r\n", ch);
-		return;
-	}
-	strcpy(name, (argument + 1));
-	argument += qend + 1;
-	name[qend - 1] = '\0';
-	rcpt = im_get_recipe_by_name(name);
-	if (rcpt < 0)
-	{
-		send_to_char("Вам такой рецепт неизвестен.\r\n", ch);
-		return;
-	}
-	rs = im_get_char_rskill(ch, rcpt);
-	if (!rs)
-	{
-		send_to_char("Вам такой рецепт неизвестен.\r\n", ch);
-		return;
-	}
-	// rs - используемый рецепт
-	// argument - список ингредиентов
+  // Определяем, что за рецепт пытаемся варить
+  skip_spaces(&argument);
+  if (!*argument) {
+    send_to_char("Пропущено название рецепта.\r\n", ch);
+    return;
+  }
+  if (!IS_RECIPE_DELIM(*argument)) {
+    send_to_char("Рецепт надо заключить в символы : ' * или !\r\n", ch);
+    return;
+  }
+  for (qend = 1; argument[qend] && !IS_RECIPE_DELIM(argument[qend]); qend++)
+    argument[qend] = LOWER(argument[qend]);
+  if (!IS_RECIPE_DELIM(argument[qend])) {
+    send_to_char("Рецепт должен быть заключен в символы : ' * или !\r\n", ch);
+    return;
+  }
+  strcpy(name, (argument + 1));
+  argument += qend + 1;
+  name[qend - 1] = '\0';
+  rcpt = im_get_recipe_by_name(name);
+  if (rcpt < 0) {
+    send_to_char("Вам такой рецепт неизвестен.\r\n", ch);
+    return;
+  }
+  rs = im_get_char_rskill(ch, rcpt);
+  if (!rs) {
+    send_to_char("Вам такой рецепт неизвестен.\r\n", ch);
+    return;
+  }
+  // rs - используемый рецепт
+  // argument - список ингредиентов
 
-	sprintf(name, "%s использует рецепт %s", GET_NAME(ch), imrecipes[rs->rid].name);
-	imlog(BRF, name);
+  sprintf(name, "%s использует рецепт %s", GET_NAME(ch), imrecipes[rs->rid].name);
+  imlog(BRF, name);
 
-	// Преобразование строки аргументов в массив объектов
-	// с проверкой повторных и т.д.
-	objs = im_obtain_ingredients(ch, argument, &num);
-	if (!objs)
-		return;
+  // Преобразование строки аргументов в массив объектов
+  // с проверкой повторных и т.д.
+  objs = im_obtain_ingredients(ch, argument, &num);
+  if (!objs)
+    return;
 
-	imlog(NRM, "Используемые ингредиенты:");
-	name[0] = 0;
-	for (i = 0; i < num; ++i)
-	{
-		sprintf(name + strlen(name), "%s:%d ",
-				imtypes[im_type_rnum(GET_OBJ_VAL(objs[i], IM_TYPE_SLOT))].
-				name, GET_OBJ_VAL(objs[i], IM_POWER_SLOT));
-	}
-	imlog(NRM, name);
+  imlog(NRM, "Используемые ингредиенты:");
+  name[0] = 0;
+  for (i = 0; i < num; ++i) {
+    sprintf(name + strlen(name), "%s:%d ",
+            imtypes[im_type_rnum(GET_OBJ_VAL(objs[i], IM_TYPE_SLOT))].
+                name, GET_OBJ_VAL(objs[i], IM_POWER_SLOT));
+  }
+  imlog(NRM, name);
 
-	imlog(NRM, "Цикл обработки базовых компонентов");
+  imlog(NRM, "Цикл обработки базовых компонентов");
 
-	W1 = 0;
-	W2 = 0;
-	osr = 0;
-	// Этап 1. Основные компоненты
-	i = 0;
-	req = imrecipes[rs->rid].require;
-	while (*req != -1)
-	{
-		int itype, ktype, osk;
-		if (i == num)
-		{
-			imlog(NRM, "Не хватает основных ингредиентов");
-			send_to_char("Похоже, вам не хватает ингредиентов.\r\n", ch);
-			free(objs);
-			return;
-		}
-		ktype = *req++;
-		osk = *req++ & 0xFFFF;
-		osr += osk;
-		sprintf(name, "Запрошенный ингредиент: type=%d,osk=%d", ktype, osk);
-		imlog(CMP, name);
-		itype = im_type_rnum(GET_OBJ_VAL(objs[i], IM_TYPE_SLOT));
-		// ktype - требуемый тип, itype - подставляемый тип
-		if (!TypeListCheck(&imtypes[itype].tlst, ktype))
-		{
-			imlog(NRM, "Ингредиенты перепутаны");
-			send_to_char("Похоже, вы перепутали ингредиенты.\r\n", ch);
-			free(objs);
-			return;
-		}
-		itype = GET_OBJ_VAL(objs[i], IM_POWER_SLOT);
-		if (itype > osk)
-			W1 += (itype - osk) * osk;
-		else
-			W2 += osk - itype;
-		// минимальное качество ингров для варки рецепта (REQ рецепта/2)
-		int min_osk = osk/2;
-		if (itype < min_osk)
-		{
-			send_to_char(ch, "Качество %s ниже минимально допустимого.\r\n", GET_OBJ_PNAME(objs[i], 1).c_str());
-			sprintf(name, "Качество ингров ниже допустимого: itype=%d, min_osk=%d", itype, min_osk);
-			imlog(NRM, name);
-			free(objs);
-			return;
-		}
-		++i;
-	}
-	add_start = i;
-	if (osr)
-		W1 /= osr;
-	sprintf(name, "Рассчитанные основные ингредиенты: W1=%f W2=%f", W1, W2);
-	imlog(CMP, name);
-	// Преобразование параметров прототипа
-	tgt = real_object(imrecipes[rs->rid].result);
-	if (tgt < 0)
-	{
-		imlog(NRM, "Прототип утерян");
-		send_to_char("Результат рецепта утерян.\r\n", ch);
-		free(objs);
-		return;
-	}
+  W1 = 0;
+  W2 = 0;
+  osr = 0;
+  // Этап 1. Основные компоненты
+  i = 0;
+  req = imrecipes[rs->rid].require;
+  while (*req != -1) {
+    int itype, ktype, osk;
+    if (i == num) {
+      imlog(NRM, "Не хватает основных ингредиентов");
+      send_to_char("Похоже, вам не хватает ингредиентов.\r\n", ch);
+      free(objs);
+      return;
+    }
+    ktype = *req++;
+    osk = *req++ & 0xFFFF;
+    osr += osk;
+    sprintf(name, "Запрошенный ингредиент: type=%d,osk=%d", ktype, osk);
+    imlog(CMP, name);
+    itype = im_type_rnum(GET_OBJ_VAL(objs[i], IM_TYPE_SLOT));
+    // ktype - требуемый тип, itype - подставляемый тип
+    if (!TypeListCheck(&imtypes[itype].tlst, ktype)) {
+      imlog(NRM, "Ингредиенты перепутаны");
+      send_to_char("Похоже, вы перепутали ингредиенты.\r\n", ch);
+      free(objs);
+      return;
+    }
+    itype = GET_OBJ_VAL(objs[i], IM_POWER_SLOT);
+    if (itype > osk)
+      W1 += (itype - osk) * osk;
+    else
+      W2 += osk - itype;
+    // минимальное качество ингров для варки рецепта (REQ рецепта/2)
+    int min_osk = osk / 2;
+    if (itype < min_osk) {
+      send_to_char(ch, "Качество %s ниже минимально допустимого.\r\n", GET_OBJ_PNAME(objs[i], 1).c_str());
+      sprintf(name, "Качество ингров ниже допустимого: itype=%d, min_osk=%d", itype, min_osk);
+      imlog(NRM, name);
+      free(objs);
+      return;
+    }
+    ++i;
+  }
+  add_start = i;
+  if (osr)
+    W1 /= osr;
+  sprintf(name, "Рассчитанные основные ингредиенты: W1=%f W2=%f", W1, W2);
+  imlog(CMP, name);
+  // Преобразование параметров прототипа
+  tgt = real_object(imrecipes[rs->rid].result);
+  if (tgt < 0) {
+    imlog(NRM, "Прототип утерян");
+    send_to_char("Результат рецепта утерян.\r\n", ch);
+    free(objs);
+    return;
+  }
 
-	switch (GET_OBJ_TYPE(obj_proto[tgt]))
-	{
-	case OBJ_DATA::ITEM_SCROLL:
-	case OBJ_DATA::ITEM_POTION:
-		param[0] = GET_OBJ_VAL(obj_proto[tgt], 0);	// уровень
-		param[1] = 1;	// количество
-		param[2] = obj_proto[tgt]->get_timer();	// таймер
-		break;
+  switch (GET_OBJ_TYPE(obj_proto[tgt])) {
+    case OBJ_DATA::ITEM_SCROLL:
+    case OBJ_DATA::ITEM_POTION: param[0] = GET_OBJ_VAL(obj_proto[tgt], 0);    // уровень
+      param[1] = 1;    // количество
+      param[2] = obj_proto[tgt]->get_timer();    // таймер
+      break;
 
-	case OBJ_DATA::ITEM_WAND:
-	case OBJ_DATA::ITEM_STAFF:
-		param[0] = GET_OBJ_VAL(obj_proto[tgt], 0);	// уровень
-		param[1] = GET_OBJ_VAL(obj_proto[tgt], 1);	// количество
-		param[2] = obj_proto[tgt]->get_timer();	// таймер
-		break;
+    case OBJ_DATA::ITEM_WAND:
+    case OBJ_DATA::ITEM_STAFF: param[0] = GET_OBJ_VAL(obj_proto[tgt], 0);    // уровень
+      param[1] = GET_OBJ_VAL(obj_proto[tgt], 1);    // количество
+      param[2] = obj_proto[tgt]->get_timer();    // таймер
+      break;
 
-	default:
-		imlog(NRM, "Прототип имеет неверный тип");
-		send_to_char("Результат варева непредсказуем.\r\n", ch);
-		free(objs);
-		return;
-	}
+    default: imlog(NRM, "Прототип имеет неверный тип");
+      send_to_char("Результат варева непредсказуем.\r\n", ch);
+      free(objs);
+      return;
+  }
 
-	sprintf(name, "Базовые параметры и курс перевода в магические Дж: %f,%f %f,%f %f,%f",
-		param[0], imrecipes[rs->rid].k[0],
-		param[1], imrecipes[rs->rid].k[1], param[2], imrecipes[rs->rid].k[2]);
-	imlog(CMP, name);
+  sprintf(name, "Базовые параметры и курс перевода в магические Дж: %f,%f %f,%f %f,%f",
+          param[0], imrecipes[rs->rid].k[0],
+          param[1], imrecipes[rs->rid].k[1], param[2], imrecipes[rs->rid].k[2]);
+  imlog(CMP, name);
 
-	W2 *= imrecipes[rs->rid].kp;
-	prob = (float) rs->perc - 5 + 2 * W1 - W2;
-	for (i = 0; i < IM_NPARAM; ++i)
-	{
-		param[i] *= imrecipes[rs->rid].k[i];
-		W1 += param[i];
-	}
+  W2 *= imrecipes[rs->rid].kp;
+  prob = (float) rs->perc - 5 + 2 * W1 - W2;
+  for (i = 0; i < IM_NPARAM; ++i) {
+    param[i] *= imrecipes[rs->rid].k[i];
+    W1 += param[i];
+  }
 
-	imlog(CMP, "Дамп расчета до поворота направляющей:");
-	sprintf(name, "Вероятность: %f", prob);
-	imlog(CMP, name);
-	sprintf(name, "Закон сохранения ДжМ: x+y+z=%f", W1);
-	imlog(CMP, name);
-	sprintf(name, "Коэффициенты направления: x0=%f y0=%f z0=%f", param[0], param[1], param[2]);
-	imlog(CMP, name);
+  imlog(CMP, "Дамп расчета до поворота направляющей:");
+  sprintf(name, "Вероятность: %f", prob);
+  imlog(CMP, name);
+  sprintf(name, "Закон сохранения ДжМ: x+y+z=%f", W1);
+  imlog(CMP, name);
+  sprintf(name, "Коэффициенты направления: x0=%f y0=%f z0=%f", param[0], param[1], param[2]);
+  imlog(CMP, name);
 
-	if (prob < 0)
-	{
-		send_to_char("С ингредиентами такого качества вам лучше даже не пытаться...\r\n", ch);
-		free(objs);
-		return;
-	}
+  if (prob < 0) {
+    send_to_char("С ингредиентами такого качества вам лучше даже не пытаться...\r\n", ch);
+    free(objs);
+    return;
+  }
 
-	// Этап 2. Дополнительные компоненты
-	for (addon = imrecipes[rs->rid].addon; addon; addon = addon->link)
-		addon->obj = NULL;
-	for (i = add_start; i < num; ++i)
-	{
-		int itype = im_type_rnum(GET_OBJ_VAL(objs[i], IM_TYPE_SLOT));
-		for (addon = imrecipes[rs->rid].addon; addon; addon = addon->link)
-			if (addon->obj == NULL && TypeListCheck(&imtypes[itype].tlst, addon->id))
-				break;
-		if (addon)
-		{
-			// "белый" список
-			int s = addon->k0 + addon->k1 + addon->k2;
-			addon->obj = objs[i];
-			param[0] += (float) GET_OBJ_VAL(objs[i], IM_POWER_SLOT) * addon->k0 / s;
-			param[1] += (float) GET_OBJ_VAL(objs[i], IM_POWER_SLOT) * addon->k1 / s;
-			param[2] += (float) GET_OBJ_VAL(objs[i], IM_POWER_SLOT) * addon->k2 / s;
-		}
-		else
-		{
-			// "черный" список
-			W1 -= GET_OBJ_VAL(objs[i], IM_POWER_SLOT);
-		}
-	}
+  // Этап 2. Дополнительные компоненты
+  for (addon = imrecipes[rs->rid].addon; addon; addon = addon->link)
+    addon->obj = NULL;
+  for (i = add_start; i < num; ++i) {
+    int itype = im_type_rnum(GET_OBJ_VAL(objs[i], IM_TYPE_SLOT));
+    for (addon = imrecipes[rs->rid].addon; addon; addon = addon->link)
+      if (addon->obj == NULL && TypeListCheck(&imtypes[itype].tlst, addon->id))
+        break;
+    if (addon) {
+      // "белый" список
+      int s = addon->k0 + addon->k1 + addon->k2;
+      addon->obj = objs[i];
+      param[0] += (float) GET_OBJ_VAL(objs[i], IM_POWER_SLOT) * addon->k0 / s;
+      param[1] += (float) GET_OBJ_VAL(objs[i], IM_POWER_SLOT) * addon->k1 / s;
+      param[2] += (float) GET_OBJ_VAL(objs[i], IM_POWER_SLOT) * addon->k2 / s;
+    } else {
+      // "черный" список
+      W1 -= GET_OBJ_VAL(objs[i], IM_POWER_SLOT);
+    }
+  }
 
-	sprintf(name, "Закон сохранения ДжМ после поворота: x+y+z=%f", W1);
-	imlog(CMP, name);
-	sprintf(name, "Коэффициенты направления после поворота: x0=%f y0=%f z0=%f", param[0], param[1], param[2]);
-	imlog(CMP, name);
+  sprintf(name, "Закон сохранения ДжМ после поворота: x+y+z=%f", W1);
+  imlog(CMP, name);
+  sprintf(name, "Коэффициенты направления после поворота: x0=%f y0=%f z0=%f", param[0], param[1], param[2]);
+  imlog(CMP, name);
 
-	// Этап 3. Получение результата
-	for (W2 = 0, i = 0; i < IM_NPARAM; ++i)
-		W2 += param[i];
-	for (i = 0; i < IM_NPARAM; ++i)
-	{
-		param[i] *= W1;
-		param[i] /= W2;
-	}
-	for (i = 0; i < IM_NPARAM; ++i)
-	{
-		if (imrecipes[rs->rid].k[i])
-			val[i] = (int)(0.5 + param[i] / imrecipes[rs->rid].k[i]);
-		else
-			val[i] = -1;	// не изменять
-	}
+  // Этап 3. Получение результата
+  for (W2 = 0, i = 0; i < IM_NPARAM; ++i)
+    W2 += param[i];
+  for (i = 0; i < IM_NPARAM; ++i) {
+    param[i] *= W1;
+    param[i] /= W2;
+  }
+  for (i = 0; i < IM_NPARAM; ++i) {
+    if (imrecipes[rs->rid].k[i])
+      val[i] = (int) (0.5 + param[i] / imrecipes[rs->rid].k[i]);
+    else
+      val[i] = -1;    // не изменять
+  }
 
-	sprintf(name, "Параметры результата: %d %d %d", val[0], val[1], val[2]);
-	imlog(CMP, name);
+  sprintf(name, "Параметры результата: %d %d %d", val[0], val[1], val[2]);
+  imlog(CMP, name);
 
-	// Удалаяю объекты
-	for (i = 0; i < num; ++i)
-		extract_obj(objs[i]);
-	free(objs);
+  // Удалаяю объекты
+  for (i = 0; i < num; ++i)
+    extract_obj(objs[i]);
+  free(objs);
 
-	imlog(CMP, "Ингредиенты удалены");
+  imlog(CMP, "Ингредиенты удалены");
 
-	// Кидаем кубики на создание
-	mres = number(1, 100 - (can_use_feat(ch, BREW_POTION_FEAT) ? 5 : 0));
-	if (mres < (int) prob)
-		mres = IM_MSG_OK;
-	else
-	{
-		mres = (100 - (int) prob) / 2;
-		if (mres >= number(1, 100))
-			mres = IM_MSG_FAIL;
-		else
-			mres = IM_MSG_DAM;
-	}
+  // Кидаем кубики на создание
+  mres = number(1, 100 - (can_use_feat(ch, BREW_POTION_FEAT) ? 5 : 0));
+  if (mres < (int) prob)
+    mres = IM_MSG_OK;
+  else {
+    mres = (100 - (int) prob) / 2;
+    if (mres >= number(1, 100))
+      mres = IM_MSG_FAIL;
+    else
+      mres = IM_MSG_DAM;
+  }
 
-	sprintf(name, "Режим - %d", mres);
-	imlog(CMP, name);
+  sprintf(name, "Режим - %d", mres);
+  imlog(CMP, name);
 
-	im_improve_recipe(ch, rs, mres == IM_MSG_OK);
+  im_improve_recipe(ch, rs, mres == IM_MSG_OK);
 
-	// Рассылаю сообщения
-	imlog(CMP, "Рассылка сообщений");
-	act(imrecipes[rs->rid].msg_char[mres], TRUE, ch, 0, 0, TO_CHAR);
-	act(imrecipes[rs->rid].msg_room[mres], TRUE, ch, 0, 0, TO_ROOM);
+  // Рассылаю сообщения
+  imlog(CMP, "Рассылка сообщений");
+  act(imrecipes[rs->rid].msg_char[mres], TRUE, ch, 0, 0, TO_CHAR);
+  act(imrecipes[rs->rid].msg_room[mres], TRUE, ch, 0, 0, TO_ROOM);
 
-	if (mres == IM_MSG_OK)
-	{
-		imlog(CMP, "Создание результата");
-		const auto result = world_objects.create_from_prototype_by_rnum(tgt);
-		if (result)
-		{
-			switch (GET_OBJ_TYPE(result))
-			{
-			case OBJ_DATA::ITEM_SCROLL:
-			case OBJ_DATA::ITEM_POTION:
-				if (val[0] > 0)
-				{
-					result->set_val(0, val[0]);
-				}
-				if (val[2] > 0)
-				{
-					result->set_timer(val[2]);
-				}
-				break;
+  if (mres == IM_MSG_OK) {
+    imlog(CMP, "Создание результата");
+    const auto result = world_objects.create_from_prototype_by_rnum(tgt);
+    if (result) {
+      switch (GET_OBJ_TYPE(result)) {
+        case OBJ_DATA::ITEM_SCROLL:
+        case OBJ_DATA::ITEM_POTION:
+          if (val[0] > 0) {
+            result->set_val(0, val[0]);
+          }
+          if (val[2] > 0) {
+            result->set_timer(val[2]);
+          }
+          break;
 
-			case OBJ_DATA::ITEM_WAND:
-			case OBJ_DATA::ITEM_STAFF:
-				if (val[0] > 0)
-				{
-					result->set_val(0, val[0]);
-				}
-				if (val[1] > 0)
-				{
-					result->set_val(1, val[1]);
-					result->set_val(2, val[1]);
-				}
-				if (val[2] > 0)
-				{
-					result->set_timer(val[2]);
-				}
-				break;
+        case OBJ_DATA::ITEM_WAND:
+        case OBJ_DATA::ITEM_STAFF:
+          if (val[0] > 0) {
+            result->set_val(0, val[0]);
+          }
+          if (val[1] > 0) {
+            result->set_val(1, val[1]);
+            result->set_val(2, val[1]);
+          }
+          if (val[2] > 0) {
+            result->set_timer(val[2]);
+          }
+          break;
 
-			default:
-				break;
-			}
-			obj_to_char(result.get(), ch);
-		}
-	}
+        default: break;
+      }
+      obj_to_char(result.get(), ch);
+    }
+  }
 
-	return;
+  return;
 }
 
-void compose_recipe(CHAR_DATA * ch, char *argument, int/* subcmd*/)
-{
-	char name[MAX_STRING_LENGTH];
-	int qend, rcpt = -1;
-	im_rskill *rs;
+void compose_recipe(CHAR_DATA *ch, char *argument, int/* subcmd*/) {
+  char name[MAX_STRING_LENGTH];
+  int qend, rcpt = -1;
+  im_rskill *rs;
 
-	// Определяем, что за рецепт пытаемся варить
-	skip_spaces(&argument);
-	if (!*argument)
-	{
-		send_to_char("Пропущено название рецепта.\r\n", ch);
-		return;
-	}
+  // Определяем, что за рецепт пытаемся варить
+  skip_spaces(&argument);
+  if (!*argument) {
+    send_to_char("Пропущено название рецепта.\r\n", ch);
+    return;
+  }
 
-	if (!IS_RECIPE_DELIM(*argument))
-	{
-		send_to_char("Рецепт надо заключить в символы : ' * или !\r\n", ch);
-		return;
-	}
+  if (!IS_RECIPE_DELIM(*argument)) {
+    send_to_char("Рецепт надо заключить в символы : ' * или !\r\n", ch);
+    return;
+  }
 
-	for (qend = 1; argument[qend] && !IS_RECIPE_DELIM(argument[qend]); qend++)
-	{
-		argument[qend] = LOWER(argument[qend]);
-	}
+  for (qend = 1; argument[qend] && !IS_RECIPE_DELIM(argument[qend]); qend++) {
+    argument[qend] = LOWER(argument[qend]);
+  }
 
-	if (!IS_RECIPE_DELIM(argument[qend]))
-	{
-		send_to_char("Рецепт должен быть заключен в символы : ' * или !\r\n", ch);
-		return;
-	}
+  if (!IS_RECIPE_DELIM(argument[qend])) {
+    send_to_char("Рецепт должен быть заключен в символы : ' * или !\r\n", ch);
+    return;
+  }
 
-	strcpy(name, (argument + 1));
-	argument += qend + 1;
-	name[qend - 1] = '\0';
-	rcpt = im_get_recipe_by_name(name);
-	if (rcpt < 0)
-	{
-		send_to_char("Вам такой рецепт неизвестен.\r\n", ch);
-		return;
-	}
+  strcpy(name, (argument + 1));
+  argument += qend + 1;
+  name[qend - 1] = '\0';
+  rcpt = im_get_recipe_by_name(name);
+  if (rcpt < 0) {
+    send_to_char("Вам такой рецепт неизвестен.\r\n", ch);
+    return;
+  }
 
-	rs = im_get_char_rskill(ch, rcpt);
-	if (!rs)
-	{
-		send_to_char("Вам такой рецепт неизвестен.\r\n", ch);
-		return;
-	}
+  rs = im_get_char_rskill(ch, rcpt);
+  if (!rs) {
+    send_to_char("Вам такой рецепт неизвестен.\r\n", ch);
+    return;
+  }
 
-	// rs - используемый рецепт
+  // rs - используемый рецепт
 
-	send_to_char("Вам потребуется :\r\n", ch);
+  send_to_char("Вам потребуется :\r\n", ch);
 
-	// Этап 1. Основные компоненты
-	for (int i = 1, *req = imrecipes[rs->rid].require; *req != -1; req += 2, ++i)
-	{
-		sprintf(name, "%s%d%s) %s%s%s\r\n", CCIGRN(ch, C_NRM), i,
-			CCNRM(ch, C_NRM), CCIYEL(ch, C_NRM), imtypes[*req].name, CCNRM(ch, C_NRM));
-		send_to_char(name, ch);
-	}
-	sprintf(name, "для приготовления отвара '%s'\r\n", imrecipes[rs->rid].name);
-	send_to_char(name, ch);
+  // Этап 1. Основные компоненты
+  for (int i = 1, *req = imrecipes[rs->rid].require; *req != -1; req += 2, ++i) {
+    sprintf(name, "%s%d%s) %s%s%s\r\n", CCIGRN(ch, C_NRM), i,
+            CCNRM(ch, C_NRM), CCIYEL(ch, C_NRM), imtypes[*req].name, CCNRM(ch, C_NRM));
+    send_to_char(name, ch);
+  }
+  sprintf(name, "для приготовления отвара '%s'\r\n", imrecipes[rs->rid].name);
+  send_to_char(name, ch);
 
-	// Этап 2. Дополнительные компоненты *** НЕ ОБРАБАТЫВАЮТСЯ ***
+  // Этап 2. Дополнительные компоненты *** НЕ ОБРАБАТЫВАЮТСЯ ***
 }
 
 // Поиск rid по имени
-void forget_recipe(CHAR_DATA * ch, char *argument, int/* subcmd*/)
-{
-	char name[MAX_STRING_LENGTH];
-	int qend, rcpt = -1;
-	im_rskill *rs;
+void forget_recipe(CHAR_DATA *ch, char *argument, int/* subcmd*/) {
+  char name[MAX_STRING_LENGTH];
+  int qend, rcpt = -1;
+  im_rskill *rs;
 
-	argument = one_argument(argument, arg);
+  argument = one_argument(argument, arg);
 
-	skip_spaces(&argument);
-	if (!*argument)
-	{
-		send_to_char("Пропущено название рецепта.\r\n", ch);
-		return;
-	}
+  skip_spaces(&argument);
+  if (!*argument) {
+    send_to_char("Пропущено название рецепта.\r\n", ch);
+    return;
+  }
 
-	if (!IS_RECIPE_DELIM(*argument))
-	{
-		send_to_char("Рецепт надо заключить в символы : ' * или !\r\n", ch);
-		return;
-	}
-	for (qend = 1; argument[qend] && !IS_RECIPE_DELIM(argument[qend]); qend++)
-		argument[qend] = LOWER(argument[qend]);
-	if (!IS_RECIPE_DELIM(argument[qend]))
-	{
-		send_to_char("Рецепт должен быть заключен в символы : ' * или !\r\n", ch);
-		return;
-	}
-	strcpy(name, (argument + 1));
-	argument += qend + 1;
-	name[qend - 1] = '\0';
+  if (!IS_RECIPE_DELIM(*argument)) {
+    send_to_char("Рецепт надо заключить в символы : ' * или !\r\n", ch);
+    return;
+  }
+  for (qend = 1; argument[qend] && !IS_RECIPE_DELIM(argument[qend]); qend++)
+    argument[qend] = LOWER(argument[qend]);
+  if (!IS_RECIPE_DELIM(argument[qend])) {
+    send_to_char("Рецепт должен быть заключен в символы : ' * или !\r\n", ch);
+    return;
+  }
+  strcpy(name, (argument + 1));
+  argument += qend + 1;
+  name[qend - 1] = '\0';
 
-	size_t i = strlen(name);
-	for (rcpt = top_imrecipes; rcpt >= 0; --rcpt)
-	{
-		if (!strn_cmp(name, imrecipes[rcpt].name, i))
-		{
-			break;
-		}
-	}
+  size_t i = strlen(name);
+  for (rcpt = top_imrecipes; rcpt >= 0; --rcpt) {
+    if (!strn_cmp(name, imrecipes[rcpt].name, i)) {
+      break;
+    }
+  }
 
-	if (rcpt < 0)
-	{
-		send_to_char("Неизвестный рецепт, введите название рецепта полностью.\r\n", ch);
-		return;
-	}
+  if (rcpt < 0) {
+    send_to_char("Неизвестный рецепт, введите название рецепта полностью.\r\n", ch);
+    return;
+  }
 
-	rs = im_get_char_rskill(ch, rcpt);
-	if (!rs || !rs->perc)
-	{
-		send_to_char("Изучите сначала этот рецепт.\r\n", ch);
-		return;
-	}
-	rs->perc = 0;
-	sprintf(buf, "Вы забыли рецепт отвара '%s'.\r\n", imrecipes[rcpt].name);
-	send_to_char(buf, ch);
+  rs = im_get_char_rskill(ch, rcpt);
+  if (!rs || !rs->perc) {
+    send_to_char("Изучите сначала этот рецепт.\r\n", ch);
+    return;
+  }
+  rs->perc = 0;
+  sprintf(buf, "Вы забыли рецепт отвара '%s'.\r\n", imrecipes[rcpt].name);
+  send_to_char(buf, ch);
 }
 
-
-int im_ing_dump(int *ping, char *s)
-{
-	int pow;
-	if (!ping || *ping == -1)
-		return 0;
-	pow = (ping[1] >> 16) & 0xFFFF;
-	if (pow != 0xFFFF)
-		sprintf(s, "%s,%d:%d", imtypes[ping[0]].name, pow, ping[1] & 0xFFFF);
-	else
-		sprintf(s, "%s:%d", imtypes[ping[0]].name, ping[1] & 0xFFFF);
-	return 1;
+int im_ing_dump(int *ping, char *s) {
+  int pow;
+  if (!ping || *ping == -1)
+    return 0;
+  pow = (ping[1] >> 16) & 0xFFFF;
+  if (pow != 0xFFFF)
+    sprintf(s, "%s,%d:%d", imtypes[ping[0]].name, pow, ping[1] & 0xFFFF);
+  else
+    sprintf(s, "%s:%d", imtypes[ping[0]].name, ping[1] & 0xFFFF);
+  return 1;
 }
 
-void im_inglist_copy(int **pdst, int *src)
-{
-	int i;
-	*pdst = NULL;
-	if (!src)
-		return;
-	for (i = 0; src[i] != -1; i += 2);
-	++i;
-	CREATE(*pdst, i);
-	memcpy(*pdst, src, i * sizeof(int));
-	return;
+void im_inglist_copy(int **pdst, int *src) {
+  int i;
+  *pdst = NULL;
+  if (!src)
+    return;
+  for (i = 0; src[i] != -1; i += 2);
+  ++i;
+  CREATE(*pdst, i);
+  memcpy(*pdst, src, i * sizeof(int));
+  return;
 }
 
 // Данная функция в настоящий момент не используется,
 // потому что конфиг ингредиентов вынесен из файлов мобов и комнат.
-void im_inglist_save_to_disk(FILE * f, int *ping)
-{
-	char str[128];
-	for (; im_ing_dump(ping, str); ping += 2)
-		fprintf(f, "I %s\r\n", str);
+void im_inglist_save_to_disk(FILE *f, int *ping) {
+  char str[128];
+  for (; im_ing_dump(ping, str); ping += 2)
+    fprintf(f, "I %s\r\n", str);
 }
 
-void im_extract_ing(int **pdst, int num)
-{
-	int *p1, *p2;
-	int i;
-	if (!*pdst)
-		return;
-	p1 = p2 = *pdst;
-	i = 0;
-	while (*p1 != -1)
-	{
-		if (i != num)
-		{
-			p2[0] = p1[0];
-			p2[1] = p1[1];
-			p2 += 2;
-		}
-		++i;
-		p1 += 2;
-	}
-	*p2 = *p1;
-	if (**pdst == -1)
-	{
-		free(*pdst);
-		*pdst = NULL;
-	}
+void im_extract_ing(int **pdst, int num) {
+  int *p1, *p2;
+  int i;
+  if (!*pdst)
+    return;
+  p1 = p2 = *pdst;
+  i = 0;
+  while (*p1 != -1) {
+    if (i != num) {
+      p2[0] = p1[0];
+      p2[1] = p1[1];
+      p2 += 2;
+    }
+    ++i;
+    p1 += 2;
+  }
+  *p2 = *p1;
+  if (**pdst == -1) {
+    free(*pdst);
+    *pdst = NULL;
+  }
 }
 
-void trg_recipeturn(CHAR_DATA * ch, int rid, int recipediff)
-{
-	im_rskill *rs;
-	rs = im_get_char_rskill(ch, rid);
-	if (rs)
-	{
-		if (recipediff)
-			return;
-		sprintf(buf, "Вас лишили рецепта '%s'.\r\n", imrecipes[rid].name);
-		send_to_char(buf, ch);
-		rs->perc = 0;
-	}
-	else
-	{
-		if (!recipediff)
-			return;
+void trg_recipeturn(CHAR_DATA *ch, int rid, int recipediff) {
+  im_rskill *rs;
+  rs = im_get_char_rskill(ch, rid);
+  if (rs) {
+    if (recipediff)
+      return;
+    sprintf(buf, "Вас лишили рецепта '%s'.\r\n", imrecipes[rid].name);
+    send_to_char(buf, ch);
+    rs->perc = 0;
+  } else {
+    if (!recipediff)
+      return;
 // +newbook.patch (Alisher)
-		if (imrecipes[rid].classknow[(int) GET_CLASS(ch)] == KNOW_RECIPE)
-		{
-			CREATE(rs, 1);
-			rs->rid = rid;
-			rs->link = GET_RSKILL(ch);
-			GET_RSKILL(ch) = rs;
-			rs->perc = 5;
-		}
+    if (imrecipes[rid].classknow[(int) GET_CLASS(ch)] == KNOW_RECIPE) {
+      CREATE(rs, 1);
+      rs->rid = rid;
+      rs->link = GET_RSKILL(ch);
+      GET_RSKILL(ch) = rs;
+      rs->perc = 5;
+    }
 // -newbook.patch (Alisher)
-		sprintf(buf, "Вы изучили рецепт '%s'.\r\n", imrecipes[rid].name);
-		send_to_char(buf, ch);
-		sprintf(buf, "RECIPE: игроку %s добавлен рецепт %s", GET_NAME(ch), imrecipes[rid].name);
-		log("%s", buf);
-	}
+    sprintf(buf, "Вы изучили рецепт '%s'.\r\n", imrecipes[rid].name);
+    send_to_char(buf, ch);
+    sprintf(buf, "RECIPE: игроку %s добавлен рецепт %s", GET_NAME(ch), imrecipes[rid].name);
+    log("%s", buf);
+  }
 }
 
-void trg_recipeadd(CHAR_DATA * ch, int rid, int recipediff)
-{
-	im_rskill *rs;
-	int skill;
+void trg_recipeadd(CHAR_DATA *ch, int rid, int recipediff) {
+  im_rskill *rs;
+  int skill;
 
-	rs = im_get_char_rskill(ch, rid);
-	if (!rs)
-		return;
+  rs = im_get_char_rskill(ch, rid);
+  if (!rs)
+    return;
 
-	skill = rs->perc;
-	rs->perc = MAX(1, MIN(skill + recipediff, 200));
+  skill = rs->perc;
+  rs->perc = MAX(1, MIN(skill + recipediff, kMaxRecipeLevel));
 
-	if (skill > rs->perc)
-		sprintf(buf, "Ваше знание рецепта '%s' понизилось.\r\n", imrecipes[rid].name);
-	else if (skill < rs->perc)
-		sprintf(buf, "Вы повысили знание рецепта '%s'.\r\n", imrecipes[rid].name);
-	else
-		sprintf(buf, "Ваше знание рецепта '%s' осталось неизменным.\r\n", imrecipes[rid].name);
-	send_to_char(buf, ch);
+  if (skill > rs->perc)
+    sprintf(buf, "Ваше знание рецепта '%s' понизилось.\r\n", imrecipes[rid].name);
+  else if (skill < rs->perc)
+    sprintf(buf, "Вы повысили знание рецепта '%s'.\r\n", imrecipes[rid].name);
+  else
+    sprintf(buf, "Ваше знание рецепта '%s' осталось неизменным.\r\n", imrecipes[rid].name);
+  send_to_char(buf, ch);
 }
 
-void do_imlist(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	send_to_char("Команда отГлючена.\r\n", ch);
-	return;
+void do_imlist(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  send_to_char("Команда отГлючена.\r\n", ch);
+  return;
 /*
 	int zone, i, rnum;
 	int *ping;

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1122,8 +1122,8 @@ void check_hiding_cmd(CHAR_DATA * ch, int percent)
 		{
 			if (AFF_FLAGGED(ch, EAffectFlag::AFF_SNEAK))
 			{
-				remove_hide = number(1, skill_info[SKILL_SNEAK].max_percent) >
-					calculate_skill(ch, SKILL_SNEAK, 0);
+				remove_hide = number(1, skill_info[SKILL_SNEAK].fail_percent) >
+                    CalcCurrentSkill(ch, SKILL_SNEAK, 0);
 			}
 			else
 			{
@@ -1137,7 +1137,7 @@ void check_hiding_cmd(CHAR_DATA * ch, int percent)
 		}
 		else if (percent > 0)
 		{
-			remove_hide = number(1, percent) > calculate_skill(ch, SKILL_HIDE, 0);
+			remove_hide = number(1, percent) > CalcCurrentSkill(ch, SKILL_HIDE, 0);
 		}
 
 		if (remove_hide)

--- a/src/item.creation.cpp
+++ b/src/item.creation.cpp
@@ -36,2610 +36,2193 @@
 #include <cmath>
 
 extern int material_value[];
-void die(CHAR_DATA * ch, CHAR_DATA * killer);
+void die(CHAR_DATA *ch, CHAR_DATA *killer);
 
 constexpr auto WEAR_TAKE = to_underlying(EWearFlag::ITEM_WEAR_TAKE);
-constexpr auto WEAR_TAKE_BOTHS_WIELD = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_BOTHS) | to_underlying(EWearFlag::ITEM_WEAR_WIELD);
+constexpr auto WEAR_TAKE_BOTHS_WIELD =
+    WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_BOTHS) | to_underlying(EWearFlag::ITEM_WEAR_WIELD);
 constexpr auto WEAR_TAKE_BODY = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_BODY);
-constexpr auto WEAR_TAKE_ARMS= WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_ARMS);
+constexpr auto WEAR_TAKE_ARMS = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_ARMS);
 constexpr auto WEAR_TAKE_LEGS = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_LEGS);
 constexpr auto WEAR_TAKE_HEAD = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_HEAD);
 constexpr auto WEAR_TAKE_BOTHS = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_BOTHS);
-constexpr auto WEAR_TAKE_DUAL = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_HOLD) | to_underlying(EWearFlag::ITEM_WEAR_WIELD);
+constexpr auto
+    WEAR_TAKE_DUAL = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_HOLD) | to_underlying(EWearFlag::ITEM_WEAR_WIELD);
 constexpr auto WEAR_TAKE_HOLD = WEAR_TAKE | to_underlying(EWearFlag::ITEM_WEAR_HOLD);
 struct create_item_type created_item[] =
-{
-	{300, 0x7E, 15, 40, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_BOTHS_WIELD},
-	{301, 0x7E, 12, 40, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_BOTHS_WIELD },
-	{302, 0x7E, 8, 25, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_DUAL },
-	{303, 0x7E, 5, 13, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_HOLD },
-	{304, 0x7E, 10, 35, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_BOTHS_WIELD },
-	{305, 0, 8, 15, {{0, 0, 0}}, SKILL_INVALID, WEAR_TAKE_BOTHS_WIELD },
-	{306, 0, 8, 20, {{0, 0, 0}}, SKILL_INVALID, WEAR_TAKE_BOTHS_WIELD },
-	{307, 0x3A, 10, 20, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_BODY},
-	{308, 0x3A, 4, 10, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_ARMS},
-	{309, 0x3A, 6, 12, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_LEGS},
-	{310, 0x3A, 4, 10, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_HEAD},
-	{312, 0, 4, 40, {{WOOD_PROTO, TETIVA_PROTO, 0}}, SKILL_CREATEBOW, WEAR_TAKE_BOTHS}
+    {
+        {300, 0x7E, 15, 40, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_BOTHS_WIELD},
+        {301, 0x7E, 12, 40, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_BOTHS_WIELD},
+        {302, 0x7E, 8, 25, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_DUAL},
+        {303, 0x7E, 5, 13, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_HOLD},
+        {304, 0x7E, 10, 35, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_BOTHS_WIELD},
+        {305, 0, 8, 15, {{0, 0, 0}}, SKILL_INVALID, WEAR_TAKE_BOTHS_WIELD},
+        {306, 0, 8, 20, {{0, 0, 0}}, SKILL_INVALID, WEAR_TAKE_BOTHS_WIELD},
+        {307, 0x3A, 10, 20, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_BODY},
+        {308, 0x3A, 4, 10, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_ARMS},
+        {309, 0x3A, 6, 12, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_LEGS},
+        {310, 0x3A, 4, 10, {{COAL_PROTO, 0, 0}}, SKILL_TRANSFORMWEAPON, WEAR_TAKE_HEAD},
+        {312, 0, 4, 40, {{WOOD_PROTO, TETIVA_PROTO, 0}}, SKILL_CREATEBOW, WEAR_TAKE_BOTHS}
+    };
+const char *create_item_name[] = {"шелепуга",
+                                  "меч",
+                                  "сабля",
+                                  "нож",
+                                  "топор",
+                                  "плеть",
+                                  "дубина",
+                                  "кольчуга",
+                                  "наручи",
+                                  "поножи",
+                                  "шлем",
+                                  "лук",
+                                  "\n"
 };
-const char *create_item_name[] = { "шелепуга",
-								   "меч",
-								   "сабля",
-								   "нож",
-								   "топор",
-								   "плеть",
-								   "дубина",
-								   "кольчуга",
-								   "наручи",
-								   "поножи",
-								   "шлем",
-								   "лук",
-								   "\n"
-								 };
 const struct make_skill_type make_skills[] =
-{
-	{"смастерить предмет","предметы", SKILL_MAKE_STAFF },
-	{"смастерить лук", "луки", SKILL_MAKE_BOW},
-	{"выковать оружие", "оружие", SKILL_MAKE_WEAPON},
-	{"выковать доспех", "доспех", SKILL_MAKE_ARMOR},
-	{"сшить одежду", "одежда", SKILL_MAKE_WEAR},
-	{"смастерить диковину", "артеф.", SKILL_MAKE_JEWEL},
-	{"смастерить оберег", "оберег", SKILL_MAKE_AMULET},
+    {
+        {"смастерить предмет", "предметы", SKILL_MAKE_STAFF},
+        {"смастерить лук", "луки", SKILL_MAKE_BOW},
+        {"выковать оружие", "оружие", SKILL_MAKE_WEAPON},
+        {"выковать доспех", "доспех", SKILL_MAKE_ARMOR},
+        {"сшить одежду", "одежда", SKILL_MAKE_WEAR},
+        {"смастерить диковину", "артеф.", SKILL_MAKE_JEWEL},
+        {"смастерить оберег", "оберег", SKILL_MAKE_AMULET},
 //  { "сварить отвар","варево", SKILL_MAKE_POTION },
-	{"\n", 0, SKILL_INVALID}		// Терминатор
+        {"\n", 0, SKILL_INVALID}        // Терминатор
+    };
+const char *create_weapon_quality[] = {"RESERVED",
+                                       "RESERVED",
+                                       "RESERVED",
+                                       "RESERVED",
+                                       "RESERVED",
+                                       "невообразимо ужасного качества",    // <3 //
+                                       "ужасного качества",    // 3 //
+                                       "более чем жуткого качества",
+                                       "жуткого качества",    // 4 //
+                                       "более чем отвратительного качества",
+                                       "отвратительного качества",    // 5 //
+                                       "более чем плохого качества",
+                                       "плохого качества",    // 6 //
+                                       "хуже чем среднего качества",
+                                       "среднего качества",    // 7 //
+                                       "лучше чем среднего качества",
+                                       "неплохого качества",    // 8 //
+                                       "более чем неплохого качества",
+                                       "хорошего качества",    // 9 //
+                                       "более чем хорошего качества",
+                                       "превосходного качества",    // 10 //
+                                       "более чем превосходного качества",
+                                       "великолепного качества",    // 11 //
+                                       "более чем великолепного качества",
+                                       "качества, достойного учеников мастера",    // 12 //
+                                       "лучшего качества, чем делают ученики мастера",
+                                       "качества, достойного мастера",    // 13 //
+                                       "лучшего качества, чем делают мастера",
+                                       "качества, достойного великого мастера",    // 14 //
+                                       "лучшего качества, чем делают великие мастера",
+                                       "качества, достойного руки сына боярского",    // 15 //
+                                       "качества, более чем достойного руки сына боярского",
+                                       "качества, достойного руки боярина",    // 16 //
+                                       "качества, более чем достойного руки боярина",
+                                       "качества, достойного руки сына воеводы",    // 17 //
+                                       "качества, более чем достойного руки сына воеводы",
+                                       "качества, достойного руки воеводы",    // 18 //
+                                       "качества, более чем достойного руки воеводы",
+                                       "качества, достойного руки княжича",    // 19 //
+                                       "качества, более чем достойного руки княжича",
+                                       "качества, достойного руки князя",    // 20 //
+                                       "качества, более чем достойного руки князя",
+                                       "качества, достойного руки героя",    // 21 //
+                                       "качества, более чем достойного руки героя",
+                                       "качества, достойного руки великого героя",    // 22 //
+                                       "качества, более чем достойного руки великого героя",
+                                       "качества, которое знали только древние титаны",    // 23 //
+                                       "качества, лучшего чем то, которое знали древние титаны",
+                                       "качества, достойного младших богов",    // 24 //
+                                       "качества, более чем достойного младших богов",
+                                       "качества, достойного богов",    // 25 //
+                                       "качества, более чем достойного богов",
+                                       "качества, которого достигают немногие", // 26
+                                       "качества, которого достигают немногие",
+                                       "качества, которого достигают немногие", // 27
+                                       "качества, которого достигают немногие",
+                                       "качества, достойного старших богов", // >= 28
+                                       "\n"
 };
-const char *create_weapon_quality[] = { "RESERVED",
-										"RESERVED",
-										"RESERVED",
-										"RESERVED",
-										"RESERVED",
-										"невообразимо ужасного качества",	// <3 //
-										"ужасного качества",	// 3 //
-										"более чем жуткого качества",
-										"жуткого качества",	// 4 //
-										"более чем отвратительного качества",
-										"отвратительного качества",	// 5 //
-										"более чем плохого качества",
-										"плохого качества",	// 6 //
-										"хуже чем среднего качества",
-										"среднего качества",	// 7 //
-										"лучше чем среднего качества",
-										"неплохого качества",	// 8 //
-										"более чем неплохого качества",
-										"хорошего качества",	// 9 //
-										"более чем хорошего качества",
-										"превосходного качества",	// 10 //
-										"более чем превосходного качества",
-										"великолепного качества",	// 11 //
-										"более чем великолепного качества",
-										"качества, достойного учеников мастера",	// 12 //
-										"лучшего качества, чем делают ученики мастера",
-										"качества, достойного мастера",	// 13 //
-										"лучшего качества, чем делают мастера",
-										"качества, достойного великого мастера",	// 14 //
-										"лучшего качества, чем делают великие мастера",
-										"качества, достойного руки сына боярского",	// 15 //
-										"качества, более чем достойного руки сына боярского",
-										"качества, достойного руки боярина",	// 16 //
-										"качества, более чем достойного руки боярина",
-										"качества, достойного руки сына воеводы",	// 17 //
-										"качества, более чем достойного руки сына воеводы",
-										"качества, достойного руки воеводы",	// 18 //
-										"качества, более чем достойного руки воеводы",
-										"качества, достойного руки княжича",	// 19 //
-										"качества, более чем достойного руки княжича",
-										"качества, достойного руки князя",	// 20 //
-										"качества, более чем достойного руки князя",
-										"качества, достойного руки героя",	// 21 //
-										"качества, более чем достойного руки героя",
-										"качества, достойного руки великого героя",	// 22 //
-										"качества, более чем достойного руки великого героя",
-										"качества, которое знали только древние титаны",	// 23 //
-										"качества, лучшего чем то, которое знали древние титаны",
-										"качества, достойного младших богов",	// 24 //
-										"качества, более чем достойного младших богов",
-										"качества, достойного богов",	// 25 //
-										"качества, более чем достойного богов",
-										"качества, которого достигают немногие", // 26
-										"качества, которого достигают немногие",
-										"качества, которого достигают немногие", // 27
-										"качества, которого достигают немногие",
-										"качества, достойного старших богов", // >= 28
-										"\n"
-									  };
 MakeReceptList make_recepts;
 // Функция вывода в поток //
-CHAR_DATA *& operator<<(CHAR_DATA * &ch, string p)
-{
-	send_to_char(p.c_str(), ch);
-	return ch;
+CHAR_DATA *&operator<<(CHAR_DATA *&ch, string p) {
+  send_to_char(p.c_str(), ch);
+  return ch;
 }
 
-void init_make_items()
-{
-	char tmpbuf[MAX_INPUT_LENGTH];
-	sprintf(tmpbuf, "Loading making recepts.");
-	mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
-	make_recepts.load();
+void init_make_items() {
+  char tmpbuf[MAX_INPUT_LENGTH];
+  sprintf(tmpbuf, "Loading making recepts.");
+  mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
+  make_recepts.load();
 }
 // Парсим ввод пользователя в меню правки рецепта
-void mredit_parse(DESCRIPTOR_DATA * d, char *arg)
-{
-	string sagr = string(arg);
-	char tmpbuf[MAX_INPUT_LENGTH];
-	string tmpstr;
-	MakeRecept *trec = OLC_MREC(d);
-	int i;
-	switch (OLC_MODE(d))
-	{
-	case MREDIT_MAIN_MENU:
-		// Ввод главного меню.
-		if (sagr == "1")
-		{
-			send_to_char("Введите VNUM изготавливаемого предмета : ", d->character.get());
-			OLC_MODE(d) = MREDIT_OBJ_PROTO;
-			return;
-		}
+void mredit_parse(DESCRIPTOR_DATA *d, char *arg) {
+  string sagr = string(arg);
+  char tmpbuf[MAX_INPUT_LENGTH];
+  string tmpstr;
+  MakeRecept *trec = OLC_MREC(d);
+  int i;
+  switch (OLC_MODE(d)) {
+    case MREDIT_MAIN_MENU:
+      // Ввод главного меню.
+      if (sagr == "1") {
+        send_to_char("Введите VNUM изготавливаемого предмета : ", d->character.get());
+        OLC_MODE(d) = MREDIT_OBJ_PROTO;
+        return;
+      }
 
-		if (sagr == "2")
-		{
-			// Выводить список умений ... или давать вводить ручками.
-			tmpstr = "\r\nСписок доступных умений:\r\n";
-			i = 0;
-			while (make_skills[i].num != 0)
-			{
-				sprintf(tmpbuf, "%s%d%s) %s.\r\n", grn, i + 1, nrm, make_skills[i].name);
-				tmpstr += string(tmpbuf);
-				i++;
-			}
-			tmpstr += "Введите номер умения : ";
-			send_to_char(tmpstr.c_str(), d->character.get());
-			OLC_MODE(d) = MREDIT_SKILL;
-			return;
-		}
+      if (sagr == "2") {
+        // Выводить список умений ... или давать вводить ручками.
+        tmpstr = "\r\nСписок доступных умений:\r\n";
+        i = 0;
+        while (make_skills[i].num != 0) {
+          sprintf(tmpbuf, "%s%d%s) %s.\r\n", grn, i + 1, nrm, make_skills[i].name);
+          tmpstr += string(tmpbuf);
+          i++;
+        }
+        tmpstr += "Введите номер умения : ";
+        send_to_char(tmpstr.c_str(), d->character.get());
+        OLC_MODE(d) = MREDIT_SKILL;
+        return;
+      }
 
-		if (sagr == "3")
-		{
-			send_to_char("Блокировать рецепт? (y/n): ", d->character.get());
-			OLC_MODE(d) = MREDIT_LOCK;
-			return;
-		}
+      if (sagr == "3") {
+        send_to_char("Блокировать рецепт? (y/n): ", d->character.get());
+        OLC_MODE(d) = MREDIT_LOCK;
+        return;
+      }
 
-		for (i = 0; i < MAX_PARTS; i++)
-		{
-			if (atoi(sagr.c_str()) - 4 == i)
-			{
-				OLC_NUM(d) = i;
-				mredit_disp_ingr_menu(d);
-				return;
-			}
-		}
+      for (i = 0; i < MAX_PARTS; i++) {
+        if (atoi(sagr.c_str()) - 4 == i) {
+          OLC_NUM(d) = i;
+          mredit_disp_ingr_menu(d);
+          return;
+        }
+      }
 
-		if (sagr == "d")
-		{
-			send_to_char("Удалить рецепт? (y/n):", d->character.get());
-			OLC_MODE(d) = MREDIT_DEL;
-			return;
-		}
+      if (sagr == "d") {
+        send_to_char("Удалить рецепт? (y/n):", d->character.get());
+        OLC_MODE(d) = MREDIT_DEL;
+        return;
+      }
 
-		if (sagr == "s")
-		{
-			// Сохраняем рецепты в файл
-			make_recepts.save();
-			send_to_char("Рецепты сохранены.\r\n", d->character.get());
-			mredit_disp_menu(d);
-			OLC_VAL(d) = 0;
-			return;
-		}
+      if (sagr == "s") {
+        // Сохраняем рецепты в файл
+        make_recepts.save();
+        send_to_char("Рецепты сохранены.\r\n", d->character.get());
+        mredit_disp_menu(d);
+        OLC_VAL(d) = 0;
+        return;
+      }
 
-		if (sagr == "q")
-		{
-			// Проверяем не производилось ли изменение
-			if (OLC_VAL(d))
-			{
-				send_to_char("Вы желаете сохранить изменения в рецепте? (y/n) : ", d->character.get());
-				OLC_MODE(d) = MREDIT_CONFIRM_SAVE;
-				return;
-			}
-			else
-			{
-				// Загружаем рецепты из файла
-				// Это восстановит текущее состояние дел.
-				make_recepts.load();
-				// Очищаем структуры OLC выходим в нормальный режим работы
-				cleanup_olc(d, CLEANUP_ALL);
-				return;
-			}
-		}
+      if (sagr == "q") {
+        // Проверяем не производилось ли изменение
+        if (OLC_VAL(d)) {
+          send_to_char("Вы желаете сохранить изменения в рецепте? (y/n) : ", d->character.get());
+          OLC_MODE(d) = MREDIT_CONFIRM_SAVE;
+          return;
+        } else {
+          // Загружаем рецепты из файла
+          // Это восстановит текущее состояние дел.
+          make_recepts.load();
+          // Очищаем структуры OLC выходим в нормальный режим работы
+          cleanup_olc(d, CLEANUP_ALL);
+          return;
+        }
+      }
 
-		send_to_char("Неверный ввод.\r\n", d->character.get());
-		mredit_disp_menu(d);
-		break;
+      send_to_char("Неверный ввод.\r\n", d->character.get());
+      mredit_disp_menu(d);
+      break;
 
-	case MREDIT_OBJ_PROTO:
-		i = atoi(sagr.c_str());
-		if (real_object(i) < 0)
-		{
-			send_to_char("Прототип выбранного вами объекта не существует.\r\n", d->character.get());
-		}
-		else
-		{
-			trec->obj_proto = i;
-			OLC_VAL(d) = 1;
-		}
-		mredit_disp_menu(d);
-		break;
+    case MREDIT_OBJ_PROTO: i = atoi(sagr.c_str());
+      if (real_object(i) < 0) {
+        send_to_char("Прототип выбранного вами объекта не существует.\r\n", d->character.get());
+      } else {
+        trec->obj_proto = i;
+        OLC_VAL(d) = 1;
+      }
+      mredit_disp_menu(d);
+      break;
 
-	case MREDIT_SKILL:
-		int skill_num;
-		skill_num = atoi(sagr.c_str());
-		i = 0;
-		while (make_skills[i].num != 0)
-		{
-			if (skill_num == i + 1)
-			{
-				trec->skill = make_skills[i].num;
-				OLC_VAL(d) = 1;
-				mredit_disp_menu(d);
-				return;
-			}
-			i++;
-		}
-		send_to_char("Выбрано некорректное умение.\r\n", d->character.get());
-		mredit_disp_menu(d);
-		break;
+    case MREDIT_SKILL: int skill_num;
+      skill_num = atoi(sagr.c_str());
+      i = 0;
+      while (make_skills[i].num != 0) {
+        if (skill_num == i + 1) {
+          trec->skill = make_skills[i].num;
+          OLC_VAL(d) = 1;
+          mredit_disp_menu(d);
+          return;
+        }
+        i++;
+      }
+      send_to_char("Выбрано некорректное умение.\r\n", d->character.get());
+      mredit_disp_menu(d);
+      break;
 
-	case MREDIT_DEL:
-		if (sagr == "Y" || sagr == "y")
-		{
-			send_to_char("Рецепт удален. Рецепты сохранены.\r\n", d->character.get());
-			make_recepts.del(trec);
-			make_recepts.save();
-			make_recepts.load();
-			// Очищаем структуры OLC выходим в нормальный режим работы
-			cleanup_olc(d, CLEANUP_ALL);
-			return;
-		}
-		else if (sagr == "N" || sagr == "n")
-		{
-			send_to_char("Рецепт не удален.\r\n", d->character.get());
-		}
-		else
-		{
-			send_to_char("Неверный ввод.\r\n", d->character.get());
-		}
-		mredit_disp_menu(d);
-		break;
+    case MREDIT_DEL:
+      if (sagr == "Y" || sagr == "y") {
+        send_to_char("Рецепт удален. Рецепты сохранены.\r\n", d->character.get());
+        make_recepts.del(trec);
+        make_recepts.save();
+        make_recepts.load();
+        // Очищаем структуры OLC выходим в нормальный режим работы
+        cleanup_olc(d, CLEANUP_ALL);
+        return;
+      } else if (sagr == "N" || sagr == "n") {
+        send_to_char("Рецепт не удален.\r\n", d->character.get());
+      } else {
+        send_to_char("Неверный ввод.\r\n", d->character.get());
+      }
+      mredit_disp_menu(d);
+      break;
 
-	case MREDIT_LOCK:
-		if (sagr == "Y" || sagr == "y")
-		{
-			send_to_char("Рецепт заблокирован от использования.\r\n", d->character.get());
-			trec->locked = true;
-			OLC_VAL(d) = 1;
-		}
-		else if (sagr == "N" || sagr == "n")
-		{
-			send_to_char("Рецепт разблокирован и может использоваться.\r\n", d->character.get());
-			trec->locked = false;
-			OLC_VAL(d) = 1;
-		}
-		else
-		{
-			send_to_char("Неверный ввод.\r\n", d->character.get());
-		}
-		mredit_disp_menu(d);
-		break;
+    case MREDIT_LOCK:
+      if (sagr == "Y" || sagr == "y") {
+        send_to_char("Рецепт заблокирован от использования.\r\n", d->character.get());
+        trec->locked = true;
+        OLC_VAL(d) = 1;
+      } else if (sagr == "N" || sagr == "n") {
+        send_to_char("Рецепт разблокирован и может использоваться.\r\n", d->character.get());
+        trec->locked = false;
+        OLC_VAL(d) = 1;
+      } else {
+        send_to_char("Неверный ввод.\r\n", d->character.get());
+      }
+      mredit_disp_menu(d);
+      break;
 
-	case MREDIT_INGR_MENU:
-		// Ввод меню ингридиентов.
-		if (sagr == "1")
-		{
-			send_to_char("Введите VNUM ингредиента : ", d->character.get());
-			OLC_MODE(d) = MREDIT_INGR_PROTO;
-			return;
-		}
+    case MREDIT_INGR_MENU:
+      // Ввод меню ингридиентов.
+      if (sagr == "1") {
+        send_to_char("Введите VNUM ингредиента : ", d->character.get());
+        OLC_MODE(d) = MREDIT_INGR_PROTO;
+        return;
+      }
 
-		if (sagr == "2")
-		{
-			send_to_char("Введите мин.вес ингредиента : ", d->character.get());
-			OLC_MODE(d) = MREDIT_INGR_WEIGHT;
-			return;
-		}
+      if (sagr == "2") {
+        send_to_char("Введите мин.вес ингредиента : ", d->character.get());
+        OLC_MODE(d) = MREDIT_INGR_WEIGHT;
+        return;
+      }
 
-		if (sagr == "3")
-		{
-			send_to_char("Введите мин.силу ингредиента : ", d->character.get());
-			OLC_MODE(d) = MREDIT_INGR_POWER;
-			return;
-		}
+      if (sagr == "3") {
+        send_to_char("Введите мин.силу ингредиента : ", d->character.get());
+        OLC_MODE(d) = MREDIT_INGR_POWER;
+        return;
+      }
 
-		if (sagr == "q")
-		{
-			mredit_disp_menu(d);
-			return;
-		}
+      if (sagr == "q") {
+        mredit_disp_menu(d);
+        return;
+      }
 
-		send_to_char("Неверный ввод.\r\n", d->character.get());
-		mredit_disp_ingr_menu(d);
-		break;
+      send_to_char("Неверный ввод.\r\n", d->character.get());
+      mredit_disp_ingr_menu(d);
+      break;
 
-	case MREDIT_INGR_PROTO:
-		i = atoi(sagr.c_str());
-		if (i == 0)
-		{
-			if (trec->parts[OLC_NUM(d)].proto != i)
-				OLC_VAL(d) = 1;
-			trec->parts[OLC_NUM(d)].proto = 0;
-			trec->parts[OLC_NUM(d)].min_weight = 0;
-			trec->parts[OLC_NUM(d)].min_power = 0;
-		}
-		else if (real_object(i) < 0)
-		{
-			send_to_char("Прототип выбранного вами ингредиента не существует.\r\n", d->character.get());
-		}
-		else
-		{
-			trec->parts[OLC_NUM(d)].proto = i;
-			OLC_VAL(d) = 1;
-		}
-		mredit_disp_ingr_menu(d);
-		break;
+    case MREDIT_INGR_PROTO: i = atoi(sagr.c_str());
+      if (i == 0) {
+        if (trec->parts[OLC_NUM(d)].proto != i)
+          OLC_VAL(d) = 1;
+        trec->parts[OLC_NUM(d)].proto = 0;
+        trec->parts[OLC_NUM(d)].min_weight = 0;
+        trec->parts[OLC_NUM(d)].min_power = 0;
+      } else if (real_object(i) < 0) {
+        send_to_char("Прототип выбранного вами ингредиента не существует.\r\n", d->character.get());
+      } else {
+        trec->parts[OLC_NUM(d)].proto = i;
+        OLC_VAL(d) = 1;
+      }
+      mredit_disp_ingr_menu(d);
+      break;
 
-	case MREDIT_INGR_WEIGHT:
-		i = atoi(sagr.c_str());
-		trec->parts[OLC_NUM(d)].min_weight = i;
-		OLC_VAL(d) = 1;
-		mredit_disp_ingr_menu(d);
-		break;
+    case MREDIT_INGR_WEIGHT: i = atoi(sagr.c_str());
+      trec->parts[OLC_NUM(d)].min_weight = i;
+      OLC_VAL(d) = 1;
+      mredit_disp_ingr_menu(d);
+      break;
 
-	case MREDIT_INGR_POWER:
-		i = atoi(sagr.c_str());
-		trec->parts[OLC_NUM(d)].min_power = i;
-		OLC_VAL(d) = 1;
-		mredit_disp_ingr_menu(d);
-		break;
+    case MREDIT_INGR_POWER: i = atoi(sagr.c_str());
+      trec->parts[OLC_NUM(d)].min_power = i;
+      OLC_VAL(d) = 1;
+      mredit_disp_ingr_menu(d);
+      break;
 
-	case MREDIT_CONFIRM_SAVE:
-		if (sagr == "Y" || sagr == "y")
-		{
-			send_to_char("Рецепты сохранены.\r\n", d->character.get());
-			make_recepts.save();
-			make_recepts.load();
-			// Очищаем структуры OLC выходим в нормальный режим работы
-			cleanup_olc(d, CLEANUP_ALL);
-			return;
-		}
-		else if (sagr == "N" || sagr == "n")
-		{
-			send_to_char("Рецепт не был сохранен.\r\n", d->character.get());
-			cleanup_olc(d, CLEANUP_ALL);
-			return;
-		}
-		else
-		{
-			send_to_char("Неверный ввод.\r\n", d->character.get());
-		}
-		mredit_disp_menu(d);
-		break;
-	}
+    case MREDIT_CONFIRM_SAVE:
+      if (sagr == "Y" || sagr == "y") {
+        send_to_char("Рецепты сохранены.\r\n", d->character.get());
+        make_recepts.save();
+        make_recepts.load();
+        // Очищаем структуры OLC выходим в нормальный режим работы
+        cleanup_olc(d, CLEANUP_ALL);
+        return;
+      } else if (sagr == "N" || sagr == "n") {
+        send_to_char("Рецепт не был сохранен.\r\n", d->character.get());
+        cleanup_olc(d, CLEANUP_ALL);
+        return;
+      } else {
+        send_to_char("Неверный ввод.\r\n", d->character.get());
+      }
+      mredit_disp_menu(d);
+      break;
+  }
 }
 
 // Входим в режим редактирования рецептов для предметов.
-void do_edit_make(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	string tmpstr;
-	DESCRIPTOR_DATA *d;
-	char tmpbuf[MAX_INPUT_LENGTH];
-	MakeRecept *trec;
+void do_edit_make(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  string tmpstr;
+  DESCRIPTOR_DATA *d;
+  char tmpbuf[MAX_INPUT_LENGTH];
+  MakeRecept *trec;
 
-	// Проверяем не правит ли кто-то рецепты для исключения конфликтов
-	for (d = descriptor_list; d; d = d->next)
-	{
-		if (d->olc && STATE(d) == CON_MREDIT)
-		{
-			sprintf(tmpbuf, "Рецепты в настоящий момент редактируются %s.\r\n", GET_PAD(d->character, 4));
-			send_to_char(tmpbuf, ch);
-			return;
-		}
-	}
+  // Проверяем не правит ли кто-то рецепты для исключения конфликтов
+  for (d = descriptor_list; d; d = d->next) {
+    if (d->olc && STATE(d) == CON_MREDIT) {
+      sprintf(tmpbuf, "Рецепты в настоящий момент редактируются %s.\r\n", GET_PAD(d->character, 4));
+      send_to_char(tmpbuf, ch);
+      return;
+    }
+  }
 
-	argument = one_argument(argument, tmpbuf);
-	if (!*tmpbuf)
-	{
-		// Номер не задан создаем новый рецепт.
-		trec = new(MakeRecept);
-		// Запихиваем рецепт но помним что он заблокирован.
-		make_recepts.add(trec);
-		ch->desc->olc = new olc_data;
-		// входим в состояние правки рецепта.
-		STATE(ch->desc) = CON_MREDIT;
-		OLC_MREC(ch->desc) = trec;
-		OLC_VAL(ch->desc) = 0;
-		mredit_disp_menu(ch->desc);
-		return;
-	}
+  argument = one_argument(argument, tmpbuf);
+  if (!*tmpbuf) {
+    // Номер не задан создаем новый рецепт.
+    trec = new(MakeRecept);
+    // Запихиваем рецепт но помним что он заблокирован.
+    make_recepts.add(trec);
+    ch->desc->olc = new olc_data;
+    // входим в состояние правки рецепта.
+    STATE(ch->desc) = CON_MREDIT;
+    OLC_MREC(ch->desc) = trec;
+    OLC_VAL(ch->desc) = 0;
+    mredit_disp_menu(ch->desc);
+    return;
+  }
 
-	size_t i = atoi(tmpbuf);
-	if ((i > make_recepts.size()) || (i <= 0))
-	{
-		send_to_char("Выбранного рецепта не существует.", ch);
-		return;
-	}
+  size_t i = atoi(tmpbuf);
+  if ((i > make_recepts.size()) || (i <= 0)) {
+    send_to_char("Выбранного рецепта не существует.", ch);
+    return;
+  }
 
-	i -= 1;
-	ch->desc->olc = new olc_data;
-	STATE(ch->desc) = CON_MREDIT;
-	OLC_MREC(ch->desc) = make_recepts[i];
-	mredit_disp_menu(ch->desc);
-	return;
+  i -= 1;
+  ch->desc->olc = new olc_data;
+  STATE(ch->desc) = CON_MREDIT;
+  OLC_MREC(ch->desc) = make_recepts[i];
+  mredit_disp_menu(ch->desc);
+  return;
 }
 
 // Отображение меню параметров ингридиента.
-void mredit_disp_ingr_menu(DESCRIPTOR_DATA * d)
-{
-	// Рисуем меню ...
-	MakeRecept *trec;
-	string objname, ingrname, tmpstr;
-	char tmpbuf[MAX_INPUT_LENGTH];
-	int index = OLC_NUM(d);
-	trec = OLC_MREC(d);
-	get_char_cols(d->character.get());
-	auto tobj = get_object_prototype(trec->obj_proto);
-	if (trec->obj_proto && tobj)
-	{
-		objname = tobj->get_PName(0);
-	}
-	else
-	{
-		objname = "Нет";
-	}
-	tobj = get_object_prototype(trec->parts[index].proto);
-	if (trec->parts[index].proto && tobj)
-	{
-		ingrname = tobj->get_PName(0);
-	}
-	else
-	{
-		ingrname = "Нет";
-	}
-	sprintf(tmpbuf,
+void mredit_disp_ingr_menu(DESCRIPTOR_DATA *d) {
+  // Рисуем меню ...
+  MakeRecept *trec;
+  string objname, ingrname, tmpstr;
+  char tmpbuf[MAX_INPUT_LENGTH];
+  int index = OLC_NUM(d);
+  trec = OLC_MREC(d);
+  get_char_cols(d->character.get());
+  auto tobj = get_object_prototype(trec->obj_proto);
+  if (trec->obj_proto && tobj) {
+    objname = tobj->get_PName(0);
+  } else {
+    objname = "Нет";
+  }
+  tobj = get_object_prototype(trec->parts[index].proto);
+  if (trec->parts[index].proto && tobj) {
+    ingrname = tobj->get_PName(0);
+  } else {
+    ingrname = "Нет";
+  }
+  sprintf(tmpbuf,
 #if defined(CLEAR_SCREEN)
-			"[H[J"
+      "[H[J"
 #endif
-			"\r\n\r\n"
-			"-- Рецепт - %s%s%s (%d) \r\n"
-			"%s1%s) Ингредиент : %s%s (%d)\r\n"
-			"%s2%s) Мин. вес   : %s%d\r\n"
-			"%s3%s) Мин. сила  : %s%d\r\n",
-			grn, objname.c_str(), nrm, trec->obj_proto,
-			grn, nrm, yel, ingrname.c_str(), trec->parts[index].proto,
-			grn, nrm, yel, trec->parts[index].min_weight, grn, nrm, yel, trec->parts[index].min_power);
-	tmpstr = string(tmpbuf);
-	tmpstr += string(grn) + "q" + string(nrm) + ") Выход\r\n";
-	tmpstr += "Ваш выбор : ";
-	send_to_char(tmpstr.c_str(), d->character.get());
-	OLC_MODE(d) = MREDIT_INGR_MENU;
+          "\r\n\r\n"
+          "-- Рецепт - %s%s%s (%d) \r\n"
+          "%s1%s) Ингредиент : %s%s (%d)\r\n"
+          "%s2%s) Мин. вес   : %s%d\r\n"
+          "%s3%s) Мин. сила  : %s%d\r\n",
+          grn, objname.c_str(), nrm, trec->obj_proto,
+          grn, nrm, yel, ingrname.c_str(), trec->parts[index].proto,
+          grn, nrm, yel, trec->parts[index].min_weight, grn, nrm, yel, trec->parts[index].min_power);
+  tmpstr = string(tmpbuf);
+  tmpstr += string(grn) + "q" + string(nrm) + ") Выход\r\n";
+  tmpstr += "Ваш выбор : ";
+  send_to_char(tmpstr.c_str(), d->character.get());
+  OLC_MODE(d) = MREDIT_INGR_MENU;
 }
 
 // Отображение главного меню.
-void mredit_disp_menu(DESCRIPTOR_DATA * d)
-{
-	// Рисуем меню ...
-	MakeRecept *trec;
-	char tmpbuf[MAX_INPUT_LENGTH];
-	string tmpstr, objname, skillname;
-	trec = OLC_MREC(d);
-	get_char_cols(d->character.get());
-	auto tobj = get_object_prototype(trec->obj_proto);
-	if (trec->obj_proto && tobj)
-	{
-		objname = tobj->get_PName(0);
-	}
-	else
-	{
-		objname = "Нет";
-	}
-	int i = 0;
-	//
-	skillname = "Нет";
-	while (make_skills[i].num != 0)
-	{
-		if (make_skills[i].num == trec->skill)
-		{
-			skillname = string(make_skills[i].name);
-			break;
-		}
-		i++;
-	}
-	sprintf(tmpbuf,
+void mredit_disp_menu(DESCRIPTOR_DATA *d) {
+  // Рисуем меню ...
+  MakeRecept *trec;
+  char tmpbuf[MAX_INPUT_LENGTH];
+  string tmpstr, objname, skillname;
+  trec = OLC_MREC(d);
+  get_char_cols(d->character.get());
+  auto tobj = get_object_prototype(trec->obj_proto);
+  if (trec->obj_proto && tobj) {
+    objname = tobj->get_PName(0);
+  } else {
+    objname = "Нет";
+  }
+  int i = 0;
+  //
+  skillname = "Нет";
+  while (make_skills[i].num != 0) {
+    if (make_skills[i].num == trec->skill) {
+      skillname = string(make_skills[i].name);
+      break;
+    }
+    i++;
+  }
+  sprintf(tmpbuf,
 #if defined(CLEAR_SCREEN)
-			"[H[J"
+      "[H[J"
 #endif
-			"\r\n\r\n"
-			"-- Рецепт --\r\n"
-			"%s1%s) Предмет    : %s%s (%d)\r\n"
-			"%s2%s) Умение     : %s%s (%d)\r\n"
-			"%s3%s) Блокирован : %s%s \r\n",
-			grn, nrm, yel, objname.c_str(), trec->obj_proto,
-			grn, nrm, yel, skillname.c_str(), trec->skill, grn, nrm, yel, (trec->locked ? "Да" : "Нет"));
-	tmpstr = string(tmpbuf);
-	for (int i = 0; i < MAX_PARTS; i++)
-	{
-		tobj = get_object_prototype(trec->parts[i].proto);
-		if (trec->parts[i].proto && tobj)
-		{
-			objname = tobj->get_PName(0);
-		}
-		else
-		{
-			objname = "Нет";
-		}
-		sprintf(tmpbuf, "%s%d%s) Компонент %d: %s%s (%d)\r\n",
-			grn, i + 4, nrm, i + 1, yel, objname.c_str(), trec->parts[i].proto);
-		tmpstr += string(tmpbuf);
-	};
-	tmpstr += string(grn) + "d" + string(nrm) + ") Удалить\r\n";
-	tmpstr += string(grn) + "s" + string(nrm) + ") Сохранить\r\n";
-	tmpstr += string(grn) + "q" + string(nrm) + ") Выход\r\n";
-	tmpstr += "Ваш выбор : ";
-	send_to_char(tmpstr.c_str(), d->character.get());
-	OLC_MODE(d) = MREDIT_MAIN_MENU;
+          "\r\n\r\n"
+          "-- Рецепт --\r\n"
+          "%s1%s) Предмет    : %s%s (%d)\r\n"
+          "%s2%s) Умение     : %s%s (%d)\r\n"
+          "%s3%s) Блокирован : %s%s \r\n",
+          grn, nrm, yel, objname.c_str(), trec->obj_proto,
+          grn, nrm, yel, skillname.c_str(), trec->skill, grn, nrm, yel, (trec->locked ? "Да" : "Нет"));
+  tmpstr = string(tmpbuf);
+  for (int i = 0; i < MAX_PARTS; i++) {
+    tobj = get_object_prototype(trec->parts[i].proto);
+    if (trec->parts[i].proto && tobj) {
+      objname = tobj->get_PName(0);
+    } else {
+      objname = "Нет";
+    }
+    sprintf(tmpbuf, "%s%d%s) Компонент %d: %s%s (%d)\r\n",
+            grn, i + 4, nrm, i + 1, yel, objname.c_str(), trec->parts[i].proto);
+    tmpstr += string(tmpbuf);
+  };
+  tmpstr += string(grn) + "d" + string(nrm) + ") Удалить\r\n";
+  tmpstr += string(grn) + "s" + string(nrm) + ") Сохранить\r\n";
+  tmpstr += string(grn) + "q" + string(nrm) + ") Выход\r\n";
+  tmpstr += "Ваш выбор : ";
+  send_to_char(tmpstr.c_str(), d->character.get());
+  OLC_MODE(d) = MREDIT_MAIN_MENU;
 }
 
-void do_list_make(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-	string tmpstr, skill_name, obj_name;
-	char tmpbuf[MAX_INPUT_LENGTH];
-	MakeRecept *trec;
-	if (make_recepts.size() == 0)
-	{
-		send_to_char("Рецепты в этом мире не определены.", ch);
-		return;
-	}
-	// Выдаем список рецептов всех рецептов как в магазине.
-	tmpstr = "###  Б  Умение  Предмет             Составляющие                         \r\n";
-	tmpstr += "------------------------------------------------------------------------------\r\n";
-	for (size_t i = 0; i < make_recepts.size(); i++)
-	{
-		int j = 0;
-		skill_name = "Нет";
-		obj_name = "Нет";
-		trec = make_recepts[i];
-		auto obj = get_object_prototype(trec->obj_proto);
-		if (obj)
-		{
-			obj_name = obj->get_PName(0).substr(0, 11);
-		}
-		while (make_skills[j].num != 0)
-		{
-			if (make_skills[j].num == trec->skill)
-			{
-				skill_name = string(make_skills[j].short_name);
-				break;
-			}
-			j++;
-		}
-		sprintf(tmpbuf, "%3zd  %-1s  %-6s  %-12s(%5d) :",
-			i + 1, (trec->locked ? "*" : " "), skill_name.c_str(), obj_name.c_str(), trec->obj_proto);
-		tmpstr += string(tmpbuf);
-		for (int j = 0; j < MAX_PARTS; j++)
-		{
-			if (trec->parts[j].proto != 0)
-			{
-				obj = get_object_prototype(trec->parts[j].proto);
-				if (obj)
-				{
-					obj_name = obj->get_PName(0).substr(0, 11);
-				}
-				else
-				{
-					obj_name = "Нет";
-				}
-				sprintf(tmpbuf, " %-12s(%5d)", obj_name.c_str(), trec->parts[j].proto);
-				if (j > 0)
-				{
-					tmpstr += ",";
-					if (j % 2 == 0)
-					{
-						// разбиваем строчки если ингров больше 2;
-						tmpstr += "\r\n";
-						tmpstr += "                                    :";
-					}
-				};
-				tmpstr += string(tmpbuf);
-			}
-			else
-			{
-				break;
-			}
-		}
-		tmpstr += "\r\n";
-	}
-	page_string(ch->desc, tmpstr);
-	return;
+void do_list_make(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  string tmpstr, skill_name, obj_name;
+  char tmpbuf[MAX_INPUT_LENGTH];
+  MakeRecept *trec;
+  if (make_recepts.size() == 0) {
+    send_to_char("Рецепты в этом мире не определены.", ch);
+    return;
+  }
+  // Выдаем список рецептов всех рецептов как в магазине.
+  tmpstr = "###  Б  Умение  Предмет             Составляющие                         \r\n";
+  tmpstr += "------------------------------------------------------------------------------\r\n";
+  for (size_t i = 0; i < make_recepts.size(); i++) {
+    int j = 0;
+    skill_name = "Нет";
+    obj_name = "Нет";
+    trec = make_recepts[i];
+    auto obj = get_object_prototype(trec->obj_proto);
+    if (obj) {
+      obj_name = obj->get_PName(0).substr(0, 11);
+    }
+    while (make_skills[j].num != 0) {
+      if (make_skills[j].num == trec->skill) {
+        skill_name = string(make_skills[j].short_name);
+        break;
+      }
+      j++;
+    }
+    sprintf(tmpbuf, "%3zd  %-1s  %-6s  %-12s(%5d) :",
+            i + 1, (trec->locked ? "*" : " "), skill_name.c_str(), obj_name.c_str(), trec->obj_proto);
+    tmpstr += string(tmpbuf);
+    for (int j = 0; j < MAX_PARTS; j++) {
+      if (trec->parts[j].proto != 0) {
+        obj = get_object_prototype(trec->parts[j].proto);
+        if (obj) {
+          obj_name = obj->get_PName(0).substr(0, 11);
+        } else {
+          obj_name = "Нет";
+        }
+        sprintf(tmpbuf, " %-12s(%5d)", obj_name.c_str(), trec->parts[j].proto);
+        if (j > 0) {
+          tmpstr += ",";
+          if (j % 2 == 0) {
+            // разбиваем строчки если ингров больше 2;
+            tmpstr += "\r\n";
+            tmpstr += "                                    :";
+          }
+        };
+        tmpstr += string(tmpbuf);
+      } else {
+        break;
+      }
+    }
+    tmpstr += "\r\n";
+  }
+  page_string(ch->desc, tmpstr);
+  return;
 }
 // Создание любого предмета из компонента.
-void do_make_item(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
-{
-	// Тут творим предмет.
-	// Если прислали без параметра то выводим список всех рецептов
-	// доступных для изготовления персонажу из его ингров
-	// Мастерить можно лук, посох , и диковину(аналог артефакта)
-	// суб команда make
-	// Выковать можно клинок и доспех (щит) умения разные. название одно
-	// Сварить отвар
-	// Сшить одежду
-	if ((subcmd == MAKE_WEAR) && (!ch->get_skill(SKILL_MAKE_WEAR))) {
-		send_to_char("Вас этому никто не научил.\r\n", ch);
-		return;
-	}
-	string tmpstr;
-	MakeReceptList canlist;
-	MakeRecept *trec;
-	char tmpbuf[MAX_INPUT_LENGTH];
-	//int used_skill = subcmd;
-	argument = one_argument(argument, tmpbuf);
-	// Разбираем в зависимости от того что набрали ... список объектов
-	switch (subcmd)
-	{
-	case(MAKE_POTION):
-		// Варим отвар.
-		tmpstr = "Вы можете сварить:\r\n";
-		make_recepts.can_make(ch, &canlist, SKILL_MAKE_POTION);
-		break;
-	case(MAKE_WEAR):
-		// Шьем одежку.
-		tmpstr = "Вы можете сшить:\r\n";
-		make_recepts.can_make(ch, &canlist, SKILL_MAKE_WEAR);
-		break;
-	case(MAKE_METALL):
-		tmpstr = "Вы можете выковать:\r\n";
-		make_recepts.can_make(ch, &canlist, SKILL_MAKE_WEAPON);
-		make_recepts.can_make(ch, &canlist, SKILL_MAKE_ARMOR);
-		break;
-	case(MAKE_CRAFT):
-		tmpstr = "Вы можете смастерить:\r\n";
-		make_recepts.can_make(ch, &canlist, SKILL_MAKE_STAFF);
-		make_recepts.can_make(ch, &canlist, SKILL_MAKE_BOW);
-		make_recepts.can_make(ch, &canlist, SKILL_MAKE_JEWEL);
-		make_recepts.can_make(ch, &canlist, SKILL_MAKE_AMULET);
-		break;
-	}
-	if (canlist.size() == 0)
-	{
-		// Чар не может сделать ничего.
-		send_to_char("Вы ничего не можете сделать.\r\n", ch);
-		return;
-	}
-	if (!*tmpbuf)
-	{
-		// Выводим тут список предметов которые можем сделать.
-		for (size_t i = 0; i < canlist.size(); i++)
-		{
-			auto tobj = get_object_prototype(canlist[i]->obj_proto);
-			if (!tobj)
-				return;
-			sprintf(tmpbuf, "%zd) %s\r\n", i + 1, tobj->get_PName(0).c_str());
-			tmpstr += string(tmpbuf);
-		};
-		send_to_char(tmpstr.c_str(), ch);
-		return;
-	}
-	// Адресуемся по списку либо по номеру, либо по названию с номером.
-	tmpstr = string(tmpbuf);
-	size_t i = atoi(tmpbuf);
-	if ((i > 0) && (i <= canlist.size())
-			&& (tmpstr.find(".") > tmpstr.size()))
-	{
-		trec = canlist[i - 1];
-	}
-	else
-	{
-		trec = canlist.get_by_name(tmpstr);
-		if (trec == NULL)
-		{
-			tmpstr = "Похоже, у вас творческий кризис.\r\n";
-			send_to_char(tmpstr.c_str(), ch);
-			return;
-		}
-	};
-	trec->make(ch);
-	return;
+void do_make_item(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  // Тут творим предмет.
+  // Если прислали без параметра то выводим список всех рецептов
+  // доступных для изготовления персонажу из его ингров
+  // Мастерить можно лук, посох , и диковину(аналог артефакта)
+  // суб команда make
+  // Выковать можно клинок и доспех (щит) умения разные. название одно
+  // Сварить отвар
+  // Сшить одежду
+  if ((subcmd == MAKE_WEAR) && (!ch->get_skill(SKILL_MAKE_WEAR))) {
+    send_to_char("Вас этому никто не научил.\r\n", ch);
+    return;
+  }
+  string tmpstr;
+  MakeReceptList canlist;
+  MakeRecept *trec;
+  char tmpbuf[MAX_INPUT_LENGTH];
+  //int used_skill = subcmd;
+  argument = one_argument(argument, tmpbuf);
+  // Разбираем в зависимости от того что набрали ... список объектов
+  switch (subcmd) {
+    case (MAKE_POTION):
+      // Варим отвар.
+      tmpstr = "Вы можете сварить:\r\n";
+      make_recepts.can_make(ch, &canlist, SKILL_MAKE_POTION);
+      break;
+    case (MAKE_WEAR):
+      // Шьем одежку.
+      tmpstr = "Вы можете сшить:\r\n";
+      make_recepts.can_make(ch, &canlist, SKILL_MAKE_WEAR);
+      break;
+    case (MAKE_METALL): tmpstr = "Вы можете выковать:\r\n";
+      make_recepts.can_make(ch, &canlist, SKILL_MAKE_WEAPON);
+      make_recepts.can_make(ch, &canlist, SKILL_MAKE_ARMOR);
+      break;
+    case (MAKE_CRAFT): tmpstr = "Вы можете смастерить:\r\n";
+      make_recepts.can_make(ch, &canlist, SKILL_MAKE_STAFF);
+      make_recepts.can_make(ch, &canlist, SKILL_MAKE_BOW);
+      make_recepts.can_make(ch, &canlist, SKILL_MAKE_JEWEL);
+      make_recepts.can_make(ch, &canlist, SKILL_MAKE_AMULET);
+      break;
+  }
+  if (canlist.size() == 0) {
+    // Чар не может сделать ничего.
+    send_to_char("Вы ничего не можете сделать.\r\n", ch);
+    return;
+  }
+  if (!*tmpbuf) {
+    // Выводим тут список предметов которые можем сделать.
+    for (size_t i = 0; i < canlist.size(); i++) {
+      auto tobj = get_object_prototype(canlist[i]->obj_proto);
+      if (!tobj)
+        return;
+      sprintf(tmpbuf, "%zd) %s\r\n", i + 1, tobj->get_PName(0).c_str());
+      tmpstr += string(tmpbuf);
+    };
+    send_to_char(tmpstr.c_str(), ch);
+    return;
+  }
+  // Адресуемся по списку либо по номеру, либо по названию с номером.
+  tmpstr = string(tmpbuf);
+  size_t i = atoi(tmpbuf);
+  if ((i > 0) && (i <= canlist.size())
+      && (tmpstr.find(".") > tmpstr.size())) {
+    trec = canlist[i - 1];
+  } else {
+    trec = canlist.get_by_name(tmpstr);
+    if (trec == NULL) {
+      tmpstr = "Похоже, у вас творческий кризис.\r\n";
+      send_to_char(tmpstr.c_str(), ch);
+      return;
+    }
+  };
+  trec->make(ch);
+  return;
 }
-void go_create_weapon(CHAR_DATA * ch, OBJ_DATA * obj, int obj_type, ESkill skill)
-{
-	char txtbuff[100];
-	const char *to_char = NULL, *to_room = NULL;
-	int prob, percent, ndice, sdice, weight;
-	float average;
-	if (obj_type == 5 || obj_type == 6)
-	{
-		weight = number(created_item[obj_type].min_weight, created_item[obj_type].max_weight);
-		percent = 100;
-		prob = 100;
-	}
-	else
-	{
-		if (!obj)
-		{
-			return;
-		}
-		skill = created_item[obj_type].skill;
-		percent = number(1, skill_info[skill].max_percent);
-		prob = train_skill(ch, skill, skill_info[skill].max_percent, 0);
-		weight = MIN(GET_OBJ_WEIGHT(obj) - 2, GET_OBJ_WEIGHT(obj) * prob / percent);
-	}
-	if (weight < created_item[obj_type].min_weight)
-	{
-		send_to_char("У вас не хватило материала.\r\n", ch);
-	}
-	else if (prob * 5 < percent)
-	{
-		send_to_char("У вас ничего не получилось.\r\n", ch);
-	}
-	else
-	{
-		const auto tobj = world_objects.create_from_prototype_by_vnum(created_item[obj_type].obj_vnum);
-		if (!tobj)
-		{
-			send_to_char("Образец был невозвратимо утерян.\r\n", ch);
-		}
-		else
-		{
-			tobj->set_weight(MIN(weight, created_item[obj_type].max_weight));
-			tobj->set_cost(2 * GET_OBJ_COST(obj) / 3);
-			tobj->set_owner(GET_UNIQUE(ch));
-			tobj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED);
-			// ковка объектов со слотами.
-			// для 5+ мортов имеем шанс сковать стаф с 3 слотами: базовый 2% и по 0.5% за морт
-			// для 2 слотов базовый шанс 5%, 1% за каждый морт
-			// для 1 слота базово 20% и 4% за каждый морт
-			// Карачун. Поправлено. Расчет не через морты а через скил.
-			if (skill == SKILL_TRANSFORMWEAPON)
-			{
-				if (ch->get_skill(skill) >= 105 && number(1, 100) <= 2 + (ch->get_skill(skill) - 105) / 10)
-				{
-					tobj->set_extra_flag(EExtraFlag::ITEM_WITH3SLOTS);
-				}
-				else if (number(1, 100) <= 5 + MAX((ch->get_skill(skill) - 80), 0) / 5)
-				{
-					tobj->set_extra_flag(EExtraFlag::ITEM_WITH2SLOTS);
-				}
-				else if (number(1, 100) <= 20 + MAX((ch->get_skill(skill) - 80), 0) / 5 * 4)
-				{
-					tobj->set_extra_flag(EExtraFlag::ITEM_WITH1SLOT);
-				}
-			}
-			switch (obj_type)
-			{
-			case 0:	// smith weapon
-			case 1:
-			case 2:
-			case 3:
-			case 4:
-			case 11:
-				{
-					// Карачун. Таймер должен зависить от таймера прототипа.
-					// Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
-					// В минимуме один день реала, в максимуме таймер из прототипа
-					const int timer_value = tobj->get_timer() / 100 * ch->get_skill(skill) - number(0, tobj->get_timer() / 100 * 25);
-					const int timer = MAX(OBJ_DATA::ONE_DAY, timer_value);
-					tobj->set_timer(timer);
-					sprintf(buf, "Ваше изделие продержится примерно %d дней\n", tobj->get_timer() / 24 / 60);
-					act(buf, FALSE, ch, tobj.get(), 0, TO_CHAR);
-					tobj->set_material(GET_OBJ_MATER(obj));
-					// Карачун. Так логичнее.
-					// было GET_OBJ_MAX(tobj) = MAX(50, MIN(300, 300 * prob / percent));
-					// Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
-					// при расчете числа умножены на 100, перед приравниванием делятся на 100. Для не потерять десятые.
-					tobj->set_maximum_durability(MAX(20000, 35000 / 100 * ch->get_skill(skill) - number(0, 35000 / 100 * 25)) / 100);
-					tobj->set_current_durability(GET_OBJ_MAX(tobj));
-					percent = number(1, skill_info[skill].max_percent);
-					prob = calculate_skill(ch, skill, 0);
-					ndice = MAX(2, MIN(4, prob / percent));
-					ndice += GET_OBJ_WEIGHT(tobj) / 10;
-					percent = number(1, skill_info[skill].max_percent);
-					prob = calculate_skill(ch, skill, 0);
-					sdice = MAX(2, MIN(5, prob / percent));
-					sdice += GET_OBJ_WEIGHT(tobj) / 10;
-					tobj->set_val(1, ndice);
-					tobj->set_val(2, sdice);
-					//			tobj->set_wear_flags(created_item[obj_type].wear); пусть wear флаги будут из прототипа
-					if (skill != SKILL_CREATEBOW)
-					{
-						if (GET_OBJ_WEIGHT(tobj) < 14 && percent * 4 > prob)
-						{
-							tobj->set_wear_flag(EWearFlag::ITEM_WEAR_HOLD);
-						}
-						to_room = "$n выковал$g $o3.";
-						average = (((float)sdice + 1) * (float)ndice / 2.0);
-						if (average < 3.0)
-						{
-							sprintf(txtbuff, "Вы выковали $o3 %s.", create_weapon_quality[(int)(2.5 * 2)]);
-						}
-						else if (average <= 27.5)
-						{
-							sprintf(txtbuff, "Вы выковали $o3 %s.", create_weapon_quality[(int)(average * 2)]);
-						}
-						else
-						{
-							sprintf(txtbuff, "Вы выковали $o3 %s!", create_weapon_quality[56]);
-						}
-						to_char = (char *)txtbuff;
-					}
-					else
-					{
-						to_room = "$n смастерил$g $o3.";
-						to_char = "Вы смастерили $o3.";
-					}
-					break;
-				}
-			case 5:	// mages weapon
-			case 6:
-				tobj->set_timer(OBJ_DATA::ONE_DAY);
-				tobj->set_maximum_durability(50);
-				tobj->set_current_durability(50);
-				ndice = MAX(2, MIN(4, GET_LEVEL(ch) / number(6, 8)));
-				ndice += (GET_OBJ_WEIGHT(tobj) / 10);
-				sdice = MAX(2, MIN(5, GET_LEVEL(ch) / number(4, 5)));
-				sdice += (GET_OBJ_WEIGHT(tobj) / 10);
-				tobj->set_val(1, ndice);
-				tobj->set_val(2, sdice);
-				tobj->set_extra_flag(EExtraFlag::ITEM_NORENT);
-				tobj->set_extra_flag(EExtraFlag::ITEM_DECAY);
-				tobj->set_extra_flag(EExtraFlag::ITEM_NOSELL);
-				tobj->set_wear_flags(created_item[obj_type].wear);
-				to_room = "$n создал$g $o3.";
-				to_char = "Вы создали $o3.";
-				break;
-			case 7:	// smith armor
-			case 8:
-			case 9:
-			case 10:
-				{
-					// Карачун. Таймер должен зависить от таймера прототипа.
-					// Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
-					// В минимуме один день реала, в максимуме таймер из прототипа
-					const int timer_value = tobj->get_timer() / 100 * ch->get_skill(skill) - number(0, tobj->get_timer() / 100 * 25);
-					const int timer = MAX(OBJ_DATA::ONE_DAY, timer_value);
-					tobj->set_timer(timer);
-					sprintf(buf, "Ваше изделие продержится примерно %d дней\n", tobj->get_timer() / 24 / 60);
-					act(buf, FALSE, ch, tobj.get(), 0, TO_CHAR);
-					tobj->set_material(GET_OBJ_MATER(obj));
-					// Карачун. Так логичнее.
-					// было GET_OBJ_MAX(tobj) = MAX(50, MIN(300, 300 * prob / percent));
-					// Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
-					// при расчете числа умножены на 100, перед приравниванием делятся на 100. Для не потерять десятые.
-					tobj->set_maximum_durability(MAX(20000, 10000 / 100 * ch->get_skill(skill) - number(0, 15000 / 100 * 25)) / 100);
-					tobj->set_current_durability(GET_OBJ_MAX(tobj));
-					percent = number(1, skill_info[skill].max_percent);
-					prob = calculate_skill(ch, skill, 0);
-					ndice = MAX(2, MIN((105 - material_value[GET_OBJ_MATER(tobj)]) / 10, prob / percent));
-					percent = number(1, skill_info[skill].max_percent);
-					prob = calculate_skill(ch, skill, 0);
-					sdice = MAX(1, MIN((105 - material_value[GET_OBJ_MATER(tobj)]) / 15, prob / percent));
-					tobj->set_val(0, ndice);
-					tobj->set_val(1, sdice);
-					tobj->set_wear_flags(created_item[obj_type].wear);
-					to_room = "$n выковал$g $o3.";
-					to_char = "Вы выковали $o3.";
-					break;
-				}
-			} // switch
+void go_create_weapon(CHAR_DATA *ch, OBJ_DATA *obj, int obj_type, ESkill skill) {
+  char txtbuff[100];
+  const char *to_char = NULL, *to_room = NULL;
+  int prob, percent, ndice, sdice, weight;
+  float average;
+  if (obj_type == 5 || obj_type == 6) {
+    weight = number(created_item[obj_type].min_weight, created_item[obj_type].max_weight);
+    percent = 100;
+    prob = 100;
+  } else {
+    if (!obj) {
+      return;
+    }
+    skill = created_item[obj_type].skill;
+    percent = number(1, skill_info[skill].max_percent);
+    prob = calculate_skill(ch, skill, nullptr);
+    train_skill(ch, skill, true, nullptr);
+    weight = MIN(GET_OBJ_WEIGHT(obj) - 2, GET_OBJ_WEIGHT(obj) * prob / percent);
+  }
+  if (weight < created_item[obj_type].min_weight) {
+    send_to_char("У вас не хватило материала.\r\n", ch);
+  } else if (prob * 5 < percent) {
+    send_to_char("У вас ничего не получилось.\r\n", ch);
+  } else {
+    const auto tobj = world_objects.create_from_prototype_by_vnum(created_item[obj_type].obj_vnum);
+    if (!tobj) {
+      send_to_char("Образец был невозвратимо утерян.\r\n", ch);
+    } else {
+      tobj->set_weight(MIN(weight, created_item[obj_type].max_weight));
+      tobj->set_cost(2 * GET_OBJ_COST(obj) / 3);
+      tobj->set_owner(GET_UNIQUE(ch));
+      tobj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED);
+      // ковка объектов со слотами.
+      // для 5+ мортов имеем шанс сковать стаф с 3 слотами: базовый 2% и по 0.5% за морт
+      // для 2 слотов базовый шанс 5%, 1% за каждый морт
+      // для 1 слота базово 20% и 4% за каждый морт
+      // Карачун. Поправлено. Расчет не через морты а через скил.
+      if (skill == SKILL_TRANSFORMWEAPON) {
+        if (ch->get_skill(skill) >= 105 && number(1, 100) <= 2 + (ch->get_skill(skill) - 105) / 10) {
+          tobj->set_extra_flag(EExtraFlag::ITEM_WITH3SLOTS);
+        } else if (number(1, 100) <= 5 + MAX((ch->get_skill(skill) - 80), 0) / 5) {
+          tobj->set_extra_flag(EExtraFlag::ITEM_WITH2SLOTS);
+        } else if (number(1, 100) <= 20 + MAX((ch->get_skill(skill) - 80), 0) / 5 * 4) {
+          tobj->set_extra_flag(EExtraFlag::ITEM_WITH1SLOT);
+        }
+      }
+      switch (obj_type) {
+        case 0:    // smith weapon
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 11: {
+          // Карачун. Таймер должен зависить от таймера прототипа.
+          // Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
+          // В минимуме один день реала, в максимуме таймер из прототипа
+          const int
+              timer_value = tobj->get_timer() / 100 * ch->get_skill(skill) - number(0, tobj->get_timer() / 100 * 25);
+          const int timer = MAX(OBJ_DATA::ONE_DAY, timer_value);
+          tobj->set_timer(timer);
+          sprintf(buf, "Ваше изделие продержится примерно %d дней\n", tobj->get_timer() / 24 / 60);
+          act(buf, FALSE, ch, tobj.get(), 0, TO_CHAR);
+          tobj->set_material(GET_OBJ_MATER(obj));
+          // Карачун. Так логичнее.
+          // было GET_OBJ_MAX(tobj) = MAX(50, MIN(300, 300 * prob / percent));
+          // Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
+          // при расчете числа умножены на 100, перед приравниванием делятся на 100. Для не потерять десятые.
+          tobj->set_maximum_durability(
+              MAX(20000, 35000 / 100 * ch->get_skill(skill) - number(0, 35000 / 100 * 25)) / 100);
+          tobj->set_current_durability(GET_OBJ_MAX(tobj));
+          percent = number(1, skill_info[skill].max_percent);
+          prob = calculate_skill(ch, skill, 0);
+          ndice = MAX(2, MIN(4, prob / percent));
+          ndice += GET_OBJ_WEIGHT(tobj) / 10;
+          percent = number(1, skill_info[skill].max_percent);
+          prob = calculate_skill(ch, skill, 0);
+          sdice = MAX(2, MIN(5, prob / percent));
+          sdice += GET_OBJ_WEIGHT(tobj) / 10;
+          tobj->set_val(1, ndice);
+          tobj->set_val(2, sdice);
+          //			tobj->set_wear_flags(created_item[obj_type].wear); пусть wear флаги будут из прототипа
+          if (skill != SKILL_CREATEBOW) {
+            if (GET_OBJ_WEIGHT(tobj) < 14 && percent * 4 > prob) {
+              tobj->set_wear_flag(EWearFlag::ITEM_WEAR_HOLD);
+            }
+            to_room = "$n выковал$g $o3.";
+            average = (((float) sdice + 1) * (float) ndice / 2.0);
+            if (average < 3.0) {
+              sprintf(txtbuff, "Вы выковали $o3 %s.", create_weapon_quality[(int) (2.5 * 2)]);
+            } else if (average <= 27.5) {
+              sprintf(txtbuff, "Вы выковали $o3 %s.", create_weapon_quality[(int) (average * 2)]);
+            } else {
+              sprintf(txtbuff, "Вы выковали $o3 %s!", create_weapon_quality[56]);
+            }
+            to_char = (char *) txtbuff;
+          } else {
+            to_room = "$n смастерил$g $o3.";
+            to_char = "Вы смастерили $o3.";
+          }
+          break;
+        }
+        case 5:    // mages weapon
+        case 6: tobj->set_timer(OBJ_DATA::ONE_DAY);
+          tobj->set_maximum_durability(50);
+          tobj->set_current_durability(50);
+          ndice = MAX(2, MIN(4, GET_LEVEL(ch) / number(6, 8)));
+          ndice += (GET_OBJ_WEIGHT(tobj) / 10);
+          sdice = MAX(2, MIN(5, GET_LEVEL(ch) / number(4, 5)));
+          sdice += (GET_OBJ_WEIGHT(tobj) / 10);
+          tobj->set_val(1, ndice);
+          tobj->set_val(2, sdice);
+          tobj->set_extra_flag(EExtraFlag::ITEM_NORENT);
+          tobj->set_extra_flag(EExtraFlag::ITEM_DECAY);
+          tobj->set_extra_flag(EExtraFlag::ITEM_NOSELL);
+          tobj->set_wear_flags(created_item[obj_type].wear);
+          to_room = "$n создал$g $o3.";
+          to_char = "Вы создали $o3.";
+          break;
+        case 7:    // smith armor
+        case 8:
+        case 9:
+        case 10: {
+          // Карачун. Таймер должен зависить от таймера прототипа.
+          // Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
+          // В минимуме один день реала, в максимуме таймер из прототипа
+          const int
+              timer_value = tobj->get_timer() / 100 * ch->get_skill(skill) - number(0, tobj->get_timer() / 100 * 25);
+          const int timer = MAX(OBJ_DATA::ONE_DAY, timer_value);
+          tobj->set_timer(timer);
+          sprintf(buf, "Ваше изделие продержится примерно %d дней\n", tobj->get_timer() / 24 / 60);
+          act(buf, FALSE, ch, tobj.get(), 0, TO_CHAR);
+          tobj->set_material(GET_OBJ_MATER(obj));
+          // Карачун. Так логичнее.
+          // было GET_OBJ_MAX(tobj) = MAX(50, MIN(300, 300 * prob / percent));
+          // Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
+          // при расчете числа умножены на 100, перед приравниванием делятся на 100. Для не потерять десятые.
+          tobj->set_maximum_durability(
+              MAX(20000, 10000 / 100 * ch->get_skill(skill) - number(0, 15000 / 100 * 25)) / 100);
+          tobj->set_current_durability(GET_OBJ_MAX(tobj));
+          percent = number(1, skill_info[skill].max_percent);
+          prob = calculate_skill(ch, skill, 0);
+          ndice = MAX(2, MIN((105 - material_value[GET_OBJ_MATER(tobj)]) / 10, prob / percent));
+          percent = number(1, skill_info[skill].max_percent);
+          prob = calculate_skill(ch, skill, 0);
+          sdice = MAX(1, MIN((105 - material_value[GET_OBJ_MATER(tobj)]) / 15, prob / percent));
+          tobj->set_val(0, ndice);
+          tobj->set_val(1, sdice);
+          tobj->set_wear_flags(created_item[obj_type].wear);
+          to_room = "$n выковал$g $o3.";
+          to_char = "Вы выковали $o3.";
+          break;
+        }
+      } // switch
 
-			if (to_char)
-			{
-				act(to_char, FALSE, ch, tobj.get(), 0, TO_CHAR);
-			}
+      if (to_char) {
+        act(to_char, FALSE, ch, tobj.get(), 0, TO_CHAR);
+      }
 
-			if (to_room)
-			{
-				act(to_room, FALSE, ch, tobj.get(), 0, TO_ROOM);
-			}
+      if (to_room) {
+        act(to_room, FALSE, ch, tobj.get(), 0, TO_ROOM);
+      }
 
-			if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch))
-			{
-				send_to_char("Вы не сможете унести столько предметов.\r\n", ch);
-				obj_to_room(tobj.get(), ch->in_room);
-				obj_decay(tobj.get());
-			}
-			else if (IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(tobj) > CAN_CARRY_W(ch))
-			{
-				send_to_char("Вы не сможете унести такой вес.\r\n", ch);
-				obj_to_room(tobj.get(), ch->in_room);
-				obj_decay(tobj.get());
-			}
-			else
-			{
-				obj_to_char(tobj.get(), ch);
-			}
-		}
-	}
+      if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch)) {
+        send_to_char("Вы не сможете унести столько предметов.\r\n", ch);
+        obj_to_room(tobj.get(), ch->in_room);
+        obj_decay(tobj.get());
+      } else if (IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(tobj) > CAN_CARRY_W(ch)) {
+        send_to_char("Вы не сможете унести такой вес.\r\n", ch);
+        obj_to_room(tobj.get(), ch->in_room);
+        obj_decay(tobj.get());
+      } else {
+        obj_to_char(tobj.get(), ch);
+      }
+    }
+  }
 
-	if (obj)
-	{
-		obj_from_char(obj);
-		extract_obj(obj);
-	}
+  if (obj) {
+    obj_from_char(obj);
+    extract_obj(obj);
+  }
 }
-void do_transform_weapon(CHAR_DATA* ch, char *argument, int/* cmd*/, int subcmd)
-{
-	char arg1[MAX_INPUT_LENGTH];
-	char arg2[MAX_INPUT_LENGTH];
-	OBJ_DATA *obj = NULL, *coal, *proto[MAX_PROTO];
-	int obj_type, i, found, rnum;
+void do_transform_weapon(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  char arg1[MAX_INPUT_LENGTH];
+  char arg2[MAX_INPUT_LENGTH];
+  OBJ_DATA *obj = NULL, *coal, *proto[MAX_PROTO];
+  int obj_type, i, found, rnum;
 
-	if (IS_NPC(ch)
-		|| !ch->get_skill(static_cast<ESkill>(subcmd)))
-	{
-		send_to_char("Вас этому никто не научил.\r\n", ch);
-		return;
-	}
+  if (IS_NPC(ch)
+      || !ch->get_skill(static_cast<ESkill>(subcmd))) {
+    send_to_char("Вас этому никто не научил.\r\n", ch);
+    return;
+  }
 
-	argument = one_argument(argument, arg1);
-	if (!*arg1)
-	{
-		switch (subcmd)
-		{
-		case SKILL_TRANSFORMWEAPON:
-			send_to_char("Во что вы хотите перековать?\r\n", ch);
-			break;
-		case SKILL_CREATEBOW:
-			send_to_char("Что вы хотите смастерить?\r\n", ch);
-			break;
-		}
-		return;
-	}
-	obj_type = search_block(arg1, create_item_name, FALSE);
-	if (-1 == obj_type)
-	{
-		switch (subcmd)
-		{
-		case SKILL_TRANSFORMWEAPON:
-			send_to_char("Перековать можно в :\r\n", ch);
-			break;
-		case SKILL_CREATEBOW:
-			send_to_char("Смастерить можно :\r\n", ch);
-			break;
-		}
-		for (obj_type = 0; *create_item_name[obj_type] != '\n'; obj_type++)
-		{
-			if (created_item[obj_type].skill == subcmd)
-			{
-				sprintf(buf, "- %s\r\n", create_item_name[obj_type]);
-				send_to_char(buf, ch);
-			}
-		}
-		return;
-	}
-	if (created_item[obj_type].skill != subcmd)
-	{
-		switch (subcmd)
-		{
-		case SKILL_TRANSFORMWEAPON:
-			send_to_char("Данный предмет выковать нельзя.\r\n", ch);
-			break;
-		case SKILL_CREATEBOW:
-			send_to_char("Данный предмет смастерить нельзя.\r\n", ch);
-			break;
-		}
-		return;
-	}
-	for (i = 0; i < MAX_PROTO; proto[i++] = NULL);
-	argument = one_argument(argument, arg2);
-	if (!*arg2)
-	{
-		send_to_char("Вам нечего перековывать.\r\n", ch);
-		return;
-	}
-	if (!(obj = get_obj_in_list_vis(ch, arg2, ch->carrying)))
-	{
-		sprintf(buf, "У Вас нет '%s'.\r\n", arg2);
-		send_to_char(buf, ch);
-		return;
-	}
-	if (obj->get_contains())
-	{
-		act("В $o5 что-то лежит.", FALSE, ch, obj, 0, TO_CHAR);
-		return;
-	}
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT)
-	{
-		for (i = 0, found = FALSE; i < MAX_PROTO; i++)
-		{
-			if (GET_OBJ_VAL(obj, 1) == created_item[obj_type].proto[i])
-			{
-				if (proto[i])
-				{
-					found = TRUE;
-				}
-				else
-				{
-					proto[i] = obj;
-					found = FALSE;
-					break;
-				}
-			}
-		}
-		if (i >= MAX_PROTO)
-		{
-			if (found)
-			{
-				act("Похоже, вы уже что-то используете вместо $o1.", FALSE, ch, obj, 0, TO_CHAR);
-			}
-			else
-			{
-				act("Похоже, $o не подойдет для этого.", FALSE, ch, obj, 0, TO_CHAR);
-			}
-			return;
-		}
-	}
-	else
-	{
-		if (created_item[obj_type].material_bits
-			&& !IS_SET(created_item[obj_type].material_bits, (1 << GET_OBJ_MATER(obj))))
-		{
-			act("$o сделан$G из неподходящего материала.", FALSE, ch, obj, 0, TO_CHAR);
-			return;
-		}
-	}
-	switch (subcmd)
-	{
-	case SKILL_TRANSFORMWEAPON:
-		// Проверяем повторно из чего сделан объект
-		// Чтобы не было абъюза с перековкой из угля.
-		if (created_item[obj_type].material_bits &&
-				!IS_SET(created_item[obj_type].material_bits, (1 << GET_OBJ_MATER(obj))))
-		{
-			act("$o сделан$G из неподходящего материала.", FALSE, ch, obj, 0, TO_CHAR);
-			return;
-		}
-		if (!IS_IMMORTAL(ch))
-		{
-			if (!ROOM_FLAGGED(ch->in_room, ROOM_SMITH))
-			{
-				send_to_char("Вам нужно попасть в кузницу для этого.\r\n", ch);
-				return;
-			}
-			for (coal = ch->carrying; coal; coal = coal->get_next_content())
-			{
-				if (GET_OBJ_TYPE(coal) == OBJ_DATA::ITEM_INGREDIENT)
-				{
-					for (i = 0; i < MAX_PROTO; i++)
-					{
-						if (proto[i] == coal)
-						{
-							break;
-						}
-						else if (!proto[i]
-							&& GET_OBJ_VAL(coal, 1) == created_item[obj_type].proto[i])
-						{
-							proto[i] = coal;
-							break;
-						}
-					}
-				}
-			}
-			for (i = 0, found = TRUE; i < MAX_PROTO; i++)
-			{
-				if (created_item[obj_type].proto[i]
-					&& !proto[i])
-				{
-					rnum = real_object(created_item[obj_type].proto[i]);
-					if (rnum < 0)
-					{
-						act("У вас нет необходимого ингредиента.", FALSE, ch, 0, 0, TO_CHAR);
-					}
-					else
-					{
-						const OBJ_DATA obj(*obj_proto[rnum]);
-						act("У вас не хватает $o1 для этого.", FALSE, ch, &obj, 0, TO_CHAR);
-					}
-					found = FALSE;
-				}
-			}
-			if (!found)
-			{
-				return;
-			}
-		}
-		for (i = 0; i < MAX_PROTO; i++)
-		{
-			if (proto[i] && proto[i] != obj)
-			{
-				obj->set_cost(GET_OBJ_COST(obj) + GET_OBJ_COST(proto[i]));
-				extract_obj(proto[i]);
-			}
-		}
-		go_create_weapon(ch, obj, obj_type, SKILL_TRANSFORMWEAPON);
-		break;
-	case SKILL_CREATEBOW:
-		for (coal = ch->carrying; coal; coal = coal->get_next_content())
-		{
-			if (GET_OBJ_TYPE(coal) == OBJ_DATA::ITEM_INGREDIENT)
-			{
-				for (i = 0; i < MAX_PROTO; i++)
-				{
-					if (proto[i] == coal)
-					{
-						break;
-					}
-					else if (!proto[i]
-						&& GET_OBJ_VAL(coal, 1) == created_item[obj_type].proto[i])
-					{
-						proto[i] = coal;
-						break;
-					}
-				}
-			}
-		}
-		for (i = 0, found = TRUE; i < MAX_PROTO; i++)
-		{
-			if (created_item[obj_type].proto[i]
-				&& !proto[i])
-			{
-				rnum = real_object(created_item[obj_type].proto[i]);
-				if (rnum < 0)
-				{
-					act("У вас нет необходимого ингредиента.", FALSE, ch, 0, 0, TO_CHAR);
-				}
-				else
-				{
-					const OBJ_DATA obj(*obj_proto[rnum]);
-					act("У вас не хватает $o1 для этого.", FALSE, ch, &obj, 0, TO_CHAR);
-				}
-				found = FALSE;
-			}
-		}
-		if (!found)
-		{
-			return;
-		}
-		for (i = 1; i < MAX_PROTO; i++)
-		{
-			if (proto[i])
-			{
-				proto[0]->add_weight(GET_OBJ_WEIGHT(proto[i]));
-				proto[0]->set_cost(GET_OBJ_COST(proto[0]) + GET_OBJ_COST(proto[i]));
-				extract_obj(proto[i]);
-			}
-		}
-		go_create_weapon(ch, proto[0], obj_type, SKILL_CREATEBOW);
-		break;
-	}
+  argument = one_argument(argument, arg1);
+  if (!*arg1) {
+    switch (subcmd) {
+      case SKILL_TRANSFORMWEAPON: send_to_char("Во что вы хотите перековать?\r\n", ch);
+        break;
+      case SKILL_CREATEBOW: send_to_char("Что вы хотите смастерить?\r\n", ch);
+        break;
+    }
+    return;
+  }
+  obj_type = search_block(arg1, create_item_name, FALSE);
+  if (-1 == obj_type) {
+    switch (subcmd) {
+      case SKILL_TRANSFORMWEAPON: send_to_char("Перековать можно в :\r\n", ch);
+        break;
+      case SKILL_CREATEBOW: send_to_char("Смастерить можно :\r\n", ch);
+        break;
+    }
+    for (obj_type = 0; *create_item_name[obj_type] != '\n'; obj_type++) {
+      if (created_item[obj_type].skill == subcmd) {
+        sprintf(buf, "- %s\r\n", create_item_name[obj_type]);
+        send_to_char(buf, ch);
+      }
+    }
+    return;
+  }
+  if (created_item[obj_type].skill != subcmd) {
+    switch (subcmd) {
+      case SKILL_TRANSFORMWEAPON: send_to_char("Данный предмет выковать нельзя.\r\n", ch);
+        break;
+      case SKILL_CREATEBOW: send_to_char("Данный предмет смастерить нельзя.\r\n", ch);
+        break;
+    }
+    return;
+  }
+  for (i = 0; i < MAX_PROTO; proto[i++] = NULL);
+  argument = one_argument(argument, arg2);
+  if (!*arg2) {
+    send_to_char("Вам нечего перековывать.\r\n", ch);
+    return;
+  }
+  if (!(obj = get_obj_in_list_vis(ch, arg2, ch->carrying))) {
+    sprintf(buf, "У Вас нет '%s'.\r\n", arg2);
+    send_to_char(buf, ch);
+    return;
+  }
+  if (obj->get_contains()) {
+    act("В $o5 что-то лежит.", FALSE, ch, obj, 0, TO_CHAR);
+    return;
+  }
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT) {
+    for (i = 0, found = FALSE; i < MAX_PROTO; i++) {
+      if (GET_OBJ_VAL(obj, 1) == created_item[obj_type].proto[i]) {
+        if (proto[i]) {
+          found = TRUE;
+        } else {
+          proto[i] = obj;
+          found = FALSE;
+          break;
+        }
+      }
+    }
+    if (i >= MAX_PROTO) {
+      if (found) {
+        act("Похоже, вы уже что-то используете вместо $o1.", FALSE, ch, obj, 0, TO_CHAR);
+      } else {
+        act("Похоже, $o не подойдет для этого.", FALSE, ch, obj, 0, TO_CHAR);
+      }
+      return;
+    }
+  } else {
+    if (created_item[obj_type].material_bits
+        && !IS_SET(created_item[obj_type].material_bits, (1 << GET_OBJ_MATER(obj)))) {
+      act("$o сделан$G из неподходящего материала.", FALSE, ch, obj, 0, TO_CHAR);
+      return;
+    }
+  }
+  switch (subcmd) {
+    case SKILL_TRANSFORMWEAPON:
+      // Проверяем повторно из чего сделан объект
+      // Чтобы не было абъюза с перековкой из угля.
+      if (created_item[obj_type].material_bits &&
+          !IS_SET(created_item[obj_type].material_bits, (1 << GET_OBJ_MATER(obj)))) {
+        act("$o сделан$G из неподходящего материала.", FALSE, ch, obj, 0, TO_CHAR);
+        return;
+      }
+      if (!IS_IMMORTAL(ch)) {
+        if (!ROOM_FLAGGED(ch->in_room, ROOM_SMITH)) {
+          send_to_char("Вам нужно попасть в кузницу для этого.\r\n", ch);
+          return;
+        }
+        for (coal = ch->carrying; coal; coal = coal->get_next_content()) {
+          if (GET_OBJ_TYPE(coal) == OBJ_DATA::ITEM_INGREDIENT) {
+            for (i = 0; i < MAX_PROTO; i++) {
+              if (proto[i] == coal) {
+                break;
+              } else if (!proto[i]
+                  && GET_OBJ_VAL(coal, 1) == created_item[obj_type].proto[i]) {
+                proto[i] = coal;
+                break;
+              }
+            }
+          }
+        }
+        for (i = 0, found = TRUE; i < MAX_PROTO; i++) {
+          if (created_item[obj_type].proto[i]
+              && !proto[i]) {
+            rnum = real_object(created_item[obj_type].proto[i]);
+            if (rnum < 0) {
+              act("У вас нет необходимого ингредиента.", FALSE, ch, 0, 0, TO_CHAR);
+            } else {
+              const OBJ_DATA obj(*obj_proto[rnum]);
+              act("У вас не хватает $o1 для этого.", FALSE, ch, &obj, 0, TO_CHAR);
+            }
+            found = FALSE;
+          }
+        }
+        if (!found) {
+          return;
+        }
+      }
+      for (i = 0; i < MAX_PROTO; i++) {
+        if (proto[i] && proto[i] != obj) {
+          obj->set_cost(GET_OBJ_COST(obj) + GET_OBJ_COST(proto[i]));
+          extract_obj(proto[i]);
+        }
+      }
+      go_create_weapon(ch, obj, obj_type, SKILL_TRANSFORMWEAPON);
+      break;
+    case SKILL_CREATEBOW:
+      for (coal = ch->carrying; coal; coal = coal->get_next_content()) {
+        if (GET_OBJ_TYPE(coal) == OBJ_DATA::ITEM_INGREDIENT) {
+          for (i = 0; i < MAX_PROTO; i++) {
+            if (proto[i] == coal) {
+              break;
+            } else if (!proto[i]
+                && GET_OBJ_VAL(coal, 1) == created_item[obj_type].proto[i]) {
+              proto[i] = coal;
+              break;
+            }
+          }
+        }
+      }
+      for (i = 0, found = TRUE; i < MAX_PROTO; i++) {
+        if (created_item[obj_type].proto[i]
+            && !proto[i]) {
+          rnum = real_object(created_item[obj_type].proto[i]);
+          if (rnum < 0) {
+            act("У вас нет необходимого ингредиента.", FALSE, ch, 0, 0, TO_CHAR);
+          } else {
+            const OBJ_DATA obj(*obj_proto[rnum]);
+            act("У вас не хватает $o1 для этого.", FALSE, ch, &obj, 0, TO_CHAR);
+          }
+          found = FALSE;
+        }
+      }
+      if (!found) {
+        return;
+      }
+      for (i = 1; i < MAX_PROTO; i++) {
+        if (proto[i]) {
+          proto[0]->add_weight(GET_OBJ_WEIGHT(proto[i]));
+          proto[0]->set_cost(GET_OBJ_COST(proto[0]) + GET_OBJ_COST(proto[i]));
+          extract_obj(proto[i]);
+        }
+      }
+      go_create_weapon(ch, proto[0], obj_type, SKILL_CREATEBOW);
+      break;
+  }
 }
 // *****************************
-MakeReceptList::MakeReceptList()
-{
-	// Инициализация класса листа .
+MakeReceptList::MakeReceptList() {
+  // Инициализация класса листа .
 }
-MakeReceptList::~MakeReceptList()
-{
-	// Разрушение списка.
-	clear();
+MakeReceptList::~MakeReceptList() {
+  // Разрушение списка.
+  clear();
 }
 int
-MakeReceptList::load()
-{
-	// Читаем тут файл с рецептом.
-	// НАДО ДОБАВИТЬ СОРТИРОВКУ !!!
-	char tmpbuf[MAX_INPUT_LENGTH];
-	string tmpstr;
-	// чистим список рецептов от старых данных.
-	clear();
-	MakeRecept *trec;
-	ifstream bifs(LIB_MISC "makeitems.lst");
-	if (!bifs)
-	{
-		sprintf(tmpbuf, "MakeReceptList:: Unable open input file !!!");
-		mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
-		return (FALSE);
-	}
-	while (!bifs.eof())
-	{
-		bifs.getline(tmpbuf, MAX_INPUT_LENGTH, '\n');
-		tmpstr = string(tmpbuf);
-		// пропускаем закомменированные строчки.
-		if (tmpstr.substr(0, 2) == "//")
-			continue;
+MakeReceptList::load() {
+  // Читаем тут файл с рецептом.
+  // НАДО ДОБАВИТЬ СОРТИРОВКУ !!!
+  char tmpbuf[MAX_INPUT_LENGTH];
+  string tmpstr;
+  // чистим список рецептов от старых данных.
+  clear();
+  MakeRecept *trec;
+  ifstream bifs(LIB_MISC "makeitems.lst");
+  if (!bifs) {
+    sprintf(tmpbuf, "MakeReceptList:: Unable open input file !!!");
+    mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
+    return (FALSE);
+  }
+  while (!bifs.eof()) {
+    bifs.getline(tmpbuf, MAX_INPUT_LENGTH, '\n');
+    tmpstr = string(tmpbuf);
+    // пропускаем закомменированные строчки.
+    if (tmpstr.substr(0, 2) == "//")
+      continue;
 //    cout << "Get str from file :" << tmpstr << endl;
-		if (tmpstr.size() == 0)
-			continue;
-		trec = new(MakeRecept);
-		if (trec->load_from_str(tmpstr))
-		{
-			recepts.push_back(trec);
-		}
-		else
-		{
-			delete trec;
-			// ошибка вытаскивания из строки написать
-			sprintf(tmpbuf, "MakeReceptList:: Fail get recept from line.");
-			mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
-		}
-	}
-	return TRUE;
+    if (tmpstr.size() == 0)
+      continue;
+    trec = new(MakeRecept);
+    if (trec->load_from_str(tmpstr)) {
+      recepts.push_back(trec);
+    } else {
+      delete trec;
+      // ошибка вытаскивания из строки написать
+      sprintf(tmpbuf, "MakeReceptList:: Fail get recept from line.");
+      mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
+    }
+  }
+  return TRUE;
 }
-int MakeReceptList::save()
-{
-	// Пишем тут файл с рецептом.
-	// Очищаем список
-	string tmpstr;
-	char tmpbuf[MAX_INPUT_LENGTH];
-	list < MakeRecept * >::iterator p;
-	ofstream bofs(LIB_MISC "makeitems.lst");
-	if (!bofs)
-	{
-		// cout << "Unable input stream to create !!!" << endl;
-		sprintf(tmpbuf, "MakeReceptList:: Unable create output file !!!");
-		mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
-		return (FALSE);
-	}
-	sort();
-	p = recepts.begin();
-	while (p != recepts.end())
-	{
-		if ((*p)->save_to_str(tmpstr))
-			bofs << tmpstr << endl;
-		p++;
-	}
-	bofs.close();
-	return 0;
+int MakeReceptList::save() {
+  // Пишем тут файл с рецептом.
+  // Очищаем список
+  string tmpstr;
+  char tmpbuf[MAX_INPUT_LENGTH];
+  list<MakeRecept *>::iterator p;
+  ofstream bofs(LIB_MISC "makeitems.lst");
+  if (!bofs) {
+    // cout << "Unable input stream to create !!!" << endl;
+    sprintf(tmpbuf, "MakeReceptList:: Unable create output file !!!");
+    mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
+    return (FALSE);
+  }
+  sort();
+  p = recepts.begin();
+  while (p != recepts.end()) {
+    if ((*p)->save_to_str(tmpstr))
+      bofs << tmpstr << endl;
+    p++;
+  }
+  bofs.close();
+  return 0;
 }
-void MakeReceptList::add(MakeRecept * recept)
-{
-	recepts.push_back(recept);
-	return;
+void MakeReceptList::add(MakeRecept *recept) {
+  recepts.push_back(recept);
+  return;
 }
-void MakeReceptList::del(MakeRecept * recept)
-{
-	recepts.remove(recept);
-	return;
+void MakeReceptList::del(MakeRecept *recept) {
+  recepts.remove(recept);
+  return;
 }
-bool by_skill(MakeRecept * const &lhs, MakeRecept * const &rhs)
-{
-	return ((lhs->skill) > (rhs->skill));
+bool by_skill(MakeRecept *const &lhs, MakeRecept *const &rhs) {
+  return ((lhs->skill) > (rhs->skill));
 }
-void MakeReceptList::sort()
-{
-	// Сделать сортировку по умениям.
-	recepts.sort(by_skill);
-	return;
+void MakeReceptList::sort() {
+  // Сделать сортировку по умениям.
+  recepts.sort(by_skill);
+  return;
 }
-size_t MakeReceptList::size()
-{
-	return recepts.size();
+size_t MakeReceptList::size() {
+  return recepts.size();
 }
-void MakeReceptList::clear()
-{
-	// Очищаем список
-	list < MakeRecept * >::iterator p;
-	p = recepts.begin();
-	while (p != recepts.end())
-	{
-		delete(*p);
-		p++;
-	}
-	recepts.erase(recepts.begin(), recepts.end());
-	return;
+void MakeReceptList::clear() {
+  // Очищаем список
+  list<MakeRecept *>::iterator p;
+  p = recepts.begin();
+  while (p != recepts.end()) {
+    delete (*p);
+    p++;
+  }
+  recepts.erase(recepts.begin(), recepts.end());
+  return;
 }
-MakeRecept *MakeReceptList::operator[](size_t i)
-{
-	list < MakeRecept * >::iterator p = recepts.begin();
-	size_t j = 0;
-	while (p != recepts.end())
-	{
-		if (i == j)
-		{
-			return (*p);
-		}
-		j++;
-		p++;
-	}
-	return (NULL);
+MakeRecept *MakeReceptList::operator[](size_t i) {
+  list<MakeRecept *>::iterator p = recepts.begin();
+  size_t j = 0;
+  while (p != recepts.end()) {
+    if (i == j) {
+      return (*p);
+    }
+    j++;
+    p++;
+  }
+  return (NULL);
 }
-MakeRecept *MakeReceptList::get_by_name(string & rname)
-{
-	// Ищем по списку рецепт с таким именем.
-	// Ищем по списку рецепты которые чар может изготовить.
-	list<MakeRecept*>::iterator p = recepts.begin();
-	int k = 1;	// count
-	// split string by '.' character and convert first part into number (store to k)
-	size_t i = rname.find(".");
-	if (std::string::npos != i)	// TODO: Check me.
-	{
-		// Строка не найдена.
-		if (0 < i)
-		{
-			k = atoi(rname.substr(0, i).c_str());
-			if (k <= 0)
-			{
-				return NULL;	// Если ввели -3.xxx
-			}
-		}
-		rname = rname.substr(i + 1);
-	}
-	int j = 0;
-	while (p != recepts.end())
-	{
-		auto tobj = get_object_prototype((*p)->obj_proto);
-		if (!tobj)
-		{
-			return 0;
-		}
-		std::string tmpstr = tobj->get_aliases() + " ";
-		while (int(tmpstr.find(' ')) > 0)
-		{
-			if ((tmpstr.substr(0, tmpstr.find(' '))).find(rname) == 0)
-			{
-				if ((k - 1) == j)
-				{
-					return *p;
-				}
-				j++;
-				break;
-			}
-			tmpstr = tmpstr.substr(tmpstr.find(' ') + 1);
-		}
-		p++;
-	}
-	return NULL;
+MakeRecept *MakeReceptList::get_by_name(string &rname) {
+  // Ищем по списку рецепт с таким именем.
+  // Ищем по списку рецепты которые чар может изготовить.
+  list<MakeRecept *>::iterator p = recepts.begin();
+  int k = 1;    // count
+  // split string by '.' character and convert first part into number (store to k)
+  size_t i = rname.find(".");
+  if (std::string::npos != i)    // TODO: Check me.
+  {
+    // Строка не найдена.
+    if (0 < i) {
+      k = atoi(rname.substr(0, i).c_str());
+      if (k <= 0) {
+        return NULL;    // Если ввели -3.xxx
+      }
+    }
+    rname = rname.substr(i + 1);
+  }
+  int j = 0;
+  while (p != recepts.end()) {
+    auto tobj = get_object_prototype((*p)->obj_proto);
+    if (!tobj) {
+      return 0;
+    }
+    std::string tmpstr = tobj->get_aliases() + " ";
+    while (int(tmpstr.find(' ')) > 0) {
+      if ((tmpstr.substr(0, tmpstr.find(' '))).find(rname) == 0) {
+        if ((k - 1) == j) {
+          return *p;
+        }
+        j++;
+        break;
+      }
+      tmpstr = tmpstr.substr(tmpstr.find(' ') + 1);
+    }
+    p++;
+  }
+  return NULL;
 }
-MakeReceptList *MakeReceptList::can_make(CHAR_DATA * ch, MakeReceptList * canlist, int use_skill)
-{
-	// Ищем по списку рецепты которые чар может изготовить.
-	list < MakeRecept * >::iterator p;
-	p = recepts.begin();
-	while (p != recepts.end())
-	{
-		if (((*p)->skill == use_skill) && ((*p)->can_make(ch)))
-		{
-			MakeRecept *trec = new MakeRecept;
-			*trec = **p;
-			canlist->add(trec);
-		}
-		p++;
-	}
-	return (canlist);
+MakeReceptList *MakeReceptList::can_make(CHAR_DATA *ch, MakeReceptList *canlist, int use_skill) {
+  // Ищем по списку рецепты которые чар может изготовить.
+  list<MakeRecept *>::iterator p;
+  p = recepts.begin();
+  while (p != recepts.end()) {
+    if (((*p)->skill == use_skill) && ((*p)->can_make(ch))) {
+      MakeRecept *trec = new MakeRecept;
+      *trec = **p;
+      canlist->add(trec);
+    }
+    p++;
+  }
+  return (canlist);
 }
-OBJ_DATA *get_obj_in_list_ingr(int num, OBJ_DATA * list) //Ингридиентом является или сам прототип с VNUM или альтернатива с VALUE 1 равным внум прототипа
+OBJ_DATA *get_obj_in_list_ingr(int num,
+                               OBJ_DATA *list) //Ингридиентом является или сам прототип с VNUM или альтернатива с VALUE 1 равным внум прототипа
 {
-	OBJ_DATA *i;
-	for (i = list; i; i = i->get_next_content())
-	{
-		if (GET_OBJ_VNUM(i) == num)
-		{
-			return i;
-		}
-		if ((GET_OBJ_VAL(i, 1) == num)
-			&& (GET_OBJ_TYPE(i) == OBJ_DATA::ITEM_INGREDIENT
-				|| GET_OBJ_TYPE(i) == OBJ_DATA::ITEM_MING
-				|| GET_OBJ_TYPE(i) == OBJ_DATA::ITEM_MATERIAL))
-		{
-			return i;
-		}
-	}
-	return NULL;
+  OBJ_DATA *i;
+  for (i = list; i; i = i->get_next_content()) {
+    if (GET_OBJ_VNUM(i) == num) {
+      return i;
+    }
+    if ((GET_OBJ_VAL(i, 1) == num)
+        && (GET_OBJ_TYPE(i) == OBJ_DATA::ITEM_INGREDIENT
+            || GET_OBJ_TYPE(i) == OBJ_DATA::ITEM_MING
+            || GET_OBJ_TYPE(i) == OBJ_DATA::ITEM_MATERIAL)) {
+      return i;
+    }
+  }
+  return NULL;
 }
-MakeRecept::MakeRecept(): skill(SKILL_INVALID)
-{
-	locked = true;		// по умолчанию рецепт залочен.
-	obj_proto = 0;
-	for (int i = 0; i < MAX_PARTS; i++)
-	{
-		parts[i].proto = 0;
-		parts[i].min_weight = 0;
-		parts[i].min_power = 0;
-	}
+MakeRecept::MakeRecept() : skill(SKILL_INVALID) {
+  locked = true;        // по умолчанию рецепт залочен.
+  obj_proto = 0;
+  for (int i = 0; i < MAX_PARTS; i++) {
+    parts[i].proto = 0;
+    parts[i].min_weight = 0;
+    parts[i].min_power = 0;
+  }
 }
-int MakeRecept::can_make(CHAR_DATA * ch)
-{
-	int i;
-	OBJ_DATA *ingrobj = NULL;
-	// char tmpbuf[MAX_INPUT_LENGTH];
-	// Сделать проверку на поле locked
-	if (!ch)
-		return (FALSE);
-	if (locked)
-		return (FALSE);
-	// Сделать проверку наличия скилла у игрока.
-	if (IS_NPC(ch) || !ch->get_skill(skill))
-	{
-		return (FALSE);
-	}
-	// Делаем проверку может ли чар сделать предмет такого типа
-	if (skill == SKILL_MAKE_STAFF)
-	{
-		return 0;
-	}
-	for (i = 0; i < MAX_PARTS; i++)
-	{
-		if (parts[i].proto == 0)
-		{
-			break;
-		}
-		if (real_object(parts[i].proto) < 0)
-			return (FALSE);
-		//send_to_char("Образец был невозвратимо утерян.\r\n",ch); //леший знает чего тут надо писать
-		if (!(ingrobj = get_obj_in_list_ingr(parts[i].proto, ch->carrying)))
-		{
-			//sprintf(tmpbuf,"Для '%d' у вас нет '%d'.\r\n",obj_proto,parts[i].proto);
-			//send_to_char(tmpbuf,ch);
-			return (FALSE);
-		}
-		int ingr_lev = get_ingr_lev(ingrobj);
-		// Если чар ниже уровня ингридиента то он не может делать рецепты с его
-		// участием.
-		if (!IS_IMPL(ch) && (ingr_lev > (GET_LEVEL(ch) + 2 * GET_REMORT(ch))))
-		{
-			send_to_char("Вы слишком малого уровня и вам что-то не подходит для шитья.\r\n", ch);
-			return (FALSE);
-		}
-	}
-	return (TRUE);
+int MakeRecept::can_make(CHAR_DATA *ch) {
+  int i;
+  OBJ_DATA *ingrobj = NULL;
+  // char tmpbuf[MAX_INPUT_LENGTH];
+  // Сделать проверку на поле locked
+  if (!ch)
+    return (FALSE);
+  if (locked)
+    return (FALSE);
+  // Сделать проверку наличия скилла у игрока.
+  if (IS_NPC(ch) || !ch->get_skill(skill)) {
+    return (FALSE);
+  }
+  // Делаем проверку может ли чар сделать предмет такого типа
+  if (skill == SKILL_MAKE_STAFF) {
+    return 0;
+  }
+  for (i = 0; i < MAX_PARTS; i++) {
+    if (parts[i].proto == 0) {
+      break;
+    }
+    if (real_object(parts[i].proto) < 0)
+      return (FALSE);
+    //send_to_char("Образец был невозвратимо утерян.\r\n",ch); //леший знает чего тут надо писать
+    if (!(ingrobj = get_obj_in_list_ingr(parts[i].proto, ch->carrying))) {
+      //sprintf(tmpbuf,"Для '%d' у вас нет '%d'.\r\n",obj_proto,parts[i].proto);
+      //send_to_char(tmpbuf,ch);
+      return (FALSE);
+    }
+    int ingr_lev = get_ingr_lev(ingrobj);
+    // Если чар ниже уровня ингридиента то он не может делать рецепты с его
+    // участием.
+    if (!IS_IMPL(ch) && (ingr_lev > (GET_LEVEL(ch) + 2 * GET_REMORT(ch)))) {
+      send_to_char("Вы слишком малого уровня и вам что-то не подходит для шитья.\r\n", ch);
+      return (FALSE);
+    }
+  }
+  return (TRUE);
 }
 
-int MakeRecept::get_ingr_lev(OBJ_DATA * ingrobj)
-{
-	// Получаем уровень ингредиента ...
-	if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_INGREDIENT)
-	{
-		// Получаем уровень игредиента до 128
-		return (GET_OBJ_VAL(ingrobj, 0) >> 8);
-	}
-	else if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_MING)
-	{
-		// У ингров типа 26 совпадает уровень и сила.
-		return GET_OBJ_VAL(ingrobj, IM_POWER_SLOT);
-	}
-	else if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_MATERIAL)
-	{
-		return GET_OBJ_VAL(ingrobj, 0);
-	}
-	else
-	{
-		return -1;
-	}
+int MakeRecept::get_ingr_lev(OBJ_DATA *ingrobj) {
+  // Получаем уровень ингредиента ...
+  if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_INGREDIENT) {
+    // Получаем уровень игредиента до 128
+    return (GET_OBJ_VAL(ingrobj, 0) >> 8);
+  } else if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_MING) {
+    // У ингров типа 26 совпадает уровень и сила.
+    return GET_OBJ_VAL(ingrobj, IM_POWER_SLOT);
+  } else if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_MATERIAL) {
+    return GET_OBJ_VAL(ingrobj, 0);
+  } else {
+    return -1;
+  }
 }
 
-int MakeRecept::get_ingr_pow(OBJ_DATA * ingrobj)
-{
-	// Получаем силу ингредиента ...
-	if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_INGREDIENT
-		|| GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_MATERIAL)
-	{
-		return GET_OBJ_VAL(ingrobj, 2);
-	}
-	else if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_MING)
-	{
-		return GET_OBJ_VAL(ingrobj, IM_POWER_SLOT);
-	}
-	else
-	{
-		return -1;
-	}
+int MakeRecept::get_ingr_pow(OBJ_DATA *ingrobj) {
+  // Получаем силу ингредиента ...
+  if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_INGREDIENT
+      || GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_MATERIAL) {
+    return GET_OBJ_VAL(ingrobj, 2);
+  } else if (GET_OBJ_TYPE(ingrobj) == OBJ_DATA::ITEM_MING) {
+    return GET_OBJ_VAL(ingrobj, IM_POWER_SLOT);
+  } else {
+    return -1;
+  }
 }
-void MakeRecept::make_value_wear(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *ingrs[MAX_PARTS])
-{
-	int wearkoeff = 50;
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY)) // 1.1
-	{
-		wearkoeff = 110;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD)) //0.8
-	{
-		wearkoeff = 80;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS)) //0.5
-	{
-		wearkoeff = 50;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET)) //0.6
-	{
-		wearkoeff = 60;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS)) //0.5
-	{
-		wearkoeff = 50;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT))//0.9
-	{
-		wearkoeff = 90;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS))//0.45
-	{
-		wearkoeff = 45;
-	}
-	obj->set_val(0, ((GET_REAL_INT(ch) * GET_REAL_INT(ch) / 10 + ch->get_skill(SKILL_MAKE_WEAR)) / 100 + (GET_OBJ_VAL(ingrs[0], 3) + 1)) * wearkoeff / 100); //АС=((инта*инта/10+умелка)/100+левл.шкуры)*коэф.части тела
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY)) //0.9
-	{
-		wearkoeff = 90;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD)) //0.7
-	{
-		wearkoeff = 70;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS)) //0.4
-	{
-		wearkoeff = 40;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET)) //0.5
-	{
-		wearkoeff = 50;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS)) //0.4
-	{
-		wearkoeff = 40;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT))//0.8
-	{
-		wearkoeff = 80;
-	}
-	if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS))//0.31
-	{
-		wearkoeff = 31;
-	}
-	obj->set_val(1, (ch->get_skill(SKILL_MAKE_WEAR) / 25 + (GET_OBJ_VAL(ingrs[0], 3) + 1)) * wearkoeff / 100); //броня=(%умелки/25+левл.шкуры)*коэф.части тела
+void MakeRecept::make_value_wear(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *ingrs[MAX_PARTS]) {
+  int wearkoeff = 50;
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY)) // 1.1
+  {
+    wearkoeff = 110;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD)) //0.8
+  {
+    wearkoeff = 80;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS)) //0.5
+  {
+    wearkoeff = 50;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET)) //0.6
+  {
+    wearkoeff = 60;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS)) //0.5
+  {
+    wearkoeff = 50;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT))//0.9
+  {
+    wearkoeff = 90;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS))//0.45
+  {
+    wearkoeff = 45;
+  }
+  obj->set_val(0,
+               ((GET_REAL_INT(ch) * GET_REAL_INT(ch) / 10 + ch->get_skill(SKILL_MAKE_WEAR)) / 100
+                   + (GET_OBJ_VAL(ingrs[0], 3) + 1)) * wearkoeff
+                   / 100); //АС=((инта*инта/10+умелка)/100+левл.шкуры)*коэф.части тела
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY)) //0.9
+  {
+    wearkoeff = 90;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD)) //0.7
+  {
+    wearkoeff = 70;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS)) //0.4
+  {
+    wearkoeff = 40;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET)) //0.5
+  {
+    wearkoeff = 50;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS)) //0.4
+  {
+    wearkoeff = 40;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT))//0.8
+  {
+    wearkoeff = 80;
+  }
+  if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS))//0.31
+  {
+    wearkoeff = 31;
+  }
+  obj->set_val(1,
+               (ch->get_skill(SKILL_MAKE_WEAR) / 25 + (GET_OBJ_VAL(ingrs[0], 3) + 1)) * wearkoeff
+                   / 100); //броня=(%умелки/25+левл.шкуры)*коэф.части тела
 }
-float MakeRecept::count_mort_requred(OBJ_DATA * obj)
-{
-	float result = 0.0;
-	const float SQRT_MOD = 1.7095f;
-	const int AFF_SHIELD_MOD = 30;
-	const int AFF_MAGICGLASS_MOD = 10;
-	const int AFF_BLINK_MOD = 10;
+float MakeRecept::count_mort_requred(OBJ_DATA *obj) {
+  float result = 0.0;
+  const float SQRT_MOD = 1.7095f;
+  const int AFF_SHIELD_MOD = 30;
+  const int AFF_MAGICGLASS_MOD = 10;
+  const int AFF_BLINK_MOD = 10;
 
-	result = 0.0;
+  result = 0.0;
 
-	float total_weight = 0.0;
+  float total_weight = 0.0;
 
-	// аффекты APPLY_x
-	for (int k = 0; k < MAX_OBJ_AFFECT; k++)
-	{
-		if (obj->get_affected(k).location == 0) continue;
+  // аффекты APPLY_x
+  for (int k = 0; k < MAX_OBJ_AFFECT; k++) {
+    if (obj->get_affected(k).location == 0) continue;
 
-		// случай, если один аффект прописан в нескольких полях
-		for (int kk = 0; kk < MAX_OBJ_AFFECT; kk++)
-		{
-			if (obj->get_affected(k).location == obj->get_affected(kk).location
-				&& k != kk)
-			{
-				log("SYSERROR: double affect=%d, obj_vnum=%d",
-					obj->get_affected(k).location, GET_OBJ_VNUM(obj));
-				return 1000000;
-			}
-		}
-		if ((obj->get_affected(k).modifier > 0) && ((obj->get_affected(k).location != APPLY_AC) &&
-			    (obj->get_affected(k).location != APPLY_SAVING_WILL) &&
-			    (obj->get_affected(k).location != APPLY_SAVING_CRITICAL) &&
-			    (obj->get_affected(k).location != APPLY_SAVING_STABILITY) &&
-			    (obj->get_affected(k).location != APPLY_SAVING_REFLEX)))
-		{
-			float weight = count_affect_weight(obj->get_affected(k).location, obj->get_affected(k).modifier);
-			log("SYSERROR: negative weight=%f, obj_vnum=%d",
-				weight, GET_OBJ_VNUM(obj));
-			total_weight += pow(weight, SQRT_MOD);
-		}
-		// савесы которые с минусом должны тогда понижать вес если в +
-		else if ((obj->get_affected(k).modifier > 0) && ((obj->get_affected(k).location == APPLY_AC) ||
-			    (obj->get_affected(k).location == APPLY_SAVING_WILL) ||
-			    (obj->get_affected(k).location == APPLY_SAVING_CRITICAL) ||
-			    (obj->get_affected(k).location == APPLY_SAVING_STABILITY) ||
-			    (obj->get_affected(k).location == APPLY_SAVING_REFLEX)))
-		{
-			float weight = count_affect_weight(obj->get_affected(k).location, 0-obj->get_affected(k).modifier);
-			total_weight -= pow(weight, -SQRT_MOD);
-		}
-		//Добавленый кусок учет савесов с - значениями
-		else if ((obj->get_affected(k).modifier < 0)
-				 && ((obj->get_affected(k).location == APPLY_AC) ||
-				      (obj->get_affected(k).location == APPLY_SAVING_WILL) ||
-				      (obj->get_affected(k).location == APPLY_SAVING_CRITICAL) ||
-				      (obj->get_affected(k).location == APPLY_SAVING_STABILITY) ||
-				      (obj->get_affected(k).location == APPLY_SAVING_REFLEX)))
-		{
-			float weight = count_affect_weight(obj->get_affected(k).location, obj->get_affected(k).modifier);
-			total_weight += pow(weight, SQRT_MOD);
-		}
-		//Добавленый кусок учет отрицательного значения но не савесов
-		else if ((obj->get_affected(k).modifier < 0)
-				 && ((obj->get_affected(k).location != APPLY_AC) &&
-				     (obj->get_affected(k).location != APPLY_SAVING_WILL) &&
-				     (obj->get_affected(k).location != APPLY_SAVING_CRITICAL) &&
-				     (obj->get_affected(k).location != APPLY_SAVING_STABILITY) &&
-				     (obj->get_affected(k).location != APPLY_SAVING_REFLEX)))
-		{
-			float weight = count_affect_weight(obj->get_affected(k).location, 0-obj->get_affected(k).modifier);
-			total_weight -= pow(weight, -SQRT_MOD);
-		}
-	}
-	// аффекты AFF_x через weapon_affect
-	for (const auto& m : weapon_affect)
-	{
-		if (IS_OBJ_AFF(obj, m.aff_pos))
-		{
-			if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_AIRSHIELD)
-			{
-				total_weight += pow(AFF_SHIELD_MOD, SQRT_MOD);
-			}
-			else if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_FIRESHIELD)
-			{
-				total_weight += pow(AFF_SHIELD_MOD, SQRT_MOD);
-			}
-			else if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_ICESHIELD)
-			{
-				total_weight += pow(AFF_SHIELD_MOD, SQRT_MOD);
-			}
-			else if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_MAGICGLASS)
-			{
-				total_weight += pow(AFF_MAGICGLASS_MOD, SQRT_MOD);
-			}
-			else if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_BLINK)
-			{
-				total_weight += pow(AFF_BLINK_MOD, SQRT_MOD);
-			}
-		}
-	}
-	if (total_weight < 1) return result;
+    // случай, если один аффект прописан в нескольких полях
+    for (int kk = 0; kk < MAX_OBJ_AFFECT; kk++) {
+      if (obj->get_affected(k).location == obj->get_affected(kk).location
+          && k != kk) {
+        log("SYSERROR: double affect=%d, obj_vnum=%d",
+            obj->get_affected(k).location, GET_OBJ_VNUM(obj));
+        return 1000000;
+      }
+    }
+    if ((obj->get_affected(k).modifier > 0) && ((obj->get_affected(k).location != APPLY_AC) &&
+        (obj->get_affected(k).location != APPLY_SAVING_WILL) &&
+        (obj->get_affected(k).location != APPLY_SAVING_CRITICAL) &&
+        (obj->get_affected(k).location != APPLY_SAVING_STABILITY) &&
+        (obj->get_affected(k).location != APPLY_SAVING_REFLEX))) {
+      float weight = count_affect_weight(obj->get_affected(k).location, obj->get_affected(k).modifier);
+      log("SYSERROR: negative weight=%f, obj_vnum=%d",
+          weight, GET_OBJ_VNUM(obj));
+      total_weight += pow(weight, SQRT_MOD);
+    }
+      // савесы которые с минусом должны тогда понижать вес если в +
+    else if ((obj->get_affected(k).modifier > 0) && ((obj->get_affected(k).location == APPLY_AC) ||
+        (obj->get_affected(k).location == APPLY_SAVING_WILL) ||
+        (obj->get_affected(k).location == APPLY_SAVING_CRITICAL) ||
+        (obj->get_affected(k).location == APPLY_SAVING_STABILITY) ||
+        (obj->get_affected(k).location == APPLY_SAVING_REFLEX))) {
+      float weight = count_affect_weight(obj->get_affected(k).location, 0 - obj->get_affected(k).modifier);
+      total_weight -= pow(weight, -SQRT_MOD);
+    }
+      //Добавленый кусок учет савесов с - значениями
+    else if ((obj->get_affected(k).modifier < 0)
+        && ((obj->get_affected(k).location == APPLY_AC) ||
+            (obj->get_affected(k).location == APPLY_SAVING_WILL) ||
+            (obj->get_affected(k).location == APPLY_SAVING_CRITICAL) ||
+            (obj->get_affected(k).location == APPLY_SAVING_STABILITY) ||
+            (obj->get_affected(k).location == APPLY_SAVING_REFLEX))) {
+      float weight = count_affect_weight(obj->get_affected(k).location, obj->get_affected(k).modifier);
+      total_weight += pow(weight, SQRT_MOD);
+    }
+      //Добавленый кусок учет отрицательного значения но не савесов
+    else if ((obj->get_affected(k).modifier < 0)
+        && ((obj->get_affected(k).location != APPLY_AC) &&
+            (obj->get_affected(k).location != APPLY_SAVING_WILL) &&
+            (obj->get_affected(k).location != APPLY_SAVING_CRITICAL) &&
+            (obj->get_affected(k).location != APPLY_SAVING_STABILITY) &&
+            (obj->get_affected(k).location != APPLY_SAVING_REFLEX))) {
+      float weight = count_affect_weight(obj->get_affected(k).location, 0 - obj->get_affected(k).modifier);
+      total_weight -= pow(weight, -SQRT_MOD);
+    }
+  }
+  // аффекты AFF_x через weapon_affect
+  for (const auto &m : weapon_affect) {
+    if (IS_OBJ_AFF(obj, m.aff_pos)) {
+      if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_AIRSHIELD) {
+        total_weight += pow(AFF_SHIELD_MOD, SQRT_MOD);
+      } else if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_FIRESHIELD) {
+        total_weight += pow(AFF_SHIELD_MOD, SQRT_MOD);
+      } else if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_ICESHIELD) {
+        total_weight += pow(AFF_SHIELD_MOD, SQRT_MOD);
+      } else if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_MAGICGLASS) {
+        total_weight += pow(AFF_MAGICGLASS_MOD, SQRT_MOD);
+      } else if (static_cast<EAffectFlag>(m.aff_bitvector) == EAffectFlag::AFF_BLINK) {
+        total_weight += pow(AFF_BLINK_MOD, SQRT_MOD);
+      }
+    }
+  }
+  if (total_weight < 1) return result;
 
-		result = ceil(pow(total_weight, 1/SQRT_MOD));
+  result = ceil(pow(total_weight, 1 / SQRT_MOD));
 
-	return result;
+  return result;
 }
 
-float MakeRecept::count_affect_weight(int num, int mod)
-{
-	float weight = 0;
+float MakeRecept::count_affect_weight(int num, int mod) {
+  float weight = 0;
 
-	switch(num)
-	{
-	case APPLY_STR:
-		weight = mod * 7.5;
-		break;
-	case APPLY_DEX:
-		weight = mod * 10.0;
-		break;
-	case APPLY_INT:
-		weight = mod * 10.0;
-		break;
-	case APPLY_WIS:
-		weight = mod * 10.0;
-		break;
-	case APPLY_CON:
-		weight = mod * 10.0;
-		break;
-	case APPLY_CHA:
-		weight = mod * 10.0;
-		break;
-	case APPLY_HIT:
-		weight = mod * 0.3;
-		break;
-	case APPLY_AC:
-		weight = mod * -0.5;
-		break;
-	case APPLY_HITROLL:
-		weight = mod * 2.3;
-		break;
-	case APPLY_DAMROLL:
-		weight = mod * 3.3;
-		break;
-	case APPLY_SAVING_WILL:
-		weight = mod * -0.5;
-		break;
-	case APPLY_SAVING_CRITICAL:
-		weight = mod * -0.5;
-		break;
-	case APPLY_SAVING_STABILITY:
-		weight = mod * -0.5;
-		break;
-	case APPLY_SAVING_REFLEX:
-		weight = mod * -0.5;
-		break;
-	case APPLY_CAST_SUCCESS:
-		weight = mod * 1.5;
-		break;
-	case APPLY_MANAREG:
-		weight = mod * 0.2;
-		break;
-	case APPLY_MORALE:
-		weight = mod * 1.0;
-		break;
-	case APPLY_INITIATIVE:
-		weight = mod * 2.0;
-		break;
-	case APPLY_ABSORBE:
-		weight = mod * 1.0;
-		break;
-	case APPLY_AR:
-		weight = mod * 1.5;
-		break;
-	case APPLY_MR:
-		weight = mod * 1.5;
-		break;
-	}
+  switch (num) {
+    case APPLY_STR: weight = mod * 7.5;
+      break;
+    case APPLY_DEX: weight = mod * 10.0;
+      break;
+    case APPLY_INT: weight = mod * 10.0;
+      break;
+    case APPLY_WIS: weight = mod * 10.0;
+      break;
+    case APPLY_CON: weight = mod * 10.0;
+      break;
+    case APPLY_CHA: weight = mod * 10.0;
+      break;
+    case APPLY_HIT: weight = mod * 0.3;
+      break;
+    case APPLY_AC: weight = mod * -0.5;
+      break;
+    case APPLY_HITROLL: weight = mod * 2.3;
+      break;
+    case APPLY_DAMROLL: weight = mod * 3.3;
+      break;
+    case APPLY_SAVING_WILL: weight = mod * -0.5;
+      break;
+    case APPLY_SAVING_CRITICAL: weight = mod * -0.5;
+      break;
+    case APPLY_SAVING_STABILITY: weight = mod * -0.5;
+      break;
+    case APPLY_SAVING_REFLEX: weight = mod * -0.5;
+      break;
+    case APPLY_CAST_SUCCESS: weight = mod * 1.5;
+      break;
+    case APPLY_MANAREG: weight = mod * 0.2;
+      break;
+    case APPLY_MORALE: weight = mod * 1.0;
+      break;
+    case APPLY_INITIATIVE: weight = mod * 2.0;
+      break;
+    case APPLY_ABSORBE: weight = mod * 1.0;
+      break;
+    case APPLY_AR: weight = mod * 1.5;
+      break;
+    case APPLY_MR: weight = mod * 1.5;
+      break;
+  }
 
-	return weight;
+  return weight;
 }
-void MakeRecept::make_object(CHAR_DATA *ch, OBJ_DATA * obj, OBJ_DATA *ingrs[MAX_PARTS], int ingr_cnt)
-{
-	int i, j;
-	//ставим именительные именительные падежи в алиасы
-	sprintf(buf, "%s %s %s %s",
-		GET_OBJ_PNAME(obj, 0).c_str(),
-		GET_OBJ_PNAME(ingrs[0], 1).c_str(),
-		GET_OBJ_PNAME(ingrs[1], 4).c_str(),
-		GET_OBJ_PNAME(ingrs[2], 4).c_str());
-	obj->set_aliases(buf);
-	for (i = 0; i < CObjectPrototype::NUM_PADS; i++) // ставим падежи в имя с учетов ингров
-	{
-		sprintf(buf, "%s", GET_OBJ_PNAME(obj, i).c_str());
-		strcat(buf, " из ");
-		strcat(buf, GET_OBJ_PNAME(ingrs[0], 1).c_str());
-		strcat(buf, " с ");
-		strcat(buf, GET_OBJ_PNAME(ingrs[1], 4).c_str());
-		strcat(buf, " и ");
-		strcat(buf, GET_OBJ_PNAME(ingrs[2], 4).c_str());
-		obj->set_PName(i, buf);
-		if (i == 0) // именительный падеж
-		{
-			obj->set_short_description(buf);
-			if (GET_OBJ_SEX(obj) == ESex::SEX_MALE)
-			{
-				snprintf(buf2, MAX_STRING_LENGTH, "Брошенный %s лежит тут.", buf);
-			}
-			else if (GET_OBJ_SEX(obj) == ESex::SEX_FEMALE)
-			{
-				snprintf(buf2, MAX_STRING_LENGTH, "Брошенная %s лежит тут.", buf);
-			}
-			else if (GET_OBJ_SEX(obj) == ESex::SEX_POLY)
-			{
-				snprintf(buf2, MAX_STRING_LENGTH, "Брошенные %s лежат тут.", buf);
-			}
-			obj->set_description(buf2); // описание на земле
-		}
-	}
-	obj->set_is_rename(true); // ставим флаг что объект переименован
+void MakeRecept::make_object(CHAR_DATA *ch, OBJ_DATA *obj, OBJ_DATA *ingrs[MAX_PARTS], int ingr_cnt) {
+  int i, j;
+  //ставим именительные именительные падежи в алиасы
+  sprintf(buf, "%s %s %s %s",
+          GET_OBJ_PNAME(obj, 0).c_str(),
+          GET_OBJ_PNAME(ingrs[0], 1).c_str(),
+          GET_OBJ_PNAME(ingrs[1], 4).c_str(),
+          GET_OBJ_PNAME(ingrs[2], 4).c_str());
+  obj->set_aliases(buf);
+  for (i = 0; i < CObjectPrototype::NUM_PADS; i++) // ставим падежи в имя с учетов ингров
+  {
+    sprintf(buf, "%s", GET_OBJ_PNAME(obj, i).c_str());
+    strcat(buf, " из ");
+    strcat(buf, GET_OBJ_PNAME(ingrs[0], 1).c_str());
+    strcat(buf, " с ");
+    strcat(buf, GET_OBJ_PNAME(ingrs[1], 4).c_str());
+    strcat(buf, " и ");
+    strcat(buf, GET_OBJ_PNAME(ingrs[2], 4).c_str());
+    obj->set_PName(i, buf);
+    if (i == 0) // именительный падеж
+    {
+      obj->set_short_description(buf);
+      if (GET_OBJ_SEX(obj) == ESex::SEX_MALE) {
+        snprintf(buf2, MAX_STRING_LENGTH, "Брошенный %s лежит тут.", buf);
+      } else if (GET_OBJ_SEX(obj) == ESex::SEX_FEMALE) {
+        snprintf(buf2, MAX_STRING_LENGTH, "Брошенная %s лежит тут.", buf);
+      } else if (GET_OBJ_SEX(obj) == ESex::SEX_POLY) {
+        snprintf(buf2, MAX_STRING_LENGTH, "Брошенные %s лежат тут.", buf);
+      }
+      obj->set_description(buf2); // описание на земле
+    }
+  }
+  obj->set_is_rename(true); // ставим флаг что объект переименован
 
 
-	auto temp_flags = obj->get_affect_flags();
-	add_flags(ch, &temp_flags, &ingrs[0]->get_affect_flags(), get_ingr_pow(ingrs[0]));
-	obj->set_affect_flags(temp_flags);
-	// перносим эффекты ... с ингров на прототип, 0 объект шкура переносим все, с остальных 1 рандом
-	temp_flags = obj->get_extra_flags();
-	add_flags(ch, &temp_flags, &GET_OBJ_EXTRA(ingrs[0]), get_ingr_pow(ingrs[0]));
-	obj->set_extra_flags(temp_flags);
-	auto temp_affected = obj->get_all_affected();
-	add_affects(ch,temp_affected, ingrs[0]->get_all_affected(), get_ingr_pow(ingrs[0]));
-	obj->set_all_affected(temp_affected);
-	add_rnd_skills(ch, ingrs[0], obj); //переносим случайную умелку со шкуры
-	obj->set_extra_flag(EExtraFlag::ITEM_NOALTER);  // нельзя сфрешить черным свитком
-	obj->set_timer((GET_OBJ_VAL(ingrs[0], 3) + 1) * 1000 + ch->get_skill(SKILL_MAKE_WEAR) / 2 * number(160, 220)); // таймер зависит в основном от умелки
-	obj->set_craft_timer(obj->get_timer()); // запомним таймер созданной вещи для правильного отображения при осм для ее сост.
-	for (j = 1; j < ingr_cnt; j++)
-	{
-		int i, raffect = 0;
-		for (i = 0; i < MAX_OBJ_AFFECT; i++) // посмотрим скока аффектов
-		{
-			if (ingrs[j]->get_affected(i).location == APPLY_NONE)
-			{
-				break;
-			}
-		}
-		if (i > 0) // если > 0 переносим случайный
-		{
-			raffect = number(0, i - 1);
-			for (int i = 0; i < MAX_OBJ_AFFECT; i++)
-			{
-				const auto& ra = ingrs[j]->get_affected(raffect);
-				if (obj->get_affected(i).location == ra.location) // если аффект такой уже висит и он меньше, переставим значение
-				{
-					if (obj->get_affected(i).modifier < ra.modifier)
-					{
-						obj->set_affected(i, obj->get_affected(i).location, ra.modifier);
-					}
-					break;
-				}
-				if (obj->get_affected(i).location == APPLY_NONE) // добавляем афф на свободное место
-				{
-					if (number(1, 100) > GET_OBJ_VAL(ingrs[j], 2)) // проверим фейл на силу ингра
-					{
-						break;
-					}
-					obj->set_affected(i, ra);
-					break;
-				}
-			}
-		}
-		// переносим аффекты ... c ингров на прототип.
-		auto temp_flags = obj->get_affect_flags();
-		add_flags(ch, &temp_flags, &ingrs[j]->get_affect_flags(), get_ingr_pow(ingrs[j]));
-		obj->set_affect_flags(temp_flags);
-		// перносим эффекты ... с ингров на прототип.
-		temp_flags = obj->get_extra_flags();
-		add_flags(ch, &temp_flags, &GET_OBJ_EXTRA(ingrs[j]), get_ingr_pow(ingrs[j]));
-		obj->set_extra_flags(temp_flags);
-		// переносим 1 рандом аффект
-		add_rnd_skills(ch, ingrs[j], obj); //переноси случайную умелку с ингров
-	}
+  auto temp_flags = obj->get_affect_flags();
+  add_flags(ch, &temp_flags, &ingrs[0]->get_affect_flags(), get_ingr_pow(ingrs[0]));
+  obj->set_affect_flags(temp_flags);
+  // перносим эффекты ... с ингров на прототип, 0 объект шкура переносим все, с остальных 1 рандом
+  temp_flags = obj->get_extra_flags();
+  add_flags(ch, &temp_flags, &GET_OBJ_EXTRA(ingrs[0]), get_ingr_pow(ingrs[0]));
+  obj->set_extra_flags(temp_flags);
+  auto temp_affected = obj->get_all_affected();
+  add_affects(ch, temp_affected, ingrs[0]->get_all_affected(), get_ingr_pow(ingrs[0]));
+  obj->set_all_affected(temp_affected);
+  add_rnd_skills(ch, ingrs[0], obj); //переносим случайную умелку со шкуры
+  obj->set_extra_flag(EExtraFlag::ITEM_NOALTER);  // нельзя сфрешить черным свитком
+  obj->set_timer((GET_OBJ_VAL(ingrs[0], 3) + 1) * 1000
+                     + ch->get_skill(SKILL_MAKE_WEAR) / 2 * number(160, 220)); // таймер зависит в основном от умелки
+  obj->set_craft_timer(obj->get_timer()); // запомним таймер созданной вещи для правильного отображения при осм для ее сост.
+  for (j = 1; j < ingr_cnt; j++) {
+    int i, raffect = 0;
+    for (i = 0; i < MAX_OBJ_AFFECT; i++) // посмотрим скока аффектов
+    {
+      if (ingrs[j]->get_affected(i).location == APPLY_NONE) {
+        break;
+      }
+    }
+    if (i > 0) // если > 0 переносим случайный
+    {
+      raffect = number(0, i - 1);
+      for (int i = 0; i < MAX_OBJ_AFFECT; i++) {
+        const auto &ra = ingrs[j]->get_affected(raffect);
+        if (obj->get_affected(i).location
+            == ra.location) // если аффект такой уже висит и он меньше, переставим значение
+        {
+          if (obj->get_affected(i).modifier < ra.modifier) {
+            obj->set_affected(i, obj->get_affected(i).location, ra.modifier);
+          }
+          break;
+        }
+        if (obj->get_affected(i).location == APPLY_NONE) // добавляем афф на свободное место
+        {
+          if (number(1, 100) > GET_OBJ_VAL(ingrs[j], 2)) // проверим фейл на силу ингра
+          {
+            break;
+          }
+          obj->set_affected(i, ra);
+          break;
+        }
+      }
+    }
+    // переносим аффекты ... c ингров на прототип.
+    auto temp_flags = obj->get_affect_flags();
+    add_flags(ch, &temp_flags, &ingrs[j]->get_affect_flags(), get_ingr_pow(ingrs[j]));
+    obj->set_affect_flags(temp_flags);
+    // перносим эффекты ... с ингров на прототип.
+    temp_flags = obj->get_extra_flags();
+    add_flags(ch, &temp_flags, &GET_OBJ_EXTRA(ingrs[j]), get_ingr_pow(ingrs[j]));
+    obj->set_extra_flags(temp_flags);
+    // переносим 1 рандом аффект
+    add_rnd_skills(ch, ingrs[j], obj); //переноси случайную умелку с ингров
+  }
 }
 // создать предмет по рецепту
-int MakeRecept::make(CHAR_DATA * ch)
-{
-	char tmpbuf[MAX_STRING_LENGTH];//, tmpbuf2[MAX_STRING_LENGTH];
-	OBJ_DATA *ingrs[MAX_PARTS];
-	string tmpstr, charwork, roomwork, charfail, roomfail, charsucc, roomsucc, chardam, roomdam, tagging, itemtag;
-	int dam = 0;
-	bool make_fail;
-	// 1. Проверить есть ли скилл у чара
-	if (IS_NPC(ch) || !ch->get_skill(skill))
-	{
-		send_to_char("Странно что вам вообще пришло в голову cделать это.\r\n", ch);
-		return (FALSE);
-	}
-	// 2. Проверить есть ли ингры у чара
-	if (!can_make(ch))
-	{
-		send_to_char("У вас нет составляющих для этого.\r\n", ch);
-		return (FALSE);
-	}
-	if (GET_MOVE(ch) < MIN_MAKE_MOVE)
-	{
-		send_to_char("Вы слишком устали и вам ничего не хочется делать.\r\n", ch);
-		return (FALSE);
-	}
-	auto tobj = get_object_prototype(obj_proto);
-	if (!tobj)
-	{
-		return 0;
-	}
-	// Проверяем возможность создания предмета
-	if (!IS_IMMORTAL(ch) && (skill == SKILL_MAKE_STAFF))
-	{
-		const OBJ_DATA obj(*tobj);
-		act("Вы не готовы к тому чтобы сделать $o3.", FALSE, ch, &obj, 0, TO_CHAR);
-		return (FALSE);
-	}
-	// Прогружаем в массив реальные ингры
-	// 3. Проверить уровни ингров и чара
-	int ingr_cnt = 0, ingr_lev, i, craft_weight, ingr_pow;
-	for (i = 0; i < MAX_PARTS; i++)
-	{
-		if (parts[i].proto == 0)
-			break;
-		ingrs[i] = get_obj_in_list_ingr(parts[i].proto, ch->carrying);
-		ingr_lev = get_ingr_lev(ingrs[i]);
-		if (!IS_IMPL(ch) && (ingr_lev > (GET_LEVEL(ch) + 2 * GET_REMORT(ch))))
-		{
-			tmpstr = "Вы побоялись испортить " + ingrs[i]->get_PName(3)
-				+ "\r\n и прекратили работу над " + tobj->get_PName(4) + ".\r\n";
-			send_to_char(tmpstr.c_str(), ch);
-			return (FALSE);
-		};
-		ingr_pow = get_ingr_pow(ingrs[i]);
-		if (ingr_pow < parts[i].min_power)
-		{
-			tmpstr = "$o не подходит для изготовления " + tobj->get_PName(1) + ".";
-			act(tmpstr.c_str(), FALSE, ch, ingrs[i], 0, TO_CHAR);
-			return (FALSE);
-		}
-		ingr_cnt++;
-	}
-	//int stat_bonus;
-	// Делаем всякие доп проверки для различных умений.
-	switch (skill)
-	{
-	case SKILL_MAKE_WEAPON:
-	case SKILL_MAKE_ARMOR:
-		// Проверяем есть ли тут наковальня или комната кузня.
-		if ((!ROOM_FLAGGED(ch->in_room, ROOM_SMITH)) && (!IS_IMMORTAL(ch)))
-		{
-			send_to_char("Вам нужно попасть в кузницу для этого.\r\n", ch);
-			return (FALSE);
-		}
-		charwork = "Вы поместили заготовку на наковальню и начали ковать $o3.";
-		roomwork = "$n поместил$g закотовку на наковальню и начал$g ковать.";
-		charfail = "Заготовка под вашими ударами покрылась сетью трещин и раскололась.";
-		roomfail = "Под ударами молота $n1 заготовка раскололась.";
-		charsucc = "Вы выковали $o3.";
-		roomsucc = "$n выковал$G $o3.";
-		chardam = "Заготовка выскочила из под молота и больно ударила вас.";
-		roomdam = "Заготовка выскочила из под молота $n1, больно $s ударив.";
-		tagging = "Вы поставили свое клеймо на $o5.";
-		itemtag = "На $o5 стоит клеймо 'Выковал$g $n'.";
-		dam = 70;
-		// Бонус сила
-		//stat_bonus = number(0, GET_REAL_STR(ch));
-		break;
-	case SKILL_MAKE_BOW:
-		charwork = "Вы начали мастерить $o3.";
-		roomwork = "$n начал$g мастерить что-то очень напоминающее $o3.";
-		charfail = "С громким треском $o сломал$U в ваших неумелых руках.";
-		roomfail = "С громким треском $o сломал$U в неумелых руках $n1.";
-		charsucc = "Вы cмастерили $o3.";
-		roomsucc = "$n смастерил$g $o3.";
-		chardam = "$o3 с громким треском сломал$U оцарапав вам руки.";
-		roomdam = "$o3 с громким треском сломал$U оцарапав руки $n2.";
-		tagging = "Вы вырезали свое имя на $o5.";
-		itemtag = "На $o5 видна метка 'Смастерил$g $n'.";
-		// Бонус ловкость
-		//stat_bonus = number(0, GET_REAL_DEX(ch));
-		dam = 40;
-		break;
-	case SKILL_MAKE_WEAR:
-		charwork = "Вы взяли в руку иголку и начали шить $o3.";
-		roomwork = "$n взял$g в руку иголку и начал$g увлеченно шить.";
-		charfail = "У вас ничего не получилось сшить.";
-		roomfail = "$n пытал$u что-то сшить, но ничего не вышло.";
-		charsucc = "Вы сшили $o3.";
-		roomsucc = "$n сшил$g $o3.";
-		chardam = "Игла глубоко вошла в вашу руку. Аккуратнее надо быть.";
-		roomdam = "$n глубоко воткнул$g иглу в себе в руку. \r\nА с виду вполне нормальный человек.";
-		tagging = "Вы пришили к $o2 бирку со своим именем.";
-		itemtag = "На $o5 вы заметили бирку 'Сшил$g $n'.";
-		// Бонус тело , не спрашивайте почему :))
-		//stat_bonus = number(0, GET_REAL_CON(ch));
-		dam = 30;
-		break;
-	case SKILL_MAKE_AMULET:
-		charwork = "Вы взяли в руки необходимые материалы и начали мастерить $o3.";
-		roomwork = "$n взял$g в руки что-то и начал$g увлеченно пыхтеть над чем-то.";
-		charfail = "У вас ничего не получилось";
-		roomfail = "$n пытал$u что-то сделать, но ничего не вышло.";
-		charsucc = "Вы смастерили $o3.";
-		roomsucc = "$n смастерил$g $o3.";
-		chardam = "Яркая вспышка дала вам знать, что с магией необходимо быть поосторожней.";
-		roomdam = "Яркая вспышка осветила все вокруг. $n2 стоит быть аккуратнее с магией! \r\n";
-		tagging = "На обратной стороне $o1 вы нацарапали свое имя.";
-		itemtag = "На обратной стороне $o1 вы заметили слово '$n', видимо, это имя создателя этой чудной вещицы.";
-		dam = 30;
-		break;
-	case SKILL_MAKE_JEWEL:
-		charwork = "Вы начали мастерить $o3.";
-		roomwork = "$n начал мастерить какую-то диковинку.";
-		charfail = "Ваше неудачное движение повредило $o5.";
-		roomfail = "Неудачное движение $n, сделало $s работу бессмысленной.";
-		charsucc = "Вы смастерили $o3.";
-		roomsucc = "$n смастерил$g $o3.";
-		chardam = "Мелкий кусочек материала отскочил и попал вам в глаз.\r\nЭто было больно!";
-		roomdam = "Мелкий кусочек материала отскочил и попал в глаз $n2.";
-		tagging = "Вы приладили к $o2 табличку со своим именем.";
-		itemtag = "С нижней стороны $o1 укреплена табличка 'Cделано $n4'.";
-		// Бонус харя
-		//stat_bonus = number(0, GET_REAL_CHA(ch));
-		dam = 30;
-		break;
-	case SKILL_MAKE_STAFF:
-		charwork = "Вы начали мастерить $o3.";
-		roomwork = "$n начал мастерить что-то, посылая всех к чертям.";
-		charfail = "$o3 осветил комнату магическим светом и истаял.";
-		roomfail = "Предмет в руках $n1 вспыхнул, озарив комнату магическим светом и истаял.";
-		charsucc =
-			"Тайные знаки нанесенные на $o3 вспыхнули и погасли.\r\nДа, $E хорошо послужит своему хозяину.";
-		roomsucc = "$n смастерил$g $o3. Вы почувствовали скрытую силу спрятанную в этом предмете.";
-		chardam = "$o взорвался в ваших руках. Вас сильно обожгло.";
-		roomdam = "$o взорвался в руках $n1, опалив его.\r\nВокруг приятно запахло жаренным мясом.";
-		tagging = "Вы начертили на $o2 свое имя.";
-		itemtag = "Среди рунных знаков видна надпись 'Создано $n4'.";
-		// Бонус ум.
-		//stat_bonus = number(0, GET_REAL_INT(ch));
-		dam = 70;
-		break;
-	case SKILL_MAKE_POTION:
-		charwork = "Вы достали небольшой горшочек и развели под ним огонь, начав варить $o3.";
-		roomwork = "$n достал горшочек и поставил его на огонь.";
-		charfail = "Вы не уследили как зелье закипело и пролилось в огонь.";
-		roomfail =
-			"Зелье которое варил$g $n закипело и пролилось в огонь,\r\n распространив по комнате ужасную вонь.";
-		charsucc = "Зелье удалось вам на славу.";
-		roomsucc = "$n сварил$g $o3. Приятный аромат зелья из горшочка, так и манит вас.";
-		chardam = "Вы опрокинули горшочек с зельем на себя, сильно ошпарившись.";
-		roomdam = "Горшочек с $o4 опрокинулся на $n1, ошпарив $s.";
-		tagging = "Вы на прикрепили к $o2 бирку со своим именем.";
-		itemtag = "На $o1 вы заметили бирку 'Сварено $n4'";
-		// Бонус мудра
-		//stat_bonus = number(0, GET_REAL_WIS(ch));
-		dam = 40;
-		break;
-	default:
-		break;
-	}
-	const OBJ_DATA object(*tobj);
-	act(charwork.c_str(), FALSE, ch, &object, 0, TO_CHAR);
-	act(roomwork.c_str(), FALSE, ch, &object, 0, TO_ROOM);
-	// Считаем вероятность испортить отдельный ингридиент
-	// если уровень чара = уровню ингра то фейл 50%
-	// если уровень чара > уровня ингра на 15 то фейл 0%
-	// уровень чара * 2 - random(30) < 15 - фейл то пропадает весь материал
-	// Выдается Вы испортили (...)
-	// и выходим.
-	make_fail = false;
-	// Это средний уровень получившегося предмета.
-	// использует при расчете макс количества предметов в мире.
-	int created_lev = 0;
-	int used_non_ingrs = 0;
-	for (i = 0; i < ingr_cnt; i++)
-	{
-		ingr_lev = get_ingr_lev(ingrs[i]);
-		if (ingr_lev < 0)
-		{
-			used_non_ingrs++;
-		}
-		else
-		{
-			created_lev += ingr_lev;
-		}
-		// Шанс испортить не ингредиент всетаки есть.
-		if ((number(0, 30) < (5 + ingr_lev - GET_LEVEL(ch) - 2 * GET_REMORT(ch))) && !IS_IMPL(ch))
-		{
-			tmpstr = "Вы испортили " + ingrs[i]->get_PName(3) + ".\r\n";
-			send_to_char(tmpstr.c_str(), ch);
-			//extract_obj(ingrs[i]); //заменим на обнуление веса
-			//чтобы не крешило дальше в обработке фейла (Купала)
-			IS_CARRYING_W(ch) -= GET_OBJ_WEIGHT(ingrs[i]);
-			ingrs[i]->set_weight(0);
-			make_fail = true;
-		}
-	};
-	created_lev = created_lev / MAX(1, (ingr_cnt - used_non_ingrs));
-	int j;
-	int craft_move = MIN_MAKE_MOVE + (created_lev / 2) - 1;
-	// Снимаем мувы за умение
-	if (GET_MOVE(ch) < craft_move)
-	{
-		GET_MOVE(ch) = 0;
-		// Вам не хватило сил доделать.
-		tmpstr = "Вам не хватило сил доделать " + tobj->get_PName(3) + ".\r\n";
-		send_to_char(tmpstr.c_str(), ch);
-		make_fail = true;
-	}
-	else
-	{
-		if (!IS_IMPL(ch))
-		{
-			GET_MOVE(ch) -= craft_move;
-		}
-	}
-	// Делаем тут прокачку умения.
-	// Прокачка должна зависеть от среднего уровня материала и игрока.
-	// При разнице со средним уровнем до 0 никаких штрафов.
-	// При разнице большей чем 1 уровней замедление в 2 раза.
-	// При разнице большей чем в 2 уровней замедление в 3 раза.
-	/*
-	if (skill == SKILL_MAKE_STAFF)
-	{
-		if (number(0, GET_LEVEL(ch) - created_lev) < GET_SPELL_MEM(ch, GET_OBJ_VAL(tobj, 3)))
-		{
-			train_skill(ch, skill, skill_info[skill].max_percent, 0);
-		}
-	}
-	*/
-	train_skill(ch, skill, skill_info[skill].max_percent, 0);
-	// 4. Считаем сколько материала треба.
-	if (!make_fail)
-	{
-		for (i = 0; i < ingr_cnt; i++)
-		{
-			if (skill == SKILL_MAKE_WEAR && i == 0) //для шитья всегда раскраиваем шкуру
-			{
-				IS_CARRYING_W(ch) -= GET_OBJ_WEIGHT(ingrs[0]);
-				ingrs[0]->set_weight(0);  // шкуру дикеим полностью
-				tmpstr = "Вы раскроили полностью " + ingrs[0]->get_PName(3) + ".\r\n";
-				send_to_char(tmpstr.c_str(), ch);
-				continue;
-			}
-			//
-			// нужный материал = мин.материал +
-			// random(100) - skill
-			// если она < 20 то мин.вес + rand(мин.вес/3)
-			// если она < 50 то мин.вес*rand(1,2) + rand(мин.вес/3)
-			// если она > 50    мин.вес*rand(2,5) + rand(мин.вес/3)
-			if (get_ingr_lev(ingrs[i]) == -1)
-				continue;	// Компонент не ингр. пропускаем.
-			craft_weight = parts[i].min_weight + number(0, (parts[i].min_weight / 3) + 1);
-			j = number(0, 100) - calculate_skill(ch, skill, 0);
-			if ((j >= 20) && (j < 50))
-				craft_weight += parts[i].min_weight * number(1, 2);
-			else if (j > 50)
-				craft_weight += parts[i].min_weight * number(2, 5);
-			// 5. Делаем проверку есть ли столько материала.
-			// если не хватает то удаляем игридиент и фейлим.
-			int state = craft_weight;
-			// Обсчет веса ингров в цикле, если не хватило веса берем следующий ингр в инве, если не хватает, делаем фэйл (make_fail) и брекаем внешний цикл, смысл дальше ингры смотреть?
-			//send_to_char(ch, "Требуется вес %d вес ингра %d требуемое кол ингров %d\r\n", state, GET_OBJ_WEIGHT(ingrs[i]), ingr_cnt);
-			int obj_vnum_tmp = GET_OBJ_VNUM(ingrs[i]);
-			while (state > 0)
-			{
-				//Переделаем слегка логику итераций
-				//Сперва проверяем сколько нам нужно. Если вес ингра больше, чем требуется, то вычитаем вес и останавливаем итерацию.
-				if (GET_OBJ_WEIGHT(ingrs[i]) > state)
-				{
-					ingrs[i]->sub_weight(state);
-					send_to_char(ch, "Вы использовали %s.\r\n", ingrs[i]->get_PName(3).c_str());
-					IS_CARRYING_W(ch) -= state;
-					break;
-				}
-				//Если вес ингра ровно столько, сколько требуется, вычитаем вес, ломаем ингр и останавливаем итерацию.
-				else if (GET_OBJ_WEIGHT(ingrs[i]) == state)
-				{
-					IS_CARRYING_W(ch) -= GET_OBJ_WEIGHT(ingrs[i]);
-					ingrs[i]->set_weight(0);
-					send_to_char(ch, "Вы полностью использовали %s.\r\n", ingrs[i]->get_PName(3).c_str());
-					//extract_obj(ingrs[i]);
-					break;
-				}
-				//Если вес ингра меньше, чем требуется, то вычтем этот вес из того, сколько требуется.
-				else
-				{
-					state = state - GET_OBJ_WEIGHT(ingrs[i]);
-					send_to_char(ch, "Вы полностью использовали %s и начали искать следующий ингредиент.\r\n", ingrs[i]->get_PName(3).c_str());
-					std::string tmpname = std::string(ingrs[i]->get_PName(1).c_str());
-					IS_CARRYING_W(ch) -= GET_OBJ_WEIGHT(ingrs[i]);
-					ingrs[i]->set_weight(0);
-					extract_obj(ingrs[i]);
-					ingrs[i] = nullptr;
-					//Если некст ингра в инве нет, то сообщаем об этом и идем в фэйл. Некст ингры все равно проверяем
-					if (!get_obj_in_list_ingr(obj_vnum_tmp, ch->carrying))
-					{
-						send_to_char(ch, "У вас в инвентаре больше нет %s.\r\n", tmpname.c_str());
-						make_fail = true;
-						break;
-					}
-					//Подцепляем некст ингр и идем в нашу проверку заново
-					else
-					{
-						ingrs[i] = get_obj_in_list_ingr(obj_vnum_tmp, ch->carrying);
-					}
-				}
-			}
-		}
-	}
-	if (make_fail)
-	{
-		// Считаем крит фейл или нет.
-		int crit_fail = number(0, 100);
-		if (crit_fail > 2)
-		{
-			const OBJ_DATA obj(*tobj);
-			act(charfail.c_str(), FALSE, ch, &obj, 0, TO_CHAR);
-			act(roomfail.c_str(), FALSE, ch, &obj, 0, TO_ROOM);
-		}
-		else
-		{
-			const OBJ_DATA obj(*tobj);
-			act(chardam.c_str(), FALSE, ch, &obj, 0, TO_CHAR);
-			act(roomdam.c_str(), FALSE, ch, &obj, 0, TO_ROOM);
-			dam = number(0, dam);
-			// Наносим дамаг.
-			if (GET_LEVEL(ch) >= LVL_IMMORT && dam > 0)
-			{
-				send_to_char("Будучи бессмертным, вы избежали повреждения...", ch);
-				return (FALSE);
-			}
-			GET_HIT(ch) -= dam;
-			update_pos(ch);
-			char_dam_message(dam, ch, ch, 0);
-			if (GET_POS(ch) == POS_DEAD)
-			{
-				// Убился веником.
-				if (!IS_NPC(ch))
-				{
-					sprintf(tmpbuf, "%s killed by a crafting at %s",
-							GET_NAME(ch),
-							ch->in_room == NOWHERE ? "NOWHERE" : world[ch->in_room]->name);
-					mudlog(tmpbuf, BRF, LVL_BUILDER, SYSLOG, TRUE);
-				}
-				die(ch, NULL);
-			}
-		}
-		for (i = 0; i < ingr_cnt; i++)
-		{
-			if (ingrs[i] && GET_OBJ_WEIGHT(ingrs[i]) <= 0)
-			{
-				extract_obj(ingrs[i]);
-			}
-		}
-		return (FALSE);
-	}
-	// Лоадим предмет игроку
-	const auto obj = world_objects.create_from_prototype_by_vnum(obj_proto);
-	act(charsucc.c_str(), FALSE, ch, obj.get(), 0, TO_CHAR);
-	act(roomsucc.c_str(), FALSE, ch, obj.get(), 0, TO_ROOM);
-	// 6. Считаем базовые статсы предмета и таймер
-	//  формула для каждого умения отдельная
-	// Для числовых х-к:  х-ка+(skill - random(100))/20;
-	// Для флагов ???: random(200) - skill > 0 то флаг переноситься.
-	// Т.к. сделать мы можем практически любой предмет.
-	// Модифицируем вес предмета и его таймер.
-	// Для маг предметов надо в сторону облегчения.
+int MakeRecept::make(CHAR_DATA *ch) {
+  char tmpbuf[MAX_STRING_LENGTH];//, tmpbuf2[MAX_STRING_LENGTH];
+  OBJ_DATA *ingrs[MAX_PARTS];
+  string tmpstr, charwork, roomwork, charfail, roomfail, charsucc, roomsucc, chardam, roomdam, tagging, itemtag;
+  int dam = 0;
+  bool make_fail;
+  // 1. Проверить есть ли скилл у чара
+  if (IS_NPC(ch) || !ch->get_skill(skill)) {
+    send_to_char("Странно что вам вообще пришло в голову cделать это.\r\n", ch);
+    return (FALSE);
+  }
+  // 2. Проверить есть ли ингры у чара
+  if (!can_make(ch)) {
+    send_to_char("У вас нет составляющих для этого.\r\n", ch);
+    return (FALSE);
+  }
+  if (GET_MOVE(ch) < MIN_MAKE_MOVE) {
+    send_to_char("Вы слишком устали и вам ничего не хочется делать.\r\n", ch);
+    return (FALSE);
+  }
+  auto tobj = get_object_prototype(obj_proto);
+  if (!tobj) {
+    return 0;
+  }
+  // Проверяем возможность создания предмета
+  if (!IS_IMMORTAL(ch) && (skill == SKILL_MAKE_STAFF)) {
+    const OBJ_DATA obj(*tobj);
+    act("Вы не готовы к тому чтобы сделать $o3.", FALSE, ch, &obj, 0, TO_CHAR);
+    return (FALSE);
+  }
+  // Прогружаем в массив реальные ингры
+  // 3. Проверить уровни ингров и чара
+  int ingr_cnt = 0, ingr_lev, i, craft_weight, ingr_pow;
+  for (i = 0; i < MAX_PARTS; i++) {
+    if (parts[i].proto == 0)
+      break;
+    ingrs[i] = get_obj_in_list_ingr(parts[i].proto, ch->carrying);
+    ingr_lev = get_ingr_lev(ingrs[i]);
+    if (!IS_IMPL(ch) && (ingr_lev > (GET_LEVEL(ch) + 2 * GET_REMORT(ch)))) {
+      tmpstr = "Вы побоялись испортить " + ingrs[i]->get_PName(3)
+          + "\r\n и прекратили работу над " + tobj->get_PName(4) + ".\r\n";
+      send_to_char(tmpstr.c_str(), ch);
+      return (FALSE);
+    };
+    ingr_pow = get_ingr_pow(ingrs[i]);
+    if (ingr_pow < parts[i].min_power) {
+      tmpstr = "$o не подходит для изготовления " + tobj->get_PName(1) + ".";
+      act(tmpstr.c_str(), FALSE, ch, ingrs[i], 0, TO_CHAR);
+      return (FALSE);
+    }
+    ingr_cnt++;
+  }
+  //int stat_bonus;
+  // Делаем всякие доп проверки для различных умений.
+  switch (skill) {
+    case SKILL_MAKE_WEAPON:
+    case SKILL_MAKE_ARMOR:
+      // Проверяем есть ли тут наковальня или комната кузня.
+      if ((!ROOM_FLAGGED(ch->in_room, ROOM_SMITH)) && (!IS_IMMORTAL(ch))) {
+        send_to_char("Вам нужно попасть в кузницу для этого.\r\n", ch);
+        return (FALSE);
+      }
+      charwork = "Вы поместили заготовку на наковальню и начали ковать $o3.";
+      roomwork = "$n поместил$g закотовку на наковальню и начал$g ковать.";
+      charfail = "Заготовка под вашими ударами покрылась сетью трещин и раскололась.";
+      roomfail = "Под ударами молота $n1 заготовка раскололась.";
+      charsucc = "Вы выковали $o3.";
+      roomsucc = "$n выковал$G $o3.";
+      chardam = "Заготовка выскочила из под молота и больно ударила вас.";
+      roomdam = "Заготовка выскочила из под молота $n1, больно $s ударив.";
+      tagging = "Вы поставили свое клеймо на $o5.";
+      itemtag = "На $o5 стоит клеймо 'Выковал$g $n'.";
+      dam = 70;
+      // Бонус сила
+      //stat_bonus = number(0, GET_REAL_STR(ch));
+      break;
+    case SKILL_MAKE_BOW: charwork = "Вы начали мастерить $o3.";
+      roomwork = "$n начал$g мастерить что-то очень напоминающее $o3.";
+      charfail = "С громким треском $o сломал$U в ваших неумелых руках.";
+      roomfail = "С громким треском $o сломал$U в неумелых руках $n1.";
+      charsucc = "Вы cмастерили $o3.";
+      roomsucc = "$n смастерил$g $o3.";
+      chardam = "$o3 с громким треском сломал$U оцарапав вам руки.";
+      roomdam = "$o3 с громким треском сломал$U оцарапав руки $n2.";
+      tagging = "Вы вырезали свое имя на $o5.";
+      itemtag = "На $o5 видна метка 'Смастерил$g $n'.";
+      // Бонус ловкость
+      //stat_bonus = number(0, GET_REAL_DEX(ch));
+      dam = 40;
+      break;
+    case SKILL_MAKE_WEAR: charwork = "Вы взяли в руку иголку и начали шить $o3.";
+      roomwork = "$n взял$g в руку иголку и начал$g увлеченно шить.";
+      charfail = "У вас ничего не получилось сшить.";
+      roomfail = "$n пытал$u что-то сшить, но ничего не вышло.";
+      charsucc = "Вы сшили $o3.";
+      roomsucc = "$n сшил$g $o3.";
+      chardam = "Игла глубоко вошла в вашу руку. Аккуратнее надо быть.";
+      roomdam = "$n глубоко воткнул$g иглу в себе в руку. \r\nА с виду вполне нормальный человек.";
+      tagging = "Вы пришили к $o2 бирку со своим именем.";
+      itemtag = "На $o5 вы заметили бирку 'Сшил$g $n'.";
+      // Бонус тело , не спрашивайте почему :))
+      //stat_bonus = number(0, GET_REAL_CON(ch));
+      dam = 30;
+      break;
+    case SKILL_MAKE_AMULET: charwork = "Вы взяли в руки необходимые материалы и начали мастерить $o3.";
+      roomwork = "$n взял$g в руки что-то и начал$g увлеченно пыхтеть над чем-то.";
+      charfail = "У вас ничего не получилось";
+      roomfail = "$n пытал$u что-то сделать, но ничего не вышло.";
+      charsucc = "Вы смастерили $o3.";
+      roomsucc = "$n смастерил$g $o3.";
+      chardam = "Яркая вспышка дала вам знать, что с магией необходимо быть поосторожней.";
+      roomdam = "Яркая вспышка осветила все вокруг. $n2 стоит быть аккуратнее с магией! \r\n";
+      tagging = "На обратной стороне $o1 вы нацарапали свое имя.";
+      itemtag = "На обратной стороне $o1 вы заметили слово '$n', видимо, это имя создателя этой чудной вещицы.";
+      dam = 30;
+      break;
+    case SKILL_MAKE_JEWEL: charwork = "Вы начали мастерить $o3.";
+      roomwork = "$n начал мастерить какую-то диковинку.";
+      charfail = "Ваше неудачное движение повредило $o5.";
+      roomfail = "Неудачное движение $n, сделало $s работу бессмысленной.";
+      charsucc = "Вы смастерили $o3.";
+      roomsucc = "$n смастерил$g $o3.";
+      chardam = "Мелкий кусочек материала отскочил и попал вам в глаз.\r\nЭто было больно!";
+      roomdam = "Мелкий кусочек материала отскочил и попал в глаз $n2.";
+      tagging = "Вы приладили к $o2 табличку со своим именем.";
+      itemtag = "С нижней стороны $o1 укреплена табличка 'Cделано $n4'.";
+      // Бонус харя
+      //stat_bonus = number(0, GET_REAL_CHA(ch));
+      dam = 30;
+      break;
+    case SKILL_MAKE_STAFF: charwork = "Вы начали мастерить $o3.";
+      roomwork = "$n начал мастерить что-то, посылая всех к чертям.";
+      charfail = "$o3 осветил комнату магическим светом и истаял.";
+      roomfail = "Предмет в руках $n1 вспыхнул, озарив комнату магическим светом и истаял.";
+      charsucc =
+          "Тайные знаки нанесенные на $o3 вспыхнули и погасли.\r\nДа, $E хорошо послужит своему хозяину.";
+      roomsucc = "$n смастерил$g $o3. Вы почувствовали скрытую силу спрятанную в этом предмете.";
+      chardam = "$o взорвался в ваших руках. Вас сильно обожгло.";
+      roomdam = "$o взорвался в руках $n1, опалив его.\r\nВокруг приятно запахло жаренным мясом.";
+      tagging = "Вы начертили на $o2 свое имя.";
+      itemtag = "Среди рунных знаков видна надпись 'Создано $n4'.";
+      // Бонус ум.
+      //stat_bonus = number(0, GET_REAL_INT(ch));
+      dam = 70;
+      break;
+    case SKILL_MAKE_POTION: charwork = "Вы достали небольшой горшочек и развели под ним огонь, начав варить $o3.";
+      roomwork = "$n достал горшочек и поставил его на огонь.";
+      charfail = "Вы не уследили как зелье закипело и пролилось в огонь.";
+      roomfail =
+          "Зелье которое варил$g $n закипело и пролилось в огонь,\r\n распространив по комнате ужасную вонь.";
+      charsucc = "Зелье удалось вам на славу.";
+      roomsucc = "$n сварил$g $o3. Приятный аромат зелья из горшочка, так и манит вас.";
+      chardam = "Вы опрокинули горшочек с зельем на себя, сильно ошпарившись.";
+      roomdam = "Горшочек с $o4 опрокинулся на $n1, ошпарив $s.";
+      tagging = "Вы на прикрепили к $o2 бирку со своим именем.";
+      itemtag = "На $o1 вы заметили бирку 'Сварено $n4'";
+      // Бонус мудра
+      //stat_bonus = number(0, GET_REAL_WIS(ch));
+      dam = 40;
+      break;
+    default: break;
+  }
+  const OBJ_DATA object(*tobj);
+  act(charwork.c_str(), FALSE, ch, &object, 0, TO_CHAR);
+  act(roomwork.c_str(), FALSE, ch, &object, 0, TO_ROOM);
+  // Считаем вероятность испортить отдельный ингридиент
+  // если уровень чара = уровню ингра то фейл 50%
+  // если уровень чара > уровня ингра на 15 то фейл 0%
+  // уровень чара * 2 - random(30) < 15 - фейл то пропадает весь материал
+  // Выдается Вы испортили (...)
+  // и выходим.
+  make_fail = false;
+  // Это средний уровень получившегося предмета.
+  // использует при расчете макс количества предметов в мире.
+  int created_lev = 0;
+  int used_non_ingrs = 0;
+  for (i = 0; i < ingr_cnt; i++) {
+    ingr_lev = get_ingr_lev(ingrs[i]);
+    if (ingr_lev < 0) {
+      used_non_ingrs++;
+    } else {
+      created_lev += ingr_lev;
+    }
+    // Шанс испортить не ингредиент всетаки есть.
+    if ((number(0, 30) < (5 + ingr_lev - GET_LEVEL(ch) - 2 * GET_REMORT(ch))) && !IS_IMPL(ch)) {
+      tmpstr = "Вы испортили " + ingrs[i]->get_PName(3) + ".\r\n";
+      send_to_char(tmpstr.c_str(), ch);
+      //extract_obj(ingrs[i]); //заменим на обнуление веса
+      //чтобы не крешило дальше в обработке фейла (Купала)
+      IS_CARRYING_W(ch) -= GET_OBJ_WEIGHT(ingrs[i]);
+      ingrs[i]->set_weight(0);
+      make_fail = true;
+    }
+  };
+  created_lev = created_lev / MAX(1, (ingr_cnt - used_non_ingrs));
+  int j;
+  int craft_move = MIN_MAKE_MOVE + (created_lev / 2) - 1;
+  // Снимаем мувы за умение
+  if (GET_MOVE(ch) < craft_move) {
+    GET_MOVE(ch) = 0;
+    // Вам не хватило сил доделать.
+    tmpstr = "Вам не хватило сил доделать " + tobj->get_PName(3) + ".\r\n";
+    send_to_char(tmpstr.c_str(), ch);
+    make_fail = true;
+  } else {
+    if (!IS_IMPL(ch)) {
+      GET_MOVE(ch) -= craft_move;
+    }
+  }
+
+  train_skill(ch, skill, !make_fail, nullptr);
+  // 4. Считаем сколько материала треба.
+  if (!make_fail) {
+    for (i = 0; i < ingr_cnt; i++) {
+      if (skill == SKILL_MAKE_WEAR && i == 0) //для шитья всегда раскраиваем шкуру
+      {
+        IS_CARRYING_W(ch) -= GET_OBJ_WEIGHT(ingrs[0]);
+        ingrs[0]->set_weight(0);  // шкуру дикеим полностью
+        tmpstr = "Вы раскроили полностью " + ingrs[0]->get_PName(3) + ".\r\n";
+        send_to_char(tmpstr.c_str(), ch);
+        continue;
+      }
+      //
+      // нужный материал = мин.материал +
+      // random(100) - skill
+      // если она < 20 то мин.вес + rand(мин.вес/3)
+      // если она < 50 то мин.вес*rand(1,2) + rand(мин.вес/3)
+      // если она > 50    мин.вес*rand(2,5) + rand(мин.вес/3)
+      if (get_ingr_lev(ingrs[i]) == -1)
+        continue;    // Компонент не ингр. пропускаем.
+      craft_weight = parts[i].min_weight + number(0, (parts[i].min_weight / 3) + 1);
+      j = number(0, 100) - calculate_skill(ch, skill, 0);
+      if ((j >= 20) && (j < 50))
+        craft_weight += parts[i].min_weight * number(1, 2);
+      else if (j > 50)
+        craft_weight += parts[i].min_weight * number(2, 5);
+      // 5. Делаем проверку есть ли столько материала.
+      // если не хватает то удаляем игридиент и фейлим.
+      int state = craft_weight;
+      // Обсчет веса ингров в цикле, если не хватило веса берем следующий ингр в инве, если не хватает, делаем фэйл (make_fail) и брекаем внешний цикл, смысл дальше ингры смотреть?
+      //send_to_char(ch, "Требуется вес %d вес ингра %d требуемое кол ингров %d\r\n", state, GET_OBJ_WEIGHT(ingrs[i]), ingr_cnt);
+      int obj_vnum_tmp = GET_OBJ_VNUM(ingrs[i]);
+      while (state > 0) {
+        //Переделаем слегка логику итераций
+        //Сперва проверяем сколько нам нужно. Если вес ингра больше, чем требуется, то вычитаем вес и останавливаем итерацию.
+        if (GET_OBJ_WEIGHT(ingrs[i]) > state) {
+          ingrs[i]->sub_weight(state);
+          send_to_char(ch, "Вы использовали %s.\r\n", ingrs[i]->get_PName(3).c_str());
+          IS_CARRYING_W(ch) -= state;
+          break;
+        }
+          //Если вес ингра ровно столько, сколько требуется, вычитаем вес, ломаем ингр и останавливаем итерацию.
+        else if (GET_OBJ_WEIGHT(ingrs[i]) == state) {
+          IS_CARRYING_W(ch) -= GET_OBJ_WEIGHT(ingrs[i]);
+          ingrs[i]->set_weight(0);
+          send_to_char(ch, "Вы полностью использовали %s.\r\n", ingrs[i]->get_PName(3).c_str());
+          //extract_obj(ingrs[i]);
+          break;
+        }
+          //Если вес ингра меньше, чем требуется, то вычтем этот вес из того, сколько требуется.
+        else {
+          state = state - GET_OBJ_WEIGHT(ingrs[i]);
+          send_to_char(ch,
+                       "Вы полностью использовали %s и начали искать следующий ингредиент.\r\n",
+                       ingrs[i]->get_PName(3).c_str());
+          std::string tmpname = std::string(ingrs[i]->get_PName(1).c_str());
+          IS_CARRYING_W(ch) -= GET_OBJ_WEIGHT(ingrs[i]);
+          ingrs[i]->set_weight(0);
+          extract_obj(ingrs[i]);
+          ingrs[i] = nullptr;
+          //Если некст ингра в инве нет, то сообщаем об этом и идем в фэйл. Некст ингры все равно проверяем
+          if (!get_obj_in_list_ingr(obj_vnum_tmp, ch->carrying)) {
+            send_to_char(ch, "У вас в инвентаре больше нет %s.\r\n", tmpname.c_str());
+            make_fail = true;
+            break;
+          }
+            //Подцепляем некст ингр и идем в нашу проверку заново
+          else {
+            ingrs[i] = get_obj_in_list_ingr(obj_vnum_tmp, ch->carrying);
+          }
+        }
+      }
+    }
+  }
+  if (make_fail) {
+    // Считаем крит фейл или нет.
+    int crit_fail = number(0, 100);
+    if (crit_fail > 2) {
+      const OBJ_DATA obj(*tobj);
+      act(charfail.c_str(), FALSE, ch, &obj, 0, TO_CHAR);
+      act(roomfail.c_str(), FALSE, ch, &obj, 0, TO_ROOM);
+    } else {
+      const OBJ_DATA obj(*tobj);
+      act(chardam.c_str(), FALSE, ch, &obj, 0, TO_CHAR);
+      act(roomdam.c_str(), FALSE, ch, &obj, 0, TO_ROOM);
+      dam = number(0, dam);
+      // Наносим дамаг.
+      if (GET_LEVEL(ch) >= LVL_IMMORT && dam > 0) {
+        send_to_char("Будучи бессмертным, вы избежали повреждения...", ch);
+        return (FALSE);
+      }
+      GET_HIT(ch) -= dam;
+      update_pos(ch);
+      char_dam_message(dam, ch, ch, 0);
+      if (GET_POS(ch) == POS_DEAD) {
+        // Убился веником.
+        if (!IS_NPC(ch)) {
+          sprintf(tmpbuf, "%s killed by a crafting at %s",
+                  GET_NAME(ch),
+                  ch->in_room == NOWHERE ? "NOWHERE" : world[ch->in_room]->name);
+          mudlog(tmpbuf, BRF, LVL_BUILDER, SYSLOG, TRUE);
+        }
+        die(ch, NULL);
+      }
+    }
+    for (i = 0; i < ingr_cnt; i++) {
+      if (ingrs[i] && GET_OBJ_WEIGHT(ingrs[i]) <= 0) {
+        extract_obj(ingrs[i]);
+      }
+    }
+    return (FALSE);
+  }
+  // Лоадим предмет игроку
+  const auto obj = world_objects.create_from_prototype_by_vnum(obj_proto);
+  act(charsucc.c_str(), FALSE, ch, obj.get(), 0, TO_CHAR);
+  act(roomsucc.c_str(), FALSE, ch, obj.get(), 0, TO_ROOM);
+  // 6. Считаем базовые статсы предмета и таймер
+  //  формула для каждого умения отдельная
+  // Для числовых х-к:  х-ка+(skill - random(100))/20;
+  // Для флагов ???: random(200) - skill > 0 то флаг переноситься.
+  // Т.к. сделать мы можем практически любой предмет.
+  // Модифицируем вес предмета и его таймер.
+  // Для маг предметов надо в сторону облегчения.
 //	i = GET_OBJ_WEIGHT(obj);
-	switch(skill) {
-		case SKILL_MAKE_BOW:
-			obj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED);
-		break;
-		case SKILL_MAKE_WEAR:
-			obj->set_extra_flag(EExtraFlag::ITEM_NOT_DEPEND_RPOTO);
-			obj->set_extra_flag(EExtraFlag::ITEM_NOT_UNLIMIT_TIMER);
-		break;
-		default:
-		break;
-	}
-	int sign = -1;
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON
-		|| GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT)
-	{
-		sign = 1;
-	}
-	obj->set_weight(stat_modify(ch, GET_OBJ_WEIGHT(obj), 20 * sign));
+  switch (skill) {
+    case SKILL_MAKE_BOW: obj->set_extra_flag(EExtraFlag::ITEM_TRANSFORMED);
+      break;
+    case SKILL_MAKE_WEAR: obj->set_extra_flag(EExtraFlag::ITEM_NOT_DEPEND_RPOTO);
+      obj->set_extra_flag(EExtraFlag::ITEM_NOT_UNLIMIT_TIMER);
+      break;
+    default: break;
+  }
+  int sign = -1;
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON
+      || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT) {
+    sign = 1;
+  }
+  obj->set_weight(stat_modify(ch, GET_OBJ_WEIGHT(obj), 20 * sign));
 
-	i = obj->get_timer();
-	obj->set_timer(stat_modify(ch, obj->get_timer(), 1));
-	// Модифицируем уникальные для предметов х-ки.
-	// Балансировка варьируется изменением делителя (!20!)
-	// при делителе 20 и умении 100 и макс везении будет +5 к параметру
-	// Можно посчитать бонусы от времени суток.
-	// Считаем среднюю силу ингров .
-	switch (GET_OBJ_TYPE(obj))
-	{
-	case OBJ_DATA::ITEM_LIGHT:
-		// Считаем длительность свечения.
-		if (GET_OBJ_VAL(obj, 2) != -1)
-		{
-			obj->set_val(2, stat_modify(ch, GET_OBJ_VAL(obj, 2), 1));
-		}
-		break;
-	case OBJ_DATA::ITEM_WAND:
-	case OBJ_DATA::ITEM_STAFF:
-		// Считаем уровень закла
-		obj->set_val(0, GET_LEVEL(ch));
-		break;
-	case OBJ_DATA::ITEM_WEAPON:
-		// Считаем число xdy
-		// модифицируем XdY
-		if (GET_OBJ_VAL(obj, 1) > GET_OBJ_VAL(obj, 2))
-		{
-			obj->set_val(1, stat_modify(ch, GET_OBJ_VAL(obj, 1), 1));
-		}
-		else
-		{
-			obj->set_val(2, stat_modify(ch, GET_OBJ_VAL(obj, 2) - 1, 1) + 1);
-		}
-		break;
-	case OBJ_DATA::ITEM_ARMOR:
-	case OBJ_DATA::ITEM_ARMOR_LIGHT:
-	case OBJ_DATA::ITEM_ARMOR_MEDIAN:
-	case OBJ_DATA::ITEM_ARMOR_HEAVY:
-		// Считаем + АС
-		obj->set_val(0, stat_modify(ch, GET_OBJ_VAL(obj, 0), 1));
-		// Считаем поглощение.
-		obj->set_val(1, stat_modify(ch, GET_OBJ_VAL(obj, 1), 1));
-		break;
-	case OBJ_DATA::ITEM_POTION:
-		// Считаем уровень итоговый напитка
-		obj->set_val(0, stat_modify(ch, GET_OBJ_VAL(obj, 0), 1));
-		break;
-	case OBJ_DATA::ITEM_CONTAINER:
-		// Считаем объем контейнера.
-		obj->set_val(0, stat_modify(ch, GET_OBJ_VAL(obj, 0), 1));
-		break;
-	case OBJ_DATA::ITEM_DRINKCON:
-		// Считаем объем контейнера.
-		obj->set_val(0, stat_modify(ch, GET_OBJ_VAL(obj, 0), 1));
-		break;
-	case OBJ_DATA::ITEM_INGREDIENT:
-		// Для ингров ничего не трогаем ... ибо опасно. :)
-		break;
-	default:
-		break;
-	}
-	// 7. Считаем доп. статсы предмета.
-	// х-ка прототипа +
-	// если (random(100) - сила ингра ) < 1 то переноситься весь параметр.
-	// если от 1 до 25 то переноситься 1/2
-	// если от 25 до 50 то переноситься 1/3
-	// больше переноситься 0
-	// переносим доп аффекты ...+мудра +ловка и т.п.
-	if (skill == SKILL_MAKE_WEAR)
-	{
-		make_object(ch, obj.get(), ingrs, ingr_cnt );
-		make_value_wear(ch, obj.get(), ingrs);
-	}
-	else // если не шитье то никаких махинаций с падежами и копированием рандом аффекта
-	{
-		for (j = 0; j < ingr_cnt; j++)
-		{
-			ingr_pow = get_ingr_pow(ingrs[j]);
-			if (ingr_pow < 0)
-			{
-				ingr_pow = 20;
-			}
-			// переносим аффекты ... c ингров на прототип.
-			auto temp_flags = obj->get_affect_flags();
-			add_flags(ch, &temp_flags, &ingrs[j]->get_affect_flags(), ingr_pow);
-			obj->set_affect_flags(temp_flags);
-			temp_flags = obj->get_extra_flags();
-			// перносим эффекты ... с ингров на прототип.
-			add_flags(ch, &temp_flags, &GET_OBJ_EXTRA(ingrs[j]), ingr_pow);
-			obj->set_extra_flags(temp_flags);
-			auto temp_affected = obj->get_all_affected();
-			add_affects(ch, temp_affected, ingrs[j]->get_all_affected(), ingr_pow);
-			obj->set_all_affected(temp_affected);
-		}
-	}
-	// Мочим истраченные ингры.
-	for (i = 0; i < ingr_cnt; i++)
-	{
-		if (GET_OBJ_WEIGHT(ingrs[i]) <= 0)
-		{
-			extract_obj(ingrs[i]);
-		}
-	}
-	// 8. Проверяем мах. инворлд.
-	// Считаем по формуле (31 - ср. уровень предмета) * 5 -
-	// овер шмота в мире не 30 лева не больше 5 штук
-	// Т.к. ср. уровень ингров будет определять
-	// число шмоток в мире то шмотки по хуже будут вытеснять
-	// шмотки по лучше (в целом это не так страшно).
-	// Ставим метку если все хорошо.
-	if ((GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_INGREDIENT
-		&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_MING)
-		&& (number(1, 100) - calculate_skill(ch, skill, 0) < 0))
-	{
-		act(tagging.c_str(), FALSE, ch, obj.get(), 0, TO_CHAR);
-		// Прибавляем в экстра описание строчку.
-		char *tagchar = format_act(itemtag.c_str(), ch, obj.get(), 0);
-		obj->set_tag(tagchar);
-		free(tagchar);
-	};
-	// простановка мортов при шитье
-	float total_weight = count_mort_requred(obj.get()) * 7 / 10;
+  i = obj->get_timer();
+  obj->set_timer(stat_modify(ch, obj->get_timer(), 1));
+  // Модифицируем уникальные для предметов х-ки.
+  // Балансировка варьируется изменением делителя (!20!)
+  // при делителе 20 и умении 100 и макс везении будет +5 к параметру
+  // Можно посчитать бонусы от времени суток.
+  // Считаем среднюю силу ингров .
+  switch (GET_OBJ_TYPE(obj)) {
+    case OBJ_DATA::ITEM_LIGHT:
+      // Считаем длительность свечения.
+      if (GET_OBJ_VAL(obj, 2) != -1) {
+        obj->set_val(2, stat_modify(ch, GET_OBJ_VAL(obj, 2), 1));
+      }
+      break;
+    case OBJ_DATA::ITEM_WAND:
+    case OBJ_DATA::ITEM_STAFF:
+      // Считаем уровень закла
+      obj->set_val(0, GET_LEVEL(ch));
+      break;
+    case OBJ_DATA::ITEM_WEAPON:
+      // Считаем число xdy
+      // модифицируем XdY
+      if (GET_OBJ_VAL(obj, 1) > GET_OBJ_VAL(obj, 2)) {
+        obj->set_val(1, stat_modify(ch, GET_OBJ_VAL(obj, 1), 1));
+      } else {
+        obj->set_val(2, stat_modify(ch, GET_OBJ_VAL(obj, 2) - 1, 1) + 1);
+      }
+      break;
+    case OBJ_DATA::ITEM_ARMOR:
+    case OBJ_DATA::ITEM_ARMOR_LIGHT:
+    case OBJ_DATA::ITEM_ARMOR_MEDIAN:
+    case OBJ_DATA::ITEM_ARMOR_HEAVY:
+      // Считаем + АС
+      obj->set_val(0, stat_modify(ch, GET_OBJ_VAL(obj, 0), 1));
+      // Считаем поглощение.
+      obj->set_val(1, stat_modify(ch, GET_OBJ_VAL(obj, 1), 1));
+      break;
+    case OBJ_DATA::ITEM_POTION:
+      // Считаем уровень итоговый напитка
+      obj->set_val(0, stat_modify(ch, GET_OBJ_VAL(obj, 0), 1));
+      break;
+    case OBJ_DATA::ITEM_CONTAINER:
+      // Считаем объем контейнера.
+      obj->set_val(0, stat_modify(ch, GET_OBJ_VAL(obj, 0), 1));
+      break;
+    case OBJ_DATA::ITEM_DRINKCON:
+      // Считаем объем контейнера.
+      obj->set_val(0, stat_modify(ch, GET_OBJ_VAL(obj, 0), 1));
+      break;
+    case OBJ_DATA::ITEM_INGREDIENT:
+      // Для ингров ничего не трогаем ... ибо опасно. :)
+      break;
+    default: break;
+  }
+  // 7. Считаем доп. статсы предмета.
+  // х-ка прототипа +
+  // если (random(100) - сила ингра ) < 1 то переноситься весь параметр.
+  // если от 1 до 25 то переноситься 1/2
+  // если от 25 до 50 то переноситься 1/3
+  // больше переноситься 0
+  // переносим доп аффекты ...+мудра +ловка и т.п.
+  if (skill == SKILL_MAKE_WEAR) {
+    make_object(ch, obj.get(), ingrs, ingr_cnt);
+    make_value_wear(ch, obj.get(), ingrs);
+  } else // если не шитье то никаких махинаций с падежами и копированием рандом аффекта
+  {
+    for (j = 0; j < ingr_cnt; j++) {
+      ingr_pow = get_ingr_pow(ingrs[j]);
+      if (ingr_pow < 0) {
+        ingr_pow = 20;
+      }
+      // переносим аффекты ... c ингров на прототип.
+      auto temp_flags = obj->get_affect_flags();
+      add_flags(ch, &temp_flags, &ingrs[j]->get_affect_flags(), ingr_pow);
+      obj->set_affect_flags(temp_flags);
+      temp_flags = obj->get_extra_flags();
+      // перносим эффекты ... с ингров на прототип.
+      add_flags(ch, &temp_flags, &GET_OBJ_EXTRA(ingrs[j]), ingr_pow);
+      obj->set_extra_flags(temp_flags);
+      auto temp_affected = obj->get_all_affected();
+      add_affects(ch, temp_affected, ingrs[j]->get_all_affected(), ingr_pow);
+      obj->set_all_affected(temp_affected);
+    }
+  }
+  // Мочим истраченные ингры.
+  for (i = 0; i < ingr_cnt; i++) {
+    if (GET_OBJ_WEIGHT(ingrs[i]) <= 0) {
+      extract_obj(ingrs[i]);
+    }
+  }
+  // 8. Проверяем мах. инворлд.
+  // Считаем по формуле (31 - ср. уровень предмета) * 5 -
+  // овер шмота в мире не 30 лева не больше 5 штук
+  // Т.к. ср. уровень ингров будет определять
+  // число шмоток в мире то шмотки по хуже будут вытеснять
+  // шмотки по лучше (в целом это не так страшно).
+  // Ставим метку если все хорошо.
+  if ((GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_INGREDIENT
+      && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_MING)
+      && (number(1, 100) - calculate_skill(ch, skill, 0) < 0)) {
+    act(tagging.c_str(), FALSE, ch, obj.get(), 0, TO_CHAR);
+    // Прибавляем в экстра описание строчку.
+    char *tagchar = format_act(itemtag.c_str(), ch, obj.get(), 0);
+    obj->set_tag(tagchar);
+    free(tagchar);
+  };
+  // простановка мортов при шитье
+  float total_weight = count_mort_requred(obj.get()) * 7 / 10;
 
-	if (total_weight > 35)
-	{
-		obj->set_minimum_remorts(12);
-	}
-	else if (total_weight > 33)
-	{
-		obj->set_minimum_remorts(11);
-	}
-	else if (total_weight > 30)
-	{
-		obj->set_minimum_remorts(9);
-	}
-	else if (total_weight > 25)
-	{
-		obj->set_minimum_remorts(6);
-	}
-	else if (total_weight > 20)
-	{
-		obj->set_minimum_remorts(3);
-	}
-	else
-	{
-		obj->set_minimum_remorts(0);
-	}
+  if (total_weight > 35) {
+    obj->set_minimum_remorts(12);
+  } else if (total_weight > 33) {
+    obj->set_minimum_remorts(11);
+  } else if (total_weight > 30) {
+    obj->set_minimum_remorts(9);
+  } else if (total_weight > 25) {
+    obj->set_minimum_remorts(6);
+  } else if (total_weight > 20) {
+    obj->set_minimum_remorts(3);
+  } else {
+    obj->set_minimum_remorts(0);
+  }
 
-	// Пишем производителя в поле.
-	obj->set_crafter_uid(GET_UNIQUE(ch));
-	// 9. Проверяем минимум 2
-	if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch))
-	{
-		send_to_char("Вы не сможете унести столько предметов.\r\n", ch);
-		obj_to_room(obj.get(), ch->in_room);
-	}
-	else if (IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(obj) > CAN_CARRY_W(ch))
-	{
-		send_to_char("Вы не сможете унести такой вес.\r\n", ch);
-		obj_to_room(obj.get(), ch->in_room);
-	}
-	else
-	{
-		obj_to_char(obj.get(), ch);
-	}
-	return (TRUE);
+  // Пишем производителя в поле.
+  obj->set_crafter_uid(GET_UNIQUE(ch));
+  // 9. Проверяем минимум 2
+  if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch)) {
+    send_to_char("Вы не сможете унести столько предметов.\r\n", ch);
+    obj_to_room(obj.get(), ch->in_room);
+  } else if (IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(obj) > CAN_CARRY_W(ch)) {
+    send_to_char("Вы не сможете унести такой вес.\r\n", ch);
+    obj_to_room(obj.get(), ch->in_room);
+  } else {
+    obj_to_char(obj.get(), ch);
+  }
+  return (TRUE);
 }
 // вытащить рецепт из строки.
-int MakeRecept::load_from_str(string & rstr)
-{
-	// Разбираем строку.
-	char tmpbuf[MAX_INPUT_LENGTH];
-	// Проверяем рецепт на блокировку .
-	if (rstr.substr(0, 1) == string("*"))
-	{
-		rstr = rstr.substr(1);
-		locked = true;
-	}
-	else
-	{
-		locked = false;
-	}
-	skill = static_cast<ESkill>(atoi(rstr.substr(0, rstr.find(" ")).c_str()));
-	rstr = rstr.substr(rstr.find(" ") + 1);
-	obj_proto = atoi((rstr.substr(0, rstr.find(" "))).c_str());
-	rstr = rstr.substr(rstr.find(" ") + 1);
+int MakeRecept::load_from_str(string &rstr) {
+  // Разбираем строку.
+  char tmpbuf[MAX_INPUT_LENGTH];
+  // Проверяем рецепт на блокировку .
+  if (rstr.substr(0, 1) == string("*")) {
+    rstr = rstr.substr(1);
+    locked = true;
+  } else {
+    locked = false;
+  }
+  skill = static_cast<ESkill>(atoi(rstr.substr(0, rstr.find(" ")).c_str()));
+  rstr = rstr.substr(rstr.find(" ") + 1);
+  obj_proto = atoi((rstr.substr(0, rstr.find(" "))).c_str());
+  rstr = rstr.substr(rstr.find(" ") + 1);
 
-	if (real_object(obj_proto) < 0)
-	{
-		// Обнаружен несуществующий прототип объекта.
-		sprintf(tmpbuf, "MakeRecept::Unfound object proto %d", obj_proto);
-		mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
-		// блокируем рецепты без ингров.
-		locked = true;
-	}
+  if (real_object(obj_proto) < 0) {
+    // Обнаружен несуществующий прототип объекта.
+    sprintf(tmpbuf, "MakeRecept::Unfound object proto %d", obj_proto);
+    mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
+    // блокируем рецепты без ингров.
+    locked = true;
+  }
 
-	for (int i = 0; i < MAX_PARTS; i++)
-	{
-		// считали номер прототипа компонента
-		parts[i].proto = atoi((rstr.substr(0, rstr.find(" "))).c_str());
-		rstr = rstr.substr(rstr.find(" ") + 1);
-		// Проверяем на конец компонентов.
-		if (parts[i].proto == 0)
-		{
-			break;
-		}
-		if (real_object(parts[i].proto) < 0)
-		{
-			// Обнаружен несуществующий прототип компонента.
-			sprintf(tmpbuf, "MakeRecept::Unfound item part %d for %d", obj_proto, parts[i].proto);
-			mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
-			// блокируем рецепты без ингров.
-			locked = true;
-		}
-		parts[i].min_weight = atoi(rstr.substr(0, rstr.find(" ")).c_str());
-		rstr = rstr.substr(rstr.find(" ") + 1);
-		parts[i].min_power = atoi(rstr.substr(0, rstr.find(" ")).c_str());
-		rstr = rstr.substr(rstr.find(" ") + 1);
-	}
-	return (TRUE);
+  for (int i = 0; i < MAX_PARTS; i++) {
+    // считали номер прототипа компонента
+    parts[i].proto = atoi((rstr.substr(0, rstr.find(" "))).c_str());
+    rstr = rstr.substr(rstr.find(" ") + 1);
+    // Проверяем на конец компонентов.
+    if (parts[i].proto == 0) {
+      break;
+    }
+    if (real_object(parts[i].proto) < 0) {
+      // Обнаружен несуществующий прототип компонента.
+      sprintf(tmpbuf, "MakeRecept::Unfound item part %d for %d", obj_proto, parts[i].proto);
+      mudlog(tmpbuf, LGH, LVL_IMMORT, SYSLOG, TRUE);
+      // блокируем рецепты без ингров.
+      locked = true;
+    }
+    parts[i].min_weight = atoi(rstr.substr(0, rstr.find(" ")).c_str());
+    rstr = rstr.substr(rstr.find(" ") + 1);
+    parts[i].min_power = atoi(rstr.substr(0, rstr.find(" ")).c_str());
+    rstr = rstr.substr(rstr.find(" ") + 1);
+  }
+  return (TRUE);
 }
 // сохранить рецепт в строку.
-int MakeRecept::save_to_str(string & rstr)
-{
-	char tmpstr[MAX_INPUT_LENGTH];
-	if (obj_proto == 0)
-	{
-		return (FALSE);
-	}
-	if (locked)
-	{
-		rstr = "*";
-	}
-	else
-	{
-		rstr = "";
-	}
-	sprintf(tmpstr, "%d %d", skill, obj_proto);
-	rstr += string(tmpstr);
-	for (int i = 0; i < MAX_PARTS; i++)
-	{
-		sprintf(tmpstr, " %d %d %d", parts[i].proto, parts[i].min_weight, parts[i].min_power);
-		rstr += string(tmpstr);
-	}
-	return (TRUE);
+int MakeRecept::save_to_str(string &rstr) {
+  char tmpstr[MAX_INPUT_LENGTH];
+  if (obj_proto == 0) {
+    return (FALSE);
+  }
+  if (locked) {
+    rstr = "*";
+  } else {
+    rstr = "";
+  }
+  sprintf(tmpstr, "%d %d", skill, obj_proto);
+  rstr += string(tmpstr);
+  for (int i = 0; i < MAX_PARTS; i++) {
+    sprintf(tmpstr, " %d %d %d", parts[i].proto, parts[i].min_weight, parts[i].min_power);
+    rstr += string(tmpstr);
+  }
+  return (TRUE);
 }
 // Модификатор базовых значений.
-int MakeRecept::stat_modify(CHAR_DATA * ch, int value, float devider)
-{
-	// Для числовых х-к:  х-ка+(skill - random(100))/20;
-	// Для флагов ???: random(200) - skill > 0 то флаг переноситься.
-	int res = value;
-	float delta = 0;
-	int skill_prc = 0;
-	if (devider <= 0)
-	{
-		return res;
-	}
-	skill_prc = calculate_skill(ch, skill, 0);
-	delta = (int)((float)(skill_prc - number(0, skill_info[skill].max_percent)));
-	if (delta > 0)
-	{
-		delta = (value / 2) * delta / skill_info[skill].max_percent / devider;
-	}
-	else
-	{
-		delta = (value / 4) * delta / skill_info[skill].max_percent / devider;
-	}
-	res += (int) delta;
-	// Если параметр завалили то возвращаем 1;
-	if (res < 0)
-	{
-		return 1;
-	}
-	return res;
+int MakeRecept::stat_modify(CHAR_DATA *ch, int value, float devider) {
+  // Для числовых х-к:  х-ка+(skill - random(100))/20;
+  // Для флагов ???: random(200) - skill > 0 то флаг переноситься.
+  int res = value;
+  float delta = 0;
+  int skill_prc = 0;
+  if (devider <= 0) {
+    return res;
+  }
+  skill_prc = calculate_skill(ch, skill, 0);
+  delta = (int) ((float) (skill_prc - number(0, skill_info[skill].max_percent)));
+  if (delta > 0) {
+    delta = (value / 2) * delta / skill_info[skill].max_percent / devider;
+  } else {
+    delta = (value / 4) * delta / skill_info[skill].max_percent / devider;
+  }
+  res += (int) delta;
+  // Если параметр завалили то возвращаем 1;
+  if (res < 0) {
+    return 1;
+  }
+  return res;
 }
-void MakeRecept::add_rnd_skills(CHAR_DATA* /*ch*/, OBJ_DATA * obj_from, OBJ_DATA *obj_to)
-{
-	if (obj_from->has_skills())
-	{
-		int skill_num, rskill;
-		int z = 0;
-		int percent;
+void MakeRecept::add_rnd_skills(CHAR_DATA * /*ch*/, OBJ_DATA *obj_from, OBJ_DATA *obj_to) {
+  if (obj_from->has_skills()) {
+    int skill_num, rskill;
+    int z = 0;
+    int percent;
 //		send_to_char("Копирую умения :\r\n", ch);
-		CObjectPrototype::skills_t skills;
-		obj_from->get_skills(skills);
-		int i = static_cast<int>(skills.size()); // сколько добавлено умелок
-		rskill = number(0, i); // берем рандом
+    CObjectPrototype::skills_t skills;
+    obj_from->get_skills(skills);
+    int i = static_cast<int>(skills.size()); // сколько добавлено умелок
+    rskill = number(0, i); // берем рандом
 //		sprintf(buf, "Всего умений %d копируем из них случайное под N %d.\r\n", i, rskill);
 //		send_to_char(buf,  ch);
-		for (const auto& it : skills)
-		{
-			if (z == rskill) // ставим рандомную умелку
-			{
-				skill_num = it.first;
-				percent = it.second;
-				if (percent == 0) // TODO: такого не должно быть?
-				{
-					continue;
-				}
+    for (const auto &it : skills) {
+      if (z == rskill) // ставим рандомную умелку
+      {
+        skill_num = it.first;
+        percent = it.second;
+        if (percent == 0) // TODO: такого не должно быть?
+        {
+          continue;
+        }
 //				sprintf(buf, "   %s%s%s%s%s%d%%%s\r\n",
 //				CCCYN(ch, C_NRM), skill_info[skill_num].name, CCNRM(ch, C_NRM),
 //				CCCYN(ch, C_NRM),
 //				percent < 0 ? " ухудшает на " : " улучшает на ", abs(percent), CCNRM(ch, C_NRM));
 //				send_to_char(buf, ch);
-				obj_to->set_skill(skill_num, percent);// копируем скиллы
-			}
-			z++;
-		}
-	}
+        obj_to->set_skill(skill_num, percent);// копируем скиллы
+      }
+      z++;
+    }
+  }
 }
-int MakeRecept::add_flags(CHAR_DATA * ch, FLAG_DATA * base_flag, const FLAG_DATA* add_flag, int/* delta*/)
-{
+int MakeRecept::add_flags(CHAR_DATA *ch, FLAG_DATA *base_flag, const FLAG_DATA *add_flag, int/* delta*/) {
 // БЕз вариантов вообще :(
-	int tmpprob;
-	for (int i = 0; i < 3; i++)
-	{
-		for (int j = 0; j < 32; j++)
-		{
-			tmpprob = number(0, 200) - calculate_skill(ch, skill, 0);
-			if ((add_flag->get_plane(i) & (1 << j)) && (tmpprob < 0))
-			{
-				base_flag->set_flag(i, 1 << j);
-			}
-		}
-	}
-	return (TRUE);
+  int tmpprob;
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 32; j++) {
+      tmpprob = number(0, 200) - calculate_skill(ch, skill, 0);
+      if ((add_flag->get_plane(i) & (1 << j)) && (tmpprob < 0)) {
+        base_flag->set_flag(i, 1 << j);
+      }
+    }
+  }
+  return (TRUE);
 }
-int MakeRecept::add_affects(CHAR_DATA * ch, std::array<obj_affected_type, MAX_OBJ_AFFECT>& base, const std::array<obj_affected_type, MAX_OBJ_AFFECT>& add, int delta)
-{
-	bool found = false;
-	int i, j;
-	for (i = 0; i < MAX_OBJ_AFFECT; i++)
-	{
-		found = false;
-		if (add[i].location == APPLY_NONE)
-			continue;
-		for (j = 0; j < MAX_OBJ_AFFECT; j++)
-		{
-			if (base[j].location == APPLY_NONE)
-				continue;
-			if (add[i].location == base[j].location)
-			{
-				// Аффекты совпали.
-				found = true;
-				if (number(0, 100) > delta)
-					break;
-				base[j].modifier += stat_modify(ch, add[i].modifier, 1);
-				break;
-			}
-		}
-		if (!found)
-		{
-			// Ищем первый свободный аффект и втыкаем туда новый.
-			for (int j = 0; j < MAX_OBJ_AFFECT; j++)
-			{
-				if (base[j].location == APPLY_NONE)
-				{
-					if (number(0, 100) > delta)
-						break;
-					base[j].location = add[i].location;
-					base[j].modifier += add[i].modifier;
-					//cout << "add affect " << int(base[j].location) <<" - " << int(base[j].modifier) << endl;
-					break;
-				}
-			}
-		}
-	}
-	return (TRUE);
+int MakeRecept::add_affects(CHAR_DATA *ch,
+                            std::array<obj_affected_type, MAX_OBJ_AFFECT> &base,
+                            const std::array<obj_affected_type, MAX_OBJ_AFFECT> &add,
+                            int delta) {
+  bool found = false;
+  int i, j;
+  for (i = 0; i < MAX_OBJ_AFFECT; i++) {
+    found = false;
+    if (add[i].location == APPLY_NONE)
+      continue;
+    for (j = 0; j < MAX_OBJ_AFFECT; j++) {
+      if (base[j].location == APPLY_NONE)
+        continue;
+      if (add[i].location == base[j].location) {
+        // Аффекты совпали.
+        found = true;
+        if (number(0, 100) > delta)
+          break;
+        base[j].modifier += stat_modify(ch, add[i].modifier, 1);
+        break;
+      }
+    }
+    if (!found) {
+      // Ищем первый свободный аффект и втыкаем туда новый.
+      for (int j = 0; j < MAX_OBJ_AFFECT; j++) {
+        if (base[j].location == APPLY_NONE) {
+          if (number(0, 100) > delta)
+            break;
+          base[j].location = add[i].location;
+          base[j].modifier += add[i].modifier;
+          //cout << "add affect " << int(base[j].location) <<" - " << int(base[j].modifier) << endl;
+          break;
+        }
+      }
+    }
+  }
+  return (TRUE);
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/liquid.cpp
+++ b/src/liquid.cpp
@@ -24,7 +24,7 @@
 
 #include <cmath>
 
-extern void weight_change_object(OBJ_DATA * obj, int weight);
+extern void weight_change_object(OBJ_DATA *obj, int weight);
 
 // виды жидскостей, наливаемых в контейнеры
 const int LIQ_WATER = 0;
@@ -58,960 +58,862 @@ const int LIQ_POISON_BELENA = 27;
 const int LIQ_POISON_DATURA = 28;
 // терминатор
 const int NUM_LIQ_TYPES = 29;
-const char *diag_liquid_timer(const OBJ_DATA * obj);
+const char *diag_liquid_timer(const OBJ_DATA *obj);
 
 // LIQ_x
-const char *drinks[] = { "воды",
-						 "пива",
-						 "вина",
-						 "медовухи",
-						 "кваса",
-						 "самогона",
-						 "морсу",
-						 "водки",
-						 "браги",
-						 "меду",
-						 "молока",
-						 "чаю",
-						 "кофею",
-						 "КРОВИ",
-						 "соленой воды",
-						 "родниковой воды",
-						 "колдовского зелья",
-						 "красного колдовского зелья",
-						 "синего колдовского зелья",
-						 "белого колдовского зелья",
-						 "золотистого колдовского зелья",
-						 "черного колдовского зелья",
-						 "серого колдовского зелья",
-						 "фиолетового колдовского зелья",
-						 "розового колдовского зелья",
-						 "настойки аконита",
-						 "настойки скополии",
-						 "настойки белены",
-						 "настойки дурмана",
-						 "\n"
-					   };
+const char *drinks[] = {"воды",
+                        "пива",
+                        "вина",
+                        "медовухи",
+                        "кваса",
+                        "самогона",
+                        "морсу",
+                        "водки",
+                        "браги",
+                        "меду",
+                        "молока",
+                        "чаю",
+                        "кофею",
+                        "КРОВИ",
+                        "соленой воды",
+                        "родниковой воды",
+                        "колдовского зелья",
+                        "красного колдовского зелья",
+                        "синего колдовского зелья",
+                        "белого колдовского зелья",
+                        "золотистого колдовского зелья",
+                        "черного колдовского зелья",
+                        "серого колдовского зелья",
+                        "фиолетового колдовского зелья",
+                        "розового колдовского зелья",
+                        "настойки аконита",
+                        "настойки скополии",
+                        "настойки белены",
+                        "настойки дурмана",
+                        "\n"
+};
 
 // one-word alias for each drink
-const char *drinknames[] = { "водой",
-							 "пивом",
-							 "вином",
-							 "медовухой",
-							 "квасом",
-							 "самогоном",
-							 "морсом",
-							 "водкой",
-							 "брагой",
-							 "медом",
-							 "молоком",
-							 "чаем",
-							 "кофе",
-							 "КРОВЬЮ",
-							 "соленой водой",
-							 "родниковой водой",
-							 "колдовским зельем",
-							 "красным колдовским зельем",
-							 "синим колдовским зельем",
-							 "белым колдовским зельем",
-							 "золотистым колдовским зельем",
-							 "черным колдовским зельем",
-							 "серым колдовским зельем",
-							 "фиолетовым колдовским зельем",
-							 "розовым колдовским зельем",
-							 "настойкой аконита",
-							 "настойкой скополии",
-							 "настойкой белены",
-							 "настойкой дурмана",
-							 "\n"
-						   };
+const char *drinknames[] = {"водой",
+                            "пивом",
+                            "вином",
+                            "медовухой",
+                            "квасом",
+                            "самогоном",
+                            "морсом",
+                            "водкой",
+                            "брагой",
+                            "медом",
+                            "молоком",
+                            "чаем",
+                            "кофе",
+                            "КРОВЬЮ",
+                            "соленой водой",
+                            "родниковой водой",
+                            "колдовским зельем",
+                            "красным колдовским зельем",
+                            "синим колдовским зельем",
+                            "белым колдовским зельем",
+                            "золотистым колдовским зельем",
+                            "черным колдовским зельем",
+                            "серым колдовским зельем",
+                            "фиолетовым колдовским зельем",
+                            "розовым колдовским зельем",
+                            "настойкой аконита",
+                            "настойкой скополии",
+                            "настойкой белены",
+                            "настойкой дурмана",
+                            "\n"
+};
 
 // effect of drinks on DRUNK, FULL, THIRST -- see values.doc
 const int drink_aff[][3] = {
-	{0, 1, -10},	        // вода
-	{2, -2, -3},			// пиво
-	{5, -2, -2},			// вино
-	{3, -2, -3},			// медовуха
-	{1, -2, -5},			// квас
-	{8,  0, 4},				// самогон (как и водка сушит, никак не влияет на голод можно пить хоть залейся, только запивать успевай)
-	{0, -1, -8},			// морс
-	{10, 0, 3},			    // водка (водка не питье! после нее обезвоживание, пить можно сколько угодно, но сушняк будет)
-	{3, -3, -3},			// брага
-	{0, -2, -8},			// мед (мед тоже ж калорийный)
-	{0, -3, -6},			// молоко
-	{0, -1, -6},			// чай
-	{0, -1, -6},			// кофе
-	{0, -2, 1},			// кровь
-	{0, -1, 2},			// соленая вода
-	{0, 0, -13},			// родниковая вода
-	{0, -1, 1},			// магическое зелье
-	{0, -1, 1},			// красное магическое зелье
-	{0, -1, 1},			// синее магическое зелье
-	{0, -1, 1},			// белое магическое зелье
-	{0, -1, 1},			// золотистое магическое зелье
-	{0, -1, 1},			// черное магическое зелье
-	{0, -1, 1},			// серое магическое зелье
-	{0, -1, 1},			// фиолетовое магическое зелье
-	{0, -1, 1},			// розовое магическое зелье
-	{0, 0, 0},			// настойка аконита
-	{0, 0, 0},			// настойка скополии
-	{0, 0, 0},			// настойка белены
-	{0, 0, 0}			// настойка дурмана
+    {0, 1, -10},            // вода
+    {2, -2, -3},            // пиво
+    {5, -2, -2},            // вино
+    {3, -2, -3},            // медовуха
+    {1, -2, -5},            // квас
+    {8, 0,
+     4},                // самогон (как и водка сушит, никак не влияет на голод можно пить хоть залейся, только запивать успевай)
+    {0, -1, -8},            // морс
+    {10, 0,
+     3},                // водка (водка не питье! после нее обезвоживание, пить можно сколько угодно, но сушняк будет)
+    {3, -3, -3},            // брага
+    {0, -2, -8},            // мед (мед тоже ж калорийный)
+    {0, -3, -6},            // молоко
+    {0, -1, -6},            // чай
+    {0, -1, -6},            // кофе
+    {0, -2, 1},            // кровь
+    {0, -1, 2},            // соленая вода
+    {0, 0, -13},            // родниковая вода
+    {0, -1, 1},            // магическое зелье
+    {0, -1, 1},            // красное магическое зелье
+    {0, -1, 1},            // синее магическое зелье
+    {0, -1, 1},            // белое магическое зелье
+    {0, -1, 1},            // золотистое магическое зелье
+    {0, -1, 1},            // черное магическое зелье
+    {0, -1, 1},            // серое магическое зелье
+    {0, -1, 1},            // фиолетовое магическое зелье
+    {0, -1, 1},            // розовое магическое зелье
+    {0, 0, 0},            // настойка аконита
+    {0, 0, 0},            // настойка скополии
+    {0, 0, 0},            // настойка белены
+    {0, 0, 0}            // настойка дурмана
 };
 
 // color of the various drinks
-const char *color_liquid[] = { "прозрачной",
-							   "коричневой",
-							   "бордовой",
-							   "золотистой",
-							   "бурой",
-							   "прозрачной",
-							   "рубиновой",
-							   "зеленой",
-							   "чистой",
-							   "светло зеленой",
-							   "белой",
-							   "коричневой",
-							   "темно-коричневой",
-							   "красной",
-							   "прозрачной",
-							   "кристально чистой",
-							   "искрящейся",
-							   "бордовой",
-							   "лазурной",
-							   "серебристой",
-							   "золотистой",
-							   "черной вязкой",
-							   "бесцветной",
-							   "фиолетовой",
-							   "розовой",
-							   "ядовитой",
-							   "ядовитой",
-							   "ядовитой",
-							   "ядовитой",
-							   "\n"
-							 };
+const char *color_liquid[] = {"прозрачной",
+                              "коричневой",
+                              "бордовой",
+                              "золотистой",
+                              "бурой",
+                              "прозрачной",
+                              "рубиновой",
+                              "зеленой",
+                              "чистой",
+                              "светло зеленой",
+                              "белой",
+                              "коричневой",
+                              "темно-коричневой",
+                              "красной",
+                              "прозрачной",
+                              "кристально чистой",
+                              "искрящейся",
+                              "бордовой",
+                              "лазурной",
+                              "серебристой",
+                              "золотистой",
+                              "черной вязкой",
+                              "бесцветной",
+                              "фиолетовой",
+                              "розовой",
+                              "ядовитой",
+                              "ядовитой",
+                              "ядовитой",
+                              "ядовитой",
+                              "\n"
+};
 
 /**
 * Зелья, перелитые в контейнеры, можно пить во время боя.
 * На случай, когда придется добавлять еще пошенов, которые
 * уже будут идти не подряд по номерам.
 */
-bool is_potion(const OBJ_DATA *obj)
-{
-	switch(GET_OBJ_VAL(obj, 2))
-	{
-	case LIQ_POTION:
-	case LIQ_POTION_RED:
-	case LIQ_POTION_BLUE:
-	case LIQ_POTION_WHITE:
-	case LIQ_POTION_GOLD:
-	case LIQ_POTION_BLACK:
-	case LIQ_POTION_GREY:
-	case LIQ_POTION_FUCHSIA:
-	case LIQ_POTION_PINK:
-		return true;
-		break;
-	}
-	return false;
+bool is_potion(const OBJ_DATA *obj) {
+  switch (GET_OBJ_VAL(obj, 2)) {
+    case LIQ_POTION:
+    case LIQ_POTION_RED:
+    case LIQ_POTION_BLUE:
+    case LIQ_POTION_WHITE:
+    case LIQ_POTION_GOLD:
+    case LIQ_POTION_BLACK:
+    case LIQ_POTION_GREY:
+    case LIQ_POTION_FUCHSIA:
+    case LIQ_POTION_PINK: return true;
+      break;
+  }
+  return false;
 }
 
-namespace drinkcon
-{
+namespace drinkcon {
 
-ObjVal::EValueKey init_spell_num(int num)
-{
-	return num == 1
-		? ObjVal::EValueKey::POTION_SPELL1_NUM
-		: (num == 2
-			? ObjVal::EValueKey::POTION_SPELL2_NUM
-			: ObjVal::EValueKey::POTION_SPELL3_NUM);
+ObjVal::EValueKey init_spell_num(int num) {
+  return num == 1
+         ? ObjVal::EValueKey::POTION_SPELL1_NUM
+         : (num == 2
+            ? ObjVal::EValueKey::POTION_SPELL2_NUM
+            : ObjVal::EValueKey::POTION_SPELL3_NUM);
 }
 
-ObjVal::EValueKey init_spell_lvl(int num)
-{
-	return num == 1
-		? ObjVal::EValueKey::POTION_SPELL1_LVL
-		: (num == 2
-			? ObjVal::EValueKey::POTION_SPELL2_LVL
-			: ObjVal::EValueKey::POTION_SPELL3_LVL);
+ObjVal::EValueKey init_spell_lvl(int num) {
+  return num == 1
+         ? ObjVal::EValueKey::POTION_SPELL1_LVL
+         : (num == 2
+            ? ObjVal::EValueKey::POTION_SPELL2_LVL
+            : ObjVal::EValueKey::POTION_SPELL3_LVL);
 }
 
-void reset_potion_values(CObjectPrototype *obj)
-{
-	obj->set_value(ObjVal::EValueKey::POTION_SPELL1_NUM, -1);
-	obj->set_value(ObjVal::EValueKey::POTION_SPELL1_LVL, -1);
-	obj->set_value(ObjVal::EValueKey::POTION_SPELL2_NUM, -1);
-	obj->set_value(ObjVal::EValueKey::POTION_SPELL2_LVL, -1);
-	obj->set_value(ObjVal::EValueKey::POTION_SPELL3_NUM, -1);
-	obj->set_value(ObjVal::EValueKey::POTION_SPELL3_LVL, -1);
-	obj->set_value(ObjVal::EValueKey::POTION_PROTO_VNUM, -1);
+void reset_potion_values(CObjectPrototype *obj) {
+  obj->set_value(ObjVal::EValueKey::POTION_SPELL1_NUM, -1);
+  obj->set_value(ObjVal::EValueKey::POTION_SPELL1_LVL, -1);
+  obj->set_value(ObjVal::EValueKey::POTION_SPELL2_NUM, -1);
+  obj->set_value(ObjVal::EValueKey::POTION_SPELL2_LVL, -1);
+  obj->set_value(ObjVal::EValueKey::POTION_SPELL3_NUM, -1);
+  obj->set_value(ObjVal::EValueKey::POTION_SPELL3_LVL, -1);
+  obj->set_value(ObjVal::EValueKey::POTION_PROTO_VNUM, -1);
 }
 
 /// уровень в зельях (GET_OBJ_VAL(from_obj, 0)) пока один на все заклы
-bool copy_value(const CObjectPrototype *from_obj, CObjectPrototype *to_obj, int num)
-{
-	if (GET_OBJ_VAL(from_obj, num) > 0)
-	{
-		to_obj->set_value(init_spell_num(num), GET_OBJ_VAL(from_obj, num));
-		to_obj->set_value(init_spell_lvl(num), GET_OBJ_VAL(from_obj, 0));
-		return true;
-	}
-	return false;
+bool copy_value(const CObjectPrototype *from_obj, CObjectPrototype *to_obj, int num) {
+  if (GET_OBJ_VAL(from_obj, num) > 0) {
+    to_obj->set_value(init_spell_num(num), GET_OBJ_VAL(from_obj, num));
+    to_obj->set_value(init_spell_lvl(num), GET_OBJ_VAL(from_obj, 0));
+    return true;
+  }
+  return false;
 }
 
 /// заполнение values емкости (to_obj) из зелья (from_obj)
-void copy_potion_values(const CObjectPrototype *from_obj, CObjectPrototype *to_obj)
-{
-	reset_potion_values(to_obj);
-	bool copied = false;
+void copy_potion_values(const CObjectPrototype *from_obj, CObjectPrototype *to_obj) {
+  reset_potion_values(to_obj);
+  bool copied = false;
 
-	for (int i = 1; i <= 3; ++i)
-	{
-		if (copy_value(from_obj, to_obj, i))
-		{
-			copied = true;
-		}
-	}
+  for (int i = 1; i <= 3; ++i) {
+    if (copy_value(from_obj, to_obj, i)) {
+      copied = true;
+    }
+  }
 
-	if (copied)
-	{
-		to_obj->set_value(ObjVal::EValueKey::POTION_PROTO_VNUM, GET_OBJ_VNUM(from_obj));
-	}
+  if (copied) {
+    to_obj->set_value(ObjVal::EValueKey::POTION_PROTO_VNUM, GET_OBJ_VNUM(from_obj));
+  }
 }
 
 } // namespace drinkcon
 
 using namespace drinkcon;
 
-int cast_potion_spell(CHAR_DATA *ch, OBJ_DATA *obj, int num)
-{
-	const int spell = obj->get_value(init_spell_num(num));
-	const int level = obj->get_value(init_spell_lvl(num));
+int cast_potion_spell(CHAR_DATA *ch, OBJ_DATA *obj, int num) {
+  const int spell = obj->get_value(init_spell_num(num));
+  const int level = obj->get_value(init_spell_lvl(num));
 
-	if (spell >= 0 && level >= 0)
-	{
-		return call_magic(ch, ch, NULL, world[ch->in_room], spell, level);
-	}
-	return 1;
+  if (spell >= 0 && level >= 0) {
+    return call_magic(ch, ch, NULL, world[ch->in_room], spell, level);
+  }
+  return 1;
 }
 
 // Выпил яду
-void do_drink_poison (CHAR_DATA *ch, OBJ_DATA *jar,int amount) {
-	if ((GET_OBJ_VAL(jar, 3) == 1) && !IS_GOD(ch))
-	{
-		send_to_char("Что-то вкус какой-то странный!\r\n", ch);
-		act("$n поперхнул$u и закашлял$g.", TRUE, ch, 0, 0, TO_ROOM);
-		AFFECT_DATA<EApplyLocation> af;
-		af.type = SPELL_POISON;
-		//если объем 0 -
-		af.duration = pc_duration(ch, amount == 0 ? 3 : amount==1 ? amount : amount * 3, 0, 0, 0, 0);
-		af.modifier = -2;
-		af.location = APPLY_STR;
-		af.bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af.battleflag = AF_SAME_TIME;
-		affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-		af.type = SPELL_POISON;
-		af.modifier = amount == 0? GET_LEVEL(ch) * 3 : amount * 3;
-		af.location = APPLY_POISON;
-		af.bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af.battleflag = AF_SAME_TIME;
-		affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-		ch->Poisoner = 0;
-	}
+void do_drink_poison(CHAR_DATA *ch, OBJ_DATA *jar, int amount) {
+  if ((GET_OBJ_VAL(jar, 3) == 1) && !IS_GOD(ch)) {
+    send_to_char("Что-то вкус какой-то странный!\r\n", ch);
+    act("$n поперхнул$u и закашлял$g.", TRUE, ch, 0, 0, TO_ROOM);
+    AFFECT_DATA<EApplyLocation> af;
+    af.type = SPELL_POISON;
+    //если объем 0 -
+    af.duration = pc_duration(ch, amount == 0 ? 3 : amount == 1 ? amount : amount * 3, 0, 0, 0, 0);
+    af.modifier = -2;
+    af.location = APPLY_STR;
+    af.bitvector = to_underlying(EAffectFlag::AFF_POISON);
+    af.battleflag = AF_SAME_TIME;
+    affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+    af.type = SPELL_POISON;
+    af.modifier = amount == 0 ? GET_LEVEL(ch) * 3 : amount * 3;
+    af.location = APPLY_POISON;
+    af.bitvector = to_underlying(EAffectFlag::AFF_POISON);
+    af.battleflag = AF_SAME_TIME;
+    affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+    ch->Poisoner = 0;
+  }
 }
 
-int cast_potion(CHAR_DATA *ch, OBJ_DATA *jar)
-{
-	// Added by Adept - обкаст если в фонтане или емкости зелье
-	if (is_potion(jar) && jar->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM) >= 0)
-	{
-		act("$n выпил$g зелья из $o1.", TRUE, ch, jar, 0, TO_ROOM);
-		send_to_char(ch, "Вы выпили зелья из %s.\r\n", OBJN(jar, ch, 1));
+int cast_potion(CHAR_DATA *ch, OBJ_DATA *jar) {
+  // Added by Adept - обкаст если в фонтане или емкости зелье
+  if (is_potion(jar) && jar->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM) >= 0) {
+    act("$n выпил$g зелья из $o1.", TRUE, ch, jar, 0, TO_ROOM);
+    send_to_char(ch, "Вы выпили зелья из %s.\r\n", OBJN(jar, ch, 1));
 
-		//не очень понятно, но так было
-		for (int i = 1; i <= 3; ++i)
-			if (cast_potion_spell(ch, jar, i) <= 0)
-				break;
+    //не очень понятно, но так было
+    for (int i = 1; i <= 3; ++i)
+      if (cast_potion_spell(ch, jar, i) <= 0)
+        break;
 
-		WAIT_STATE(ch, PULSE_VIOLENCE);
-		jar->dec_weight();
-		// все выпито
-		jar->dec_val(1);
+    WAIT_STATE(ch, PULSE_VIOLENCE);
+    jar->dec_weight();
+    // все выпито
+    jar->dec_val(1);
 
-		if (GET_OBJ_VAL(jar, 1) <= 0
-			&& GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_FOUNTAIN)
-		{
-			name_from_drinkcon(jar);
-			jar->set_skill(SKILL_INVALID);
-			reset_potion_values(jar);
-		}
-		do_drink_poison(ch,jar,0);
-		return 1;
-	}
-	return 0;
+    if (GET_OBJ_VAL(jar, 1) <= 0
+        && GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_FOUNTAIN) {
+      name_from_drinkcon(jar);
+      jar->set_skill(SKILL_INVALID);
+      reset_potion_values(jar);
+    }
+    do_drink_poison(ch, jar, 0);
+    return 1;
+  }
+  return 0;
 }
 
-int do_drink_check(CHAR_DATA *ch, OBJ_DATA *jar)
-{
-	//Проверка в бою?
-	if (PRF_FLAGS(ch).get(PRF_IRON_WIND))
-	{
-		send_to_char("Не стоит отвлекаться в бою!\r\n", ch);
-		return 0;
-	}
+int do_drink_check(CHAR_DATA *ch, OBJ_DATA *jar) {
+  //Проверка в бою?
+  if (PRF_FLAGS(ch).get(PRF_IRON_WIND)) {
+    send_to_char("Не стоит отвлекаться в бою!\r\n", ch);
+    return 0;
+  }
 
-	//Сообщение на случай попытки проглотить ингры
-	if (GET_OBJ_TYPE(jar) == OBJ_DATA::ITEM_MING)
-	{
-		send_to_char("Не можешь приготовить - покупай готовое!\r\n", ch);
-		return 0;
-	}
-	//Проверяем можно ли из этого пить
+  //Сообщение на случай попытки проглотить ингры
+  if (GET_OBJ_TYPE(jar) == OBJ_DATA::ITEM_MING) {
+    send_to_char("Не можешь приготовить - покупай готовое!\r\n", ch);
+    return 0;
+  }
+  //Проверяем можно ли из этого пить
 
-	if (GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_DRINKCON
-		&& GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_FOUNTAIN)
-	{
-		send_to_char("Не стоит. Козлят и так много!\r\n", ch);
-		return 0;
-	}
+  if (GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_DRINKCON
+      && GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_FOUNTAIN) {
+    send_to_char("Не стоит. Козлят и так много!\r\n", ch);
+    return 0;
+  }
 
-	// Если удушение - пить нельзя
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_STRANGLED))
-	{
-		send_to_char("Да вам сейчас и глоток воздуха не проглотить!\r\n", ch);
-		return 0;
-	}
+  // Если удушение - пить нельзя
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_STRANGLED)) {
+    send_to_char("Да вам сейчас и глоток воздуха не проглотить!\r\n", ch);
+    return 0;
+  }
 
-	// Пустой контейнер
-	if (!GET_OBJ_VAL(jar, 1))
-	{
-		send_to_char("Пусто.\r\n", ch);
-		return 0;
-	}
+  // Пустой контейнер
+  if (!GET_OBJ_VAL(jar, 1)) {
+    send_to_char("Пусто.\r\n", ch);
+    return 0;
+  }
 
-	return 1;
+  return 1;
 }
 
 //получение контейнера для питья
-OBJ_DATA* do_drink_get_jar (CHAR_DATA *ch, char *jar_name)
-{
-	OBJ_DATA* jar = NULL;
-	if (!(jar = get_obj_in_list_vis(ch, jar_name, ch->carrying)))
-	{
-		if (!(jar = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents)))
-		{
-			send_to_char("Вы не смогли это найти!\r\n", ch);
-			return jar;
-		}
+OBJ_DATA *do_drink_get_jar(CHAR_DATA *ch, char *jar_name) {
+  OBJ_DATA *jar = NULL;
+  if (!(jar = get_obj_in_list_vis(ch, jar_name, ch->carrying))) {
+    if (!(jar = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents))) {
+      send_to_char("Вы не смогли это найти!\r\n", ch);
+      return jar;
+    }
 
-		if (GET_OBJ_TYPE(jar) == OBJ_DATA::ITEM_DRINKCON)
-		{
-			send_to_char("Прежде это стоит поднять.\r\n", ch);
-			return jar;
-		}
-	}
-	return jar;
+    if (GET_OBJ_TYPE(jar) == OBJ_DATA::ITEM_DRINKCON) {
+      send_to_char("Прежде это стоит поднять.\r\n", ch);
+      return jar;
+    }
+  }
+  return jar;
 }
 
 int do_drink_get_amount(CHAR_DATA *ch, OBJ_DATA *jar, int subcmd) {
 
-	int amount = 1; //по умолчанию 1 глоток
-	float V = 1;
+  int amount = 1; //по умолчанию 1 глоток
+  float V = 1;
 
-	// Если жидкость с градусом
-	if (drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK] > 0)
-	{
-		if (GET_COND(ch,DRUNK)>= CHAR_MORTALLY_DRUNKED){
-				amount = -1; //мимо будет
-		} else {
-			//Тут магия из-за /4
-			amount = ( 2 * CHAR_MORTALLY_DRUNKED - GET_COND(ch,DRUNK) ) / drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK];
-			amount = MAX(1,amount); // ну еще чуть-чуть
-		}
-	}
-	// Если без градуса
-	else
-	{
-		// рандом 3-10 глотков
-		amount = number(3, 10);
-	}
+  // Если жидкость с градусом
+  if (drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK] > 0) {
+    if (GET_COND(ch, DRUNK) >= CHAR_MORTALLY_DRUNKED) {
+      amount = -1; //мимо будет
+    } else {
+      //Тут магия из-за /4
+      amount = (2 * CHAR_MORTALLY_DRUNKED - GET_COND(ch, DRUNK)) / drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK];
+      amount = MAX(1, amount); // ну еще чуть-чуть
+    }
+  }
+    // Если без градуса
+  else {
+    // рандом 3-10 глотков
+    amount = number(3, 10);
+  }
 
-	// Если жидкость утоляет жаду
-	if (drink_aff[GET_OBJ_VAL(jar, 2)][THIRST]<0)
-	{
-		V = (float) - GET_COND(ch,THIRST)/drink_aff[GET_OBJ_VAL(jar, 2)][THIRST];
-	}
-	// Если жидоксть вызывает сушняк
-	else if (drink_aff[GET_OBJ_VAL(jar, 2)][THIRST]>0)
-	{
-		V = (float) (MAX_COND_VALUE-GET_COND(ch,THIRST))/drink_aff[GET_OBJ_VAL(jar, 2)][THIRST];
-	} else {
-		V = 999.0;
-	}
-	amount = MIN(amount, round(V+0.49999));
+  // Если жидкость утоляет жаду
+  if (drink_aff[GET_OBJ_VAL(jar, 2)][THIRST] < 0) {
+    V = (float) -GET_COND(ch, THIRST) / drink_aff[GET_OBJ_VAL(jar, 2)][THIRST];
+  }
+    // Если жидоксть вызывает сушняк
+  else if (drink_aff[GET_OBJ_VAL(jar, 2)][THIRST] > 0) {
+    V = (float) (MAX_COND_VALUE - GET_COND(ch, THIRST)) / drink_aff[GET_OBJ_VAL(jar, 2)][THIRST];
+  } else {
+    V = 999.0;
+  }
+  amount = MIN(amount, round(V + 0.49999));
 
-	if (subcmd != SCMD_DRINK) // пьем прямо, не глотаем, не пробуем
-	{
-		amount = MIN(amount,1);
-	}
+  if (subcmd != SCMD_DRINK) // пьем прямо, не глотаем, не пробуем
+  {
+    amount = MIN(amount, 1);
+  }
 
-	//обрезаем до объема контейнера
-	amount = MIN(amount, GET_OBJ_VAL(jar, 1));
-	return amount;
+  //обрезаем до объема контейнера
+  amount = MIN(amount, GET_OBJ_VAL(jar, 1));
+  return amount;
 }
 
-int do_drink_check_conditions(CHAR_DATA *ch, OBJ_DATA *jar, int amount)
-{
-	//Сушняк, если у чара жажда - а напиток сушит (ВОДКА и САМОГОН!!!), заодно спасаем пьяниц от штрафов
-	if (
-		drink_aff[GET_OBJ_VAL(jar, 2)][THIRST]>0 &&
-	 	GET_COND_M(ch,THIRST) > 5 // Когда попить уже хочется сильней чем выпить :)
-	) {
-		send_to_char("У вас пересохло в горле, нужно что-то попить.\r\n",ch);
-		return 0;
-	}
+int do_drink_check_conditions(CHAR_DATA *ch, OBJ_DATA *jar, int amount) {
+  //Сушняк, если у чара жажда - а напиток сушит (ВОДКА и САМОГОН!!!), заодно спасаем пьяниц от штрафов
+  if (
+      drink_aff[GET_OBJ_VAL(jar, 2)][THIRST] > 0 &&
+          GET_COND_M(ch, THIRST) > 5 // Когда попить уже хочется сильней чем выпить :)
+      ) {
+    send_to_char("У вас пересохло в горле, нужно что-то попить.\r\n", ch);
+    return 0;
+  }
 
 
-	// Если жидкость с градусом
-	if (drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK]>0)
-	{
-		// Если у чара бадун - пусть похмеляется, бухать нельзя
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_ABSTINENT)) {
-			if (GET_SKILL(ch,SKILL_DRUNKOFF)>0) {//если опохмел есть
-				send_to_char("Вас передернуло от одной мысли о том что бы выпить.\r\nПохоже, вам стоит опохмелиться.\r\n", ch);
-			} else {//если опохмела нет
-				send_to_char("Вы пытались... но не смогли заставить себя выпить...\r\n", ch);
-			}
-			return 0;
-		}
-		// Если чар уже пьяный
-		if (GET_COND(ch, DRUNK) >= CHAR_DRUNKED) {
-			// Если допился до кондиции или уже начал трезветь
-			if (GET_DRUNK_STATE(ch) == CHAR_MORTALLY_DRUNKED || GET_COND(ch, DRUNK) < GET_DRUNK_STATE(ch))
-			{
-				send_to_char("На сегодня вам достаточно, крошки уже плавают...\r\n", ch);
-				return 0;
-			}
-		}
-	}
+  // Если жидкость с градусом
+  if (drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK] > 0) {
+    // Если у чара бадун - пусть похмеляется, бухать нельзя
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_ABSTINENT)) {
+      if (GET_SKILL(ch, SKILL_DRUNKOFF) > 0) {//если опохмел есть
+        send_to_char("Вас передернуло от одной мысли о том что бы выпить.\r\nПохоже, вам стоит опохмелиться.\r\n", ch);
+      } else {//если опохмела нет
+        send_to_char("Вы пытались... но не смогли заставить себя выпить...\r\n", ch);
+      }
+      return 0;
+    }
+    // Если чар уже пьяный
+    if (GET_COND(ch, DRUNK) >= CHAR_DRUNKED) {
+      // Если допился до кондиции или уже начал трезветь
+      if (GET_DRUNK_STATE(ch) == CHAR_MORTALLY_DRUNKED || GET_COND(ch, DRUNK) < GET_DRUNK_STATE(ch)) {
+        send_to_char("На сегодня вам достаточно, крошки уже плавают...\r\n", ch);
+        return 0;
+      }
+    }
+  }
 
-	// Не хочет пить, ну вот вообще не лезет больше
-	if ( amount <= 0 && !IS_GOD(ch) ) {
-		send_to_char("В вас больше не лезет.\r\n", ch);
-		return 0;
-	}
+  // Не хочет пить, ну вот вообще не лезет больше
+  if (amount <= 0 && !IS_GOD(ch)) {
+    send_to_char("В вас больше не лезет.\r\n", ch);
+    return 0;
+  }
 
-	// Нельзя пить в бою
-	if (ch->get_fighting())
-	{
-		send_to_char("Не стоит отвлекаться в бою.\r\n", ch);
-		return 0;
-	}
-	return 1;
+  // Нельзя пить в бою
+  if (ch->get_fighting()) {
+    send_to_char("Не стоит отвлекаться в бою.\r\n", ch);
+    return 0;
+  }
+  return 1;
 }
 
-void do_drink_drunk(CHAR_DATA *ch, OBJ_DATA *jar, int amount){
-	int duration;
+void do_drink_drunk(CHAR_DATA *ch, OBJ_DATA *jar, int amount) {
+  int duration;
 
-	if (drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK]<=0)
-		return;
+  if (drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK] <= 0)
+    return;
 
-	if (amount == 0)
-		return;
+  if (amount == 0)
+    return;
 
-	if (GET_COND(ch, DRUNK) >= CHAR_DRUNKED)
-	{
-		if (GET_COND(ch, DRUNK) >= CHAR_MORTALLY_DRUNKED)
-		{
-			send_to_char("Напилися вы пьяны, не дойти вам до дому....\r\n", ch);
-		}
-		else
-		{
-			send_to_char("Приятное тепло разлилось по вашему телу.\r\n", ch);
-		}
+  if (GET_COND(ch, DRUNK) >= CHAR_DRUNKED) {
+    if (GET_COND(ch, DRUNK) >= CHAR_MORTALLY_DRUNKED) {
+      send_to_char("Напилися вы пьяны, не дойти вам до дому....\r\n", ch);
+    } else {
+      send_to_char("Приятное тепло разлилось по вашему телу.\r\n", ch);
+    }
 
-		duration = 2 + MAX(0, GET_COND(ch, DRUNK) - CHAR_DRUNKED);
+    duration = 2 + MAX(0, GET_COND(ch, DRUNK) - CHAR_DRUNKED);
 
-		if (can_use_feat(ch, DRUNKARD_FEAT))
-			duration += duration/2;
+    if (can_use_feat(ch, DRUNKARD_FEAT))
+      duration += duration / 2;
 
-		if (!AFF_FLAGGED(ch, EAffectFlag::AFF_ABSTINENT)
-				&& GET_DRUNK_STATE(ch) < MAX_COND_VALUE
-					&& GET_DRUNK_STATE(ch) == GET_COND(ch, DRUNK))
-		{
-			send_to_char("Винные пары ударили вам в голову.\r\n", ch);
-			// **** Decrease AC ***** //
-			AFFECT_DATA<EApplyLocation> af;
-			af.type = SPELL_DRUNKED;
-			af.duration = pc_duration(ch, duration, 0, 0, 0, 0);
-			af.modifier = -20;
-			af.location = APPLY_AC;
-			af.bitvector = to_underlying(EAffectFlag::AFF_DRUNKED);
-			af.battleflag = 0;
-			affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-			// **** Decrease HR ***** //
-			af.type = SPELL_DRUNKED;
-			af.duration = pc_duration(ch, duration, 0, 0, 0, 0);
-			af.modifier = -2;
-			af.location = APPLY_HITROLL;
-			af.bitvector = to_underlying(EAffectFlag::AFF_DRUNKED);
-			af.battleflag = 0;
-			affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-			// **** Increase DR ***** //
-			af.type = SPELL_DRUNKED;
-			af.duration = pc_duration(ch, duration, 0, 0, 0, 0);
-			af.modifier = (GET_LEVEL(ch) + 4) / 5;
-			af.location = APPLY_DAMROLL;
-			af.bitvector = to_underlying(EAffectFlag::AFF_DRUNKED);
-			af.battleflag = 0;
-			affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-		}
-	}
+    if (!AFF_FLAGGED(ch, EAffectFlag::AFF_ABSTINENT)
+        && GET_DRUNK_STATE(ch) < MAX_COND_VALUE
+        && GET_DRUNK_STATE(ch) == GET_COND(ch, DRUNK)) {
+      send_to_char("Винные пары ударили вам в голову.\r\n", ch);
+      // **** Decrease AC ***** //
+      AFFECT_DATA<EApplyLocation> af;
+      af.type = SPELL_DRUNKED;
+      af.duration = pc_duration(ch, duration, 0, 0, 0, 0);
+      af.modifier = -20;
+      af.location = APPLY_AC;
+      af.bitvector = to_underlying(EAffectFlag::AFF_DRUNKED);
+      af.battleflag = 0;
+      affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+      // **** Decrease HR ***** //
+      af.type = SPELL_DRUNKED;
+      af.duration = pc_duration(ch, duration, 0, 0, 0, 0);
+      af.modifier = -2;
+      af.location = APPLY_HITROLL;
+      af.bitvector = to_underlying(EAffectFlag::AFF_DRUNKED);
+      af.battleflag = 0;
+      affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+      // **** Increase DR ***** //
+      af.type = SPELL_DRUNKED;
+      af.duration = pc_duration(ch, duration, 0, 0, 0, 0);
+      af.modifier = (GET_LEVEL(ch) + 4) / 5;
+      af.location = APPLY_DAMROLL;
+      af.bitvector = to_underlying(EAffectFlag::AFF_DRUNKED);
+      af.battleflag = 0;
+      affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+    }
+  }
 }
 
-void do_drink(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
-{
-	OBJ_DATA *jar;
-	int amount;
+void do_drink(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  OBJ_DATA *jar;
+  int amount;
 
-	//мобы не пьют
-	if (IS_NPC(ch))
-		return;
+  //мобы не пьют
+  if (IS_NPC(ch))
+    return;
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
-	if (!*arg)
-	{
-		send_to_char("Пить из чего?\r\n", ch);
-		return;
-	}
+  if (!*arg) {
+    send_to_char("Пить из чего?\r\n", ch);
+    return;
+  }
 
-	// Выбираем контейнер с птьем
-	if (!(jar = do_drink_get_jar(ch,arg)))
-		return;
+  // Выбираем контейнер с птьем
+  if (!(jar = do_drink_get_jar(ch, arg)))
+    return;
 
-	// Общие проверки
-	if (!do_drink_check(ch,jar))
-		return;
+  // Общие проверки
+  if (!do_drink_check(ch, jar))
+    return;
 
-	// Бухаем зелье
-	if (cast_potion(ch, jar))
-		return;
+  // Бухаем зелье
+  if (cast_potion(ch, jar))
+    return;
 
-	// Вычисляем объем жидкости доступный для потребления
-	amount = do_drink_get_amount(ch,jar,subcmd);
+  // Вычисляем объем жидкости доступный для потребления
+  amount = do_drink_get_amount(ch, jar, subcmd);
 
-	// Проверяем может ли чар пить
-	if (!do_drink_check_conditions(ch,jar,amount))
-		return;
+  // Проверяем может ли чар пить
+  if (!do_drink_check_conditions(ch, jar, amount))
+    return;
 
-	if (subcmd == SCMD_DRINK)
-	{
-		sprintf(buf, "$n выпил$g %s из $o1.", drinks[GET_OBJ_VAL(jar, 2)]);
-		act(buf, TRUE, ch, jar, 0, TO_ROOM);
-		sprintf(buf, "Вы выпили %s из %s.\r\n", drinks[GET_OBJ_VAL(jar, 2)], OBJN(jar, ch, 1));
-		send_to_char(buf, ch);
-	}
-	else
-	{
-		act("$n отхлебнул$g из $o1.", TRUE, ch, jar, 0, TO_ROOM);
-		sprintf(buf, "Вы узнали вкус %s.\r\n", drinks[GET_OBJ_VAL(jar, 2)]);
-		send_to_char(buf, ch);
-	}
+  if (subcmd == SCMD_DRINK) {
+    sprintf(buf, "$n выпил$g %s из $o1.", drinks[GET_OBJ_VAL(jar, 2)]);
+    act(buf, TRUE, ch, jar, 0, TO_ROOM);
+    sprintf(buf, "Вы выпили %s из %s.\r\n", drinks[GET_OBJ_VAL(jar, 2)], OBJN(jar, ch, 1));
+    send_to_char(buf, ch);
+  } else {
+    act("$n отхлебнул$g из $o1.", TRUE, ch, jar, 0, TO_ROOM);
+    sprintf(buf, "Вы узнали вкус %s.\r\n", drinks[GET_OBJ_VAL(jar, 2)]);
+    send_to_char(buf, ch);
+  }
 
-	// вес отнимаемый вес не моежт быть больше веса контейнера
+  // вес отнимаемый вес не моежт быть больше веса контейнера
 
-	if (GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_FOUNTAIN)
-	{
-		weight_change_object(jar, - MIN(amount, GET_OBJ_WEIGHT(jar)));	// Subtract amount
-	}
+  if (GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_FOUNTAIN) {
+    weight_change_object(jar, -MIN(amount, GET_OBJ_WEIGHT(jar)));    // Subtract amount
+  }
 
-	if (
-		(drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK]>0) && //Если жидкость с градусом
-		(
-			// Чар все еще не смертельно пьян и не начал трезветь
-			(GET_DRUNK_STATE(ch) < CHAR_MORTALLY_DRUNKED && GET_DRUNK_STATE(ch) == GET_COND(ch, DRUNK)) ||
-			// Или Чар еще не пьян
-			(GET_COND(ch, DRUNK) < CHAR_DRUNKED)
-		)
-	)
-	{
-		// Не понимаю зачем делить на 4, но оставим для пьянки 2
-		gain_condition(ch, DRUNK, (int)((int) drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK] * amount) / 2);
-		GET_DRUNK_STATE(ch) = MAX(GET_DRUNK_STATE(ch), GET_COND(ch, DRUNK));
-	}
+  if (
+      (drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK] > 0) && //Если жидкость с градусом
+          (
+              // Чар все еще не смертельно пьян и не начал трезветь
+              (GET_DRUNK_STATE(ch) < CHAR_MORTALLY_DRUNKED && GET_DRUNK_STATE(ch) == GET_COND(ch, DRUNK)) ||
+                  // Или Чар еще не пьян
+                  (GET_COND(ch, DRUNK) < CHAR_DRUNKED)
+          )
+      ) {
+    // Не понимаю зачем делить на 4, но оставим для пьянки 2
+    gain_condition(ch, DRUNK, (int) ((int) drink_aff[GET_OBJ_VAL(jar, 2)][DRUNK] * amount) / 2);
+    GET_DRUNK_STATE(ch) = MAX(GET_DRUNK_STATE(ch), GET_COND(ch, DRUNK));
+  }
 
-	if (drink_aff[GET_OBJ_VAL(jar, 2)][FULL]!=0) {
-		gain_condition(ch, FULL, drink_aff[GET_OBJ_VAL(jar, 2)][FULL] * amount);
-		if (drink_aff[GET_OBJ_VAL(jar, 2)][FULL]<0 && GET_COND(ch, FULL) <= NORM_COND_VALUE)
-			send_to_char("Вы чувствуете приятную тяжесть в желудке.\r\n", ch);
-	}
+  if (drink_aff[GET_OBJ_VAL(jar, 2)][FULL] != 0) {
+    gain_condition(ch, FULL, drink_aff[GET_OBJ_VAL(jar, 2)][FULL] * amount);
+    if (drink_aff[GET_OBJ_VAL(jar, 2)][FULL] < 0 && GET_COND(ch, FULL) <= NORM_COND_VALUE)
+      send_to_char("Вы чувствуете приятную тяжесть в желудке.\r\n", ch);
+  }
 
-	if (drink_aff[GET_OBJ_VAL(jar, 2)][THIRST]!=0) {
-		gain_condition(ch, THIRST, drink_aff[GET_OBJ_VAL(jar, 2)][THIRST] * amount);
-		if (drink_aff[GET_OBJ_VAL(jar, 2)][THIRST]<0 && GET_COND(ch, THIRST) <= NORM_COND_VALUE)
-			send_to_char("Вы не чувствуете жажды.\r\n", ch);
-	}
+  if (drink_aff[GET_OBJ_VAL(jar, 2)][THIRST] != 0) {
+    gain_condition(ch, THIRST, drink_aff[GET_OBJ_VAL(jar, 2)][THIRST] * amount);
+    if (drink_aff[GET_OBJ_VAL(jar, 2)][THIRST] < 0 && GET_COND(ch, THIRST) <= NORM_COND_VALUE)
+      send_to_char("Вы не чувствуете жажды.\r\n", ch);
+  }
 
-	// Опьянение
-	do_drink_drunk(ch,jar,amount);
-	// Отравление
-	do_drink_poison(ch,jar,amount);
+  // Опьянение
+  do_drink_drunk(ch, jar, amount);
+  // Отравление
+  do_drink_poison(ch, jar, amount);
 
-	// empty the container, and no longer poison. 999 - whole fountain //
-	if (GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_FOUNTAIN
-		|| GET_OBJ_VAL(jar, 1) != 999)
-	{
-		jar->sub_val(1, amount);
-	}
-	if (!GET_OBJ_VAL(jar, 1))  	// The last bit //
-	{
-		jar->set_val(2, 0);
-		jar->set_val(3, 0);
-		name_from_drinkcon(jar);
-	}
+  // empty the container, and no longer poison. 999 - whole fountain //
+  if (GET_OBJ_TYPE(jar) != OBJ_DATA::ITEM_FOUNTAIN
+      || GET_OBJ_VAL(jar, 1) != 999) {
+    jar->sub_val(1, amount);
+  }
+  if (!GET_OBJ_VAL(jar, 1))    // The last bit //
+  {
+    jar->set_val(2, 0);
+    jar->set_val(3, 0);
+    name_from_drinkcon(jar);
+  }
 
-	return;
+  return;
 }
 
-void do_drunkoff(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	OBJ_DATA *obj;
-	struct timed_type timed;
-	int amount, weight, prob, percent, duration;
-	int on_ground = 0;
+void do_drunkoff(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  OBJ_DATA *obj;
+  struct timed_type timed;
+  int amount, weight, prob, percent, duration;
+  int on_ground = 0;
 
-	if (IS_NPC(ch))		// Cannot use GET_COND() on mobs. //
-		return;
+  if (IS_NPC(ch))        // Cannot use GET_COND() on mobs. //
+    return;
 
-	if (ch->get_fighting())
-	{
-		send_to_char("Не стоит отвлекаться в бою.\r\n", ch);
-		return;
-	}
+  if (ch->get_fighting()) {
+    send_to_char("Не стоит отвлекаться в бою.\r\n", ch);
+    return;
+  }
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_DRUNKED))
-	{
-		send_to_char("Вы хотите испортить себе весь кураж?\r\n" "Это не есть по русски!\r\n", ch);
-		return;
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_DRUNKED)) {
+    send_to_char("Вы хотите испортить себе весь кураж?\r\n" "Это не есть по русски!\r\n", ch);
+    return;
+  }
 
-	if (!AFF_FLAGGED(ch, EAffectFlag::AFF_ABSTINENT) && GET_COND(ch, DRUNK) < CHAR_DRUNKED)
-	{
-		send_to_char("Не стоит делать этого на трезвую голову.\r\n", ch);
-		return;
-	}
+  if (!AFF_FLAGGED(ch, EAffectFlag::AFF_ABSTINENT) && GET_COND(ch, DRUNK) < CHAR_DRUNKED) {
+    send_to_char("Не стоит делать этого на трезвую голову.\r\n", ch);
+    return;
+  }
 
-	if (timed_by_skill(ch, SKILL_DRUNKOFF))
-	{
-		send_to_char("Вы не в состоянии так часто похмеляться.\r\n"
-					 "Попросите Богов закодировать вас.\r\n", ch);
-		return;
-	}
+  if (timed_by_skill(ch, SKILL_DRUNKOFF)) {
+    send_to_char("Вы не в состоянии так часто похмеляться.\r\n"
+                 "Попросите Богов закодировать вас.\r\n", ch);
+    return;
+  }
 
-	one_argument(argument, arg);
+  one_argument(argument, arg);
 
-	if (!*arg)
-	{
-		for (obj = ch->carrying; obj; obj = obj->get_next_content())
-		{
-			if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON)
-			{
-				break;
-			}
-		}
-		if (!obj)
-		{
-			send_to_char("У вас нет подходящего напитка для похмелья.\r\n", ch);
-			return;
-		}
-	}
-	else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying)))
-	{
-		if (!(obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents)))
-		{
-			send_to_char("Вы не смогли это найти!\r\n", ch);
-			return;
-		}
-		else
-		{
-			on_ground = 1;
-		}
-	}
+  if (!*arg) {
+    for (obj = ch->carrying; obj; obj = obj->get_next_content()) {
+      if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON) {
+        break;
+      }
+    }
+    if (!obj) {
+      send_to_char("У вас нет подходящего напитка для похмелья.\r\n", ch);
+      return;
+    }
+  } else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
+    if (!(obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents))) {
+      send_to_char("Вы не смогли это найти!\r\n", ch);
+      return;
+    } else {
+      on_ground = 1;
+    }
+  }
 
-	if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_DRINKCON
-		&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_FOUNTAIN)
-	{
-		send_to_char("Этим вы вряд-ли сможете похмелиться.\r\n", ch);
-		return;
-	}
+  if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_DRINKCON
+      && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_FOUNTAIN) {
+    send_to_char("Этим вы вряд-ли сможете похмелиться.\r\n", ch);
+    return;
+  }
 
-	if (on_ground && (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON))
-	{
-		send_to_char("Прежде это стоит поднять.\r\n", ch);
-		return;
-	}
+  if (on_ground && (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON)) {
+    send_to_char("Прежде это стоит поднять.\r\n", ch);
+    return;
+  }
 
-	if (!GET_OBJ_VAL(obj, 1))
-	{
-		send_to_char("Пусто.\r\n", ch);
-		return;
-	}
+  if (!GET_OBJ_VAL(obj, 1)) {
+    send_to_char("Пусто.\r\n", ch);
+    return;
+  }
 
-	switch (GET_OBJ_VAL(obj, 2))
-	{
-	case LIQ_BEER:
-	case LIQ_WINE:
-	case LIQ_ALE:
-	case LIQ_QUAS:
-	case LIQ_BRANDY:
-	case LIQ_VODKA:
-	case LIQ_BRAGA:
-		break;
-	default:
-		send_to_char("Вспомните народную мудрость :\r\n" "\"Клин вышибают клином...\"\r\n", ch);
-		return;
-	}
+  switch (GET_OBJ_VAL(obj, 2)) {
+    case LIQ_BEER:
+    case LIQ_WINE:
+    case LIQ_ALE:
+    case LIQ_QUAS:
+    case LIQ_BRANDY:
+    case LIQ_VODKA:
+    case LIQ_BRAGA: break;
+    default: send_to_char("Вспомните народную мудрость :\r\n" "\"Клин вышибают клином...\"\r\n", ch);
+      return;
+  }
 
-	amount = MAX(1, GET_WEIGHT(ch) / 50);
-	if (amount > GET_OBJ_VAL(obj, 1))
-	{
-		send_to_char("Вам точно не хватит этого количества для опохмела...\r\n", ch);
-		return;
-	}
+  amount = MAX(1, GET_WEIGHT(ch) / 50);
+  if (amount > GET_OBJ_VAL(obj, 1)) {
+    send_to_char("Вам точно не хватит этого количества для опохмела...\r\n", ch);
+    return;
+  }
 
-	timed.skill = SKILL_DRUNKOFF;
-	timed.time = can_use_feat(ch, DRUNKARD_FEAT) ? getModifier(DRUNKARD_FEAT, FEAT_TIMER) : 12;
-	timed_to_char(ch, &timed);
+  timed.skill = SKILL_DRUNKOFF;
+  timed.time = can_use_feat(ch, DRUNKARD_FEAT) ? getModifier(DRUNKARD_FEAT, FEAT_TIMER) : 12;
+  timed_to_char(ch, &timed);
 
-	percent = number(1, skill_info[SKILL_DRUNKOFF].max_percent);
-	prob = train_skill(ch, SKILL_DRUNKOFF, skill_info[SKILL_DRUNKOFF].max_percent, 0);
-	amount = MIN(amount, GET_OBJ_VAL(obj, 1));
-	weight = MIN(amount, GET_OBJ_WEIGHT(obj));
-	weight_change_object(obj, -weight);	// Subtract amount //
-	obj->sub_val(1, amount);
-	if (!GET_OBJ_VAL(obj, 1))  	// The last bit //
-	{
-		obj->set_val(2, 0);
-		obj->set_val(3, 0);
-		name_from_drinkcon(obj);
-	}
+  percent = number(1, skill_info[SKILL_DRUNKOFF].max_percent);
+  prob = calculate_skill(ch, SKILL_DRUNKOFF, nullptr);
+  train_skill(ch, SKILL_DRUNKOFF, percent <= prob, nullptr);
+  amount = MIN(amount, GET_OBJ_VAL(obj, 1));
+  weight = MIN(amount, GET_OBJ_WEIGHT(obj));
+  weight_change_object(obj, -weight);    // Subtract amount //
+  obj->sub_val(1, amount);
+  if (!GET_OBJ_VAL(obj, 1))    // The last bit //
+  {
+    obj->set_val(2, 0);
+    obj->set_val(3, 0);
+    name_from_drinkcon(obj);
+  }
 
-	if (percent > prob)
-	{
-		sprintf(buf, "Вы отхлебнули %s из $o1, но ваша голова стала еще тяжелее...", drinks[GET_OBJ_VAL(obj, 2)]);
-		act(buf, FALSE, ch, obj, 0, TO_CHAR);
-		act("$n попробовал$g похмелиться, но это не пошло $m на пользу.", FALSE, ch, 0, 0, TO_ROOM);
-		duration = MAX(1, amount / 3);
-		AFFECT_DATA<EApplyLocation> af[3];
-		af[0].type = SPELL_ABSTINENT;
-		af[0].duration = pc_duration(ch, duration, 0, 0, 0, 0);
-		af[0].modifier = 0;
-		af[0].location = APPLY_DAMROLL;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_ABSTINENT);
-		af[0].battleflag = 0;
-		af[1].type = SPELL_ABSTINENT;
-		af[1].duration = pc_duration(ch, duration, 0, 0, 0, 0);
-		af[1].modifier = 0;
-		af[1].location = APPLY_HITROLL;
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_ABSTINENT);
-		af[1].battleflag = 0;
-		af[2].type = SPELL_ABSTINENT;
-		af[2].duration = pc_duration(ch, duration, 0, 0, 0, 0);
-		af[2].modifier = 0;
-		af[2].location = APPLY_AC;
-		af[2].bitvector = to_underlying(EAffectFlag::AFF_ABSTINENT);
-		af[2].battleflag = 0;
-		switch (number(0, ch->get_skill(SKILL_DRUNKOFF) / 20))
-		{
-		case 0:
-		case 1:
-			af[0].modifier = -2;
-			break;
-		case 2:
-		case 3:
-			af[0].modifier = -2;
-			af[1].modifier = -2;
-			break;
-		default:
-			af[0].modifier = -2;
-			af[1].modifier = -2;
-			af[2].modifier = 10;
-			break;
-		}
-		for (prob = 0; prob < 3; prob++)
-		{
-			affect_join(ch, af[prob], TRUE, FALSE, TRUE, FALSE);
-		}
-		gain_condition(ch, DRUNK, amount);
-	}
-	else
-	{
-		sprintf(buf, "Вы отхлебнули %s из $o1 и почувствовали приятную легкость во всем теле...",
-			drinks[GET_OBJ_VAL(obj, 2)]);
-		act(buf, FALSE, ch, obj, 0, TO_CHAR);
-		act("$n похмелил$u и расцвел$g прям на глазах.", FALSE, ch, 0, 0, TO_ROOM);
-		affect_from_char(ch, SPELL_ABSTINENT);
-	}
+  if (percent > prob) {
+    sprintf(buf, "Вы отхлебнули %s из $o1, но ваша голова стала еще тяжелее...", drinks[GET_OBJ_VAL(obj, 2)]);
+    act(buf, FALSE, ch, obj, 0, TO_CHAR);
+    act("$n попробовал$g похмелиться, но это не пошло $m на пользу.", FALSE, ch, 0, 0, TO_ROOM);
+    duration = MAX(1, amount / 3);
+    AFFECT_DATA<EApplyLocation> af[3];
+    af[0].type = SPELL_ABSTINENT;
+    af[0].duration = pc_duration(ch, duration, 0, 0, 0, 0);
+    af[0].modifier = 0;
+    af[0].location = APPLY_DAMROLL;
+    af[0].bitvector = to_underlying(EAffectFlag::AFF_ABSTINENT);
+    af[0].battleflag = 0;
+    af[1].type = SPELL_ABSTINENT;
+    af[1].duration = pc_duration(ch, duration, 0, 0, 0, 0);
+    af[1].modifier = 0;
+    af[1].location = APPLY_HITROLL;
+    af[1].bitvector = to_underlying(EAffectFlag::AFF_ABSTINENT);
+    af[1].battleflag = 0;
+    af[2].type = SPELL_ABSTINENT;
+    af[2].duration = pc_duration(ch, duration, 0, 0, 0, 0);
+    af[2].modifier = 0;
+    af[2].location = APPLY_AC;
+    af[2].bitvector = to_underlying(EAffectFlag::AFF_ABSTINENT);
+    af[2].battleflag = 0;
+    switch (number(0, ch->get_skill(SKILL_DRUNKOFF) / 20)) {
+      case 0:
+      case 1: af[0].modifier = -2;
+        break;
+      case 2:
+      case 3: af[0].modifier = -2;
+        af[1].modifier = -2;
+        break;
+      default: af[0].modifier = -2;
+        af[1].modifier = -2;
+        af[2].modifier = 10;
+        break;
+    }
+    for (prob = 0; prob < 3; prob++) {
+      affect_join(ch, af[prob], TRUE, FALSE, TRUE, FALSE);
+    }
+    gain_condition(ch, DRUNK, amount);
+  } else {
+    sprintf(buf, "Вы отхлебнули %s из $o1 и почувствовали приятную легкость во всем теле...",
+            drinks[GET_OBJ_VAL(obj, 2)]);
+    act(buf, FALSE, ch, obj, 0, TO_CHAR);
+    act("$n похмелил$u и расцвел$g прям на глазах.", FALSE, ch, 0, 0, TO_ROOM);
+    affect_from_char(ch, SPELL_ABSTINENT);
+  }
 
-	return;
+  return;
 }
 
-void generate_drinkcon_name(OBJ_DATA *to_obj, int spell)
-{
-	switch (spell)
-	{
-		// восстановление (красное) //
-	case SPELL_REFRESH:
-	case SPELL_GROUP_REFRESH:
-		to_obj->set_val(2, LIQ_POTION_RED);
-		name_to_drinkcon(to_obj, LIQ_POTION_RED);
-		break;
-		// насыщение (синее) //
-	case SPELL_FULL:
-	case SPELL_COMMON_MEAL:
-		to_obj->set_val(2, LIQ_POTION_BLUE);
-		name_to_drinkcon(to_obj, LIQ_POTION_BLUE);
-		break;
-		// детекты (белое) //
-	case SPELL_DETECT_INVIS:
-	case SPELL_ALL_SEEING_EYE:
-	case SPELL_DETECT_MAGIC:
-	case SPELL_MAGICAL_GAZE:
-	case SPELL_DETECT_POISON:
-	case SPELL_SNAKE_EYES:
-	case SPELL_DETECT_ALIGN:
-	case SPELL_GENERAL_SINCERITY:
-	case SPELL_SENSE_LIFE:
-	case SPELL_EYE_OF_GODS:
-	case SPELL_INFRAVISION:
-	case SPELL_SIGHT_OF_DARKNESS:
-		to_obj->set_val(2, LIQ_POTION_WHITE);
-		name_to_drinkcon(to_obj, LIQ_POTION_WHITE);
-		break;
-		// защитные (золотистое) //
-	case SPELL_ARMOR:
-	case SPELL_GROUP_ARMOR:
-	case SPELL_CLOUDLY:
-		to_obj->set_val(2, LIQ_POTION_GOLD);
-		name_to_drinkcon(to_obj, LIQ_POTION_GOLD);
-		break;
-		// восстанавливающие здоровье (черное) //
-	case SPELL_CURE_CRITIC:
-	case SPELL_CURE_LIGHT:
-	case SPELL_HEAL:
-	case SPELL_GROUP_HEAL:
-	case SPELL_CURE_SERIOUS:
-		to_obj->set_val(2, LIQ_POTION_BLACK);
-		name_to_drinkcon(to_obj, LIQ_POTION_BLACK);
-		break;
-		// снимающее вредные аффекты (серое) //
-	case SPELL_CURE_BLIND:
-	case SPELL_REMOVE_CURSE:
-	case SPELL_REMOVE_HOLD:
-	case SPELL_REMOVE_SILENCE:
-	case SPELL_CURE_PLAQUE:
-	case SPELL_REMOVE_DEAFNESS:
-	case SPELL_REMOVE_POISON:
-		to_obj->set_val(2, LIQ_POTION_GREY);
-		name_to_drinkcon(to_obj, LIQ_POTION_GREY);
-		break;
-		// прочие полезности (фиолетовое) //
-	case SPELL_INVISIBLE:
-	case SPELL_GROUP_INVISIBLE:
-	case SPELL_STRENGTH:
-	case SPELL_GROUP_STRENGTH:
-	case SPELL_FLY:
-	case SPELL_GROUP_FLY:
-	case SPELL_BLESS:
-	case SPELL_GROUP_BLESS:
-	case SPELL_HASTE:
-	case SPELL_GROUP_HASTE:
-	case SPELL_STONESKIN:
-	case SPELL_STONE_WALL:
-	case SPELL_BLINK:
-	case SPELL_EXTRA_HITS:
-	case SPELL_WATERBREATH:
-		to_obj->set_val(2, LIQ_POTION_FUCHSIA);
-		name_to_drinkcon(to_obj, LIQ_POTION_FUCHSIA);
-		break;
-	case SPELL_PRISMATICAURA:
-	case SPELL_GROUP_PRISMATICAURA:
-	case SPELL_AIR_AURA:
-	case SPELL_EARTH_AURA:
-	case SPELL_FIRE_AURA:
-	case SPELL_ICE_AURA:
-		to_obj->set_val(2, LIQ_POTION_PINK);
-		name_to_drinkcon(to_obj, LIQ_POTION_PINK);
-		break;
-	default:
-		to_obj->set_val(2, LIQ_POTION);
-		name_to_drinkcon(to_obj, LIQ_POTION);	// добавляем новый синоним //
-	}
+void generate_drinkcon_name(OBJ_DATA *to_obj, int spell) {
+  switch (spell) {
+    // восстановление (красное) //
+    case SPELL_REFRESH:
+    case SPELL_GROUP_REFRESH: to_obj->set_val(2, LIQ_POTION_RED);
+      name_to_drinkcon(to_obj, LIQ_POTION_RED);
+      break;
+      // насыщение (синее) //
+    case SPELL_FULL:
+    case SPELL_COMMON_MEAL: to_obj->set_val(2, LIQ_POTION_BLUE);
+      name_to_drinkcon(to_obj, LIQ_POTION_BLUE);
+      break;
+      // детекты (белое) //
+    case SPELL_DETECT_INVIS:
+    case SPELL_ALL_SEEING_EYE:
+    case SPELL_DETECT_MAGIC:
+    case SPELL_MAGICAL_GAZE:
+    case SPELL_DETECT_POISON:
+    case SPELL_SNAKE_EYES:
+    case SPELL_DETECT_ALIGN:
+    case SPELL_GENERAL_SINCERITY:
+    case SPELL_SENSE_LIFE:
+    case SPELL_EYE_OF_GODS:
+    case SPELL_INFRAVISION:
+    case SPELL_SIGHT_OF_DARKNESS: to_obj->set_val(2, LIQ_POTION_WHITE);
+      name_to_drinkcon(to_obj, LIQ_POTION_WHITE);
+      break;
+      // защитные (золотистое) //
+    case SPELL_ARMOR:
+    case SPELL_GROUP_ARMOR:
+    case SPELL_CLOUDLY: to_obj->set_val(2, LIQ_POTION_GOLD);
+      name_to_drinkcon(to_obj, LIQ_POTION_GOLD);
+      break;
+      // восстанавливающие здоровье (черное) //
+    case SPELL_CURE_CRITIC:
+    case SPELL_CURE_LIGHT:
+    case SPELL_HEAL:
+    case SPELL_GROUP_HEAL:
+    case SPELL_CURE_SERIOUS: to_obj->set_val(2, LIQ_POTION_BLACK);
+      name_to_drinkcon(to_obj, LIQ_POTION_BLACK);
+      break;
+      // снимающее вредные аффекты (серое) //
+    case SPELL_CURE_BLIND:
+    case SPELL_REMOVE_CURSE:
+    case SPELL_REMOVE_HOLD:
+    case SPELL_REMOVE_SILENCE:
+    case SPELL_CURE_PLAQUE:
+    case SPELL_REMOVE_DEAFNESS:
+    case SPELL_REMOVE_POISON: to_obj->set_val(2, LIQ_POTION_GREY);
+      name_to_drinkcon(to_obj, LIQ_POTION_GREY);
+      break;
+      // прочие полезности (фиолетовое) //
+    case SPELL_INVISIBLE:
+    case SPELL_GROUP_INVISIBLE:
+    case SPELL_STRENGTH:
+    case SPELL_GROUP_STRENGTH:
+    case SPELL_FLY:
+    case SPELL_GROUP_FLY:
+    case SPELL_BLESS:
+    case SPELL_GROUP_BLESS:
+    case SPELL_HASTE:
+    case SPELL_GROUP_HASTE:
+    case SPELL_STONESKIN:
+    case SPELL_STONE_WALL:
+    case SPELL_BLINK:
+    case SPELL_EXTRA_HITS:
+    case SPELL_WATERBREATH: to_obj->set_val(2, LIQ_POTION_FUCHSIA);
+      name_to_drinkcon(to_obj, LIQ_POTION_FUCHSIA);
+      break;
+    case SPELL_PRISMATICAURA:
+    case SPELL_GROUP_PRISMATICAURA:
+    case SPELL_AIR_AURA:
+    case SPELL_EARTH_AURA:
+    case SPELL_FIRE_AURA:
+    case SPELL_ICE_AURA: to_obj->set_val(2, LIQ_POTION_PINK);
+      name_to_drinkcon(to_obj, LIQ_POTION_PINK);
+      break;
+    default: to_obj->set_val(2, LIQ_POTION);
+      name_to_drinkcon(to_obj, LIQ_POTION);    // добавляем новый синоним //
+  }
 }
 
-int check_potion_spell(OBJ_DATA *from_obj, OBJ_DATA *to_obj, int num)
-{
-	const auto spell = init_spell_num(num);
-	const auto level = init_spell_lvl(num);
+int check_potion_spell(OBJ_DATA *from_obj, OBJ_DATA *to_obj, int num) {
+  const auto spell = init_spell_num(num);
+  const auto level = init_spell_lvl(num);
 
-	if (GET_OBJ_VAL(from_obj, num) != to_obj->get_value(spell))
-	{
-		// не совпали заклы
-		return 0;
-	}
-	if (GET_OBJ_VAL(from_obj, 0) < to_obj->get_value(level))
-	{
-		// переливаемое зелье ниже уровня закла в емкости
-		return -1;
-	}
-	return 1;
+  if (GET_OBJ_VAL(from_obj, num) != to_obj->get_value(spell)) {
+    // не совпали заклы
+    return 0;
+  }
+  if (GET_OBJ_VAL(from_obj, 0) < to_obj->get_value(level)) {
+    // переливаемое зелье ниже уровня закла в емкости
+    return -1;
+  }
+  return 1;
 }
 
 /// \return 1 - можно переливать
 ///         0 - нельзя смешивать разные зелья
 ///        -1 - попытка перелить зелье с меньшим уровнем закла
-int check_equal_potions(OBJ_DATA *from_obj, OBJ_DATA *to_obj)
-{
-	// емкость с уже перелитым ранее зельем
-	if (to_obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM) > 0
-		&& GET_OBJ_VNUM(from_obj) != to_obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM))
-	{
-		return 0;
-	}
-	// совпадение заклов и не меньшего уровня
-	for (int i = 1; i <= 3; ++i)
-	{
-		if (GET_OBJ_VAL(from_obj, i) > 0)
-		{
-			int result = check_potion_spell(from_obj, to_obj, i);
-			if (result <= 0)
-			{
-				return result;
-			}
-		}
-	}
-	return 1;
+int check_equal_potions(OBJ_DATA *from_obj, OBJ_DATA *to_obj) {
+  // емкость с уже перелитым ранее зельем
+  if (to_obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM) > 0
+      && GET_OBJ_VNUM(from_obj) != to_obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM)) {
+    return 0;
+  }
+  // совпадение заклов и не меньшего уровня
+  for (int i = 1; i <= 3; ++i) {
+    if (GET_OBJ_VAL(from_obj, i) > 0) {
+      int result = check_potion_spell(from_obj, to_obj, i);
+      if (result <= 0) {
+        return result;
+      }
+    }
+  }
+  return 1;
 }
 
 /// см check_equal_drinkcon()
-int check_drincon_spell(OBJ_DATA *from_obj, OBJ_DATA *to_obj, int num)
-{
-	const auto spell = init_spell_num(num);
-	const auto level = init_spell_lvl(num);
+int check_drincon_spell(OBJ_DATA *from_obj, OBJ_DATA *to_obj, int num) {
+  const auto spell = init_spell_num(num);
+  const auto level = init_spell_lvl(num);
 
-	if (from_obj->get_value(spell) != to_obj->get_value(spell))
-	{
-		// не совпали заклы
-		return 0;
-	}
-	if (from_obj->get_value(level) < to_obj->get_value(level))
-	{
-		// переливаемое зелье ниже уровня закла в емкости
-		return -1;
-	}
-	return 1;
+  if (from_obj->get_value(spell) != to_obj->get_value(spell)) {
+    // не совпали заклы
+    return 0;
+  }
+  if (from_obj->get_value(level) < to_obj->get_value(level)) {
+    // переливаемое зелье ниже уровня закла в емкости
+    return -1;
+  }
+  return 1;
 }
 
 /// Временная версия check_equal_potions для двух емкостей, пока в пошенах
@@ -1019,457 +921,392 @@ int check_drincon_spell(OBJ_DATA *from_obj, OBJ_DATA *to_obj, int num)
 /// \return 1 - можно переливать
 ///         0 - нельзя смешивать разные зелья
 ///        -1 - попытка перелить зелье с меньшим уровнем закла
-int check_equal_drinkcon(OBJ_DATA *from_obj, OBJ_DATA *to_obj)
-{
-	// совпадение заклов и не меньшего уровня (и в том же порядке, ибо влом)
-	for (int i = 1; i <= 3; ++i)
-	{
-		if (GET_OBJ_VAL(from_obj, i) > 0)
-		{
-			int result = check_drincon_spell(from_obj, to_obj, i);
-			if (result <= 0)
-			{
-				return result;
-			}
-		}
-	}
-	return 1;
+int check_equal_drinkcon(OBJ_DATA *from_obj, OBJ_DATA *to_obj) {
+  // совпадение заклов и не меньшего уровня (и в том же порядке, ибо влом)
+  for (int i = 1; i <= 3; ++i) {
+    if (GET_OBJ_VAL(from_obj, i) > 0) {
+      int result = check_drincon_spell(from_obj, to_obj, i);
+      if (result <= 0) {
+        return result;
+      }
+    }
+  }
+  return 1;
 }
 
 /// копирование полей заклинаний при переливании из емкости с зельем в пустую емкость
-void spells_to_drinkcon(OBJ_DATA *from_obj, OBJ_DATA *to_obj)
-{
-	// инит заклов
-	for (int i = 1; i <= 3; ++i)
-	{
-		const auto spell = init_spell_num(i);
-		const auto level = init_spell_lvl(i);
-		to_obj->set_value(spell, from_obj->get_value(spell));
-		to_obj->set_value(level, from_obj->get_value(level));
-	}
-	// сохранение инфы о первоначальном источнике зелья
-	const int proto_vnum = from_obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM) > 0
-		? from_obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM)
-		: GET_OBJ_VNUM(from_obj);
-	to_obj->set_value(ObjVal::EValueKey::POTION_PROTO_VNUM, proto_vnum);
+void spells_to_drinkcon(OBJ_DATA *from_obj, OBJ_DATA *to_obj) {
+  // инит заклов
+  for (int i = 1; i <= 3; ++i) {
+    const auto spell = init_spell_num(i);
+    const auto level = init_spell_lvl(i);
+    to_obj->set_value(spell, from_obj->get_value(spell));
+    to_obj->set_value(level, from_obj->get_value(level));
+  }
+  // сохранение инфы о первоначальном источнике зелья
+  const int proto_vnum = from_obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM) > 0
+                         ? from_obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM)
+                         : GET_OBJ_VNUM(from_obj);
+  to_obj->set_value(ObjVal::EValueKey::POTION_PROTO_VNUM, proto_vnum);
 }
 
-void do_pour(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd)
-{
-	char arg1[MAX_INPUT_LENGTH];
-	char arg2[MAX_INPUT_LENGTH];
-	OBJ_DATA *from_obj = NULL, *to_obj = NULL;
-	int amount;
+void do_pour(CHAR_DATA *ch, char *argument, int/* cmd*/, int subcmd) {
+  char arg1[MAX_INPUT_LENGTH];
+  char arg2[MAX_INPUT_LENGTH];
+  OBJ_DATA *from_obj = NULL, *to_obj = NULL;
+  int amount;
 
-	two_arguments(argument, arg1, arg2);
+  two_arguments(argument, arg1, arg2);
 
-	if (subcmd == SCMD_POUR)
-	{
-		if (!*arg1)  	// No arguments //
-		{
-			send_to_char("Откуда переливаем?\r\n", ch);
-			return;
-		}
-		if (!(from_obj = get_obj_in_list_vis(ch, arg1, ch->carrying)))
-		{
-			send_to_char("У вас нет этого!\r\n", ch);
-			return;
-		}
-		if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_DRINKCON
-			&& GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_POTION)
-		{
-			send_to_char("Вы не можете из этого переливать!\r\n", ch);
-			return;
-		}
-	}
-	if (subcmd == SCMD_FILL)
-	{
-		if (!*arg1)  	// no arguments //
-		{
-			send_to_char("Что и из чего вы хотели бы наполнить?\r\n", ch);
-			return;
-		}
-		if (!(to_obj = get_obj_in_list_vis(ch, arg1, ch->carrying)))
-		{
-			send_to_char("У вас этого нет!\r\n", ch);
-			return;
-		}
-		if (GET_OBJ_TYPE(to_obj) != OBJ_DATA::ITEM_DRINKCON)
-		{
-			act("Вы не можете наполнить $o3!", FALSE, ch, to_obj, 0, TO_CHAR);
-			return;
-		}
-		if (!*arg2)  	// no 2nd argument //
-		{
-			act("Из чего вы планируете наполнить $o3?", FALSE, ch, to_obj, 0, TO_CHAR);
-			return;
-		}
-		if (!(from_obj = get_obj_in_list_vis(ch, arg2, world[ch->in_room]->contents)))
-		{
-			sprintf(buf, "Вы не видите здесь '%s'.\r\n", arg2);
-			send_to_char(buf, ch);
-			return;
-		}
-		if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_FOUNTAIN)
-		{
-			act("Вы не сможете ничего наполнить из $o1.", FALSE, ch, from_obj, 0, TO_CHAR);
-			return;
-		}
-	}
-	if (GET_OBJ_VAL(from_obj, 1) == 0)
-	{
-		act("Пусто.", FALSE, ch, from_obj, 0, TO_CHAR);
-		return;
-	}
-	if (subcmd == SCMD_POUR)  	// pour //
-	{
-		if (!*arg2)
-		{
-			send_to_char("Куда вы хотите лить? На землю или во что-то?\r\n", ch);
-			return;
-		}
-		if (!str_cmp(arg2, "out") || !str_cmp(arg2, "земля"))
-		{
-			act("$n опустошил$g $o3.", TRUE, ch, from_obj, 0, TO_ROOM);
-			act("Вы опустошили $o3.", FALSE, ch, from_obj, 0, TO_CHAR);
+  if (subcmd == SCMD_POUR) {
+    if (!*arg1)    // No arguments //
+    {
+      send_to_char("Откуда переливаем?\r\n", ch);
+      return;
+    }
+    if (!(from_obj = get_obj_in_list_vis(ch, arg1, ch->carrying))) {
+      send_to_char("У вас нет этого!\r\n", ch);
+      return;
+    }
+    if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_DRINKCON
+        && GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_POTION) {
+      send_to_char("Вы не можете из этого переливать!\r\n", ch);
+      return;
+    }
+  }
+  if (subcmd == SCMD_FILL) {
+    if (!*arg1)    // no arguments //
+    {
+      send_to_char("Что и из чего вы хотели бы наполнить?\r\n", ch);
+      return;
+    }
+    if (!(to_obj = get_obj_in_list_vis(ch, arg1, ch->carrying))) {
+      send_to_char("У вас этого нет!\r\n", ch);
+      return;
+    }
+    if (GET_OBJ_TYPE(to_obj) != OBJ_DATA::ITEM_DRINKCON) {
+      act("Вы не можете наполнить $o3!", FALSE, ch, to_obj, 0, TO_CHAR);
+      return;
+    }
+    if (!*arg2)    // no 2nd argument //
+    {
+      act("Из чего вы планируете наполнить $o3?", FALSE, ch, to_obj, 0, TO_CHAR);
+      return;
+    }
+    if (!(from_obj = get_obj_in_list_vis(ch, arg2, world[ch->in_room]->contents))) {
+      sprintf(buf, "Вы не видите здесь '%s'.\r\n", arg2);
+      send_to_char(buf, ch);
+      return;
+    }
+    if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_FOUNTAIN) {
+      act("Вы не сможете ничего наполнить из $o1.", FALSE, ch, from_obj, 0, TO_CHAR);
+      return;
+    }
+  }
+  if (GET_OBJ_VAL(from_obj, 1) == 0) {
+    act("Пусто.", FALSE, ch, from_obj, 0, TO_CHAR);
+    return;
+  }
+  if (subcmd == SCMD_POUR)    // pour //
+  {
+    if (!*arg2) {
+      send_to_char("Куда вы хотите лить? На землю или во что-то?\r\n", ch);
+      return;
+    }
+    if (!str_cmp(arg2, "out") || !str_cmp(arg2, "земля")) {
+      act("$n опустошил$g $o3.", TRUE, ch, from_obj, 0, TO_ROOM);
+      act("Вы опустошили $o3.", FALSE, ch, from_obj, 0, TO_CHAR);
 
-			weight_change_object(from_obj, -GET_OBJ_VAL(from_obj, 1));	// Empty //
+      weight_change_object(from_obj, -GET_OBJ_VAL(from_obj, 1));    // Empty //
 
-			from_obj->set_val(1, 0);
-			from_obj->set_val(2, 0);
-			from_obj->set_val(3, 0);
-			from_obj->set_skill(SKILL_INVALID);
-			name_from_drinkcon(from_obj);
-			reset_potion_values(from_obj);
+      from_obj->set_val(1, 0);
+      from_obj->set_val(2, 0);
+      from_obj->set_val(3, 0);
+      from_obj->set_skill(SKILL_INVALID);
+      name_from_drinkcon(from_obj);
+      reset_potion_values(from_obj);
 
-			return;
-		}
-		if (!(to_obj = get_obj_in_list_vis(ch, arg2, ch->carrying)))
-		{
-			send_to_char("Вы не можете этого найти!\r\n", ch);
-			return;
-		}
-		if (GET_OBJ_TYPE(to_obj) != OBJ_DATA::ITEM_DRINKCON
-			&& GET_OBJ_TYPE(to_obj) != OBJ_DATA::ITEM_FOUNTAIN)
-		{
-			send_to_char("Вы не сможете в это налить.\r\n", ch);
-			return;
-		}
-	}
-	if (to_obj == from_obj)
-	{
-		send_to_char("Более тупого действа вы придумать, конечно, не могли.\r\n", ch);
-		return;
-	}
+      return;
+    }
+    if (!(to_obj = get_obj_in_list_vis(ch, arg2, ch->carrying))) {
+      send_to_char("Вы не можете этого найти!\r\n", ch);
+      return;
+    }
+    if (GET_OBJ_TYPE(to_obj) != OBJ_DATA::ITEM_DRINKCON
+        && GET_OBJ_TYPE(to_obj) != OBJ_DATA::ITEM_FOUNTAIN) {
+      send_to_char("Вы не сможете в это налить.\r\n", ch);
+      return;
+    }
+  }
+  if (to_obj == from_obj) {
+    send_to_char("Более тупого действа вы придумать, конечно, не могли.\r\n", ch);
+    return;
+  }
 
-	if (GET_OBJ_VAL(to_obj, 1) != 0
-		&& GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_POTION
-		&& GET_OBJ_VAL(to_obj, 2) != GET_OBJ_VAL(from_obj, 2))
-	{
-		send_to_char("Вы станете неплохим Химиком, но не в нашей игре.\r\n", ch);
-		return;
-	}
-	if (GET_OBJ_VAL(to_obj, 1) >= GET_OBJ_VAL(to_obj, 0))
-	{
-		send_to_char("Там нет места.\r\n", ch);
-		return;
-	}
-		if (OBJ_FLAGGED(from_obj, EExtraFlag::ITEM_NOPOUR))
-		{
-			send_to_char(ch,"Вы перевернули %s, потрусили, но ничего перелить не удалось.\r\n",
-					GET_OBJ_PNAME(from_obj, 3).c_str());
-			return;
-		}
+  if (GET_OBJ_VAL(to_obj, 1) != 0
+      && GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_POTION
+      && GET_OBJ_VAL(to_obj, 2) != GET_OBJ_VAL(from_obj, 2)) {
+    send_to_char("Вы станете неплохим Химиком, но не в нашей игре.\r\n", ch);
+    return;
+  }
+  if (GET_OBJ_VAL(to_obj, 1) >= GET_OBJ_VAL(to_obj, 0)) {
+    send_to_char("Там нет места.\r\n", ch);
+    return;
+  }
+  if (OBJ_FLAGGED(from_obj, EExtraFlag::ITEM_NOPOUR)) {
+    send_to_char(ch, "Вы перевернули %s, потрусили, но ничего перелить не удалось.\r\n",
+                 GET_OBJ_PNAME(from_obj, 3).c_str());
+    return;
+  }
 //Added by Adept - переливание зелья из бутылки или емкости в емкость
 
-	//Переливает из бутылки с зельем в емкость
-	if (GET_OBJ_TYPE(from_obj) == OBJ_DATA::ITEM_POTION)
-	{
-		int result = check_equal_potions(from_obj, to_obj);
-		if (GET_OBJ_VAL(to_obj, 1) == 0 || result > 0)
-		{
-			send_to_char(ch, "Вы занялись переливанием зелья в %s.\r\n",
-				OBJN(to_obj, ch, 3));
-				int n1 = GET_OBJ_VAL(from_obj, 1);
-				int n2 = GET_OBJ_VAL(to_obj, 1);
-				int t1 = GET_OBJ_VAL(from_obj, 3);
-				int t2 = GET_OBJ_VAL(to_obj, 3);
-				to_obj->set_val(3, (n1*t1 + n2*t2) / (n1 + n2)); //усредним таймер в зависимости от наполненности обоих емкостей
+  //Переливает из бутылки с зельем в емкость
+  if (GET_OBJ_TYPE(from_obj) == OBJ_DATA::ITEM_POTION) {
+    int result = check_equal_potions(from_obj, to_obj);
+    if (GET_OBJ_VAL(to_obj, 1) == 0 || result > 0) {
+      send_to_char(ch, "Вы занялись переливанием зелья в %s.\r\n",
+                   OBJN(to_obj, ch, 3));
+      int n1 = GET_OBJ_VAL(from_obj, 1);
+      int n2 = GET_OBJ_VAL(to_obj, 1);
+      int t1 = GET_OBJ_VAL(from_obj, 3);
+      int t2 = GET_OBJ_VAL(to_obj, 3);
+      to_obj->set_val(3,
+                      (n1 * t1 + n2 * t2) / (n1 + n2)); //усредним таймер в зависимости от наполненности обоих емкостей
 //				send_to_char(ch, "n1 == %d, n2 == %d, t1 == %d, t2== %d, результат %d\r\n", n1, n2, t1, t2, GET_OBJ_VAL(to_obj, 3));
-			if (GET_OBJ_VAL(to_obj, 1) == 0)
-			{
-				copy_potion_values(from_obj, to_obj);
-				// определение названия зелья по содержащемуся заклинанию //
-				generate_drinkcon_name(to_obj, GET_OBJ_VAL(from_obj, 1));
-			}
-			weight_change_object(to_obj, 1);
-			to_obj->inc_val(1);
-			extract_obj(from_obj);
-			return;
-		}
-		else if (result < 0)
-		{
-			send_to_char("Не пытайтесь подмешать более слабое зелье!\r\n", ch);
-			return;
-		}
-		else
-		{
-			send_to_char(
-				"Смешивать разные зелья?! Да вы, батенька, гурман!\r\n", ch);
-			return;
-		}
-	}
+      if (GET_OBJ_VAL(to_obj, 1) == 0) {
+        copy_potion_values(from_obj, to_obj);
+        // определение названия зелья по содержащемуся заклинанию //
+        generate_drinkcon_name(to_obj, GET_OBJ_VAL(from_obj, 1));
+      }
+      weight_change_object(to_obj, 1);
+      to_obj->inc_val(1);
+      extract_obj(from_obj);
+      return;
+    } else if (result < 0) {
+      send_to_char("Не пытайтесь подмешать более слабое зелье!\r\n", ch);
+      return;
+    } else {
+      send_to_char(
+          "Смешивать разные зелья?! Да вы, батенька, гурман!\r\n", ch);
+      return;
+    }
+  }
 
-	//Переливает из емкости или колодца с зельем куда-то
-	if ((GET_OBJ_TYPE(from_obj) == OBJ_DATA::ITEM_DRINKCON
-		|| GET_OBJ_TYPE(from_obj) == OBJ_DATA::ITEM_FOUNTAIN)
-		&& is_potion(from_obj))
-	{
-		if (GET_OBJ_VAL(to_obj, 1) == 0)
-		{
-			spells_to_drinkcon(from_obj, to_obj);
-		}
-		else
-		{
-			const int result = check_equal_drinkcon(from_obj, to_obj);
-			if (result < 0)
-			{
-				send_to_char("Не пытайтесь подмешать более слабое зелье!\r\n", ch);
-				return;
-			}
-			else if (!result)
-			{
-				send_to_char(
-					"Смешивать разные зелья?! Да вы, батенька, гурман!\r\n", ch);
-				return;
-			}
-		}
-	}
+  //Переливает из емкости или колодца с зельем куда-то
+  if ((GET_OBJ_TYPE(from_obj) == OBJ_DATA::ITEM_DRINKCON
+      || GET_OBJ_TYPE(from_obj) == OBJ_DATA::ITEM_FOUNTAIN)
+      && is_potion(from_obj)) {
+    if (GET_OBJ_VAL(to_obj, 1) == 0) {
+      spells_to_drinkcon(from_obj, to_obj);
+    } else {
+      const int result = check_equal_drinkcon(from_obj, to_obj);
+      if (result < 0) {
+        send_to_char("Не пытайтесь подмешать более слабое зелье!\r\n", ch);
+        return;
+      } else if (!result) {
+        send_to_char(
+            "Смешивать разные зелья?! Да вы, батенька, гурман!\r\n", ch);
+        return;
+      }
+    }
+  }
 //Конец изменений Adept'ом
 
-	if (subcmd == SCMD_POUR)
-	{
-		send_to_char(ch, "Вы занялись переливанием %s в %s.\r\n",
-			drinks[GET_OBJ_VAL(from_obj, 2)], OBJN(to_obj, ch, 3));
-	}
-	if (subcmd == SCMD_FILL)
-	{
-		act("Вы наполнили $o3 из $O1.", FALSE, ch, to_obj, from_obj, TO_CHAR);
-		act("$n наполнил$g $o3 из $O1.", TRUE, ch, to_obj, from_obj, TO_ROOM);
-	}
+  if (subcmd == SCMD_POUR) {
+    send_to_char(ch, "Вы занялись переливанием %s в %s.\r\n",
+                 drinks[GET_OBJ_VAL(from_obj, 2)], OBJN(to_obj, ch, 3));
+  }
+  if (subcmd == SCMD_FILL) {
+    act("Вы наполнили $o3 из $O1.", FALSE, ch, to_obj, from_obj, TO_CHAR);
+    act("$n наполнил$g $o3 из $O1.", TRUE, ch, to_obj, from_obj, TO_ROOM);
+  }
 
-	// копируем тип жидкости //
-	to_obj->set_val(2, GET_OBJ_VAL(from_obj, 2));
+  // копируем тип жидкости //
+  to_obj->set_val(2, GET_OBJ_VAL(from_obj, 2));
 
-	int n1 = GET_OBJ_VAL(from_obj, 1);
-	int n2 = GET_OBJ_VAL(to_obj, 1);
-	int t1 = GET_OBJ_VAL(from_obj, 3);
-	int t2 = GET_OBJ_VAL(to_obj, 3);
-	to_obj->set_val(3, (n1*t1 + n2*t2) / (n1 + n2)); //усредним таймер в зависимости от наполненности обоих емкостей
+  int n1 = GET_OBJ_VAL(from_obj, 1);
+  int n2 = GET_OBJ_VAL(to_obj, 1);
+  int t1 = GET_OBJ_VAL(from_obj, 3);
+  int t2 = GET_OBJ_VAL(to_obj, 3);
+  to_obj->set_val(3, (n1 * t1 + n2 * t2) / (n1 + n2)); //усредним таймер в зависимости от наполненности обоих емкостей
 //	send_to_char(ch, "n1 == %d, n2 == %d, t1 == %d, t2== %d, результат %d\r\n", n1, n2, t1, t2, GET_OBJ_VAL(to_obj, 3));
 
-	// New alias //
-	if (GET_OBJ_VAL(to_obj, 1) == 0)
-		name_to_drinkcon(to_obj, GET_OBJ_VAL(from_obj, 2));
-	// Then how much to pour //
-	amount = (GET_OBJ_VAL(to_obj, 0) - GET_OBJ_VAL(to_obj, 1));
-	if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_FOUNTAIN
-		|| GET_OBJ_VAL(from_obj, 1) != 999)
-	{
-		from_obj->sub_val(1, amount);
-	}
-	to_obj->set_val(1, GET_OBJ_VAL(to_obj, 0));
+  // New alias //
+  if (GET_OBJ_VAL(to_obj, 1) == 0)
+    name_to_drinkcon(to_obj, GET_OBJ_VAL(from_obj, 2));
+  // Then how much to pour //
+  amount = (GET_OBJ_VAL(to_obj, 0) - GET_OBJ_VAL(to_obj, 1));
+  if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_FOUNTAIN
+      || GET_OBJ_VAL(from_obj, 1) != 999) {
+    from_obj->sub_val(1, amount);
+  }
+  to_obj->set_val(1, GET_OBJ_VAL(to_obj, 0));
 
-	// Then the poison boogie //
+  // Then the poison boogie //
 
 
-	if (GET_OBJ_VAL(from_obj, 1) <= 0)  	// There was too little //
-	{
-		to_obj->add_val(1, GET_OBJ_VAL(from_obj, 1));
-		amount += GET_OBJ_VAL(from_obj, 1);
-		from_obj->set_val(1, 0);
-		from_obj->set_val(2, 0);
-		from_obj->set_val(3, 0);
-		name_from_drinkcon(from_obj);
-		reset_potion_values(from_obj);
-	}
+  if (GET_OBJ_VAL(from_obj, 1) <= 0)    // There was too little //
+  {
+    to_obj->add_val(1, GET_OBJ_VAL(from_obj, 1));
+    amount += GET_OBJ_VAL(from_obj, 1);
+    from_obj->set_val(1, 0);
+    from_obj->set_val(2, 0);
+    from_obj->set_val(3, 0);
+    name_from_drinkcon(from_obj);
+    reset_potion_values(from_obj);
+  }
 
-	// And the weight boogie //
-	if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_FOUNTAIN)
-	{
-		weight_change_object(from_obj, -amount);
-	}
-	weight_change_object(to_obj, amount);	// Add weight //
+  // And the weight boogie //
+  if (GET_OBJ_TYPE(from_obj) != OBJ_DATA::ITEM_FOUNTAIN) {
+    weight_change_object(from_obj, -amount);
+  }
+  weight_change_object(to_obj, amount);    // Add weight //
 }
 
-size_t find_liquid_name(const char * name)
-{
-	std::string tmp = std::string(name);
-	size_t pos, result = std::string::npos;
-	for (int i = 0; strcmp(drinknames[i],"\n"); i++)
-	{
-		pos = tmp.find(drinknames[i]);
-		if (pos != std::string::npos)
-		{
-			result = pos;
-		}
-	}
-	return result;
+size_t find_liquid_name(const char *name) {
+  std::string tmp = std::string(name);
+  size_t pos, result = std::string::npos;
+  for (int i = 0; strcmp(drinknames[i], "\n"); i++) {
+    pos = tmp.find(drinknames[i]);
+    if (pos != std::string::npos) {
+      result = pos;
+    }
+  }
+  return result;
 }
 
-void name_from_drinkcon(OBJ_DATA * obj)
-{
-	char new_name[MAX_STRING_LENGTH];
-	std::string tmp;
+void name_from_drinkcon(OBJ_DATA *obj) {
+  char new_name[MAX_STRING_LENGTH];
+  std::string tmp;
 
-	size_t pos = find_liquid_name(obj->get_aliases().c_str());
-	if (pos == std::string::npos) return;
-	tmp = obj->get_aliases().substr(0, pos - 1);
+  size_t pos = find_liquid_name(obj->get_aliases().c_str());
+  if (pos == std::string::npos) return;
+  tmp = obj->get_aliases().substr(0, pos - 1);
 
-	sprintf(new_name, "%s", tmp.c_str());
-	obj->set_aliases(new_name);
+  sprintf(new_name, "%s", tmp.c_str());
+  obj->set_aliases(new_name);
 
-	pos = find_liquid_name(obj->get_short_description().c_str());
-	if (pos == std::string::npos) return;
-	tmp = obj->get_short_description().substr(0, pos - 3);
+  pos = find_liquid_name(obj->get_short_description().c_str());
+  if (pos == std::string::npos) return;
+  tmp = obj->get_short_description().substr(0, pos - 3);
 
-	sprintf(new_name, "%s", tmp.c_str());
-	obj->set_short_description(new_name);
+  sprintf(new_name, "%s", tmp.c_str());
+  obj->set_short_description(new_name);
 
-	for (int c = 0; c < CObjectPrototype::NUM_PADS; c++)
-	{
-		pos = find_liquid_name(obj->get_PName(c).c_str());
-		if (pos == std::string::npos) return;
-		tmp = obj->get_PName(c).substr(0, pos - 3);
-		sprintf(new_name, "%s", tmp.c_str());
-		obj->set_PName(c, new_name);
-	}
+  for (int c = 0; c < CObjectPrototype::NUM_PADS; c++) {
+    pos = find_liquid_name(obj->get_PName(c).c_str());
+    if (pos == std::string::npos) return;
+    tmp = obj->get_PName(c).substr(0, pos - 3);
+    sprintf(new_name, "%s", tmp.c_str());
+    obj->set_PName(c, new_name);
+  }
 }
 
-void name_to_drinkcon(OBJ_DATA * obj, int type)
-{
-	int c;
-	char new_name[MAX_INPUT_LENGTH];
+void name_to_drinkcon(OBJ_DATA *obj, int type) {
+  int c;
+  char new_name[MAX_INPUT_LENGTH];
 
-	sprintf(new_name, "%s %s", obj->get_aliases().c_str(), drinknames[type]);
-	obj->set_aliases(new_name);
+  sprintf(new_name, "%s %s", obj->get_aliases().c_str(), drinknames[type]);
+  obj->set_aliases(new_name);
 
-	sprintf(new_name, "%s с %s", obj->get_short_description().c_str(), drinknames[type]);
-	obj->set_short_description(new_name);
+  sprintf(new_name, "%s с %s", obj->get_short_description().c_str(), drinknames[type]);
+  obj->set_short_description(new_name);
 
-	for (c = 0; c < CObjectPrototype::NUM_PADS; c++)
-	{
-		sprintf(new_name, "%s с %s", obj->get_PName(c).c_str(), drinknames[type]);
-		obj->set_PName(c, new_name);
-	}
+  for (c = 0; c < CObjectPrototype::NUM_PADS; c++) {
+    sprintf(new_name, "%s с %s", obj->get_PName(c).c_str(), drinknames[type]);
+    obj->set_PName(c, new_name);
+  }
 }
 
-std::string print_spell(CHAR_DATA *ch, const OBJ_DATA *obj, int num)
-{
-	const auto spell = init_spell_num(num);
-	const auto level = init_spell_lvl(num);
+std::string print_spell(CHAR_DATA *ch, const OBJ_DATA *obj, int num) {
+  const auto spell = init_spell_num(num);
+  const auto level = init_spell_lvl(num);
 
-	if (obj->get_value(spell) == -1)
-	{
-		return "";
-	}
+  if (obj->get_value(spell) == -1) {
+    return "";
+  }
 
-	char buf_[MAX_INPUT_LENGTH];
-	snprintf(buf_, sizeof(buf_), "Содержит заклинание: %s%s (%d ур.)%s\r\n",
-		CCCYN(ch, C_NRM),
-		spell_name(obj->get_value(spell)),
-		obj->get_value(level),
-		CCNRM(ch, C_NRM));
+  char buf_[MAX_INPUT_LENGTH];
+  snprintf(buf_, sizeof(buf_), "Содержит заклинание: %s%s (%d ур.)%s\r\n",
+           CCCYN(ch, C_NRM),
+           spell_name(obj->get_value(spell)),
+           obj->get_value(level),
+           CCNRM(ch, C_NRM));
 
-	return buf_;
+  return buf_;
 }
 
-namespace drinkcon
-{
+namespace drinkcon {
 
-std::string print_spells(CHAR_DATA *ch, const OBJ_DATA *obj)
-{
-	std::string out;
-	char buf_[MAX_INPUT_LENGTH];
+std::string print_spells(CHAR_DATA *ch, const OBJ_DATA *obj) {
+  std::string out;
+  char buf_[MAX_INPUT_LENGTH];
 
-	for (int i = 1; i <= 3; ++i)
-	{
-		out += print_spell(ch, obj, i);
-	}
+  for (int i = 1; i <= 3; ++i) {
+    out += print_spell(ch, obj, i);
+  }
 
-	if (!out.empty() && !is_potion(obj))
-	{
-		snprintf(buf_, sizeof(buf_), "%sВНИМАНИЕ%s: тип жидкости не является зельем\r\n",
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-		out += buf_;
-	}
-	else if (out.empty() && is_potion(obj))
-	{
-		snprintf(buf_, sizeof(buf_), "%sВНИМАНИЕ%s: у данного зелья отсутствуют заклинания\r\n",
-			CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-		out += buf_;
-	}
+  if (!out.empty() && !is_potion(obj)) {
+    snprintf(buf_, sizeof(buf_), "%sВНИМАНИЕ%s: тип жидкости не является зельем\r\n",
+             CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+    out += buf_;
+  } else if (out.empty() && is_potion(obj)) {
+    snprintf(buf_, sizeof(buf_), "%sВНИМАНИЕ%s: у данного зелья отсутствуют заклинания\r\n",
+             CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
+    out += buf_;
+  }
 
-	return out;
+  return out;
 }
 
-void identify(CHAR_DATA *ch, const OBJ_DATA *obj)
-{
-	std::string out;
-	char buf_[MAX_INPUT_LENGTH];
-	int volume = GET_OBJ_VAL(obj, 0);
-	int amount = GET_OBJ_VAL(obj, 1);
+void identify(CHAR_DATA *ch, const OBJ_DATA *obj) {
+  std::string out;
+  char buf_[MAX_INPUT_LENGTH];
+  int volume = GET_OBJ_VAL(obj, 0);
+  int amount = GET_OBJ_VAL(obj, 1);
 
-	snprintf(buf_, sizeof(buf_), "Может вместить зелья: %s%d %s%s\r\n",
-		CCCYN(ch, C_NRM),
-		volume, desc_count(volume, WHAT_GULP),
-		CCNRM(ch, C_NRM));
-	out += buf_;
+  snprintf(buf_, sizeof(buf_), "Может вместить зелья: %s%d %s%s\r\n",
+           CCCYN(ch, C_NRM),
+           volume, desc_count(volume, WHAT_GULP),
+           CCNRM(ch, C_NRM));
+  out += buf_;
 
-	// емкость не пуста
-	if (amount > 0)
-	{
-		// есть какие-то заклы
-		if (obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM) >= 0)
-		{
-			if (IS_IMMORTAL(ch))
-			{
-				snprintf(buf_, sizeof(buf_), "Содержит %d %s %s (VNUM: %d).\r\n",
-					amount,
-					desc_count(amount, WHAT_GULP),
-					drinks[GET_OBJ_VAL(obj, 2)],
-					obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM));
-			}
-			else
-			{
-				snprintf(buf_, sizeof(buf_), "Содержит %d %s %s.\r\n",
-					amount,
-					desc_count(amount, WHAT_GULP),
-					drinks[GET_OBJ_VAL(obj, 2)]);
-			}
-			out += buf_;
-			out += print_spells(ch, obj);
-		}
-		else
-		{
-			snprintf(buf_, sizeof(buf_), "Заполнен%s %s на %d%%\r\n",
-				GET_OBJ_SUF_6(obj),
-				drinknames[GET_OBJ_VAL(obj, 2)],
-				amount*100/(volume ? volume : 1));
-			out += buf_;
-			// чтобы выдать варнинг на тему зелья без заклов
-			if (is_potion(obj))
-			{
-				out += print_spells(ch, obj);
-			}
-		}
-	}
-	if (amount > 0) //если что-то плескается
-	{
-		sprintf(buf1, "Качество: %s \r\n", diag_liquid_timer(obj)); // состояние жижки
-		out += buf1;
-	}
-	send_to_char(out, ch);
+  // емкость не пуста
+  if (amount > 0) {
+    // есть какие-то заклы
+    if (obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM) >= 0) {
+      if (IS_IMMORTAL(ch)) {
+        snprintf(buf_, sizeof(buf_), "Содержит %d %s %s (VNUM: %d).\r\n",
+                 amount,
+                 desc_count(amount, WHAT_GULP),
+                 drinks[GET_OBJ_VAL(obj, 2)],
+                 obj->get_value(ObjVal::EValueKey::POTION_PROTO_VNUM));
+      } else {
+        snprintf(buf_, sizeof(buf_), "Содержит %d %s %s.\r\n",
+                 amount,
+                 desc_count(amount, WHAT_GULP),
+                 drinks[GET_OBJ_VAL(obj, 2)]);
+      }
+      out += buf_;
+      out += print_spells(ch, obj);
+    } else {
+      snprintf(buf_, sizeof(buf_), "Заполнен%s %s на %d%%\r\n",
+               GET_OBJ_SUF_6(obj),
+               drinknames[GET_OBJ_VAL(obj, 2)],
+               amount * 100 / (volume ? volume : 1));
+      out += buf_;
+      // чтобы выдать варнинг на тему зелья без заклов
+      if (is_potion(obj)) {
+        out += print_spells(ch, obj);
+      }
+    }
+  }
+  if (amount > 0) //если что-то плескается
+  {
+    sprintf(buf1, "Качество: %s \r\n", diag_liquid_timer(obj)); // состояние жижки
+    out += buf1;
+  }
+  send_to_char(out, ch);
 }
 
 } // namespace drinkcon

--- a/src/liquid.cpp
+++ b/src/liquid.cpp
@@ -716,9 +716,9 @@ void do_drunkoff(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
   timed.time = can_use_feat(ch, DRUNKARD_FEAT) ? getModifier(DRUNKARD_FEAT, FEAT_TIMER) : 12;
   timed_to_char(ch, &timed);
 
-  percent = number(1, skill_info[SKILL_DRUNKOFF].max_percent);
-  prob = calculate_skill(ch, SKILL_DRUNKOFF, nullptr);
-  train_skill(ch, SKILL_DRUNKOFF, percent <= prob, nullptr);
+  percent = number(1, skill_info[SKILL_DRUNKOFF].fail_percent);
+  prob = CalcCurrentSkill(ch, SKILL_DRUNKOFF, nullptr);
+  TrainSkill(ch, SKILL_DRUNKOFF, percent <= prob, nullptr);
   amount = MIN(amount, GET_OBJ_VAL(obj, 1));
   weight = MIN(amount, GET_OBJ_WEIGHT(obj));
   weight_change_object(obj, -weight);    // Subtract amount //

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -38,23 +38,23 @@ extern int what_sky;
 extern DESCRIPTOR_DATA *descriptor_list;
 extern struct spell_create_type spell_create[];
 extern int interpolate(int min_value, int pulse);
-extern int attack_best(CHAR_DATA * ch, CHAR_DATA * victim);
+extern int attack_best(CHAR_DATA *ch, CHAR_DATA *victim);
 
-byte saving_throws(int class_num, int type, int level);	// class.cpp
+byte saving_throws(int class_num, int type, int level);    // class.cpp
 byte extend_saving_throws(int class_num, int type, int level);
-int check_charmee(CHAR_DATA * ch, CHAR_DATA * victim, int spellnum);
-void cast_reaction(CHAR_DATA * victim, CHAR_DATA * caster, int spellnum);
+int check_charmee(CHAR_DATA *ch, CHAR_DATA *victim, int spellnum);
+void cast_reaction(CHAR_DATA *victim, CHAR_DATA *caster, int spellnum);
 
 bool material_component_processing(CHAR_DATA *caster, CHAR_DATA *victim, int spellnum);
 bool material_component_processing(CHAR_DATA *caster, int vnum, int spellnum);
 
-bool is_room_forbidden(ROOM_DATA * room) {
-	for (const auto& af : room->affected) {
-		if (af->type == SPELL_FORBIDDEN && (number(1, 100) <= af->modifier)) {
-			return true;
-		}
-	}
-	return false;
+bool is_room_forbidden(ROOM_DATA *room) {
+  for (const auto &af : room->affected) {
+    if (af->type == SPELL_FORBIDDEN && (number(1, 100) <= af->modifier)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // * Saving throws are now in class.cpp as of bpl13.
@@ -67,496 +67,454 @@ bool is_room_forbidden(ROOM_DATA * room) {
  * in some other systems.
  */
 
-int calc_anti_savings(CHAR_DATA * ch)
-{
-	int modi = 0;
+int calc_anti_savings(CHAR_DATA *ch) {
+  int modi = 0;
 
-	if (WAITLESS(ch))
-		modi = 350;
-	else if (GET_GOD_FLAG(ch, GF_GODSLIKE))
-		modi = 250;
-	else if (GET_GOD_FLAG(ch, GF_GODSCURSE))
-		modi = -250;
-	else
-		modi = GET_CAST_SUCCESS(ch);
-	modi += MAX(0, MIN(20, (int)((GET_REAL_WIS(ch) - 23) * 3 / 2)));
-	if (!IS_NPC(ch))
-	{
-		modi *= ch->get_cond_penalty(P_CAST);
-	}
+  if (WAITLESS(ch))
+    modi = 350;
+  else if (GET_GOD_FLAG(ch, GF_GODSLIKE))
+    modi = 250;
+  else if (GET_GOD_FLAG(ch, GF_GODSCURSE))
+    modi = -250;
+  else
+    modi = GET_CAST_SUCCESS(ch);
+  modi += MAX(0, MIN(20, (int) ((GET_REAL_WIS(ch) - 23) * 3 / 2)));
+  if (!IS_NPC(ch)) {
+    modi *= ch->get_cond_penalty(P_CAST);
+  }
 //  log("[EXT_APPLY] Name==%s modi==%d",GET_NAME(ch), modi);
-	return modi;
+  return modi;
 }
 
-int calculateSaving(CHAR_DATA *killer, CHAR_DATA *victim, int type, int ext_apply)
-{
-	int temp_save_stat = 0, temp_awake_mod = 0;
+int calculateSaving(CHAR_DATA *killer, CHAR_DATA *victim, int type, int ext_apply) {
+  int temp_save_stat = 0, temp_awake_mod = 0;
 
-	if (- GET_SAVE(victim, type) / 10 > number(1, 100))
-	{
-		return 1;
-	}
+  if (-GET_SAVE(victim, type) / 10 > number(1, 100)) {
+    return 1;
+  }
 
-	// NPCs use warrior tables according to some book
-	int save;
-	int class_sav = GET_CLASS(victim);
+  // NPCs use warrior tables according to some book
+  int save;
+  int class_sav = GET_CLASS(victim);
 
-	if (IS_NPC(victim))
-	{
-		class_sav = CLASS_MOB;	// неизвестный класс моба
-	}
-	else
-	{
-		if (class_sav < 0 || class_sav >= NUM_PLAYER_CLASSES)
-			class_sav = CLASS_WARRIOR;	// неизвестный класс игрока
-	}
+  if (IS_NPC(victim)) {
+    class_sav = CLASS_MOB;    // неизвестный класс моба
+  } else {
+    if (class_sav < 0 || class_sav >= NUM_PLAYER_CLASSES)
+      class_sav = CLASS_WARRIOR;    // неизвестный класс игрока
+  }
 
-	// Базовые спасброски профессии/уровня
-	save = extend_saving_throws(class_sav, type, GET_LEVEL(victim));
+  // Базовые спасброски профессии/уровня
+  save = extend_saving_throws(class_sav, type, GET_LEVEL(victim));
 
-	switch (type)
-	{
-	case SAVING_REFLEX:      //3 реакция
-		if ((save > 0) && can_use_feat(victim, DODGER_FEAT))
-			save >>= 1;
-		save -= dex_bonus(GET_REAL_DEX(victim));
-		temp_save_stat = dex_bonus(GET_REAL_DEX(victim));
-		if (victim->ahorse())
-			save += 20;
-		break;
-	case SAVING_STABILITY:   //2  стойкость
-		save += -GET_REAL_CON(victim);
-		if (victim->ahorse())
-			save -= 20;
-		temp_save_stat = GET_REAL_CON(victim);
-		break;
-	case SAVING_WILL:        //1  воля
-		save += -GET_REAL_WIS(victim);
-		temp_save_stat = GET_REAL_WIS(victim);
-		break;
-	case SAVING_CRITICAL:   //0   здоровье
-		save += -GET_REAL_CON(victim);
-		temp_save_stat = GET_REAL_CON(victim);
-		break;
-	}
+  switch (type) {
+    case SAVING_REFLEX:      //3 реакция
+      if ((save > 0) && can_use_feat(victim, DODGER_FEAT))
+        save >>= 1;
+      save -= dex_bonus(GET_REAL_DEX(victim));
+      temp_save_stat = dex_bonus(GET_REAL_DEX(victim));
+      if (victim->ahorse())
+        save += 20;
+      break;
+    case SAVING_STABILITY:   //2  стойкость
+      save += -GET_REAL_CON(victim);
+      if (victim->ahorse())
+        save -= 20;
+      temp_save_stat = GET_REAL_CON(victim);
+      break;
+    case SAVING_WILL:        //1  воля
+      save += -GET_REAL_WIS(victim);
+      temp_save_stat = GET_REAL_WIS(victim);
+      break;
+    case SAVING_CRITICAL:   //0   здоровье
+      save += -GET_REAL_CON(victim);
+      temp_save_stat = GET_REAL_CON(victim);
+      break;
+  }
 
-	// Ослабление магических атак
-	if (type != SAVING_REFLEX)
-	{
-		if ((save > 0) &&
-			(AFF_FLAGGED(victim, EAffectFlag::AFF_AIRAURA)
-			    || AFF_FLAGGED(victim, EAffectFlag::AFF_FIREAURA)
-			    || AFF_FLAGGED(victim, EAffectFlag::AFF_EARTHAURA)
-			    || AFF_FLAGGED(victim, EAffectFlag::AFF_ICEAURA)))
-		{
-			save >>= 1;
-		}
-	}
-	// Учет осторожного стиля
-	if (PRF_FLAGGED(victim, PRF_AWAKE))
-	{
-		if (can_use_feat(victim, IMPREGNABLE_FEAT))
-			{
-			save -= MAX(0, victim->get_skill(SKILL_AWAKE) - 80)  /  2;
-			temp_awake_mod = MAX(0, victim->get_skill(SKILL_AWAKE) - 80)  /  2;
-			}
-		temp_awake_mod +=calculate_awake_mod(killer, victim);
-		save -= calculate_awake_mod(killer, victim);
-	}
+  // Ослабление магических атак
+  if (type != SAVING_REFLEX) {
+    if ((save > 0) &&
+        (AFF_FLAGGED(victim, EAffectFlag::AFF_AIRAURA)
+            || AFF_FLAGGED(victim, EAffectFlag::AFF_FIREAURA)
+            || AFF_FLAGGED(victim, EAffectFlag::AFF_EARTHAURA)
+            || AFF_FLAGGED(victim, EAffectFlag::AFF_ICEAURA))) {
+      save >>= 1;
+    }
+  }
+  // Учет осторожного стиля
+  if (PRF_FLAGGED(victim, PRF_AWAKE)) {
+    if (can_use_feat(victim, IMPREGNABLE_FEAT)) {
+      save -= MAX(0, victim->get_skill(SKILL_AWAKE) - 80) / 2;
+      temp_awake_mod = MAX(0, victim->get_skill(SKILL_AWAKE) - 80) / 2;
+    }
+    temp_awake_mod += CalcAwakeMod(killer, victim);
+    save -= CalcAwakeMod(killer, victim);
+  }
 
-	save += GET_SAVE(victim, type);	// одежда
-	save += ext_apply;	// внешний модификатор
+  save += GET_SAVE(victim, type);    // одежда
+  save += ext_apply;    // внешний модификатор
 
-	if (IS_GOD(victim))
-		save = -150;
-	else if (GET_GOD_FLAG(victim, GF_GODSLIKE))
-		save -= 50;
-	else if (GET_GOD_FLAG(victim, GF_GODSCURSE))
-		save += 50;
-	if (IS_NPC(victim) && !IS_NPC(killer))
-		log("SAVING: Caster==%s  Mob==%s vnum==%d Level==%d type==%d base_save==%d stat_bonus==%d awake_bonus==%d save_ext==%d cast_apply==%d result==%d new_random==%d", GET_NAME(killer), GET_NAME(victim), GET_MOB_VNUM(victim), GET_LEVEL(victim), type, extend_saving_throws(class_sav, type, GET_LEVEL(victim)), temp_save_stat, temp_awake_mod, GET_SAVE(victim, type), ext_apply, save, number(1, 200));
-	// Throwing a 0 is always a failure.
-	return save;
+  if (IS_GOD(victim))
+    save = -150;
+  else if (GET_GOD_FLAG(victim, GF_GODSLIKE))
+    save -= 50;
+  else if (GET_GOD_FLAG(victim, GF_GODSCURSE))
+    save += 50;
+  if (IS_NPC(victim) && !IS_NPC(killer))
+    log("SAVING: Caster==%s  Mob==%s vnum==%d Level==%d type==%d base_save==%d stat_bonus==%d awake_bonus==%d save_ext==%d cast_apply==%d result==%d new_random==%d",
+        GET_NAME(killer),
+        GET_NAME(victim),
+        GET_MOB_VNUM(victim),
+        GET_LEVEL(victim),
+        type,
+        extend_saving_throws(class_sav, type, GET_LEVEL(victim)),
+        temp_save_stat,
+        temp_awake_mod,
+        GET_SAVE(victim, type),
+        ext_apply,
+        save,
+        number(1, 200));
+  // Throwing a 0 is always a failure.
+  return save;
 }
 
-int general_savingthrow(CHAR_DATA *killer, CHAR_DATA *victim, int type, int ext_apply)
-{
-	int save = calculateSaving(killer, victim, type, ext_apply);
-	if (MAX(10, save) <= number(1, 200))
-		return (true);
+int general_savingthrow(CHAR_DATA *killer, CHAR_DATA *victim, int type, int ext_apply) {
+  int save = calculateSaving(killer, victim, type, ext_apply);
+  if (MAX(10, save) <= number(1, 200))
+    return (true);
 
-	// Oops, failed. Sorry.
-	return (false);
+  // Oops, failed. Sorry.
+  return (false);
 }
 
-int multi_cast_say(CHAR_DATA * ch)
-{
-	if (!IS_NPC(ch))
-		return 1;
-	switch (GET_RACE(ch))
-	{
-	case NPC_RACE_EVIL_SPIRIT:
-	case NPC_RACE_GHOST:
-	case NPC_RACE_HUMAN:
-	case NPC_RACE_ZOMBIE:
-	case NPC_RACE_SPIRIT:
-		return 1;
-	}
-	return 0;
+int multi_cast_say(CHAR_DATA *ch) {
+  if (!IS_NPC(ch))
+    return 1;
+  switch (GET_RACE(ch)) {
+    case NPC_RACE_EVIL_SPIRIT:
+    case NPC_RACE_GHOST:
+    case NPC_RACE_HUMAN:
+    case NPC_RACE_ZOMBIE:
+    case NPC_RACE_SPIRIT: return 1;
+  }
+  return 0;
 }
 
-void show_spell_off(int aff, CHAR_DATA * ch)
-{
-	if (!IS_NPC(ch) && PLR_FLAGGED(ch, PLR_WRITING))
-		return;
-	sprintf(buf, "%s", spell_wear_off_msg[aff]);
-	if (buf[0] != '*')
-	{
-		act(buf, FALSE, ch, 0, 0, TO_CHAR | TO_SLEEP);
-		send_to_char("\r\n", ch);
-	}
+void show_spell_off(int aff, CHAR_DATA *ch) {
+  if (!IS_NPC(ch) && PLR_FLAGGED(ch, PLR_WRITING))
+    return;
+  sprintf(buf, "%s", spell_wear_off_msg[aff]);
+  if (buf[0] != '*') {
+    act(buf, FALSE, ch, 0, 0, TO_CHAR | TO_SLEEP);
+    send_to_char("\r\n", ch);
+  }
 }
 
 // зависимость длительности закла от скила магии
-float func_koef_duration(int spellnum, int percent)
-{
-	switch (spellnum)
-	{
-		case SPELL_STRENGTH:
-		case SPELL_DEXTERITY:
-			return 1 + percent / 400.00;
-		break;
-		case SPELL_GROUP_BLINK:
-		case SPELL_BLINK:
-			return 1 + percent / 400.00;
-		break;
-		default:
-			return 1;
-		break;
-	}
+float func_koef_duration(int spellnum, int percent) {
+  switch (spellnum) {
+    case SPELL_STRENGTH:
+    case SPELL_DEXTERITY: return 1 + percent / 400.00;
+      break;
+    case SPELL_GROUP_BLINK:
+    case SPELL_BLINK: return 1 + percent / 400.00;
+      break;
+    default: return 1;
+      break;
+  }
 }
 
 // зависимость модификации спелла от скила магии
-float func_koef_modif(int spellnum, int percent)
-{
-	switch (spellnum)
-	{
-	case SPELL_STRENGTH:
-	case SPELL_DEXTERITY:
-		if (percent > 100)
-			return 1;
-		return 0;
-	break;
-	case SPELL_MASS_SLOW:
-	case SPELL_SLOW:
-	{
-		if (percent >= 80)
-		{
-			return (percent - 80) / 20.00 + 1.00;
-		}
-	}
-	break;
-	default:
-		return 1;
-	}
-	return 0;
+float func_koef_modif(int spellnum, int percent) {
+  switch (spellnum) {
+    case SPELL_STRENGTH:
+    case SPELL_DEXTERITY:
+      if (percent > 100)
+        return 1;
+      return 0;
+      break;
+    case SPELL_MASS_SLOW:
+    case SPELL_SLOW: {
+      if (percent >= 80) {
+        return (percent - 80) / 20.00 + 1.00;
+      }
+    }
+      break;
+    default: return 1;
+  }
+  return 0;
 }
 
-int magic_skill_damage_calc(CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int dam) {
-	if (IS_NPC(ch)) {
-		dam += dam * ((GET_REAL_WIS(ch) - 22) * 5) / 100;
-		return (dam);
-	}
+int magic_skill_damage_calc(CHAR_DATA *ch, CHAR_DATA *victim, int spellnum, int dam) {
+  if (IS_NPC(ch)) {
+    dam += dam * ((GET_REAL_WIS(ch) - 22) * 5) / 100;
+    return (dam);
+  }
 
-	const ESkill skill_number = get_magic_skill_number_by_spell(spellnum);
+  const ESkill skill_number = get_magic_skill_number_by_spell(spellnum);
 
-	if (skill_number > 0) {
-		dam += dam * (1 +  static_cast<double>(MIN(CAP_SKILLS, ch->get_skill(skill_number))) / 500);
-	}
+  if (skill_number > 0) {
+    dam += dam * (1 + static_cast<double>(std::min(CalcSkillMinCap(ch, skill_number), ch->get_skill(skill_number))) / 500);
+  }
 
+  if (GET_REAL_WIS(ch) >= 23) {
+    dam += dam * (1 + static_cast<double>((GET_REAL_WIS(ch) - 22)) / 200);
+  }
 
-	if (GET_REAL_WIS(ch) >= 23) {
-		dam += dam * (1 +  static_cast<double>((GET_REAL_WIS(ch) - 22)) / 200);
-	}
+  if (!IS_NPC(ch)) {
+    dam = (IS_NPC(victim) ? MIN(dam, 6 * GET_MAX_HIT(ch)) : MIN(dam, 2 * GET_MAX_HIT(ch)));
+  }
 
-	if (!IS_NPC(ch)) {
-		dam = (IS_NPC(victim) ? MIN(dam, 6 * GET_MAX_HIT(ch)) : MIN(dam, 2 * GET_MAX_HIT(ch)));
-	}
-
-	return (dam);
+  return (dam);
 }
 
-int mag_damage(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int savetype)
-{
-	int dam = 0, rand = 0, count = 1, modi = 0, ndice = 0, sdice = 0, adice = 0, no_savings = FALSE;
-	OBJ_DATA *obj = nullptr;
+int mag_damage(int level, CHAR_DATA *ch, CHAR_DATA *victim, int spellnum, int savetype) {
+  int dam = 0, rand = 0, count = 1, modi = 0, ndice = 0, sdice = 0, adice = 0, no_savings = FALSE;
+  OBJ_DATA *obj = nullptr;
 
-	if (victim == nullptr || IN_ROOM(victim) == NOWHERE || ch == nullptr)
-		return (0);
+  if (victim == nullptr || IN_ROOM(victim) == NOWHERE || ch == nullptr)
+    return (0);
 
-	if (!pk_agro_action(ch, victim))
-		return (0);
+  if (!pk_agro_action(ch, victim))
+    return (0);
 
-	log("[MAG DAMAGE] %s damage %s (%d)",GET_NAME(ch),GET_NAME(victim),spellnum);
-	// Magic glass
-	if ((spellnum != SPELL_LIGHTNING_BREATH && spellnum != SPELL_FIRE_BREATH && spellnum != SPELL_GAS_BREATH && spellnum != SPELL_ACID_BREATH)
-		|| ch == victim) {
-		if (!IS_SET(SpINFO.routines, MAG_WARCRY)) {
-			if (ch != victim && spellnum < MAX_SPELLS &&
-				((AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICGLASS) && number(1, 100) < (GET_LEVEL(victim) / 3)))) {
-				act("Магическое зеркало $N1 отразило вашу магию!", FALSE, ch, 0, victim, TO_CHAR);
-				act("Магическое зеркало $N1 отразило магию $n1!", FALSE, ch, 0, victim, TO_NOTVICT);
-				act("Ваше магическое зеркало отразило поражение $n1!", FALSE, ch, 0, victim, TO_VICT);
-				log("[MAG DAMAGE] Зеркало - полное отражение: %s damage %s (%d)",GET_NAME(ch),GET_NAME(victim),spellnum);
-				return (mag_damage(level, ch, ch, spellnum, savetype));
-			}
-		} else {
-			if (ch != victim && spellnum < MAX_SPELLS && IS_GOD(victim) && (IS_NPC(ch) || GET_LEVEL(victim) > GET_LEVEL(ch))) {
-				act("Звуковой барьер $N1 отразил ваш крик!", FALSE, ch, 0, victim, TO_CHAR);
-				act("Звуковой барьер $N1 отразил крик $n1!", FALSE, ch, 0, victim, TO_NOTVICT);
-				act("Ваш звуковой барьер отразил крик $n1!", FALSE, ch, 0, victim, TO_VICT);
-				return (mag_damage(level, ch, ch, spellnum, savetype));
-			}
-		}
+  log("[MAG DAMAGE] %s damage %s (%d)", GET_NAME(ch), GET_NAME(victim), spellnum);
+  // Magic glass
+  if ((spellnum != SPELL_LIGHTNING_BREATH && spellnum != SPELL_FIRE_BREATH && spellnum != SPELL_GAS_BREATH
+      && spellnum != SPELL_ACID_BREATH)
+      || ch == victim) {
+    if (!IS_SET(SpINFO.routines, MAG_WARCRY)) {
+      if (ch != victim && spellnum < MAX_SPELLS &&
+          ((AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICGLASS) && number(1, 100) < (GET_LEVEL(victim) / 3)))) {
+        act("Магическое зеркало $N1 отразило вашу магию!", FALSE, ch, 0, victim, TO_CHAR);
+        act("Магическое зеркало $N1 отразило магию $n1!", FALSE, ch, 0, victim, TO_NOTVICT);
+        act("Ваше магическое зеркало отразило поражение $n1!", FALSE, ch, 0, victim, TO_VICT);
+        log("[MAG DAMAGE] Зеркало - полное отражение: %s damage %s (%d)", GET_NAME(ch), GET_NAME(victim), spellnum);
+        return (mag_damage(level, ch, ch, spellnum, savetype));
+      }
+    } else {
+      if (ch != victim && spellnum < MAX_SPELLS && IS_GOD(victim)
+          && (IS_NPC(ch) || GET_LEVEL(victim) > GET_LEVEL(ch))) {
+        act("Звуковой барьер $N1 отразил ваш крик!", FALSE, ch, 0, victim, TO_CHAR);
+        act("Звуковой барьер $N1 отразил крик $n1!", FALSE, ch, 0, victim, TO_NOTVICT);
+        act("Ваш звуковой барьер отразил крик $n1!", FALSE, ch, 0, victim, TO_VICT);
+        return (mag_damage(level, ch, ch, spellnum, savetype));
+      }
+    }
 
-		if (!IS_SET(SpINFO.routines, MAG_WARCRY) && AFF_FLAGGED(victim, EAffectFlag::AFF_SHADOW_CLOAK) && spellnum < MAX_SPELLS && number(1, 100) < 21)
-		{
-			act("Густая тень вокруг $N1 жадно поглотила вашу магию.", FALSE, ch, 0, victim, TO_CHAR);
-			act("Густая тень вокруг $N1 жадно поглотила магию $n1.", FALSE, ch, 0, victim, TO_NOTVICT);
-			act("Густая тень вокруг вас поглотила магию $n1.", FALSE, ch, 0, victim, TO_VICT);
-			log("[MAG DAMAGE] Мантия  - поглощение урона: %s damage %s (%d)",GET_NAME(ch),GET_NAME(victim),spellnum);
-			return (0);
-		}
-	}
+    if (!IS_SET(SpINFO.routines, MAG_WARCRY) && AFF_FLAGGED(victim, EAffectFlag::AFF_SHADOW_CLOAK)
+        && spellnum < MAX_SPELLS && number(1, 100) < 21) {
+      act("Густая тень вокруг $N1 жадно поглотила вашу магию.", FALSE, ch, 0, victim, TO_CHAR);
+      act("Густая тень вокруг $N1 жадно поглотила магию $n1.", FALSE, ch, 0, victim, TO_NOTVICT);
+      act("Густая тень вокруг вас поглотила магию $n1.", FALSE, ch, 0, victim, TO_VICT);
+      log("[MAG DAMAGE] Мантия  - поглощение урона: %s damage %s (%d)", GET_NAME(ch), GET_NAME(victim), spellnum);
+      return (0);
+    }
+  }
 
-	// позиции до начала атаки для расчета модификаторов в damage()
-	// в принципе могут меняться какими-то заклами, но пока по дефолту нет
-	int ch_start_pos = GET_POS(ch);
-	int victim_start_pos = GET_POS(victim);
+  // позиции до начала атаки для расчета модификаторов в damage()
+  // в принципе могут меняться какими-то заклами, но пока по дефолту нет
+  int ch_start_pos = GET_POS(ch);
+  int victim_start_pos = GET_POS(victim);
 
-	if (ch != victim)
-	{
-		modi = calc_anti_savings(ch);
-		if (can_use_feat(ch, RELATED_TO_MAGIC_FEAT) && !IS_NPC(victim))
-		{
-			modi -= 80; //бонуса на непись нету
-		}
-		if (can_use_feat(ch, MAGICAL_INSTINCT_FEAT) && !IS_NPC(victim))
-		{
-			modi -= 30; //бонуса на непись нету
-		}
-	}
+  if (ch != victim) {
+    modi = calc_anti_savings(ch);
+    if (can_use_feat(ch, RELATED_TO_MAGIC_FEAT) && !IS_NPC(victim)) {
+      modi -= 80; //бонуса на непись нету
+    }
+    if (can_use_feat(ch, MAGICAL_INSTINCT_FEAT) && !IS_NPC(victim)) {
+      modi -= 30; //бонуса на непись нету
+    }
+  }
 
-	if (!IS_NPC(ch) && (GET_LEVEL(ch) > 10))
-		modi += (GET_LEVEL(ch) - 10);
+  if (!IS_NPC(ch) && (GET_LEVEL(ch) > 10))
+    modi += (GET_LEVEL(ch) - 10);
 //  if (!IS_NPC(ch) && !IS_NPC(victim))
 //     modi = 0;
-	if (PRF_FLAGGED(ch, PRF_AWAKE) && !IS_NPC(victim))
-		modi = modi - 50;
+  if (PRF_FLAGGED(ch, PRF_AWAKE) && !IS_NPC(victim))
+    modi = modi - 50;
 
-	switch (spellnum)
-	{
-		// ******** ДЛЯ ВСЕХ МАГОВ ********
-		// магическая стрела - для всех с 1го левела 1го круга(8 слотов)
-		// *** мин 15 макс 45 (360)
-		// нейтрал
-	case SPELL_MAGIC_MISSILE:
-		modi += 300;//hotelos by postavit "no_saving = THRUE" no ono po idiotski propisano
-		ndice = 2;
-		sdice = 4;
-		adice = 10;
-		// если есть фит магическая стрела, то стрелок на 30 уровне будет 6
-		if (can_use_feat(ch, MAGICARROWS_FEAT))
-			count = (level + 9) / 5;
-		else
-			count = (level + 9) / 10;
-		break;
-		// ледяное прикосновение - для всех с 7го левела 3го круга(7 слотов)
-		// *** мин 29.5 макс 55.5  (390)
-		// нейтрал
-	case SPELL_CHILL_TOUCH:
-		savetype = SAVING_REFLEX;
-		ndice = 15;
-		sdice = 2;
-		adice = level;
-		break;
-		// кислота - для всех с 18го левела 5го круга (6 слотов)
-		// *** мин 48 макс 70 (420)
-		// нейтрал
-	case SPELL_ACID:
-		savetype = SAVING_REFLEX;
-		obj = nullptr;
-		if (IS_NPC(victim))
-		{
-			rand = number(1, 50);
-			if (rand <= WEAR_BOTHS)
-			{
-				obj = GET_EQ(victim, rand);
-			}
-			else
-			{
-				for (rand -= WEAR_BOTHS, obj = victim->carrying; rand && obj; rand--, obj = obj->get_next_content());
-			}
-		}
-		if (obj)
-		{
-			ndice = 6;
-			sdice = 10;
-			adice = level;
-			act("Кислота покрыла $o3.", FALSE, victim, obj, 0, TO_CHAR);
-			alterate_object(obj, number(level * 2, level * 4), 100);
-		}
-		else
-		{
-			ndice = 6;
-			sdice = 15;
-			adice = (level - 18) * 2;
-		}
-		break;
+  switch (spellnum) {
+    // ******** ДЛЯ ВСЕХ МАГОВ ********
+    // магическая стрела - для всех с 1го левела 1го круга(8 слотов)
+    // *** мин 15 макс 45 (360)
+    // нейтрал
+    case SPELL_MAGIC_MISSILE: modi += 300;//hotelos by postavit "no_saving = THRUE" no ono po idiotski propisano
+      ndice = 2;
+      sdice = 4;
+      adice = 10;
+      // если есть фит магическая стрела, то стрелок на 30 уровне будет 6
+      if (can_use_feat(ch, MAGICARROWS_FEAT))
+        count = (level + 9) / 5;
+      else
+        count = (level + 9) / 10;
+      break;
+      // ледяное прикосновение - для всех с 7го левела 3го круга(7 слотов)
+      // *** мин 29.5 макс 55.5  (390)
+      // нейтрал
+    case SPELL_CHILL_TOUCH: savetype = SAVING_REFLEX;
+      ndice = 15;
+      sdice = 2;
+      adice = level;
+      break;
+      // кислота - для всех с 18го левела 5го круга (6 слотов)
+      // *** мин 48 макс 70 (420)
+      // нейтрал
+    case SPELL_ACID: savetype = SAVING_REFLEX;
+      obj = nullptr;
+      if (IS_NPC(victim)) {
+        rand = number(1, 50);
+        if (rand <= WEAR_BOTHS) {
+          obj = GET_EQ(victim, rand);
+        } else {
+          for (rand -= WEAR_BOTHS, obj = victim->carrying; rand && obj; rand--, obj = obj->get_next_content());
+        }
+      }
+      if (obj) {
+        ndice = 6;
+        sdice = 10;
+        adice = level;
+        act("Кислота покрыла $o3.", FALSE, victim, obj, 0, TO_CHAR);
+        alterate_object(obj, number(level * 2, level * 4), 100);
+      } else {
+        ndice = 6;
+        sdice = 15;
+        adice = (level - 18) * 2;
+      }
+      break;
 
-		// землетрясение чернокнижники 22 уровень 7 круг (4)
-		// *** мин 48 макс 60 (240)
-		// нейтрал
-	case SPELL_EARTHQUAKE:
-		savetype = SAVING_REFLEX;
-		ndice = 6;
-		sdice = 15;
-		adice = (level - 22) * 2;
-		// если наездник, то считаем не сейвисы, а SKILL_HORSE
-		if (ch->ahorse()) {
+      // землетрясение чернокнижники 22 уровень 7 круг (4)
+      // *** мин 48 макс 60 (240)
+      // нейтрал
+    case SPELL_EARTHQUAKE: savetype = SAVING_REFLEX;
+      ndice = 6;
+      sdice = 15;
+      adice = (level - 22) * 2;
+      // если наездник, то считаем не сейвисы, а SKILL_HORSE
+      if (ch->ahorse()) {
 //		    5% шанс успеха,
-            rand = number(1,100);
-            if (rand > 95)
-                break;
-            // провал - 5% шанс или скилл наездника vs скилл магии кастера на кубике d6
-            if (rand < 5 || (calculate_skill(victim, SKILL_HORSE, nullptr) * number (1, 6)) < GET_SKILL(ch, SKILL_EARTH_MAGIC) * number (1, 6) ) {//фейл
-                ch->drop_from_horse();
-                break;
-            }
-		}
-		if (GET_POS(victim) > POS_SITTING && !WAITLESS(victim) && (number(1, 999)  > GET_AR(victim) * 10) &&
-				(GET_MOB_HOLD(victim) || !general_savingthrow(ch, victim, SAVING_REFLEX, CALC_SUCCESS(modi, 30))))
-		{
-            if (IS_HORSE(ch))
-                ch->drop_from_horse();
-			act("$n3 повалило на землю.", FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-			act("Вас повалило на землю.", FALSE, victim, 0, 0, TO_CHAR);
-			GET_POS(victim) = POS_SITTING;
-			update_pos(victim);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-		}
-		break;
+        rand = number(1, 100);
+        if (rand > 95)
+          break;
+        // провал - 5% шанс или скилл наездника vs скилл магии кастера на кубике d6
+        if (rand < 5 || (CalcCurrentSkill(victim, SKILL_HORSE, nullptr) * number(1, 6))
+            < GET_SKILL(ch, SKILL_EARTH_MAGIC) * number(1, 6)) {//фейл
+          ch->drop_from_horse();
+          break;
+        }
+      }
+      if (GET_POS(victim) > POS_SITTING && !WAITLESS(victim) && (number(1, 999) > GET_AR(victim) * 10) &&
+          (GET_MOB_HOLD(victim) || !general_savingthrow(ch, victim, SAVING_REFLEX, CALC_SUCCESS(modi, 30)))) {
+        if (IS_HORSE(ch))
+          ch->drop_from_horse();
+        act("$n3 повалило на землю.", FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        act("Вас повалило на землю.", FALSE, victim, 0, 0, TO_CHAR);
+        GET_POS(victim) = POS_SITTING;
+        update_pos(victim);
+        WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+      }
+      break;
 
-	case SPELL_SONICWAVE:
-		savetype = SAVING_STABILITY;
-		ndice = 6;
-		sdice = 8;
-		adice = (level - 25) * 3;
-		if (GET_POS(victim) > POS_SITTING &&
-				!WAITLESS(victim) && (number(1, 999)  > GET_AR(victim) * 10) &&
-				(GET_MOB_HOLD(victim) || !general_savingthrow(ch, victim, SAVING_STABILITY, CALC_SUCCESS(modi, 60))))
-		{
-			act("$n3 повалило на землю.", FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-			act("Вас повалило на землю.", FALSE, victim, 0, 0, TO_CHAR);
-			GET_POS(victim) = POS_SITTING;
-			update_pos(victim);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-		}
-		break;
+    case SPELL_SONICWAVE: savetype = SAVING_STABILITY;
+      ndice = 6;
+      sdice = 8;
+      adice = (level - 25) * 3;
+      if (GET_POS(victim) > POS_SITTING &&
+          !WAITLESS(victim) && (number(1, 999) > GET_AR(victim) * 10) &&
+          (GET_MOB_HOLD(victim) || !general_savingthrow(ch, victim, SAVING_STABILITY, CALC_SUCCESS(modi, 60)))) {
+        act("$n3 повалило на землю.", FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        act("Вас повалило на землю.", FALSE, victim, 0, 0, TO_CHAR);
+        GET_POS(victim) = POS_SITTING;
+        update_pos(victim);
+        WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+      }
+      break;
 
-		// ********** ДЛЯ ФРАГЕРОВ **********
-		// горящие руки - с 1го левела 1го круга (8 слотов)
-		// *** мин 21 мах 30 (240)
-		// ОГОНЬ
-	case SPELL_BURNING_HANDS:
-		savetype = SAVING_REFLEX;
-		ndice = 8;
-		sdice = 3;
-		adice = (level + 2) / 3;
-		break;
+      // ********** ДЛЯ ФРАГЕРОВ **********
+      // горящие руки - с 1го левела 1го круга (8 слотов)
+      // *** мин 21 мах 30 (240)
+      // ОГОНЬ
+    case SPELL_BURNING_HANDS: savetype = SAVING_REFLEX;
+      ndice = 8;
+      sdice = 3;
+      adice = (level + 2) / 3;
+      break;
 
-		// обжигающая хватка - с 4го левела 2го круга (8 слотов)
-		// *** мин 36 макс 45 (360)
-		// ОГОНЬ
-	case SPELL_SHOCKING_GRASP:
-		savetype = SAVING_REFLEX;
-		ndice = 10;
-		sdice = 6;
-		adice = (level + 2) / 3;
-		break;
+      // обжигающая хватка - с 4го левела 2го круга (8 слотов)
+      // *** мин 36 макс 45 (360)
+      // ОГОНЬ
+    case SPELL_SHOCKING_GRASP: savetype = SAVING_REFLEX;
+      ndice = 10;
+      sdice = 6;
+      adice = (level + 2) / 3;
+      break;
 
-		// молния - с 7го левела 3го круга (7 слотов)
-		// *** мин 18 - макс 45 (315)
-		// ВОЗДУХ
-	case SPELL_LIGHTNING_BOLT:
-		savetype = SAVING_REFLEX;
-		ndice = 3;
-		sdice = 5;
-		count = (level + 5) / 6;
-		break;
+      // молния - с 7го левела 3го круга (7 слотов)
+      // *** мин 18 - макс 45 (315)
+      // ВОЗДУХ
+    case SPELL_LIGHTNING_BOLT: savetype = SAVING_REFLEX;
+      ndice = 3;
+      sdice = 5;
+      count = (level + 5) / 6;
+      break;
 
-		// яркий блик - с 7го 3го круга (7 слотов)
-		// *** мин 33 - макс 40 (280)
-		// ОГОНЬ
-	case SPELL_SHINEFLASH:
-		ndice = 10;
-		sdice = 5;
-		adice = (level + 2) / 3;
-		break;
+      // яркий блик - с 7го 3го круга (7 слотов)
+      // *** мин 33 - макс 40 (280)
+      // ОГОНЬ
+    case SPELL_SHINEFLASH: ndice = 10;
+      sdice = 5;
+      adice = (level + 2) / 3;
+      break;
 
-		// шаровая молния - с 10го левела 4го круга (6 слотов)
-		// *** мин 35 макс 55 (330)
-		// ВОЗДУХ
-	case SPELL_CALL_LIGHTNING:
-		savetype = SAVING_REFLEX;
-		ndice = 7+ch->get_remort();
-		sdice = 6;
-		adice = level;
-		break;
+      // шаровая молния - с 10го левела 4го круга (6 слотов)
+      // *** мин 35 макс 55 (330)
+      // ВОЗДУХ
+    case SPELL_CALL_LIGHTNING: savetype = SAVING_REFLEX;
+      ndice = 7 + ch->get_remort();
+      sdice = 6;
+      adice = level;
+      break;
 
-		// ледяные стрелы - уровень 14 круг 5 (6 слотов)
-		// *** мин 44 макс 60 (360)
-		// ОГОНЬ
-	case SPELL_COLOR_SPRAY:
-		savetype = SAVING_STABILITY;
-		ndice = 6;
-		sdice = 5;
-		adice = level;
-		break;
+      // ледяные стрелы - уровень 14 круг 5 (6 слотов)
+      // *** мин 44 макс 60 (360)
+      // ОГОНЬ
+    case SPELL_COLOR_SPRAY: savetype = SAVING_STABILITY;
+      ndice = 6;
+      sdice = 5;
+      adice = level;
+      break;
 
-		// ледяной ветер - уровень 14 круг 5 (6 слотов)
-		// *** мин 44 макс 60 (360)
-		// ВОДА
-	case SPELL_CONE_OF_COLD:
-		savetype = SAVING_STABILITY;
-		ndice = 10;
-		sdice = 5;
-		adice = level;
-		break;
+      // ледяной ветер - уровень 14 круг 5 (6 слотов)
+      // *** мин 44 макс 60 (360)
+      // ВОДА
+    case SPELL_CONE_OF_COLD: savetype = SAVING_STABILITY;
+      ndice = 10;
+      sdice = 5;
+      adice = level;
+      break;
 
-		// Огненный шар - уровень 25 круг 7 (4 слотов)
-		// *** мин 66 макс 80 (400)
-		// ОГОНЬ
-	case SPELL_FIREBALL:
-		savetype = SAVING_REFLEX;
-		ndice = 10;
-		sdice = 21;
-		adice = (level - 25) * 5;
-		break;
+      // Огненный шар - уровень 25 круг 7 (4 слотов)
+      // *** мин 66 макс 80 (400)
+      // ОГОНЬ
+    case SPELL_FIREBALL: savetype = SAVING_REFLEX;
+      ndice = 10;
+      sdice = 21;
+      adice = (level - 25) * 5;
+      break;
 
-		// Огненный поток - уровень 18 круг 6 (5 слотов)
-		// ***  мин 38 макс 50 (250)
-		// ОГОНЬ, ареа
-	case SPELL_FIREBLAST:
-		savetype = SAVING_STABILITY;
-		ndice = 10+ch->get_remort();
-		sdice = 3;
-		adice = level;
-		break;
+      // Огненный поток - уровень 18 круг 6 (5 слотов)
+      // ***  мин 38 макс 50 (250)
+      // ОГОНЬ, ареа
+    case SPELL_FIREBLAST: savetype = SAVING_STABILITY;
+      ndice = 10 + ch->get_remort();
+      sdice = 3;
+      adice = level;
+      break;
 
-		// метеоритный шторм - уровень 22 круг 7 (4 слота)
-		// *** мин 66 макс 80  (240)
-		// нейтрал, ареа
+      // метеоритный шторм - уровень 22 круг 7 (4 слота)
+      // *** мин 66 макс 80  (240)
+      // нейтрал, ареа
 /*	case SPELL_METEORSTORM:
 		savetype = SAVING_REFLEX;
 		ndice = 11+ch->get_remort();
@@ -564,2452 +522,2226 @@ int mag_damage(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int 
 		adice = (level - 22) * 3;
 		break;*/
 
-		// цепь молний - уровень 22 круг 7 (4 слота)
-		// *** мин 76 макс 100 (400)
-		// ВОЗДУХ, ареа
-	case SPELL_CHAIN_LIGHTNING:
-		savetype = SAVING_STABILITY;
-		ndice = 2+ch->get_remort();
-		sdice = 4;
-		adice = (level+ch->get_remort()) * 2;
-		break;
+      // цепь молний - уровень 22 круг 7 (4 слота)
+      // *** мин 76 макс 100 (400)
+      // ВОЗДУХ, ареа
+    case SPELL_CHAIN_LIGHTNING: savetype = SAVING_STABILITY;
+      ndice = 2 + ch->get_remort();
+      sdice = 4;
+      adice = (level + ch->get_remort()) * 2;
+      break;
 
-		// гнев богов - уровень 26 круг 8 (2 слота)
-		// *** мин 226 макс 250 (500)
-		// ВОДА
-	case SPELL_IMPLOSION:
-		savetype = SAVING_WILL;
-		ndice = 10;
-		sdice = 13;
-		adice = level * 6;
-		break;
+      // гнев богов - уровень 26 круг 8 (2 слота)
+      // *** мин 226 макс 250 (500)
+      // ВОДА
+    case SPELL_IMPLOSION: savetype = SAVING_WILL;
+      ndice = 10;
+      sdice = 13;
+      adice = level * 6;
+      break;
 
-		// ледяной шторм - 26 левела 8й круг (2)
-		// *** мин 55 макс 75 (150)
-		// ВОДА, ареа
-	case SPELL_ICESTORM:
-		savetype = SAVING_STABILITY;
-		ndice = 5;
-		sdice = 10;
-		adice = (level - 26) * 5;
-		break;
+      // ледяной шторм - 26 левела 8й круг (2)
+      // *** мин 55 макс 75 (150)
+      // ВОДА, ареа
+    case SPELL_ICESTORM: savetype = SAVING_STABILITY;
+      ndice = 5;
+      sdice = 10;
+      adice = (level - 26) * 5;
+      break;
 
-		// суд богов - уровень 28 круг 9 (1 слот)
-		// *** мин 188 макс 200 (200)
-		// ВОЗДУХ, ареа
-	case SPELL_ARMAGEDDON:
-		savetype = SAVING_WILL;
-		//в современных реалиях колдуны имеют 12+ мортов
-		if (!(IS_NPC(ch)))
-		{
-			ndice = 10+((ch->get_remort()/3) - 4);
-			sdice = level / 9;
-			adice = level * (number(4, 6));
-		}
-		else
-		{
-			ndice = 12;
-			sdice = 3;
-			adice = level *  6;
-		}
-		break;
+      // суд богов - уровень 28 круг 9 (1 слот)
+      // *** мин 188 макс 200 (200)
+      // ВОЗДУХ, ареа
+    case SPELL_ARMAGEDDON: savetype = SAVING_WILL;
+      //в современных реалиях колдуны имеют 12+ мортов
+      if (!(IS_NPC(ch))) {
+        ndice = 10 + ((ch->get_remort() / 3) - 4);
+        sdice = level / 9;
+        adice = level * (number(4, 6));
+      } else {
+        ndice = 12;
+        sdice = 3;
+        adice = level * 6;
+      }
+      break;
 
-		// ******* ХАЙЛЕВЕЛ СУПЕРДАМАДЖ МАГИЯ ******
-		// каменное проклятие - круг 28 уровень 9 (1)
-		// для всех
-	case SPELL_STUNNING:
-		if (ch == victim ||
-				((number(1, 999)  > GET_AR(victim) * 10) &&
-				 !general_savingthrow(ch, victim, SAVING_CRITICAL, CALC_SUCCESS(modi, GET_REAL_WIS(ch)))))
-		{
-			savetype = SAVING_STABILITY;
-			ndice = GET_REAL_WIS(ch) / 5;
-			sdice = GET_REAL_WIS(ch);
-			adice = 5 + (GET_REAL_WIS(ch) - 20) / 6;
-			int choice_stunning = 750;
-			if (can_use_feat(ch, DARKDEAL_FEAT))
-				choice_stunning -= GET_REMORT(ch) * 15;
-			if (number(1, 999) > choice_stunning)
-			{
-				act("Ваше каменное проклятие отшибло сознание у $N1.", FALSE, ch, 0, victim, TO_CHAR);
-				act("Каменное проклятие $n1 отшибло сознание у $N1.", FALSE, ch, 0, victim, TO_NOTVICT);
-				act("У вас отшибло сознание, вам очень плохо...", FALSE, ch, 0, victim, TO_VICT);
-				GET_POS(victim) = POS_STUNNED;
-				WAIT_STATE(victim, adice * PULSE_VIOLENCE);
-			}
-		}
-		else
-		{
-			ndice = GET_REAL_WIS(ch) / 7;
-			sdice = GET_REAL_WIS(ch);
-			adice = level;
-		}
-		break;
+      // ******* ХАЙЛЕВЕЛ СУПЕРДАМАДЖ МАГИЯ ******
+      // каменное проклятие - круг 28 уровень 9 (1)
+      // для всех
+    case SPELL_STUNNING:
+      if (ch == victim ||
+          ((number(1, 999) > GET_AR(victim) * 10) &&
+              !general_savingthrow(ch, victim, SAVING_CRITICAL, CALC_SUCCESS(modi, GET_REAL_WIS(ch))))) {
+        savetype = SAVING_STABILITY;
+        ndice = GET_REAL_WIS(ch) / 5;
+        sdice = GET_REAL_WIS(ch);
+        adice = 5 + (GET_REAL_WIS(ch) - 20) / 6;
+        int choice_stunning = 750;
+        if (can_use_feat(ch, DARKDEAL_FEAT))
+          choice_stunning -= GET_REMORT(ch) * 15;
+        if (number(1, 999) > choice_stunning) {
+          act("Ваше каменное проклятие отшибло сознание у $N1.", FALSE, ch, 0, victim, TO_CHAR);
+          act("Каменное проклятие $n1 отшибло сознание у $N1.", FALSE, ch, 0, victim, TO_NOTVICT);
+          act("У вас отшибло сознание, вам очень плохо...", FALSE, ch, 0, victim, TO_VICT);
+          GET_POS(victim) = POS_STUNNED;
+          WAIT_STATE(victim, adice * PULSE_VIOLENCE);
+        }
+      } else {
+        ndice = GET_REAL_WIS(ch) / 7;
+        sdice = GET_REAL_WIS(ch);
+        adice = level;
+      }
+      break;
 
-		// круг пустоты - круг 28 уровень 9 (1)
-		// для всех
-	case SPELL_VACUUM:
-		savetype = SAVING_STABILITY;
-		ndice = MAX(1, (GET_REAL_WIS(ch) - 10) / 2);
-		sdice = MAX(1, GET_REAL_WIS(ch) - 10);
-		//	    adice = MAX(1, 2 + 30 - GET_LEVEL(ch) + (GET_REAL_WIS(ch) - 29)) / 7;
-		//	    Ну явно кривота была. Отбалансил на свой вкус. В 50 мудры на 25м леве лаг на 3 на 30 лаг на 4 а не наоборот
-		//чтобы не обижать колдунов
-		adice = 4 + MAX(1, GET_LEVEL(ch) + 1 + (GET_REAL_WIS(ch) - 29)) / 7;
-		if (ch == victim ||
-				(!general_savingthrow(ch, victim, SAVING_CRITICAL, CALC_SUCCESS(modi, GET_REAL_WIS(ch))) &&
-				 (number(1, 999)  > GET_AR(victim) * 10) &&
-				 number(0, 1000) <= 500))
-		{
-			GET_POS(victim) = POS_STUNNED;
-			WAIT_STATE(victim, adice * PULSE_VIOLENCE);
-		}
-		break;
+      // круг пустоты - круг 28 уровень 9 (1)
+      // для всех
+    case SPELL_VACUUM: savetype = SAVING_STABILITY;
+      ndice = MAX(1, (GET_REAL_WIS(ch) - 10) / 2);
+      sdice = MAX(1, GET_REAL_WIS(ch) - 10);
+      //	    adice = MAX(1, 2 + 30 - GET_LEVEL(ch) + (GET_REAL_WIS(ch) - 29)) / 7;
+      //	    Ну явно кривота была. Отбалансил на свой вкус. В 50 мудры на 25м леве лаг на 3 на 30 лаг на 4 а не наоборот
+      //чтобы не обижать колдунов
+      adice = 4 + MAX(1, GET_LEVEL(ch) + 1 + (GET_REAL_WIS(ch) - 29)) / 7;
+      if (ch == victim ||
+          (!general_savingthrow(ch, victim, SAVING_CRITICAL, CALC_SUCCESS(modi, GET_REAL_WIS(ch))) &&
+              (number(1, 999) > GET_AR(victim) * 10) &&
+              number(0, 1000) <= 500)) {
+        GET_POS(victim) = POS_STUNNED;
+        WAIT_STATE(victim, adice * PULSE_VIOLENCE);
+      }
+      break;
 
-		// ********* СПЕЦИФИЧНАЯ ДЛЯ КЛЕРИКОВ МАГИЯ **********
-	case SPELL_DAMAGE_LIGHT:
-		savetype = SAVING_CRITICAL;
-		ndice = 4;
-		sdice = 3;
-		adice = (level + 2) / 3;
-		break;
-	case SPELL_DAMAGE_SERIOUS:
-		savetype = SAVING_CRITICAL;
-		ndice = 10;
-		sdice = 3;
-		adice = (level + 1) / 2;
-		break;
-	case SPELL_DAMAGE_CRITIC:
-		savetype = SAVING_CRITICAL;
-		ndice = 15;
-		sdice = 4;
-		adice = (level + 1) / 2;
-		break;
-	case SPELL_DISPEL_EVIL:
-		ndice = 4;
-		sdice = 4;
-		adice = level;
-		if (ch != victim && IS_EVIL(ch) && !WAITLESS(ch) && GET_HIT(ch) > 1)
-		{
-			send_to_char("Ваша магия обратилась против вас.", ch);
-			GET_HIT(ch) = 1;
-		}
-		if (!IS_EVIL(victim))
-		{
-			if (victim != ch)
-				act("Боги защитили $N3 от вашей магии.", FALSE, ch, 0, victim, TO_CHAR);
-			return (0);
-		};
-		break;
-	case SPELL_DISPEL_GOOD:
-		ndice = 4;
-		sdice = 4;
-		adice = level;
-		if (ch != victim && IS_GOOD(ch) && !WAITLESS(ch) && GET_HIT(ch) > 1)
-		{
-			send_to_char("Ваша магия обратилась против вас.", ch);
-			GET_HIT(ch) = 1;
-		}
-		if (!IS_GOOD(victim))
-		{
-			if (victim != ch)
-				act("Боги защитили $N3 от вашей магии.", FALSE, ch, 0, victim, TO_CHAR);
-			return (0);
-		};
-		break;
-	case SPELL_HARM:
-		savetype = SAVING_CRITICAL;
-		ndice = 7;
-		sdice = level;
-		adice = level * GET_REMORT(ch) / 4;
-		//adice = (level + 4) / 5;
-		break;
+      // ********* СПЕЦИФИЧНАЯ ДЛЯ КЛЕРИКОВ МАГИЯ **********
+    case SPELL_DAMAGE_LIGHT: savetype = SAVING_CRITICAL;
+      ndice = 4;
+      sdice = 3;
+      adice = (level + 2) / 3;
+      break;
+    case SPELL_DAMAGE_SERIOUS: savetype = SAVING_CRITICAL;
+      ndice = 10;
+      sdice = 3;
+      adice = (level + 1) / 2;
+      break;
+    case SPELL_DAMAGE_CRITIC: savetype = SAVING_CRITICAL;
+      ndice = 15;
+      sdice = 4;
+      adice = (level + 1) / 2;
+      break;
+    case SPELL_DISPEL_EVIL: ndice = 4;
+      sdice = 4;
+      adice = level;
+      if (ch != victim && IS_EVIL(ch) && !WAITLESS(ch) && GET_HIT(ch) > 1) {
+        send_to_char("Ваша магия обратилась против вас.", ch);
+        GET_HIT(ch) = 1;
+      }
+      if (!IS_EVIL(victim)) {
+        if (victim != ch)
+          act("Боги защитили $N3 от вашей магии.", FALSE, ch, 0, victim, TO_CHAR);
+        return (0);
+      };
+      break;
+    case SPELL_DISPEL_GOOD: ndice = 4;
+      sdice = 4;
+      adice = level;
+      if (ch != victim && IS_GOOD(ch) && !WAITLESS(ch) && GET_HIT(ch) > 1) {
+        send_to_char("Ваша магия обратилась против вас.", ch);
+        GET_HIT(ch) = 1;
+      }
+      if (!IS_GOOD(victim)) {
+        if (victim != ch)
+          act("Боги защитили $N3 от вашей магии.", FALSE, ch, 0, victim, TO_CHAR);
+        return (0);
+      };
+      break;
+    case SPELL_HARM: savetype = SAVING_CRITICAL;
+      ndice = 7;
+      sdice = level;
+      adice = level * GET_REMORT(ch) / 4;
+      //adice = (level + 4) / 5;
+      break;
 
-	case SPELL_FIRE_BREATH:
-	case SPELL_FROST_BREATH:
-	case SPELL_ACID_BREATH:
-	case SPELL_LIGHTNING_BREATH:
-	case SPELL_GAS_BREATH:
-		savetype = SAVING_STABILITY;
-		if (!IS_NPC(ch))
-			return (0);
-		ndice = ch->mob_specials.damnodice;
-		sdice = ch->mob_specials.damsizedice;
-		adice = GET_REAL_DR(ch) + str_bonus(GET_REAL_STR(ch), STR_TO_DAM);
-		break;
+    case SPELL_FIRE_BREATH:
+    case SPELL_FROST_BREATH:
+    case SPELL_ACID_BREATH:
+    case SPELL_LIGHTNING_BREATH:
+    case SPELL_GAS_BREATH: savetype = SAVING_STABILITY;
+      if (!IS_NPC(ch))
+        return (0);
+      ndice = ch->mob_specials.damnodice;
+      sdice = ch->mob_specials.damsizedice;
+      adice = GET_REAL_DR(ch) + str_bonus(GET_REAL_STR(ch), STR_TO_DAM);
+      break;
 
-	case SPELL_SACRIFICE:
-		if (WAITLESS(victim))
-			break;
-		ndice = 8;
-		sdice = 8;
-		adice = level;
-		break;
+    case SPELL_SACRIFICE:
+      if (WAITLESS(victim))
+        break;
+      ndice = 8;
+      sdice = 8;
+      adice = level;
+      break;
 
-	case SPELL_DUSTSTORM:
-		savetype = SAVING_STABILITY;
-		ndice = 5;
-		sdice = 6;
-		adice = level + ch->get_remort() * 3;
-		if (GET_POS(victim) > POS_SITTING &&
-				!WAITLESS(victim) && (number(1, 999)  > GET_AR(victim) * 10) &&
-				(!general_savingthrow(ch, victim, SAVING_REFLEX, CALC_SUCCESS(modi, 30))))
-		{
-			act("$n3 повалило на землю.", FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-			act("Вас повалило на землю.", FALSE, victim, 0, 0, TO_CHAR);
-			GET_POS(victim) = POS_SITTING;
-			update_pos(victim);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-		}
-		break;
+    case SPELL_DUSTSTORM: savetype = SAVING_STABILITY;
+      ndice = 5;
+      sdice = 6;
+      adice = level + ch->get_remort() * 3;
+      if (GET_POS(victim) > POS_SITTING &&
+          !WAITLESS(victim) && (number(1, 999) > GET_AR(victim) * 10) &&
+          (!general_savingthrow(ch, victim, SAVING_REFLEX, CALC_SUCCESS(modi, 30)))) {
+        act("$n3 повалило на землю.", FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        act("Вас повалило на землю.", FALSE, victim, 0, 0, TO_CHAR);
+        GET_POS(victim) = POS_SITTING;
+        update_pos(victim);
+        WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+      }
+      break;
 
-	case SPELL_EARTHFALL:
-		savetype = SAVING_REFLEX;
-		ndice = 8;
-		sdice = 8;
-		adice = level * 2;
-		break;
+    case SPELL_EARTHFALL: savetype = SAVING_REFLEX;
+      ndice = 8;
+      sdice = 8;
+      adice = level * 2;
+      break;
 
-	case SPELL_SHOCK:
-		savetype = SAVING_REFLEX;
-		ndice = 6;
-		sdice = level / 2;
-		adice = (level + GET_REMORT(ch)) * 2;
-		break;
+    case SPELL_SHOCK: savetype = SAVING_REFLEX;
+      ndice = 6;
+      sdice = level / 2;
+      adice = (level + GET_REMORT(ch)) * 2;
+      break;
 
-	case SPELL_SCREAM:
-		savetype = SAVING_STABILITY;
-		ndice = 10;
-		sdice = (level + GET_REMORT(ch)) / 5;
-		adice = level + GET_REMORT(ch) * 2;
-		break;
+    case SPELL_SCREAM: savetype = SAVING_STABILITY;
+      ndice = 10;
+      sdice = (level + GET_REMORT(ch)) / 5;
+      adice = level + GET_REMORT(ch) * 2;
+      break;
 
-	case SPELL_WHIRLWIND:
-		savetype = SAVING_REFLEX;
-		if (!(IS_NPC(ch)))
-		{
-			ndice = 10+((ch->get_remort()/3) - 4);
-			sdice = 18 + (3 - (30 - level) / 3 );
-			adice = (level + ch->get_remort() - 25)*(number(1, 4));
-		}
-		else
-		{
-			ndice = 10;
-			sdice = 21;
-			adice = (level - 5)*(number(2, 4));
-		}
-		break;
+    case SPELL_WHIRLWIND: savetype = SAVING_REFLEX;
+      if (!(IS_NPC(ch))) {
+        ndice = 10 + ((ch->get_remort() / 3) - 4);
+        sdice = 18 + (3 - (30 - level) / 3);
+        adice = (level + ch->get_remort() - 25) * (number(1, 4));
+      } else {
+        ndice = 10;
+        sdice = 21;
+        adice = (level - 5) * (number(2, 4));
+      }
+      break;
 
-	case SPELL_INDRIKS_TEETH:
-		ndice = 3+ch->get_remort();
-		sdice = 4;
-		adice = level + ch->get_remort() + 1;
-		break;
+    case SPELL_INDRIKS_TEETH: ndice = 3 + ch->get_remort();
+      sdice = 4;
+      adice = level + ch->get_remort() + 1;
+      break;
 
-	case SPELL_MELFS_ACID_ARROW:
-		savetype = SAVING_REFLEX;
-		ndice = 10+ch->get_remort()/3;
-		sdice = 20;
-		adice = level + ch->get_remort() - 25;
-		break;
+    case SPELL_MELFS_ACID_ARROW: savetype = SAVING_REFLEX;
+      ndice = 10 + ch->get_remort() / 3;
+      sdice = 20;
+      adice = level + ch->get_remort() - 25;
+      break;
 
-	case SPELL_THUNDERSTONE:
-		savetype = SAVING_REFLEX;
-		ndice = 3+ch->get_remort();
-		sdice = 6;
-		adice = 1+level+ch->get_remort();
-		break;
+    case SPELL_THUNDERSTONE: savetype = SAVING_REFLEX;
+      ndice = 3 + ch->get_remort();
+      sdice = 6;
+      adice = 1 + level + ch->get_remort();
+      break;
 
-	case SPELL_CLOD:
-		savetype = SAVING_REFLEX;
-		ndice = 10+ch->get_remort()/3;
-		sdice = 20;
-		adice = (level + ch->get_remort() - 25)*(number(1, 4));
-		break;
+    case SPELL_CLOD: savetype = SAVING_REFLEX;
+      ndice = 10 + ch->get_remort() / 3;
+      sdice = 20;
+      adice = (level + ch->get_remort() - 25) * (number(1, 4));
+      break;
 
-	case SPELL_HOLYSTRIKE:
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_EVILESS))
-		{
-			dam = -1;
-			no_savings = TRUE;
-			// смерть или диспелл :)
-			if (general_savingthrow(ch, victim, SAVING_WILL, modi))
-			{
-				act("Черное облако вокруг вас нейтрализовало действие тумана, растворившись в нем.",
-					FALSE, victim, 0, 0, TO_CHAR);
-				act("Черное облако вокруг $n1 нейтрализовало действие тумана.",
-					FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-				affect_from_char(victim, SPELL_EVILESS);
-			}
-			else
-			{
-				dam = MAX(1, GET_HIT(victim) + 1);
-				if (IS_NPC(victim))
-					dam += 99;	// чтобы насмерть
-			}
-		}
-		else
-		{
-			ndice = 10;
-			sdice = 8;
-			adice = level * 5;
-		}
-		break;
+    case SPELL_HOLYSTRIKE:
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_EVILESS)) {
+        dam = -1;
+        no_savings = TRUE;
+        // смерть или диспелл :)
+        if (general_savingthrow(ch, victim, SAVING_WILL, modi)) {
+          act("Черное облако вокруг вас нейтрализовало действие тумана, растворившись в нем.",
+              FALSE, victim, 0, 0, TO_CHAR);
+          act("Черное облако вокруг $n1 нейтрализовало действие тумана.",
+              FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+          affect_from_char(victim, SPELL_EVILESS);
+        } else {
+          dam = MAX(1, GET_HIT(victim) + 1);
+          if (IS_NPC(victim))
+            dam += 99;    // чтобы насмерть
+        }
+      } else {
+        ndice = 10;
+        sdice = 8;
+        adice = level * 5;
+      }
+      break;
 
-	case SPELL_WC_OF_RAGE:
-		ndice = (level + 3) / 4;
-		sdice = 6;
-		adice = dice(GET_REMORT(ch) / 2, 8);
-		break;
+    case SPELL_WC_OF_RAGE: ndice = (level + 3) / 4;
+      sdice = 6;
+      adice = dice(GET_REMORT(ch) / 2, 8);
+      break;
 
-	case SPELL_WC_OF_THUNDER:
-		{
-		ndice = GET_REMORT(ch) + (level + 2) / 3;
-		sdice = 5;
-		if (GET_POS(victim) > POS_SITTING &&
-				!WAITLESS(victim) &&
-				(GET_MOB_HOLD(victim) || !general_savingthrow(ch, victim, SAVING_STABILITY, GET_REAL_CON(ch))))
-		{
-			act("$n3 повалило на землю.", FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-			act("Вас повалило на землю.", FALSE, victim, 0, 0, TO_CHAR);
-			GET_POS(victim) = POS_SITTING;
-			update_pos(victim);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-		}
-		break;
-		}
+    case SPELL_WC_OF_THUNDER: {
+      ndice = GET_REMORT(ch) + (level + 2) / 3;
+      sdice = 5;
+      if (GET_POS(victim) > POS_SITTING &&
+          !WAITLESS(victim) &&
+          (GET_MOB_HOLD(victim) || !general_savingthrow(ch, victim, SAVING_STABILITY, GET_REAL_CON(ch)))) {
+        act("$n3 повалило на землю.", FALSE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+        act("Вас повалило на землю.", FALSE, victim, 0, 0, TO_CHAR);
+        GET_POS(victim) = POS_SITTING;
+        update_pos(victim);
+        WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+      }
+      break;
+    }
 
-	case SPELL_ARROWS_FIRE:
-	case SPELL_ARROWS_WATER:
-	case SPELL_ARROWS_EARTH:
-	case SPELL_ARROWS_AIR:
-	case SPELL_ARROWS_DEATH:
-		if (!(IS_NPC(ch)))
-		{
-			act("Ваша магическая стрела поразила $N1.", FALSE, ch, 0, victim, TO_CHAR);
-			act("Магическая стрела $n1 поразила $N1.", FALSE, ch, 0, victim, TO_NOTVICT);
-			act("Магическая стрела настигла вас.", FALSE, ch, 0, victim, TO_VICT);
-			ndice = 3+ch->get_remort();
-			sdice = 4;
-			adice = level + ch->get_remort() + 1;
-		}
-		else
-		{
-			ndice = 20;
-			sdice = 4;
-			adice = level * 3;
-		}
+    case SPELL_ARROWS_FIRE:
+    case SPELL_ARROWS_WATER:
+    case SPELL_ARROWS_EARTH:
+    case SPELL_ARROWS_AIR:
+    case SPELL_ARROWS_DEATH:
+      if (!(IS_NPC(ch))) {
+        act("Ваша магическая стрела поразила $N1.", FALSE, ch, 0, victim, TO_CHAR);
+        act("Магическая стрела $n1 поразила $N1.", FALSE, ch, 0, victim, TO_NOTVICT);
+        act("Магическая стрела настигла вас.", FALSE, ch, 0, victim, TO_VICT);
+        ndice = 3 + ch->get_remort();
+        sdice = 4;
+        adice = level + ch->get_remort() + 1;
+      } else {
+        ndice = 20;
+        sdice = 4;
+        adice = level * 3;
+      }
 
-		break;
+      break;
 
-	}			// switch(spellnum)
+  }            // switch(spellnum)
 
-	if (!dam && !no_savings)
-	{
-		double koeff = 1;
-		if (IS_NPC(victim))
-		{
-			if (NPC_FLAGGED(victim, NPC_FIRECREATURE))
-			{
-				if (IS_SET(SpINFO.spell_class, STYPE_FIRE))
-					koeff /= 2;
-				if (IS_SET(SpINFO.spell_class, STYPE_WATER))
-					koeff *= 2;
-			}
-			if (NPC_FLAGGED(victim, NPC_AIRCREATURE))
-			{
-				if (IS_SET(SpINFO.spell_class, STYPE_EARTH))
-					koeff *= 2;
-				if (IS_SET(SpINFO.spell_class, STYPE_AIR))
-					koeff /= 2;
-			}
-			if (NPC_FLAGGED(victim, NPC_WATERCREATURE))
-			{
-				if (IS_SET(SpINFO.spell_class, STYPE_FIRE))
-					koeff *= 2;
-				if (IS_SET(SpINFO.spell_class, STYPE_WATER))
-					koeff /= 2;
-			}
-			if (NPC_FLAGGED(victim, NPC_EARTHCREATURE))
-			{
-				if (IS_SET(SpINFO.spell_class, STYPE_EARTH))
-					koeff /= 2;
-				if (IS_SET(SpINFO.spell_class, STYPE_AIR))
-					koeff *= 2;
-			}
-		}
-		dam = dice(ndice, sdice) + adice;
-		dam = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_EFFECT, dam);
+  if (!dam && !no_savings) {
+    double koeff = 1;
+    if (IS_NPC(victim)) {
+      if (NPC_FLAGGED(victim, NPC_FIRECREATURE)) {
+        if (IS_SET(SpINFO.spell_class, STYPE_FIRE))
+          koeff /= 2;
+        if (IS_SET(SpINFO.spell_class, STYPE_WATER))
+          koeff *= 2;
+      }
+      if (NPC_FLAGGED(victim, NPC_AIRCREATURE)) {
+        if (IS_SET(SpINFO.spell_class, STYPE_EARTH))
+          koeff *= 2;
+        if (IS_SET(SpINFO.spell_class, STYPE_AIR))
+          koeff /= 2;
+      }
+      if (NPC_FLAGGED(victim, NPC_WATERCREATURE)) {
+        if (IS_SET(SpINFO.spell_class, STYPE_FIRE))
+          koeff *= 2;
+        if (IS_SET(SpINFO.spell_class, STYPE_WATER))
+          koeff /= 2;
+      }
+      if (NPC_FLAGGED(victim, NPC_EARTHCREATURE)) {
+        if (IS_SET(SpINFO.spell_class, STYPE_EARTH))
+          koeff /= 2;
+        if (IS_SET(SpINFO.spell_class, STYPE_AIR))
+          koeff *= 2;
+      }
+    }
+    dam = dice(ndice, sdice) + adice;
+    dam = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_EFFECT, dam);
 
-		// колдуны в 2 раза сильнее фрагают по мобам
-		if (can_use_feat(ch, POWER_MAGIC_FEAT) && IS_NPC(victim)) {
-			dam += (int) dam * 0.5;
-		}
+    // колдуны в 2 раза сильнее фрагают по мобам
+    if (can_use_feat(ch, POWER_MAGIC_FEAT) && IS_NPC(victim)) {
+      dam += (int) dam * 0.5;
+    }
 
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_DATURA_POISON))
+      dam -= dam * GET_POISON(ch) / 100;
 
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_DATURA_POISON))
-			dam -= dam * GET_POISON(ch) / 100;
+    if (!IS_SET(SpINFO.routines, MAG_WARCRY)) {
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
+        koeff /= 2;
+    }
 
-		if (!IS_SET(SpINFO.routines, MAG_WARCRY))
-		{
-			if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-				koeff /= 2;
-		}
+    if (dam > 0) {
+      koeff *= 1000;
+      dam = (int) MMAX(1.0, (dam * MMAX(300.0, MMIN(koeff, 2500.0)) / 1000.0));
+    }
+    //вместо старого учета мудры добавлена обработка с учетом скиллов
+    //после коэффициента - так как в самой функции стоит планка по дамагу, пусть и относительная
+    dam = magic_skill_damage_calc(ch, victim, spellnum, dam);
+  }
 
-		if (dam > 0)
-		{
-			koeff *= 1000;
-			dam = (int)MMAX(1.0, (dam * MMAX(300.0, MMIN(koeff, 2500.0)) / 1000.0));
-		}
-		//вместо старого учета мудры добавлена обработка с учетом скиллов
-		//после коэффициента - так как в самой функции стоит планка по дамагу, пусть и относительная
-		dam = magic_skill_damage_calc(ch, victim, spellnum, dam);
-	}
+  //Голодный кастер меньше дамажит!
+  if (!IS_NPC(ch))
+    dam *= ch->get_cond_penalty(P_DAMROLL);
 
-	//Голодный кастер меньше дамажит!
-	if (!IS_NPC(ch))
-		dam*=ch->get_cond_penalty(P_DAMROLL);
+  if (number(1, 100) <= GET_MR(victim))
+    dam = 0;
 
-	if (number(1, 100) <= GET_MR(victim))
-		dam = 0;
-
-	for (; count > 0 && rand >= 0; count--)
-	{
-		if (ch->in_room != NOWHERE
-			&& IN_ROOM(victim) != NOWHERE
-			&& GET_POS(ch) > POS_STUNNED
-			&& GET_POS(victim) > POS_DEAD)
-		{
-			// инит полей для дамага
-			Damage dmg(SpellDmg(spellnum), dam, FightSystem::MAGE_DMG);
-			dmg.ch_start_pos = ch_start_pos;
-			dmg.victim_start_pos = victim_start_pos;
-			// колдуны игнорят поглощение у мобов
-			if (can_use_feat(ch, POWER_MAGIC_FEAT) && IS_NPC(victim))
-			{
-				dmg.flags.set(FightSystem::IGNORE_ABSORBE);
-			}
-			// отражение магии в кастующего
-			if (ch == victim)
-			{
-				dmg.flags.set(FightSystem::MAGIC_REFLECT);
-			}
-			if (count <= 1)
-			{
-				dmg.flags.reset(FightSystem::NO_FLEE_DMG);
-			}
-			else
-			{
-				dmg.flags.set(FightSystem::NO_FLEE_DMG);
-			}
-			rand = dmg.process(ch, victim);
-		}
-	}
-	return rand;
+  for (; count > 0 && rand >= 0; count--) {
+    if (ch->in_room != NOWHERE
+        && IN_ROOM(victim) != NOWHERE
+        && GET_POS(ch) > POS_STUNNED
+        && GET_POS(victim) > POS_DEAD) {
+      // инит полей для дамага
+      Damage dmg(SpellDmg(spellnum), dam, FightSystem::MAGE_DMG);
+      dmg.ch_start_pos = ch_start_pos;
+      dmg.victim_start_pos = victim_start_pos;
+      // колдуны игнорят поглощение у мобов
+      if (can_use_feat(ch, POWER_MAGIC_FEAT) && IS_NPC(victim)) {
+        dmg.flags.set(FightSystem::IGNORE_ABSORBE);
+      }
+      // отражение магии в кастующего
+      if (ch == victim) {
+        dmg.flags.set(FightSystem::MAGIC_REFLECT);
+      }
+      if (count <= 1) {
+        dmg.flags.reset(FightSystem::NO_FLEE_DMG);
+      } else {
+        dmg.flags.set(FightSystem::NO_FLEE_DMG);
+      }
+      rand = dmg.process(ch, victim);
+    }
+  }
+  return rand;
 }
 
-int pc_duration(CHAR_DATA * ch, int cnst, int level, int level_divisor, int min, int max)
-{
-	int result = 0;
-	if (IS_NPC(ch))
-	{
-		result = cnst;
-		if (level > 0 && level_divisor > 0)
-			level = level / level_divisor;
-		else
-			level = 0;
-		if (min > 0)
-			level = MIN(level, min);
-		if (max > 0)
-			level = MAX(level, max);
-		return (level + result);
-	}
-	result = cnst * SECS_PER_MUD_HOUR;
-	if (level > 0 && level_divisor > 0)
-		level = level * SECS_PER_MUD_HOUR / level_divisor;
-	else
-		level = 0;
-	if (min > 0)
-		level = MIN(level, min * SECS_PER_MUD_HOUR);
-	if (max > 0)
-		level = MAX(level, max * SECS_PER_MUD_HOUR);
-	result = (level + result) / SECS_PER_PLAYER_AFFECT;
-	return (result);
+int pc_duration(CHAR_DATA *ch, int cnst, int level, int level_divisor, int min, int max) {
+  int result = 0;
+  if (IS_NPC(ch)) {
+    result = cnst;
+    if (level > 0 && level_divisor > 0)
+      level = level / level_divisor;
+    else
+      level = 0;
+    if (min > 0)
+      level = MIN(level, min);
+    if (max > 0)
+      level = MAX(level, max);
+    return (level + result);
+  }
+  result = cnst * SECS_PER_MUD_HOUR;
+  if (level > 0 && level_divisor > 0)
+    level = level * SECS_PER_MUD_HOUR / level_divisor;
+  else
+    level = 0;
+  if (min > 0)
+    level = MIN(level, min * SECS_PER_MUD_HOUR);
+  if (max > 0)
+    level = MAX(level, max * SECS_PER_MUD_HOUR);
+  result = (level + result) / SECS_PER_PLAYER_AFFECT;
+  return (result);
 }
 
-bool material_component_processing(CHAR_DATA *caster, CHAR_DATA *victim, int spellnum)
-{
-	int vnum = 0;
-	const char *missing = nullptr, *use = nullptr, *exhausted = nullptr;
-	switch (spellnum)
-	{
-		case SPELL_FASCINATION:
-			vnum = 3000;
-			use = "Вы попытались вспомнить уроки старой цыганки, что учила вас людям головы морочить.\r\nХотя вы ее не очень то слушали.\r\n";
-			missing = "Батюшки светы! А помаду-то я дома забыл$g.\r\n";
-			exhausted = "$o рассыпался в ваших руках от неловкого движения.\r\n";
-			break;
-		case SPELL_HYPNOTIC_PATTERN:
-			vnum = 3006;
-			use = "Вы разожгли палочку заморских благовоний.\r\n";
-			missing = "Вы начали суматошно искать свои благовония, но тщетно.\r\n";
-			exhausted = "$o дотлели и рассыпались пеплом.\r\n";
-			break;
-		case SPELL_ENCHANT_WEAPON:
-			vnum = 1930;
-			use = "Вы подготовили дополнительные компоненты для зачарования.\r\n";
-			missing = "Вы были уверены что положили его в этот карман.\r\n";
-			exhausted = "$o вспыхнул голубоватым светом, когда его вставили в предмет.\r\n";
-			break;
+bool material_component_processing(CHAR_DATA *caster, CHAR_DATA *victim, int spellnum) {
+  int vnum = 0;
+  const char *missing = nullptr, *use = nullptr, *exhausted = nullptr;
+  switch (spellnum) {
+    case SPELL_FASCINATION: vnum = 3000;
+      use =
+          "Вы попытались вспомнить уроки старой цыганки, что учила вас людям головы морочить.\r\nХотя вы ее не очень то слушали.\r\n";
+      missing = "Батюшки светы! А помаду-то я дома забыл$g.\r\n";
+      exhausted = "$o рассыпался в ваших руках от неловкого движения.\r\n";
+      break;
+    case SPELL_HYPNOTIC_PATTERN: vnum = 3006;
+      use = "Вы разожгли палочку заморских благовоний.\r\n";
+      missing = "Вы начали суматошно искать свои благовония, но тщетно.\r\n";
+      exhausted = "$o дотлели и рассыпались пеплом.\r\n";
+      break;
+    case SPELL_ENCHANT_WEAPON: vnum = 1930;
+      use = "Вы подготовили дополнительные компоненты для зачарования.\r\n";
+      missing = "Вы были уверены что положили его в этот карман.\r\n";
+      exhausted = "$o вспыхнул голубоватым светом, когда его вставили в предмет.\r\n";
+      break;
 
-		default:
-			log("WARNING: wrong spellnum %d in %s:%d", spellnum, __FILE__, __LINE__);
-			return false;
-	}
-	OBJ_DATA *tobj = get_obj_in_list_vnum(vnum, caster->carrying);
-	if (!tobj)
-	{
-		act(missing, FALSE, victim, 0, caster, TO_CHAR);
-		return (TRUE);
-	}
-	tobj->dec_val(2);
-	act(use, FALSE, caster, tobj, 0, TO_CHAR);
-	if (GET_OBJ_VAL(tobj,2) < 1)
-	{
-		act(exhausted, FALSE, caster, tobj, 0, TO_CHAR);
-		obj_from_char(tobj);
-		extract_obj(tobj);
-	}
-	return (FALSE);
+    default: log("WARNING: wrong spellnum %d in %s:%d", spellnum, __FILE__, __LINE__);
+      return false;
+  }
+  OBJ_DATA *tobj = get_obj_in_list_vnum(vnum, caster->carrying);
+  if (!tobj) {
+    act(missing, FALSE, victim, 0, caster, TO_CHAR);
+    return (TRUE);
+  }
+  tobj->dec_val(2);
+  act(use, FALSE, caster, tobj, 0, TO_CHAR);
+  if (GET_OBJ_VAL(tobj, 2) < 1) {
+    act(exhausted, FALSE, caster, tobj, 0, TO_CHAR);
+    obj_from_char(tobj);
+    extract_obj(tobj);
+  }
+  return (FALSE);
 }
 
-bool material_component_processing(CHAR_DATA *caster, int /*vnum*/, int spellnum)
-{
-	const char *missing = nullptr, *use = nullptr, *exhausted = nullptr;
-	switch (spellnum)
-	{
-		case SPELL_ENCHANT_WEAPON:
-			use = "Вы подготовили дополнительные компоненты для зачарования.\r\n";
-			missing = "Вы были уверены что положили его в этот карман.\r\n";
-			exhausted = "$o вспыхнул голубоватым светом, когда его вставили в предмет.\r\n";
-			break;
+bool material_component_processing(CHAR_DATA *caster, int /*vnum*/, int spellnum) {
+  const char *missing = nullptr, *use = nullptr, *exhausted = nullptr;
+  switch (spellnum) {
+    case SPELL_ENCHANT_WEAPON: use = "Вы подготовили дополнительные компоненты для зачарования.\r\n";
+      missing = "Вы были уверены что положили его в этот карман.\r\n";
+      exhausted = "$o вспыхнул голубоватым светом, когда его вставили в предмет.\r\n";
+      break;
 
-		default:
-			log("WARNING: wrong spellnum %d in %s:%d", spellnum, __FILE__, __LINE__);
-			return false;
-	}
-	OBJ_DATA *tobj = GET_EQ(caster, WEAR_HOLD);
-	if (!tobj)
-	{
-		act(missing, FALSE, caster, 0, caster, TO_CHAR);
-		return (TRUE);
-	}
-	tobj->dec_val(2);
-	act(use, FALSE, caster, tobj, 0, TO_CHAR);
-	if (GET_OBJ_VAL(tobj,2) < 1)
-	{
-		act(exhausted, FALSE, caster, tobj, 0, TO_CHAR);
-		obj_from_char(tobj);
-		extract_obj(tobj);
-	}
-	return (FALSE);
+    default: log("WARNING: wrong spellnum %d in %s:%d", spellnum, __FILE__, __LINE__);
+      return false;
+  }
+  OBJ_DATA *tobj = GET_EQ(caster, WEAR_HOLD);
+  if (!tobj) {
+    act(missing, FALSE, caster, 0, caster, TO_CHAR);
+    return (TRUE);
+  }
+  tobj->dec_val(2);
+  act(use, FALSE, caster, tobj, 0, TO_CHAR);
+  if (GET_OBJ_VAL(tobj, 2) < 1) {
+    act(exhausted, FALSE, caster, tobj, 0, TO_CHAR);
+    obj_from_char(tobj);
+    extract_obj(tobj);
+  }
+  return (FALSE);
 }
 
-int mag_affects(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int savetype)
-{
-	bool accum_affect = FALSE, accum_duration = FALSE, success = TRUE;
-	bool update_spell = FALSE;
-	const char *to_vict = nullptr, *to_room = nullptr;
-	int i, modi = 0;
-	int rnd = 0;
-	int decline_mod = 0;
-	if (victim == nullptr
-		|| IN_ROOM(victim) == NOWHERE
-		|| ch == nullptr)
-	{
-		return 0;
-	}
+int mag_affects(int level, CHAR_DATA *ch, CHAR_DATA *victim, int spellnum, int savetype) {
+  bool accum_affect = FALSE, accum_duration = FALSE, success = TRUE;
+  bool update_spell = FALSE;
+  const char *to_vict = nullptr, *to_room = nullptr;
+  int i, modi = 0;
+  int rnd = 0;
+  int decline_mod = 0;
+  if (victim == nullptr
+      || IN_ROOM(victim) == NOWHERE
+      || ch == nullptr) {
+    return 0;
+  }
 
-	// Calculate PKILL's affects
-	//   1) "NPC affect PC spellflag"  for victim
-	//   2) "NPC affect NPC spellflag" if victim cann't pkill FICHTING(victim)
-	if (ch != victim)  	//send_to_char("Start\r\n",ch);
-	{
-		//send_to_char("Start\r\n",victim);
-		if (IS_SET(SpINFO.routines, NPC_AFFECT_PC))  	//send_to_char("1\r\n",ch);
-		{
-			//send_to_char("1\r\n",victim);
-			if (!pk_agro_action(ch, victim))
-				return 0;
-		}
-		else if (IS_SET(SpINFO.routines, NPC_AFFECT_NPC) && victim->get_fighting())  	//send_to_char("2\r\n",ch);
-		{
-			//send_to_char("2\r\n",victim);
-			if (!pk_agro_action(ch, victim->get_fighting()))
-				return 0;
-		}
-		//send_to_char("Stop\r\n",ch);
-		//send_to_char("Stop\r\n",victim);
-	}
-	// Magic glass
-	if (!IS_SET(SpINFO.routines, MAG_WARCRY))
-	{
-		if (ch != victim
-		    && SpINFO.violent
-		    && ((!IS_GOD(ch)
-		         && AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICGLASS)
-		         && (ch->in_room == IN_ROOM(victim)) //зеркало сработает только если оба в одной комнате
-		         && number(1, 100) < (GET_LEVEL(victim) / 3))
-		        || (IS_GOD(victim)
-		            && (IS_NPC(ch)
-		                || GET_LEVEL(victim) > (GET_LEVEL(ch))))))
-		{
-			act("Магическое зеркало $N1 отразило вашу магию!", FALSE, ch, 0, victim, TO_CHAR);
-			act("Магическое зеркало $N1 отразило магию $n1!", FALSE, ch, 0, victim, TO_NOTVICT);
-			act("Ваше магическое зеркало отразило поражение $n1!", FALSE, ch, 0, victim, TO_VICT);
-			mag_affects(level, ch, ch, spellnum, savetype);
-			return 0;
-		}
-	}
-	else
-	{
-		if (ch != victim && SpINFO.violent && IS_GOD(victim) && (IS_NPC(ch) || GET_LEVEL(victim) > (GET_LEVEL(ch) + GET_REMORT(ch) / 2)))
-		{
-			act("Звуковой барьер $N1 отразил ваш крик!", FALSE, ch, 0, victim, TO_CHAR);
-			act("Звуковой барьер $N1 отразил крик $n1!", FALSE, ch, 0, victim, TO_NOTVICT);
-			act("Ваш звуковой барьер отразил крик $n1!", FALSE, ch, 0, victim, TO_VICT);
-			mag_affects(level, ch, ch, spellnum, savetype);
-			return 0;
-		}
-	}
+  // Calculate PKILL's affects
+  //   1) "NPC affect PC spellflag"  for victim
+  //   2) "NPC affect NPC spellflag" if victim cann't pkill FICHTING(victim)
+  if (ch != victim)    //send_to_char("Start\r\n",ch);
+  {
+    //send_to_char("Start\r\n",victim);
+    if (IS_SET(SpINFO.routines, NPC_AFFECT_PC))    //send_to_char("1\r\n",ch);
+    {
+      //send_to_char("1\r\n",victim);
+      if (!pk_agro_action(ch, victim))
+        return 0;
+    } else if (IS_SET(SpINFO.routines, NPC_AFFECT_NPC) && victim->get_fighting())    //send_to_char("2\r\n",ch);
+    {
+      //send_to_char("2\r\n",victim);
+      if (!pk_agro_action(ch, victim->get_fighting()))
+        return 0;
+    }
+    //send_to_char("Stop\r\n",ch);
+    //send_to_char("Stop\r\n",victim);
+  }
+  // Magic glass
+  if (!IS_SET(SpINFO.routines, MAG_WARCRY)) {
+    if (ch != victim
+        && SpINFO.violent
+        && ((!IS_GOD(ch)
+            && AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICGLASS)
+            && (ch->in_room == IN_ROOM(victim)) //зеркало сработает только если оба в одной комнате
+            && number(1, 100) < (GET_LEVEL(victim) / 3))
+            || (IS_GOD(victim)
+                && (IS_NPC(ch)
+                    || GET_LEVEL(victim) > (GET_LEVEL(ch)))))) {
+      act("Магическое зеркало $N1 отразило вашу магию!", FALSE, ch, 0, victim, TO_CHAR);
+      act("Магическое зеркало $N1 отразило магию $n1!", FALSE, ch, 0, victim, TO_NOTVICT);
+      act("Ваше магическое зеркало отразило поражение $n1!", FALSE, ch, 0, victim, TO_VICT);
+      mag_affects(level, ch, ch, spellnum, savetype);
+      return 0;
+    }
+  } else {
+    if (ch != victim && SpINFO.violent && IS_GOD(victim)
+        && (IS_NPC(ch) || GET_LEVEL(victim) > (GET_LEVEL(ch) + GET_REMORT(ch) / 2))) {
+      act("Звуковой барьер $N1 отразил ваш крик!", FALSE, ch, 0, victim, TO_CHAR);
+      act("Звуковой барьер $N1 отразил крик $n1!", FALSE, ch, 0, victim, TO_NOTVICT);
+      act("Ваш звуковой барьер отразил крик $n1!", FALSE, ch, 0, victim, TO_VICT);
+      mag_affects(level, ch, ch, spellnum, savetype);
+      return 0;
+    }
+  }
 
-	if (!IS_SET(SpINFO.routines, MAG_WARCRY) && ch != victim && SpINFO.violent
-		&& number(1, 999) <= GET_AR(victim) * 10)
-	{
-		send_to_char(NOEFFECT, ch);
-		return 0;
-	}
+  if (!IS_SET(SpINFO.routines, MAG_WARCRY) && ch != victim && SpINFO.violent
+      && number(1, 999) <= GET_AR(victim) * 10) {
+    send_to_char(NOEFFECT, ch);
+    return 0;
+  }
 
-	AFFECT_DATA<EApplyLocation> af[MAX_SPELL_AFFECTS];
-	for (i = 0; i < MAX_SPELL_AFFECTS; i++)
-	{
-		af[i].type = spellnum;
-		af[i].bitvector = 0;
-		af[i].modifier = 0;
-		af[i].battleflag = 0;
-		af[i].location = APPLY_NONE;
-	}
+  AFFECT_DATA<EApplyLocation> af[MAX_SPELL_AFFECTS];
+  for (i = 0; i < MAX_SPELL_AFFECTS; i++) {
+    af[i].type = spellnum;
+    af[i].bitvector = 0;
+    af[i].modifier = 0;
+    af[i].battleflag = 0;
+    af[i].location = APPLY_NONE;
+  }
 
-	// decrease modi for failing, increese fo success
-	if (ch != victim)
-	{
-		modi = calc_anti_savings(ch);
-		if (can_use_feat(ch, RELATED_TO_MAGIC_FEAT) && !IS_NPC(victim))
-		{
-			modi -= 80; //бонуса на непись нету
-		}
-		if (can_use_feat(ch, MAGICAL_INSTINCT_FEAT) && !IS_NPC(victim))
-		{
-			modi -= 30; //бонуса на непись нету
-		}
+  // decrease modi for failing, increese fo success
+  if (ch != victim) {
+    modi = calc_anti_savings(ch);
+    if (can_use_feat(ch, RELATED_TO_MAGIC_FEAT) && !IS_NPC(victim)) {
+      modi -= 80; //бонуса на непись нету
+    }
+    if (can_use_feat(ch, MAGICAL_INSTINCT_FEAT) && !IS_NPC(victim)) {
+      modi -= 30; //бонуса на непись нету
+    }
 
-	}
+  }
 
-	if (PRF_FLAGGED(ch, PRF_AWAKE) && !IS_NPC(victim))
-	{
-		modi = modi - 50;
-	}
+  if (PRF_FLAGGED(ch, PRF_AWAKE) && !IS_NPC(victim)) {
+    modi = modi - 50;
+  }
 
 //  log("[MAG Affect] Modifier value for %s (caster %s) = %d(spell %d)",
 //      GET_NAME(victim), GET_NAME(ch), modi, spellnum);
 
-	const int koef_duration = func_koef_duration(spellnum, ch->get_skill(get_magic_skill_number_by_spell(spellnum)));
-	const int koef_modifier = func_koef_modif(spellnum, ch->get_skill(get_magic_skill_number_by_spell(spellnum)));
-
-
-	switch (spellnum)
-	{
-	case SPELL_CHILL_TOUCH:
-		savetype = SAVING_STABILITY;
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		af[0].location = APPLY_STR;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 2, level, 4, 6, 0)) * koef_duration;
-		af[0].modifier = -1 - GET_REMORT(ch) / 2;
-		af[0].battleflag = AF_BATTLEDEC;
-		accum_duration = TRUE;
-		to_room = "Боевой пыл $n1 несколько остыл.";
-		to_vict = "Вы почувствовали себя слабее!";
-		break;
-
-	case SPELL_ENERGY_DRAIN:
-	case SPELL_WEAKNESS:
-		savetype = SAVING_WILL;
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		if (affected_by_spell(victim, SPELL_STRENGTH))
-		{
-			affect_from_char(victim, SPELL_STRENGTH);
-			success = FALSE;
-			break;
-		}
-		if (affected_by_spell(victim, SPELL_DEXTERITY))
-		{
-			affect_from_char(victim, SPELL_DEXTERITY);
-			success = FALSE;
-			break;
-		}
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 4, level, 5, 4, 0)) * koef_duration;
-		af[0].location = APPLY_STR;
-		if (spellnum == SPELL_WEAKNESS)
-			af[0].modifier = -1 * ((level / 6 + GET_REMORT(ch) / 2));
-		else
-			af[0].modifier = -2 * ((level / 6 + GET_REMORT(ch) / 2));
-		if (IS_NPC(ch) && level >= (LVL_IMMORT))
-			af[0].modifier += (LVL_IMMORT - level - 1);	//1 str per mob level above 30
-		af[0].battleflag = AF_BATTLEDEC;
-		accum_duration = TRUE;
-		to_room = "$n стал$g немного слабее.";
-		to_vict = "Вы почувствовали себя слабее!";
-		spellnum = SPELL_WEAKNESS;
-		break;
-	case SPELL_STONE_WALL:
-	case SPELL_STONESKIN:
-		af[0].location = APPLY_ABSORBE;
-		af[0].modifier = (level * 2 + 1) / 3;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "Кожа $n1 покрылась каменными пластинами.";
-		to_vict = "Вы стали менее чувствительны к ударам.";
-		spellnum = SPELL_STONESKIN;
-		break;
-
-	case SPELL_GENERAL_RECOVERY:
-	case SPELL_FAST_REGENERATION:
-		af[0].location = APPLY_HITREG;
-		af[0].modifier = 50 + GET_REMORT(ch);
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[1].location = APPLY_MOVEREG;
-		af[1].modifier = 50 + GET_REMORT(ch);
-		af[1].duration = af[0].duration;
-		accum_duration = TRUE;
-		to_room = "$n расцвел$g на ваших глазах.";
-		to_vict = "Вас наполнила живительная сила.";
-		spellnum = SPELL_FAST_REGENERATION;
-		break;
-
-	case SPELL_AIR_SHIELD:
-		if (affected_by_spell(victim, SPELL_ICE_SHIELD))
-			affect_from_char(victim, SPELL_ICE_SHIELD);
-		if (affected_by_spell(victim, SPELL_FIRE_SHIELD))
-			affect_from_char(victim, SPELL_FIRE_SHIELD);
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_AIRSHIELD);
-		af[0].battleflag = AF_BATTLEDEC;
-		if (IS_NPC(victim) || victim == ch)
-			af[0].duration = pc_duration(victim, 10 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
-		else
-			af[0].duration = pc_duration(victim, 4 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
-		to_room = "$n3 окутал воздушный щит.";
-		to_vict = "Вас окутал воздушный щит.";
-		break;
-
-	case SPELL_FIRE_SHIELD:
-		if (affected_by_spell(victim, SPELL_ICE_SHIELD))
-			affect_from_char(victim, SPELL_ICE_SHIELD);
-		if (affected_by_spell(victim, SPELL_AIR_SHIELD))
-			affect_from_char(victim, SPELL_AIR_SHIELD);
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_FIRESHIELD);
-		af[0].battleflag = AF_BATTLEDEC;
-		if (IS_NPC(victim) || victim == ch)
-			af[0].duration = pc_duration(victim, 10 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
-		else
-			af[0].duration = pc_duration(victim, 4 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
-		to_room = "$n3 окутал огненный щит.";
-		to_vict = "Вас окутал огненный щит.";
-		break;
-
-	case SPELL_ICE_SHIELD:
-		if (affected_by_spell(victim, SPELL_FIRE_SHIELD))
-			affect_from_char(victim, SPELL_FIRE_SHIELD);
-		if (affected_by_spell(victim, SPELL_AIR_SHIELD))
-			affect_from_char(victim, SPELL_AIR_SHIELD);
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_ICESHIELD);
-		af[0].battleflag = AF_BATTLEDEC;
-		if (IS_NPC(victim) || victim == ch)
-			af[0].duration = pc_duration(victim, 10 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
-		else
-			af[0].duration = pc_duration(victim, 4 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
-		to_room = "$n3 окутал ледяной щит.";
-		to_vict = "Вас окутал ледяной щит.";
-		break;
-
-	case SPELL_AIR_AURA:
-		af[0].location = APPLY_RESIST_AIR;
-		af[0].modifier = level;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_AIRAURA);
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n3 окружила воздушная аура.";
-		to_vict = "Вас окружила воздушная аура.";
-		break;
-
-	case SPELL_EARTH_AURA:
-		af[0].location = APPLY_RESIST_EARTH;
-		af[0].modifier = level;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_EARTHAURA);
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n глубоко поклонил$u земле.";
-		to_vict = "Глубокий поклон тебе, матушка земля.";
-		break;
-
-	case SPELL_FIRE_AURA:
-		af[0].location = APPLY_RESIST_WATER;
-		af[0].modifier = level;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_FIREAURA);
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n3 окружила огненная аура.";
-		to_vict = "Вас окружила огненная аура.";
-		break;
-
-	case SPELL_ICE_AURA:
-		af[0].location = APPLY_RESIST_FIRE;
-		af[0].modifier = level;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_ICEAURA);
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n3 окружила ледяная аура.";
-		to_vict = "Вас окружила ледяная аура.";
-		break;
-
-	case SPELL_GROUP_CLOUDLY:
-	case SPELL_CLOUDLY:
-		af[0].location = APPLY_AC;
-		af[0].modifier = -20;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "Очертания $n1 расплылись и стали менее отчетливыми.";
-		to_vict = "Ваше тело стало прозрачным, как туман.";
-		spellnum = SPELL_CLOUDLY;
-		break;
-
-	case SPELL_GROUP_ARMOR:
-	case SPELL_ARMOR:
-		af[0].location = APPLY_AC;
-		af[0].modifier = -20;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[1].location = APPLY_SAVING_REFLEX;
-		af[1].modifier = -5;
-		af[1].duration = af[0].duration;
-		af[2].location = APPLY_SAVING_STABILITY;
-		af[2].modifier = -5;
-		af[2].duration = af[0].duration;
-		accum_duration = TRUE;
-		to_room = "Вокруг $n1 вспыхнул белый щит и тут же погас.";
-		to_vict = "Вы почувствовали вокруг себя невидимую защиту.";
-		spellnum = SPELL_ARMOR;
-		break;
-
-	case SPELL_FASCINATION:
-		if (affected_by_spell(ch, SPELL_FASCINATION))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		if (material_component_processing(ch, victim, spellnum))
-		{
-			success = FALSE;
-			break;
-		}
-
-		af[0].location = APPLY_CHA;
-		rnd = number(1, 10);
-		if (rnd < 4)
-		{
-			rnd = number(0, 4);
-			af[0].modifier = -rnd;	//(  10 - int(GET_REMORT(victim)/2));
-		}
-		else
-		{
-			rnd = number(0, 15);
-			if (rnd < 1)
-				af[0].modifier = 4;	//(  10 - int(GET_REMORT(victim)/2));
-			else if (rnd < 4)
-				af[0].modifier = 3;
-			else if (rnd < 8)
-				af[0].modifier = 2;
-			else if (rnd < 15)
-				af[0].modifier = 1;
-			else
-				af[0].modifier = 0;
-		}
-		if (af[0].modifier > 0)
-		{
-			af[0].modifier = af[0].modifier / int ((GET_REMORT(ch) + 3) / 3);	//модификатор мортов
-		}
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_vict =
-			"Вы попытались вспомнить уроки старой цыганки, что учила вас людям головы морочить.\r\nХотя вы ее не очень то слушали.\r\n";
-		to_room =
-			"$n0 достал$g из маленькой сумочки какие-то вонючие порошки и отвернул$u, бормоча под нос \r\n\"..так это на ресницы надо, кажется... Эх, только бы не перепутать...\" \r\n";
-
-		break;
-
-	case SPELL_GROUP_BLESS:
-	case SPELL_BLESS:
-		af[0].location = APPLY_SAVING_STABILITY;
-		af[0].modifier = -5 - GET_REMORT(ch) / 3;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_BLESS);
-		af[1].location = APPLY_SAVING_WILL;
-		af[1].modifier = -5 - GET_REMORT(ch) / 4;
-		af[1].duration = af[0].duration;
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_BLESS);
-		to_room = "$n осветил$u на миг неземным светом.";
-		to_vict = "Боги одарили вас своей улыбкой.";
-		spellnum = SPELL_BLESS;
-		break;
-
-	case SPELL_CALL_LIGHTNING:
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-		}
-		af[0].location = APPLY_HITROLL;
-		af[0].modifier = -dice(1+level/8+ch->get_remort()/4, 4);
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 2, level + 7, 8, 0, 0)) * koef_duration;
-		af[1].location = APPLY_CAST_SUCCESS;
-		af[1].modifier = -dice(1+level/4+ch->get_remort()/2, 4);
-		af[1].duration = af[0].duration;
-		spellnum = SPELL_MAGICBATTLE;
-		to_room = "$n зашатал$u, пытаясь прийти в себя от взрыва шаровой молнии.";
-		to_vict = "Взрыв шаровой молнии $N1 отдался в вашей голове громким звоном.";
-		break;
-
-	case SPELL_CONE_OF_COLD:
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-		}
-		af[0].location = APPLY_DEX;
-		af[0].modifier = -dice(int (MAX(1, ((level - 14) / 7))), 3);
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 9, 0, 0, 0, 0)) * koef_duration;
-		to_vict = "Вы покрылись серебристым инеем.";
-		to_room = "$n покрыл$u красивым серебристым инеем.";
-		break;
-	case SPELL_GROUP_AWARNESS:
-	case SPELL_AWARNESS:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_AWARNESS);
-		af[1].location = APPLY_SAVING_REFLEX;
-		af[1].modifier = -1 - GET_REMORT(ch)  / 4;
-		af[1].duration = af[0].duration;
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_AWARNESS);
-		to_room = "$n начал$g внимательно осматриваться по сторонам.";
-		to_vict = "Вы стали более внимательны к окружающему.";
-		spellnum = SPELL_AWARNESS;
-		break;
-
-	case SPELL_SHIELD:
-		af[0].duration = pc_duration(victim, 4, 0, 0, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_SHIELD);
-		af[0].location = APPLY_SAVING_STABILITY;
-		af[0].modifier = -10;
-		af[0].battleflag = AF_BATTLEDEC;
-		af[1].duration = af[0].duration;
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_SHIELD);
-		af[1].location = APPLY_SAVING_WILL;
-		af[1].modifier = -10;
-		af[1].battleflag = AF_BATTLEDEC;
-		af[2].duration = af[0].duration;
-		af[2].bitvector = to_underlying(EAffectFlag::AFF_SHIELD);
-		af[2].location = APPLY_SAVING_REFLEX;
-		af[2].modifier = -10;
-		af[2].battleflag = AF_BATTLEDEC;
-
-		to_room = "$n покрыл$u сверкающим коконом.";
-		to_vict = "Вас покрыл голубой кокон.";
-		break;
-
-	case SPELL_GROUP_HASTE:
-	case SPELL_HASTE:
-		if (affected_by_spell(victim, SPELL_SLOW))
-		{
-			affect_from_char(victim, SPELL_SLOW);
-			success = FALSE;
-			break;
-		}
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_HASTE);
-		af[0].location = APPLY_SAVING_REFLEX;
-		af[0].modifier = -1 - GET_REMORT(ch) / 5;
-		to_vict = "Вы начали двигаться быстрее.";
-		to_room = "$n начал$g двигаться заметно быстрее.";
-		spellnum = SPELL_HASTE;
-		break;
-
-	case SPELL_SHADOW_CLOAK:
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_SHADOW_CLOAK);
-		af[0].location = APPLY_SAVING_STABILITY;
-		af[0].modifier = - (GET_LEVEL(ch) / 3  + GET_REMORT(ch)) / 4 ;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n скрыл$u в густой тени.";
-		to_vict = "Густые тени окутали вас.";
-		break;
-
-	case SPELL_ENLARGE:
-		if (affected_by_spell(victim, SPELL_ENLESS))
-		{
-			affect_from_char(victim, SPELL_ENLESS);
-			success = FALSE;
-			break;
-		}
-		af[0].location = APPLY_SIZE;
-		af[0].modifier = 5 + level / 2 + GET_REMORT(ch) / 3;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n начал$g расти, как на дрожжах.";
-		to_vict = "Вы стали крупнее.";
-		break;
-
-	case SPELL_ENLESS:
-		if (affected_by_spell(victim, SPELL_ENLARGE))
-		{
-			affect_from_char(victim, SPELL_ENLARGE);
-			success = FALSE;
-			break;
-		}
-		af[0].location = APPLY_SIZE;
-		af[0].modifier = -(5 + level / 3);
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n скукожил$u.";
-		to_vict = "Вы стали мельче.";
-		break;
-
-	case SPELL_MAGICGLASS:
-	case SPELL_GROUP_MAGICGLASS:
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_MAGICGLASS);
-		af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n3 покрыла зеркальная пелена.";
-		to_vict = "Вас покрыло зеркало магии.";
-		spellnum = SPELL_MAGICGLASS;
-		break;
-
-	case SPELL_CLOUD_OF_ARROWS:
-		af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_CLOUD_OF_ARROWS);
-		af[0].location = APPLY_HITROLL;
-		af[0].modifier = level / 6;
-		accum_duration = TRUE;
-		to_room = "$n3 окружило облако летающих огненных стрел.";
-		to_vict = "Вас окружило облако летающих огненных стрел.";
-		break;
-
-	case SPELL_STONEHAND:
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_STONEHAND);
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "Руки $n1 задубели.";
-		to_vict = "Ваши руки задубели.";
-		break;
-
-	case SPELL_GROUP_PRISMATICAURA:
-	case SPELL_PRISMATICAURA:
-		if (!IS_NPC(ch) && !same_group(ch, victim))
-		{
-			send_to_char("Только на себя или одногруппника!\r\n", ch);
-			return 0;
-		}
-		if (affected_by_spell(victim, SPELL_SANCTUARY))
-		{
-			affect_from_char(victim, SPELL_SANCTUARY);
-			success = FALSE;
-			break;
-		}
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_SANCTUARY))
-		{
-			success = FALSE;
-			break;
-		}
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_PRISMATICAURA);
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		accum_duration = TRUE;
-		to_room = "$n3 покрыла призматическая аура.";
-		to_vict = "Вас покрыла призматическая аура.";
-		spellnum = SPELL_PRISMATICAURA;
-		break;
-
-	case SPELL_MINDLESS:
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		af[0].location = APPLY_MANAREG;
-		af[0].modifier = -50;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 0, GET_REAL_WIS(ch) + GET_REAL_INT(ch), 10, 0, 0)) * koef_duration;
-		af[1].location = APPLY_CAST_SUCCESS;
-		af[1].modifier = -50;
-		af[1].duration = af[0].duration;
-		af[2].location = APPLY_HITROLL;
-		af[2].modifier = -5;
-		af[2].duration = af[0].duration;
-
-		to_room = "$n0 стал$g слаб$g на голову!";
-		to_vict = "Ваш разум помутился!";
-		break;
-
-	case SPELL_DUSTSTORM:
-	case SPELL_SHINEFLASH:
-	case SPELL_MASS_BLINDNESS:
-	case SPELL_POWER_BLINDNESS:
-	case SPELL_BLINDNESS:
-			savetype = SAVING_STABILITY;
-		if (MOB_FLAGGED(victim, MOB_NOBLIND) ||
-				WAITLESS(victim) ||
-				((ch != victim) &&
-				 !GET_GOD_FLAG(victim, GF_GODSCURSE) && general_savingthrow(ch, victim, savetype, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		switch (spellnum)
-		{
-		case SPELL_DUSTSTORM:
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 3, level, 6, 0, 0)) * koef_duration;
-			break;
-		case SPELL_SHINEFLASH:
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 2, level + 7, 8, 0, 0)) * koef_duration;
-			break;
-		case SPELL_MASS_BLINDNESS:
-		case SPELL_BLINDNESS:
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 2, level, 8, 0, 0)) * koef_duration;
-			break;
-		case SPELL_POWER_BLINDNESS:
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 3, level, 6, 0, 0)) * koef_duration;
-			break;
-		}
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_BLIND);
-		af[0].battleflag = AF_BATTLEDEC;
-		to_room = "$n0 ослеп$q!";
-		to_vict = "Вы ослепли!";
-		spellnum = SPELL_BLINDNESS;
-		break;
-
-	case SPELL_MADNESS:
-		savetype = SAVING_WILL;
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 3, 0, 0, 0, 0)) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-		af[1].location = APPLY_MADNESS;
-		af[1].duration = af[0].duration;
-		af[1].modifier = level;
-		to_room = "Теперь $n не сможет сбежать из боя!";
-		to_vict = "Вас обуяло безумие!";
-		break;
-
-	case SPELL_WEB:
-		savetype = SAVING_REFLEX;
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_BROKEN_CHAINS)
-				|| (ch != victim && general_savingthrow(ch, victim, savetype, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		af[0].location = APPLY_HITROLL;
-		af[0].modifier = -2 - GET_REMORT(ch) / 5;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 3, level, 6, 0, 0)) * koef_duration;
-		af[0].battleflag = AF_BATTLEDEC;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-		af[1].location = APPLY_AC;
-		af[1].modifier = 20;
-		af[1].duration = af[0].duration;
-		af[1].battleflag = AF_BATTLEDEC;
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-		to_room = "$n3 покрыла невидимая паутина, сковывая $s движения!";
-		to_vict = "Вас покрыла невидимая паутина!";
-		break;
-
-
-	case SPELL_MASS_CURSE:
-	case SPELL_CURSE:
-		savetype = SAVING_WILL;
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		// если есть фит порча
-		if (can_use_feat(ch, DECLINE_FEAT))
-			decline_mod += GET_REMORT(ch);
-		af[0].location = APPLY_INITIATIVE;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 1, level, 2, 0, 0)) * koef_duration;
-		af[0].modifier = -(5 + decline_mod);
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_CURSE);
-
-		af[1].location = APPLY_HITROLL;
-		af[1].duration = af[0].duration;
-		af[1].modifier = -(level/6 + decline_mod + GET_REMORT(ch) / 5);
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_CURSE);
-
-		if (level >= 20)
-		{
-			af[2].location = APPLY_CAST_SUCCESS;
-			af[2].duration = af[0].duration;
-			af[2].modifier = - (level / 3 + GET_REMORT(ch));
-			if (IS_NPC(ch) && level >= (LVL_IMMORT))
-				af[2].modifier += (LVL_IMMORT - level - 1);	//1 cast per mob level above 30
-			af[2].bitvector = to_underlying(EAffectFlag::AFF_CURSE);
-		}
-		accum_duration = TRUE;
-		accum_affect = TRUE;
-		to_room = "Красное сияние вспыхнуло над $n4 и тут же погасло!";
-		to_vict = "Боги сурово поглядели на вас.";
-		spellnum = SPELL_CURSE;
-		break;
-
-	case SPELL_MASS_SLOW:
-	case SPELL_SLOW:
-		savetype = SAVING_STABILITY;
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_BROKEN_CHAINS)
-				|| (ch != victim && general_savingthrow(ch, victim, savetype, modi *  number(1, koef_modifier / 2))))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		if (affected_by_spell(victim, SPELL_HASTE))
-		{
-			affect_from_char(victim, SPELL_HASTE);
-			success = FALSE;
-			break;
-		}
-
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 9, 0, 0, 0, 0)) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_SLOW);
-		af[1].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),  pc_duration(victim, 9, 0, 0, 0, 0)) * koef_duration;
-		af[1].location = APPLY_DEX;
-		af[1].modifier = -koef_modifier;
-		to_room = "Движения $n1 заметно замедлились.";
-		to_vict = "Ваши движения заметно замедлились.";
-		spellnum = SPELL_SLOW;
-		break;
-
-	case SPELL_GENERAL_SINCERITY:
-	case SPELL_DETECT_ALIGN:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_DETECT_ALIGN);
-		accum_duration = TRUE;
-		to_vict = "Ваши глаза приобрели зеленый оттенок.";
-		to_room = "Глаза $n1 приобрели зеленый оттенок.";
-		spellnum = SPELL_DETECT_ALIGN;
-		break;
-
-	case SPELL_ALL_SEEING_EYE:
-	case SPELL_DETECT_INVIS:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_DETECT_INVIS);
-		accum_duration = TRUE;
-		to_vict = "Ваши глаза приобрели золотистый оттенок.";
-		to_room = "Глаза $n1 приобрели золотистый оттенок.";
-		spellnum = SPELL_DETECT_INVIS;
-		break;
-
-	case SPELL_MAGICAL_GAZE:
-	case SPELL_DETECT_MAGIC:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_DETECT_MAGIC);
-		accum_duration = TRUE;
-		to_vict = "Ваши глаза приобрели желтый оттенок.";
-		to_room = "Глаза $n1 приобрели желтый оттенок.";
-		spellnum = SPELL_DETECT_MAGIC;
-		break;
-
-	case SPELL_SIGHT_OF_DARKNESS:
-	case SPELL_INFRAVISION:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_INFRAVISION);
-		accum_duration = TRUE;
-		to_vict = "Ваши глаза приобрели красный оттенок.";
-		to_room = "Глаза $n1 приобрели красный оттенок.";
-		spellnum = SPELL_INFRAVISION;
-		break;
-
-	case SPELL_SNAKE_EYES:
-	case SPELL_DETECT_POISON:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_DETECT_POISON);
-		accum_duration = TRUE;
-		to_vict = "Ваши глаза приобрели карий оттенок.";
-		to_room = "Глаза $n1 приобрели карий оттенок.";
-		spellnum = SPELL_DETECT_POISON;
-		break;
-
-	case SPELL_GROUP_INVISIBLE:
-	case SPELL_INVISIBLE:
-		if (!victim)
-			victim = ch;
-		if (affected_by_spell(victim, SPELL_GLITTERDUST))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].modifier = -40;
-		af[0].location = APPLY_AC;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_INVISIBLE);
-		accum_duration = TRUE;
-		to_vict = "Вы стали невидимы для окружающих.";
-		to_room = "$n медленно растворил$u в пустоте.";
-		spellnum = SPELL_INVISIBLE;
-		break;
-
-	case SPELL_PLAQUE:
-		savetype = SAVING_STABILITY;
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		af[0].location = APPLY_HITREG;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 0, level, 2, 0, 0)) * koef_duration;
-		af[0].modifier = -95;
-		af[1].location = APPLY_MANAREG;
-		af[1].duration = af[0].duration;
-		af[1].modifier = -95;
-		af[2].location = APPLY_MOVEREG;
-		af[2].duration = af[0].duration;
-		af[2].modifier = -95;
-		af[3].location = APPLY_PLAQUE;
-		af[3].duration = af[0].duration;
-		af[3].modifier = level;
-		af[4].location = APPLY_WIS;
-		af[4].duration = af[0].duration;
-		af[4].modifier = -GET_REMORT(ch) / 5;
-		af[5].location = APPLY_INT;
-		af[5].duration = af[0].duration;
-		af[5].modifier = -GET_REMORT(ch) / 5;
-		af[6].location = APPLY_DEX;
-		af[6].duration = af[0].duration;
-		af[6].modifier = -GET_REMORT(ch) / 5;
-		af[7].location = APPLY_STR;
-		af[7].duration = af[0].duration;
-		af[7].modifier = -GET_REMORT(ch) / 5;
-		to_vict = "Вас скрутило в жестокой лихорадке.";
-		to_room = "$n3 скрутило в жестокой лихорадке.";
-		break;
-
-
-	case SPELL_POISON:
-		savetype = SAVING_CRITICAL;
-		if (ch != victim && (AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD) ||
-							 general_savingthrow(ch, victim, savetype, modi - GET_REAL_CON(victim) / 2)))
-		{
-			if (ch->in_room == IN_ROOM(victim)) // Добавлено чтобы яд нанесенный SPELL_POISONED_FOG не спамил чару постоянно
-				send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		af[0].location = APPLY_STR;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-				pc_duration(victim, 0, level, 1, 0, 0)) * koef_duration;
-		af[0].modifier = -2;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af[0].battleflag = AF_SAME_TIME;
-
-		af[1].location = APPLY_POISON;
-		af[1].duration = af[0].duration;
-		af[1].modifier = level + GET_REMORT(ch) / 2;
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af[1].battleflag = AF_SAME_TIME;
-
-		to_vict = "Вы почувствовали себя отравленным.";
-		to_room = "$n позеленел$g от действия яда.";
-
-		break;
-
-	case SPELL_PROT_FROM_EVIL:
-	case SPELL_GROUP_PROT_FROM_EVIL:
-		if (!IS_NPC(ch) && !same_group(ch, victim))
-		{
-			send_to_char("Только на себя или одногруппника!\r\n", ch);
-			return 0;
-		}
-		af[0].location = APPLY_RESIST_DARK;
-		if (spellnum == SPELL_PROT_FROM_EVIL)
-		{
-			affect_from_char(ch, SPELL_GROUP_PROT_FROM_EVIL);
-			af[0].modifier = 5;
-		}
-		else
-		{
-			affect_from_char(ch, SPELL_PROT_FROM_EVIL);
-			af[0].modifier = level;
-		}
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_PROTECT_EVIL);
-		accum_duration = TRUE;
-		to_vict = "Вы подавили в себе страх к тьме.";
-		to_room = "$n подавил$g в себе страх к тьме.";
-		break;
-
-	case SPELL_GROUP_SANCTUARY:
-	case SPELL_SANCTUARY:
-		if (!IS_NPC(ch) && !same_group(ch, victim))
-		{
-			send_to_char("Только на себя или одногруппника!\r\n", ch);
-			return 0;
-		}
-		if (affected_by_spell(victim, SPELL_PRISMATICAURA))
-		{
-			affect_from_char(victim, SPELL_PRISMATICAURA);
-			success = FALSE;
-			break;
-		}
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_PRISMATICAURA))
-		{
-			success = FALSE;
-			break;
-		}
-
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_SANCTUARY);
-		to_vict = "Белая аура мгновенно окружила вас.";
-		to_room = "Белая аура покрыла $n3 с головы до пят.";
-		spellnum = SPELL_SANCTUARY;
-		break;
-
-	case SPELL_SLEEP:
-		savetype = SAVING_WILL;
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_HOLD) || MOB_FLAGGED(victim, MOB_NOSLEEP)
-				|| (ch != victim && general_savingthrow(ch, victim, SAVING_WILL, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		};
-
-		if (victim->get_fighting())
-			stop_fighting(victim, FALSE);
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 1, level, 6, 1, 6)) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_SLEEP);
-		af[0].battleflag = AF_BATTLEDEC;
-		if (GET_POS(victim) > POS_SLEEPING && success)
-		{
-			// add by Pereplut
-			if (victim->ahorse())
-			    victim->drop_from_horse();
-			send_to_char("Вы слишком устали... Спать... Спа...\r\n", victim);
-			act("$n прилег$q подремать.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-
-			GET_POS(victim) = POS_SLEEPING;
-		}
-		break;
-
-	case SPELL_GROUP_STRENGTH:
-	case SPELL_STRENGTH:
-		if (affected_by_spell(victim, SPELL_WEAKNESS))
-		{
-			affect_from_char(victim, SPELL_WEAKNESS);
-			success = FALSE;
-			break;
-		}
-		af[0].location = APPLY_STR;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		if (ch == victim)
-			af[0].modifier = (level + 9) / 10 + koef_modifier + GET_REMORT(ch) / 5;
-		else
-			af[0].modifier = (level + 14) / 15 + koef_modifier + GET_REMORT(ch) / 5;
-		accum_duration = TRUE;
-		accum_affect = TRUE;
-		to_vict = "Вы почувствовали себя сильнее.";
-		to_room = "Мышцы $n1 налились силой.";
-		spellnum = SPELL_STRENGTH;
-		break;
-
-	case SPELL_DEXTERITY:
-		if (affected_by_spell(victim, SPELL_WEAKNESS))
-		{
-			affect_from_char(victim, SPELL_WEAKNESS);
-			success = FALSE;
-			break;
-		}
-		af[0].location = APPLY_DEX;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		if (ch == victim)
-			af[0].modifier = (level + 9) / 10 + koef_modifier + GET_REMORT(ch) / 5;
-		else
-			af[0].modifier = (level + 14) / 15 + koef_modifier + GET_REMORT(ch) / 5;
-		accum_duration = TRUE;
-		accum_affect = TRUE;
-		to_vict = "Вы почувствовали себя более шустрым.";
-		to_room = "$n0 будет двигаться более шустро.";
-		spellnum = SPELL_DEXTERITY;
-		break;
-
-	case SPELL_PATRONAGE:
-		af[0].location = APPLY_HIT;
-		af[0].duration = pc_duration(victim, 3, level, 10, 0, 0) * koef_duration;
-		af[0].modifier = GET_LEVEL(ch) * 2 + GET_REMORT(ch);
-		if (GET_ALIGNMENT(victim) >= 0)
-		{
-			to_vict = "Исходящий с небес свет на мгновение озарил вас.";
-			to_room = "Исходящий с небес свет на мгновение озарил $n3.";
-		}
-		else
-		{
-			to_vict = "Вас окутало клубящееся облако Тьмы.";
-			to_room = "Клубящееся темное облако на мгновение окутало $n3.";
-		}
-		break;
-
-	case SPELL_EYE_OF_GODS:
-	case SPELL_SENSE_LIFE:
-		to_vict = "Вы способны разглядеть даже микроба.";
-		to_room = "$n0 начал$g замечать любые движения.";
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_SENSE_LIFE);
-		accum_duration = TRUE;
-		spellnum = SPELL_SENSE_LIFE;
-		break;
-
-	case SPELL_WATERWALK:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_WATERWALK);
-		accum_duration = TRUE;
-		to_vict = "На рыбалку вы можете отправляться без лодки.";
-		break;
-
-	case SPELL_BREATHING_AT_DEPTH:
-	case SPELL_WATERBREATH:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_WATERBREATH);
-		accum_duration = TRUE;
-		to_vict = "У вас выросли жабры.";
-		to_room = "У $n1 выросли жабры.";
-		spellnum = SPELL_WATERBREATH;
-		break;
-
-	case SPELL_HOLYSTRIKE:
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_EVILESS))
-		{
-			// все решится в дамадже части спелла
-			success = FALSE;
-			break;
-		}
-		// тут break не нужен
-
-		// fall through
-	case SPELL_MASS_HOLD:
-	case SPELL_POWER_HOLD:
-	case SPELL_HOLD:
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_SLEEP)
-				|| MOB_FLAGGED(victim, MOB_NOHOLD) || AFF_FLAGGED(victim, EAffectFlag::AFF_BROKEN_CHAINS)
-				|| (ch != victim && general_savingthrow(ch, victim, SAVING_WILL, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 spellnum == SPELL_POWER_HOLD ? pc_duration(victim, 2, level + 7, 8, 2, 5)
-						 : pc_duration(victim, 1, level + 9, 10, 1, 3)) * koef_duration;
-
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_HOLD);
-		af[0].battleflag = AF_BATTLEDEC;
-		to_room = "$n0 замер$q на месте!";
-		to_vict = "Вы замерли на месте, не в силах пошевельнуться.";
-		spellnum = SPELL_HOLD;
-		break;
-
-	case SPELL_WC_OF_RAGE:
-	case SPELL_SONICWAVE:
-	case SPELL_MASS_DEAFNESS:
-	case SPELL_POWER_DEAFNESS:
-	case SPELL_DEAFNESS:
-		switch (spellnum)
-		{
-		case SPELL_WC_OF_RAGE:
-			savetype = SAVING_WILL;
-			modi = GET_REAL_CON(ch);
-			break;
-		case SPELL_SONICWAVE:
-		case SPELL_MASS_DEAFNESS:
-		case SPELL_POWER_DEAFNESS:
-		case SPELL_DEAFNESS:
-			savetype = SAVING_STABILITY;
-			break;
-		}
-		if (  //MOB_FLAGGED(victim, MOB_NODEAFNESS) ||
-			(ch != victim && general_savingthrow(ch, victim, savetype, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		switch (spellnum)
-		{
-		case SPELL_WC_OF_RAGE:
-		case SPELL_POWER_DEAFNESS:
-		case SPELL_SONICWAVE:
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
-			break;
-		case SPELL_MASS_DEAFNESS:
-		case SPELL_DEAFNESS:
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 2, level + 7, 8, 3, 0)) * koef_duration;
-			break;
-		}
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_DEAFNESS);
-		af[0].battleflag = AF_BATTLEDEC;
-		to_room = "$n0 оглох$q!";
-		to_vict = "Вы оглохли.";
-		spellnum = SPELL_DEAFNESS;
-		break;
-
-	case SPELL_MASS_SILENCE:
-	case SPELL_POWER_SILENCE:
-	case SPELL_SILENCE:
-		savetype = SAVING_WILL;
-		if (MOB_FLAGGED(victim, MOB_NOSIELENCE) ||
-				(ch != victim && general_savingthrow(ch, victim, savetype, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 spellnum == SPELL_POWER_SILENCE ? pc_duration(victim, 2, level + 3, 4, 6, 0)
-						 : pc_duration(victim, 2, level + 7, 8, 3, 0)) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_SILENCE);
-		af[0].battleflag = AF_BATTLEDEC;
-		to_room = "$n0 прикусил$g язык!";
-		to_vict = "Вы не в состоянии вымолвить ни слова.";
-		spellnum = SPELL_SILENCE;
-		break;
-
-	case SPELL_GROUP_FLY:
-	case SPELL_FLY:
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_FLY);
-		to_room = "$n0 медленно поднял$u в воздух.";
-		to_vict = "Вы медленно поднялись в воздух.";
-		spellnum = SPELL_FLY;
-		break;
-
-	case SPELL_BROKEN_CHAINS:
-		af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_BROKEN_CHAINS);
-		af[0].battleflag = AF_BATTLEDEC;
-		to_room = "Ярко-синий ореол вспыхнул вокруг $n1 и тут же угас.";
-		to_vict = "Волна ярко-синего света омыла вас с головы до ног.";
-		break;
-	case SPELL_GROUP_BLINK:
-	case SPELL_BLINK:
-		af[0].location = APPLY_SPELL_BLINK;
-		af[0].modifier = 5 + GET_REMORT(ch) * 2 / 3.0;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		to_room = "$n начал$g мигать.";
-		to_vict = "Вы начали мигать.";
-		spellnum = SPELL_BLINK;
-		break;
-
-	case SPELL_MAGICSHIELD:
-		af[0].location = APPLY_AC;
-		af[0].modifier = - GET_LEVEL(ch) * 10 / 6;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[1].location = APPLY_SAVING_REFLEX;
-		af[1].modifier = - GET_LEVEL(ch) / 5;
-		af[1].duration = af[0].duration;
-		af[2].location = APPLY_SAVING_STABILITY;
-		af[2].modifier = - GET_LEVEL(ch) / 5;
-		af[2].duration = af[0].duration;
-		accum_duration = TRUE;
-		to_room = "Сверкающий щит вспыхнул вокруг $n1 и угас.";
-		to_vict = "Сверкающий щит вспыхнул вокруг вас и угас.";
-		break;
-
-	case SPELL_NOFLEE: // "приковать противника"
-	case SPELL_INDRIKS_TEETH:
-	case SPELL_MASS_NOFLEE:
-		af[0].battleflag = AF_BATTLEDEC;
-		savetype = SAVING_WILL;
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_BROKEN_CHAINS)
-				|| (ch != victim && general_savingthrow(ch, victim, savetype, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-				 pc_duration(victim, 3, level, 4, 4, 0)) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_NOTELEPORT);
-		to_room = "$n0 теперь прикован$a к $N2.";
-		to_vict = "Вы не сможете покинуть $N3.";
-		break;
-
-	case SPELL_LIGHT:
-		if (!IS_NPC(ch) && !same_group(ch, victim))
-		{
-			send_to_char("Только на себя или одногруппника!\r\n", ch);
-			return 0;
-		}
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_HOLYLIGHT);
-		to_room = "$n0 начал$g светиться ярким светом.";
-		to_vict = "Вы засветились, освещая комнату.";
-		break;
-
-	case SPELL_DARKNESS:
-		if (!IS_NPC(ch) && !same_group(ch, victim))
-		{
-			send_to_char("Только на себя или одногруппника!\r\n", ch);
-			return 0;
-		}
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_HOLYDARK);
-		to_room = "$n0 погрузил$g комнату во мрак.";
-		to_vict = "Вы погрузили комнату в непроглядную тьму.";
-		break;
-	case SPELL_VAMPIRE:
-		af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].location = APPLY_DAMROLL;
-		af[0].modifier = 0;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_VAMPIRE);
-		to_room = "Зрачки $n3 приобрели красный оттенок.";
-		to_vict = "Ваши зрачки приобрели красный оттенок.";
-		break;
-
-	case SPELL_EVILESS:
-		if (!IS_NPC(victim) || victim->get_master() != ch || !MOB_FLAGGED(victim, MOB_CORPSE)) {
-			//тихо уходим, т.к. заклинание массовое
-			break;
-		}
-		af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].location = APPLY_DAMROLL;
-		af[0].modifier = 15 + (GET_REMORT(ch) > 8 ? (GET_REMORT(ch) - 8) : 0);
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
-		af[1].duration = af[0].duration;
-		af[1].location = APPLY_HITROLL;
-		af[1].modifier = 7 + (GET_REMORT(ch) > 8 ? (GET_REMORT(ch) - 8) : 0);;
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
-		af[2].duration = af[0].duration;
-		af[2].location = APPLY_HIT;
-		af[2].bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
-
-		// иначе, при рекасте, модификатор суммируется с текущим аффектом.
-		if (!AFF_FLAGGED(victim, EAffectFlag::AFF_EVILESS)){
-			af[2].modifier = GET_REAL_MAX_HIT(victim);
-			// не очень красивый способ передать сигнал на лечение в mag_points
-			AFFECT_DATA<EApplyLocation> tmpaf;
-			tmpaf.type = SPELL_EVILESS;
-			tmpaf.duration = 1;
-			tmpaf.modifier = 0;
-			tmpaf.location = EApplyLocation::APPLY_NONE;
-			tmpaf.battleflag = 0;
-			tmpaf.bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
-			affect_to_char(ch, tmpaf);
-		}
-		to_vict = "Черное облако покрыло вас.";
-		to_room = "Черное облако покрыло $n3 с головы до пят.";
-		break;
-
-	case SPELL_WC_OF_THUNDER:
-	case SPELL_ICESTORM:
-	case SPELL_EARTHFALL:
-	case SPELL_SHOCK:
-		{
-		switch (spellnum)
-		{
-		case SPELL_WC_OF_THUNDER:
-			savetype = SAVING_WILL;
-			modi = GET_REAL_CON(ch) * 3 / 2;
-			break;
-		case SPELL_ICESTORM:
-			savetype = SAVING_REFLEX;
-			modi = CALC_SUCCESS(modi, 30);
-			break;
-		case SPELL_EARTHFALL:
-			savetype = SAVING_REFLEX;
-			modi = CALC_SUCCESS(modi, 95);
-			break;
-		case SPELL_SHOCK:
-			savetype = SAVING_REFLEX;
-			if (GET_CLASS(ch) == CLASS_CLERIC) {
-				modi = CALC_SUCCESS(modi, 75);
-			} else {
-				modi = CALC_SUCCESS(modi, 25);
-			}
-			break;
-		}
-		if (WAITLESS(victim) || (!WAITLESS(ch) && general_savingthrow(ch, victim, savetype, modi)))
-		{
-			success = FALSE;
-			break;
-		}
-		switch (spellnum)
-		{
-		case SPELL_WC_OF_THUNDER:
-			af[0].type = SPELL_DEAFNESS;
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
-			af[0].duration = complex_spell_modifier(ch, SPELL_DEAFNESS, GAPPLY_SPELL_EFFECT, af[0].duration);
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_DEAFNESS);
-			af[0].battleflag = AF_BATTLEDEC;
-			to_room = "$n0 оглох$q!";
-			to_vict = "Вы оглохли.";
-
-			if ((IS_NPC(victim)
-					&& AFF_FLAGGED(victim, static_cast<EAffectFlag>(af[0].bitvector)))
-				|| (ch != victim
-					&& affected_by_spell(victim, SPELL_DEAFNESS)))
-			{
-				if (ch->in_room == IN_ROOM(victim))
-					send_to_char(NOEFFECT, ch);
-			}
-			else
-			{
-				affect_join(victim, af[0], accum_duration, FALSE, accum_affect, FALSE);
-				act(to_vict, FALSE, victim, 0, ch, TO_CHAR);
-				act(to_room, TRUE, victim, 0, ch, TO_ROOM | TO_ARENA_LISTEN);
-			}
-			break;
-
-		case SPELL_ICESTORM:
-		case SPELL_EARTHFALL:
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 2, 0, 0, 0, 0)) * koef_duration;
-			af[0].bitvector = to_underlying(EAffectFlag::AFF_MAGICSTOPFIGHT);
-			af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-			to_room = "$n3 оглушило.";
-			to_vict = "Вас оглушило.";
-			spellnum = SPELL_MAGICBATTLE;
-			break;
-
-		case SPELL_SHOCK:
-				WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-				af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-								 pc_duration(victim, 2, 0, 0, 0, 0)) * koef_duration;
-				af[0].bitvector = to_underlying(EAffectFlag::AFF_MAGICSTOPFIGHT);
-				af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-				to_room = "$n3 оглушило.";
-				to_vict = "Вас оглушило.";
-				spellnum = SPELL_MAGICBATTLE;
-				mag_affects(level, ch, victim, SPELL_BLINDNESS, SAVING_STABILITY);
-				break;
-		}
-		break;
-	}
+  const int koef_duration = func_koef_duration(spellnum, ch->get_skill(get_magic_skill_number_by_spell(spellnum)));
+  const int koef_modifier = func_koef_modif(spellnum, ch->get_skill(get_magic_skill_number_by_spell(spellnum)));
+
+  switch (spellnum) {
+    case SPELL_CHILL_TOUCH: savetype = SAVING_STABILITY;
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      af[0].location = APPLY_STR;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 2, level, 4, 6, 0)) * koef_duration;
+      af[0].modifier = -1 - GET_REMORT(ch) / 2;
+      af[0].battleflag = AF_BATTLEDEC;
+      accum_duration = TRUE;
+      to_room = "Боевой пыл $n1 несколько остыл.";
+      to_vict = "Вы почувствовали себя слабее!";
+      break;
+
+    case SPELL_ENERGY_DRAIN:
+    case SPELL_WEAKNESS: savetype = SAVING_WILL;
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      if (affected_by_spell(victim, SPELL_STRENGTH)) {
+        affect_from_char(victim, SPELL_STRENGTH);
+        success = FALSE;
+        break;
+      }
+      if (affected_by_spell(victim, SPELL_DEXTERITY)) {
+        affect_from_char(victim, SPELL_DEXTERITY);
+        success = FALSE;
+        break;
+      }
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 4, level, 5, 4, 0)) * koef_duration;
+      af[0].location = APPLY_STR;
+      if (spellnum == SPELL_WEAKNESS)
+        af[0].modifier = -1 * ((level / 6 + GET_REMORT(ch) / 2));
+      else
+        af[0].modifier = -2 * ((level / 6 + GET_REMORT(ch) / 2));
+      if (IS_NPC(ch) && level >= (LVL_IMMORT))
+        af[0].modifier += (LVL_IMMORT - level - 1);    //1 str per mob level above 30
+      af[0].battleflag = AF_BATTLEDEC;
+      accum_duration = TRUE;
+      to_room = "$n стал$g немного слабее.";
+      to_vict = "Вы почувствовали себя слабее!";
+      spellnum = SPELL_WEAKNESS;
+      break;
+    case SPELL_STONE_WALL:
+    case SPELL_STONESKIN: af[0].location = APPLY_ABSORBE;
+      af[0].modifier = (level * 2 + 1) / 3;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "Кожа $n1 покрылась каменными пластинами.";
+      to_vict = "Вы стали менее чувствительны к ударам.";
+      spellnum = SPELL_STONESKIN;
+      break;
+
+    case SPELL_GENERAL_RECOVERY:
+    case SPELL_FAST_REGENERATION: af[0].location = APPLY_HITREG;
+      af[0].modifier = 50 + GET_REMORT(ch);
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[1].location = APPLY_MOVEREG;
+      af[1].modifier = 50 + GET_REMORT(ch);
+      af[1].duration = af[0].duration;
+      accum_duration = TRUE;
+      to_room = "$n расцвел$g на ваших глазах.";
+      to_vict = "Вас наполнила живительная сила.";
+      spellnum = SPELL_FAST_REGENERATION;
+      break;
+
+    case SPELL_AIR_SHIELD:
+      if (affected_by_spell(victim, SPELL_ICE_SHIELD))
+        affect_from_char(victim, SPELL_ICE_SHIELD);
+      if (affected_by_spell(victim, SPELL_FIRE_SHIELD))
+        affect_from_char(victim, SPELL_FIRE_SHIELD);
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_AIRSHIELD);
+      af[0].battleflag = AF_BATTLEDEC;
+      if (IS_NPC(victim) || victim == ch)
+        af[0].duration = pc_duration(victim, 10 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
+      else
+        af[0].duration = pc_duration(victim, 4 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
+      to_room = "$n3 окутал воздушный щит.";
+      to_vict = "Вас окутал воздушный щит.";
+      break;
+
+    case SPELL_FIRE_SHIELD:
+      if (affected_by_spell(victim, SPELL_ICE_SHIELD))
+        affect_from_char(victim, SPELL_ICE_SHIELD);
+      if (affected_by_spell(victim, SPELL_AIR_SHIELD))
+        affect_from_char(victim, SPELL_AIR_SHIELD);
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_FIRESHIELD);
+      af[0].battleflag = AF_BATTLEDEC;
+      if (IS_NPC(victim) || victim == ch)
+        af[0].duration = pc_duration(victim, 10 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
+      else
+        af[0].duration = pc_duration(victim, 4 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
+      to_room = "$n3 окутал огненный щит.";
+      to_vict = "Вас окутал огненный щит.";
+      break;
+
+    case SPELL_ICE_SHIELD:
+      if (affected_by_spell(victim, SPELL_FIRE_SHIELD))
+        affect_from_char(victim, SPELL_FIRE_SHIELD);
+      if (affected_by_spell(victim, SPELL_AIR_SHIELD))
+        affect_from_char(victim, SPELL_AIR_SHIELD);
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_ICESHIELD);
+      af[0].battleflag = AF_BATTLEDEC;
+      if (IS_NPC(victim) || victim == ch)
+        af[0].duration = pc_duration(victim, 10 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
+      else
+        af[0].duration = pc_duration(victim, 4 + GET_REMORT(ch), 0, 0, 0, 0) * koef_duration;
+      to_room = "$n3 окутал ледяной щит.";
+      to_vict = "Вас окутал ледяной щит.";
+      break;
+
+    case SPELL_AIR_AURA: af[0].location = APPLY_RESIST_AIR;
+      af[0].modifier = level;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_AIRAURA);
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n3 окружила воздушная аура.";
+      to_vict = "Вас окружила воздушная аура.";
+      break;
+
+    case SPELL_EARTH_AURA: af[0].location = APPLY_RESIST_EARTH;
+      af[0].modifier = level;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_EARTHAURA);
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n глубоко поклонил$u земле.";
+      to_vict = "Глубокий поклон тебе, матушка земля.";
+      break;
+
+    case SPELL_FIRE_AURA: af[0].location = APPLY_RESIST_WATER;
+      af[0].modifier = level;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_FIREAURA);
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n3 окружила огненная аура.";
+      to_vict = "Вас окружила огненная аура.";
+      break;
+
+    case SPELL_ICE_AURA: af[0].location = APPLY_RESIST_FIRE;
+      af[0].modifier = level;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_ICEAURA);
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n3 окружила ледяная аура.";
+      to_vict = "Вас окружила ледяная аура.";
+      break;
+
+    case SPELL_GROUP_CLOUDLY:
+    case SPELL_CLOUDLY: af[0].location = APPLY_AC;
+      af[0].modifier = -20;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "Очертания $n1 расплылись и стали менее отчетливыми.";
+      to_vict = "Ваше тело стало прозрачным, как туман.";
+      spellnum = SPELL_CLOUDLY;
+      break;
+
+    case SPELL_GROUP_ARMOR:
+    case SPELL_ARMOR: af[0].location = APPLY_AC;
+      af[0].modifier = -20;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[1].location = APPLY_SAVING_REFLEX;
+      af[1].modifier = -5;
+      af[1].duration = af[0].duration;
+      af[2].location = APPLY_SAVING_STABILITY;
+      af[2].modifier = -5;
+      af[2].duration = af[0].duration;
+      accum_duration = TRUE;
+      to_room = "Вокруг $n1 вспыхнул белый щит и тут же погас.";
+      to_vict = "Вы почувствовали вокруг себя невидимую защиту.";
+      spellnum = SPELL_ARMOR;
+      break;
+
+    case SPELL_FASCINATION:
+      if (affected_by_spell(ch, SPELL_FASCINATION)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      if (material_component_processing(ch, victim, spellnum)) {
+        success = FALSE;
+        break;
+      }
+
+      af[0].location = APPLY_CHA;
+      rnd = number(1, 10);
+      if (rnd < 4) {
+        rnd = number(0, 4);
+        af[0].modifier = -rnd;    //(  10 - int(GET_REMORT(victim)/2));
+      } else {
+        rnd = number(0, 15);
+        if (rnd < 1)
+          af[0].modifier = 4;    //(  10 - int(GET_REMORT(victim)/2));
+        else if (rnd < 4)
+          af[0].modifier = 3;
+        else if (rnd < 8)
+          af[0].modifier = 2;
+        else if (rnd < 15)
+          af[0].modifier = 1;
+        else
+          af[0].modifier = 0;
+      }
+      if (af[0].modifier > 0) {
+        af[0].modifier = af[0].modifier / int((GET_REMORT(ch) + 3) / 3);    //модификатор мортов
+      }
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_vict =
+          "Вы попытались вспомнить уроки старой цыганки, что учила вас людям головы морочить.\r\nХотя вы ее не очень то слушали.\r\n";
+      to_room =
+          "$n0 достал$g из маленькой сумочки какие-то вонючие порошки и отвернул$u, бормоча под нос \r\n\"..так это на ресницы надо, кажется... Эх, только бы не перепутать...\" \r\n";
+
+      break;
+
+    case SPELL_GROUP_BLESS:
+    case SPELL_BLESS: af[0].location = APPLY_SAVING_STABILITY;
+      af[0].modifier = -5 - GET_REMORT(ch) / 3;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_BLESS);
+      af[1].location = APPLY_SAVING_WILL;
+      af[1].modifier = -5 - GET_REMORT(ch) / 4;
+      af[1].duration = af[0].duration;
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_BLESS);
+      to_room = "$n осветил$u на миг неземным светом.";
+      to_vict = "Боги одарили вас своей улыбкой.";
+      spellnum = SPELL_BLESS;
+      break;
+
+    case SPELL_CALL_LIGHTNING:
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+      }
+      af[0].location = APPLY_HITROLL;
+      af[0].modifier = -dice(1 + level / 8 + ch->get_remort() / 4, 4);
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 2, level + 7, 8, 0, 0)) * koef_duration;
+      af[1].location = APPLY_CAST_SUCCESS;
+      af[1].modifier = -dice(1 + level / 4 + ch->get_remort() / 2, 4);
+      af[1].duration = af[0].duration;
+      spellnum = SPELL_MAGICBATTLE;
+      to_room = "$n зашатал$u, пытаясь прийти в себя от взрыва шаровой молнии.";
+      to_vict = "Взрыв шаровой молнии $N1 отдался в вашей голове громким звоном.";
+      break;
+
+    case SPELL_CONE_OF_COLD:
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+      }
+      af[0].location = APPLY_DEX;
+      af[0].modifier = -dice(int(MAX(1, ((level - 14) / 7))), 3);
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 9, 0, 0, 0, 0)) * koef_duration;
+      to_vict = "Вы покрылись серебристым инеем.";
+      to_room = "$n покрыл$u красивым серебристым инеем.";
+      break;
+    case SPELL_GROUP_AWARNESS:
+    case SPELL_AWARNESS:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_AWARNESS);
+      af[1].location = APPLY_SAVING_REFLEX;
+      af[1].modifier = -1 - GET_REMORT(ch) / 4;
+      af[1].duration = af[0].duration;
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_AWARNESS);
+      to_room = "$n начал$g внимательно осматриваться по сторонам.";
+      to_vict = "Вы стали более внимательны к окружающему.";
+      spellnum = SPELL_AWARNESS;
+      break;
+
+    case SPELL_SHIELD: af[0].duration = pc_duration(victim, 4, 0, 0, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_SHIELD);
+      af[0].location = APPLY_SAVING_STABILITY;
+      af[0].modifier = -10;
+      af[0].battleflag = AF_BATTLEDEC;
+      af[1].duration = af[0].duration;
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_SHIELD);
+      af[1].location = APPLY_SAVING_WILL;
+      af[1].modifier = -10;
+      af[1].battleflag = AF_BATTLEDEC;
+      af[2].duration = af[0].duration;
+      af[2].bitvector = to_underlying(EAffectFlag::AFF_SHIELD);
+      af[2].location = APPLY_SAVING_REFLEX;
+      af[2].modifier = -10;
+      af[2].battleflag = AF_BATTLEDEC;
+
+      to_room = "$n покрыл$u сверкающим коконом.";
+      to_vict = "Вас покрыл голубой кокон.";
+      break;
+
+    case SPELL_GROUP_HASTE:
+    case SPELL_HASTE:
+      if (affected_by_spell(victim, SPELL_SLOW)) {
+        affect_from_char(victim, SPELL_SLOW);
+        success = FALSE;
+        break;
+      }
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_HASTE);
+      af[0].location = APPLY_SAVING_REFLEX;
+      af[0].modifier = -1 - GET_REMORT(ch) / 5;
+      to_vict = "Вы начали двигаться быстрее.";
+      to_room = "$n начал$g двигаться заметно быстрее.";
+      spellnum = SPELL_HASTE;
+      break;
+
+    case SPELL_SHADOW_CLOAK: af[0].bitvector = to_underlying(EAffectFlag::AFF_SHADOW_CLOAK);
+      af[0].location = APPLY_SAVING_STABILITY;
+      af[0].modifier = -(GET_LEVEL(ch) / 3 + GET_REMORT(ch)) / 4;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n скрыл$u в густой тени.";
+      to_vict = "Густые тени окутали вас.";
+      break;
+
+    case SPELL_ENLARGE:
+      if (affected_by_spell(victim, SPELL_ENLESS)) {
+        affect_from_char(victim, SPELL_ENLESS);
+        success = FALSE;
+        break;
+      }
+      af[0].location = APPLY_SIZE;
+      af[0].modifier = 5 + level / 2 + GET_REMORT(ch) / 3;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n начал$g расти, как на дрожжах.";
+      to_vict = "Вы стали крупнее.";
+      break;
+
+    case SPELL_ENLESS:
+      if (affected_by_spell(victim, SPELL_ENLARGE)) {
+        affect_from_char(victim, SPELL_ENLARGE);
+        success = FALSE;
+        break;
+      }
+      af[0].location = APPLY_SIZE;
+      af[0].modifier = -(5 + level / 3);
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n скукожил$u.";
+      to_vict = "Вы стали мельче.";
+      break;
+
+    case SPELL_MAGICGLASS:
+    case SPELL_GROUP_MAGICGLASS: af[0].bitvector = to_underlying(EAffectFlag::AFF_MAGICGLASS);
+      af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n3 покрыла зеркальная пелена.";
+      to_vict = "Вас покрыло зеркало магии.";
+      spellnum = SPELL_MAGICGLASS;
+      break;
+
+    case SPELL_CLOUD_OF_ARROWS: af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_CLOUD_OF_ARROWS);
+      af[0].location = APPLY_HITROLL;
+      af[0].modifier = level / 6;
+      accum_duration = TRUE;
+      to_room = "$n3 окружило облако летающих огненных стрел.";
+      to_vict = "Вас окружило облако летающих огненных стрел.";
+      break;
+
+    case SPELL_STONEHAND: af[0].bitvector = to_underlying(EAffectFlag::AFF_STONEHAND);
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "Руки $n1 задубели.";
+      to_vict = "Ваши руки задубели.";
+      break;
+
+    case SPELL_GROUP_PRISMATICAURA:
+    case SPELL_PRISMATICAURA:
+      if (!IS_NPC(ch) && !same_group(ch, victim)) {
+        send_to_char("Только на себя или одногруппника!\r\n", ch);
+        return 0;
+      }
+      if (affected_by_spell(victim, SPELL_SANCTUARY)) {
+        affect_from_char(victim, SPELL_SANCTUARY);
+        success = FALSE;
+        break;
+      }
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_SANCTUARY)) {
+        success = FALSE;
+        break;
+      }
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_PRISMATICAURA);
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      accum_duration = TRUE;
+      to_room = "$n3 покрыла призматическая аура.";
+      to_vict = "Вас покрыла призматическая аура.";
+      spellnum = SPELL_PRISMATICAURA;
+      break;
+
+    case SPELL_MINDLESS:
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      af[0].location = APPLY_MANAREG;
+      af[0].modifier = -50;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 0, GET_REAL_WIS(ch) + GET_REAL_INT(ch), 10, 0, 0))
+          * koef_duration;
+      af[1].location = APPLY_CAST_SUCCESS;
+      af[1].modifier = -50;
+      af[1].duration = af[0].duration;
+      af[2].location = APPLY_HITROLL;
+      af[2].modifier = -5;
+      af[2].duration = af[0].duration;
+
+      to_room = "$n0 стал$g слаб$g на голову!";
+      to_vict = "Ваш разум помутился!";
+      break;
+
+    case SPELL_DUSTSTORM:
+    case SPELL_SHINEFLASH:
+    case SPELL_MASS_BLINDNESS:
+    case SPELL_POWER_BLINDNESS:
+    case SPELL_BLINDNESS: savetype = SAVING_STABILITY;
+      if (MOB_FLAGGED(victim, MOB_NOBLIND) ||
+          WAITLESS(victim) ||
+          ((ch != victim) &&
+              !GET_GOD_FLAG(victim, GF_GODSCURSE) && general_savingthrow(ch, victim, savetype, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      switch (spellnum) {
+        case SPELL_DUSTSTORM:
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 3, level, 6, 0, 0)) * koef_duration;
+          break;
+        case SPELL_SHINEFLASH:
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 2, level + 7, 8, 0, 0)) * koef_duration;
+          break;
+        case SPELL_MASS_BLINDNESS:
+        case SPELL_BLINDNESS:
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 2, level, 8, 0, 0)) * koef_duration;
+          break;
+        case SPELL_POWER_BLINDNESS:
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 3, level, 6, 0, 0)) * koef_duration;
+          break;
+      }
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_BLIND);
+      af[0].battleflag = AF_BATTLEDEC;
+      to_room = "$n0 ослеп$q!";
+      to_vict = "Вы ослепли!";
+      spellnum = SPELL_BLINDNESS;
+      break;
+
+    case SPELL_MADNESS: savetype = SAVING_WILL;
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 3, 0, 0, 0, 0)) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+      af[1].location = APPLY_MADNESS;
+      af[1].duration = af[0].duration;
+      af[1].modifier = level;
+      to_room = "Теперь $n не сможет сбежать из боя!";
+      to_vict = "Вас обуяло безумие!";
+      break;
+
+    case SPELL_WEB: savetype = SAVING_REFLEX;
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_BROKEN_CHAINS)
+          || (ch != victim && general_savingthrow(ch, victim, savetype, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      af[0].location = APPLY_HITROLL;
+      af[0].modifier = -2 - GET_REMORT(ch) / 5;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 3, level, 6, 0, 0)) * koef_duration;
+      af[0].battleflag = AF_BATTLEDEC;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+      af[1].location = APPLY_AC;
+      af[1].modifier = 20;
+      af[1].duration = af[0].duration;
+      af[1].battleflag = AF_BATTLEDEC;
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+      to_room = "$n3 покрыла невидимая паутина, сковывая $s движения!";
+      to_vict = "Вас покрыла невидимая паутина!";
+      break;
+
+    case SPELL_MASS_CURSE:
+    case SPELL_CURSE: savetype = SAVING_WILL;
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      // если есть фит порча
+      if (can_use_feat(ch, DECLINE_FEAT))
+        decline_mod += GET_REMORT(ch);
+      af[0].location = APPLY_INITIATIVE;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 1, level, 2, 0, 0)) * koef_duration;
+      af[0].modifier = -(5 + decline_mod);
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_CURSE);
+
+      af[1].location = APPLY_HITROLL;
+      af[1].duration = af[0].duration;
+      af[1].modifier = -(level / 6 + decline_mod + GET_REMORT(ch) / 5);
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_CURSE);
+
+      if (level >= 20) {
+        af[2].location = APPLY_CAST_SUCCESS;
+        af[2].duration = af[0].duration;
+        af[2].modifier = -(level / 3 + GET_REMORT(ch));
+        if (IS_NPC(ch) && level >= (LVL_IMMORT))
+          af[2].modifier += (LVL_IMMORT - level - 1);    //1 cast per mob level above 30
+        af[2].bitvector = to_underlying(EAffectFlag::AFF_CURSE);
+      }
+      accum_duration = TRUE;
+      accum_affect = TRUE;
+      to_room = "Красное сияние вспыхнуло над $n4 и тут же погасло!";
+      to_vict = "Боги сурово поглядели на вас.";
+      spellnum = SPELL_CURSE;
+      break;
+
+    case SPELL_MASS_SLOW:
+    case SPELL_SLOW: savetype = SAVING_STABILITY;
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_BROKEN_CHAINS)
+          || (ch != victim && general_savingthrow(ch, victim, savetype, modi * number(1, koef_modifier / 2)))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      if (affected_by_spell(victim, SPELL_HASTE)) {
+        affect_from_char(victim, SPELL_HASTE);
+        success = FALSE;
+        break;
+      }
+
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 9, 0, 0, 0, 0)) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_SLOW);
+      af[1].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum), pc_duration(victim, 9, 0, 0, 0, 0))
+          * koef_duration;
+      af[1].location = APPLY_DEX;
+      af[1].modifier = -koef_modifier;
+      to_room = "Движения $n1 заметно замедлились.";
+      to_vict = "Ваши движения заметно замедлились.";
+      spellnum = SPELL_SLOW;
+      break;
+
+    case SPELL_GENERAL_SINCERITY:
+    case SPELL_DETECT_ALIGN:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_DETECT_ALIGN);
+      accum_duration = TRUE;
+      to_vict = "Ваши глаза приобрели зеленый оттенок.";
+      to_room = "Глаза $n1 приобрели зеленый оттенок.";
+      spellnum = SPELL_DETECT_ALIGN;
+      break;
+
+    case SPELL_ALL_SEEING_EYE:
+    case SPELL_DETECT_INVIS:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_DETECT_INVIS);
+      accum_duration = TRUE;
+      to_vict = "Ваши глаза приобрели золотистый оттенок.";
+      to_room = "Глаза $n1 приобрели золотистый оттенок.";
+      spellnum = SPELL_DETECT_INVIS;
+      break;
+
+    case SPELL_MAGICAL_GAZE:
+    case SPELL_DETECT_MAGIC:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_DETECT_MAGIC);
+      accum_duration = TRUE;
+      to_vict = "Ваши глаза приобрели желтый оттенок.";
+      to_room = "Глаза $n1 приобрели желтый оттенок.";
+      spellnum = SPELL_DETECT_MAGIC;
+      break;
+
+    case SPELL_SIGHT_OF_DARKNESS:
+    case SPELL_INFRAVISION:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_INFRAVISION);
+      accum_duration = TRUE;
+      to_vict = "Ваши глаза приобрели красный оттенок.";
+      to_room = "Глаза $n1 приобрели красный оттенок.";
+      spellnum = SPELL_INFRAVISION;
+      break;
+
+    case SPELL_SNAKE_EYES:
+    case SPELL_DETECT_POISON:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_DETECT_POISON);
+      accum_duration = TRUE;
+      to_vict = "Ваши глаза приобрели карий оттенок.";
+      to_room = "Глаза $n1 приобрели карий оттенок.";
+      spellnum = SPELL_DETECT_POISON;
+      break;
+
+    case SPELL_GROUP_INVISIBLE:
+    case SPELL_INVISIBLE:
+      if (!victim)
+        victim = ch;
+      if (affected_by_spell(victim, SPELL_GLITTERDUST)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].modifier = -40;
+      af[0].location = APPLY_AC;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_INVISIBLE);
+      accum_duration = TRUE;
+      to_vict = "Вы стали невидимы для окружающих.";
+      to_room = "$n медленно растворил$u в пустоте.";
+      spellnum = SPELL_INVISIBLE;
+      break;
+
+    case SPELL_PLAQUE: savetype = SAVING_STABILITY;
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      af[0].location = APPLY_HITREG;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 0, level, 2, 0, 0)) * koef_duration;
+      af[0].modifier = -95;
+      af[1].location = APPLY_MANAREG;
+      af[1].duration = af[0].duration;
+      af[1].modifier = -95;
+      af[2].location = APPLY_MOVEREG;
+      af[2].duration = af[0].duration;
+      af[2].modifier = -95;
+      af[3].location = APPLY_PLAQUE;
+      af[3].duration = af[0].duration;
+      af[3].modifier = level;
+      af[4].location = APPLY_WIS;
+      af[4].duration = af[0].duration;
+      af[4].modifier = -GET_REMORT(ch) / 5;
+      af[5].location = APPLY_INT;
+      af[5].duration = af[0].duration;
+      af[5].modifier = -GET_REMORT(ch) / 5;
+      af[6].location = APPLY_DEX;
+      af[6].duration = af[0].duration;
+      af[6].modifier = -GET_REMORT(ch) / 5;
+      af[7].location = APPLY_STR;
+      af[7].duration = af[0].duration;
+      af[7].modifier = -GET_REMORT(ch) / 5;
+      to_vict = "Вас скрутило в жестокой лихорадке.";
+      to_room = "$n3 скрутило в жестокой лихорадке.";
+      break;
+
+    case SPELL_POISON: savetype = SAVING_CRITICAL;
+      if (ch != victim && (AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD) ||
+          general_savingthrow(ch, victim, savetype, modi - GET_REAL_CON(victim) / 2))) {
+        if (ch->in_room == IN_ROOM(victim)) // Добавлено чтобы яд нанесенный SPELL_POISONED_FOG не спамил чару постоянно
+          send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      af[0].location = APPLY_STR;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 0, level, 1, 0, 0)) * koef_duration;
+      af[0].modifier = -2;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON);
+      af[0].battleflag = AF_SAME_TIME;
+
+      af[1].location = APPLY_POISON;
+      af[1].duration = af[0].duration;
+      af[1].modifier = level + GET_REMORT(ch) / 2;
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_POISON);
+      af[1].battleflag = AF_SAME_TIME;
+
+      to_vict = "Вы почувствовали себя отравленным.";
+      to_room = "$n позеленел$g от действия яда.";
+
+      break;
+
+    case SPELL_PROT_FROM_EVIL:
+    case SPELL_GROUP_PROT_FROM_EVIL:
+      if (!IS_NPC(ch) && !same_group(ch, victim)) {
+        send_to_char("Только на себя или одногруппника!\r\n", ch);
+        return 0;
+      }
+      af[0].location = APPLY_RESIST_DARK;
+      if (spellnum == SPELL_PROT_FROM_EVIL) {
+        affect_from_char(ch, SPELL_GROUP_PROT_FROM_EVIL);
+        af[0].modifier = 5;
+      } else {
+        affect_from_char(ch, SPELL_PROT_FROM_EVIL);
+        af[0].modifier = level;
+      }
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_PROTECT_EVIL);
+      accum_duration = TRUE;
+      to_vict = "Вы подавили в себе страх к тьме.";
+      to_room = "$n подавил$g в себе страх к тьме.";
+      break;
+
+    case SPELL_GROUP_SANCTUARY:
+    case SPELL_SANCTUARY:
+      if (!IS_NPC(ch) && !same_group(ch, victim)) {
+        send_to_char("Только на себя или одногруппника!\r\n", ch);
+        return 0;
+      }
+      if (affected_by_spell(victim, SPELL_PRISMATICAURA)) {
+        affect_from_char(victim, SPELL_PRISMATICAURA);
+        success = FALSE;
+        break;
+      }
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_PRISMATICAURA)) {
+        success = FALSE;
+        break;
+      }
+
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_SANCTUARY);
+      to_vict = "Белая аура мгновенно окружила вас.";
+      to_room = "Белая аура покрыла $n3 с головы до пят.";
+      spellnum = SPELL_SANCTUARY;
+      break;
+
+    case SPELL_SLEEP: savetype = SAVING_WILL;
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_HOLD) || MOB_FLAGGED(victim, MOB_NOSLEEP)
+          || (ch != victim && general_savingthrow(ch, victim, SAVING_WILL, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      };
+
+      if (victim->get_fighting())
+        stop_fighting(victim, FALSE);
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 1, level, 6, 1, 6)) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_SLEEP);
+      af[0].battleflag = AF_BATTLEDEC;
+      if (GET_POS(victim) > POS_SLEEPING && success) {
+        // add by Pereplut
+        if (victim->ahorse())
+          victim->drop_from_horse();
+        send_to_char("Вы слишком устали... Спать... Спа...\r\n", victim);
+        act("$n прилег$q подремать.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+
+        GET_POS(victim) = POS_SLEEPING;
+      }
+      break;
+
+    case SPELL_GROUP_STRENGTH:
+    case SPELL_STRENGTH:
+      if (affected_by_spell(victim, SPELL_WEAKNESS)) {
+        affect_from_char(victim, SPELL_WEAKNESS);
+        success = FALSE;
+        break;
+      }
+      af[0].location = APPLY_STR;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      if (ch == victim)
+        af[0].modifier = (level + 9) / 10 + koef_modifier + GET_REMORT(ch) / 5;
+      else
+        af[0].modifier = (level + 14) / 15 + koef_modifier + GET_REMORT(ch) / 5;
+      accum_duration = TRUE;
+      accum_affect = TRUE;
+      to_vict = "Вы почувствовали себя сильнее.";
+      to_room = "Мышцы $n1 налились силой.";
+      spellnum = SPELL_STRENGTH;
+      break;
+
+    case SPELL_DEXTERITY:
+      if (affected_by_spell(victim, SPELL_WEAKNESS)) {
+        affect_from_char(victim, SPELL_WEAKNESS);
+        success = FALSE;
+        break;
+      }
+      af[0].location = APPLY_DEX;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      if (ch == victim)
+        af[0].modifier = (level + 9) / 10 + koef_modifier + GET_REMORT(ch) / 5;
+      else
+        af[0].modifier = (level + 14) / 15 + koef_modifier + GET_REMORT(ch) / 5;
+      accum_duration = TRUE;
+      accum_affect = TRUE;
+      to_vict = "Вы почувствовали себя более шустрым.";
+      to_room = "$n0 будет двигаться более шустро.";
+      spellnum = SPELL_DEXTERITY;
+      break;
+
+    case SPELL_PATRONAGE: af[0].location = APPLY_HIT;
+      af[0].duration = pc_duration(victim, 3, level, 10, 0, 0) * koef_duration;
+      af[0].modifier = GET_LEVEL(ch) * 2 + GET_REMORT(ch);
+      if (GET_ALIGNMENT(victim) >= 0) {
+        to_vict = "Исходящий с небес свет на мгновение озарил вас.";
+        to_room = "Исходящий с небес свет на мгновение озарил $n3.";
+      } else {
+        to_vict = "Вас окутало клубящееся облако Тьмы.";
+        to_room = "Клубящееся темное облако на мгновение окутало $n3.";
+      }
+      break;
+
+    case SPELL_EYE_OF_GODS:
+    case SPELL_SENSE_LIFE: to_vict = "Вы способны разглядеть даже микроба.";
+      to_room = "$n0 начал$g замечать любые движения.";
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_SENSE_LIFE);
+      accum_duration = TRUE;
+      spellnum = SPELL_SENSE_LIFE;
+      break;
+
+    case SPELL_WATERWALK:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_WATERWALK);
+      accum_duration = TRUE;
+      to_vict = "На рыбалку вы можете отправляться без лодки.";
+      break;
+
+    case SPELL_BREATHING_AT_DEPTH:
+    case SPELL_WATERBREATH:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_WATERBREATH);
+      accum_duration = TRUE;
+      to_vict = "У вас выросли жабры.";
+      to_room = "У $n1 выросли жабры.";
+      spellnum = SPELL_WATERBREATH;
+      break;
+
+    case SPELL_HOLYSTRIKE:
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_EVILESS)) {
+        // все решится в дамадже части спелла
+        success = FALSE;
+        break;
+      }
+      // тут break не нужен
+
+      // fall through
+    case SPELL_MASS_HOLD:
+    case SPELL_POWER_HOLD:
+    case SPELL_HOLD:
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_SLEEP)
+          || MOB_FLAGGED(victim, MOB_NOHOLD) || AFF_FLAGGED(victim, EAffectFlag::AFF_BROKEN_CHAINS)
+          || (ch != victim && general_savingthrow(ch, victim, SAVING_WILL, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  spellnum == SPELL_POWER_HOLD ? pc_duration(victim,
+                                                                                             2,
+                                                                                             level + 7,
+                                                                                             8,
+                                                                                             2,
+                                                                                             5)
+                                                                               : pc_duration(victim,
+                                                                                             1,
+                                                                                             level + 9,
+                                                                                             10,
+                                                                                             1,
+                                                                                             3)) * koef_duration;
+
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_HOLD);
+      af[0].battleflag = AF_BATTLEDEC;
+      to_room = "$n0 замер$q на месте!";
+      to_vict = "Вы замерли на месте, не в силах пошевельнуться.";
+      spellnum = SPELL_HOLD;
+      break;
+
+    case SPELL_WC_OF_RAGE:
+    case SPELL_SONICWAVE:
+    case SPELL_MASS_DEAFNESS:
+    case SPELL_POWER_DEAFNESS:
+    case SPELL_DEAFNESS:
+      switch (spellnum) {
+        case SPELL_WC_OF_RAGE: savetype = SAVING_WILL;
+          modi = GET_REAL_CON(ch);
+          break;
+        case SPELL_SONICWAVE:
+        case SPELL_MASS_DEAFNESS:
+        case SPELL_POWER_DEAFNESS:
+        case SPELL_DEAFNESS: savetype = SAVING_STABILITY;
+          break;
+      }
+      if (  //MOB_FLAGGED(victim, MOB_NODEAFNESS) ||
+          (ch != victim && general_savingthrow(ch, victim, savetype, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      switch (spellnum) {
+        case SPELL_WC_OF_RAGE:
+        case SPELL_POWER_DEAFNESS:
+        case SPELL_SONICWAVE:
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
+          break;
+        case SPELL_MASS_DEAFNESS:
+        case SPELL_DEAFNESS:
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 2, level + 7, 8, 3, 0)) * koef_duration;
+          break;
+      }
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_DEAFNESS);
+      af[0].battleflag = AF_BATTLEDEC;
+      to_room = "$n0 оглох$q!";
+      to_vict = "Вы оглохли.";
+      spellnum = SPELL_DEAFNESS;
+      break;
+
+    case SPELL_MASS_SILENCE:
+    case SPELL_POWER_SILENCE:
+    case SPELL_SILENCE: savetype = SAVING_WILL;
+      if (MOB_FLAGGED(victim, MOB_NOSIELENCE) ||
+          (ch != victim && general_savingthrow(ch, victim, savetype, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  spellnum == SPELL_POWER_SILENCE ? pc_duration(victim,
+                                                                                                2,
+                                                                                                level + 3,
+                                                                                                4,
+                                                                                                6,
+                                                                                                0)
+                                                                                  : pc_duration(victim,
+                                                                                                2,
+                                                                                                level + 7,
+                                                                                                8,
+                                                                                                3,
+                                                                                                0)) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_SILENCE);
+      af[0].battleflag = AF_BATTLEDEC;
+      to_room = "$n0 прикусил$g язык!";
+      to_vict = "Вы не в состоянии вымолвить ни слова.";
+      spellnum = SPELL_SILENCE;
+      break;
+
+    case SPELL_GROUP_FLY:
+    case SPELL_FLY:
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_FLY);
+      to_room = "$n0 медленно поднял$u в воздух.";
+      to_vict = "Вы медленно поднялись в воздух.";
+      spellnum = SPELL_FLY;
+      break;
+
+    case SPELL_BROKEN_CHAINS: af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_BROKEN_CHAINS);
+      af[0].battleflag = AF_BATTLEDEC;
+      to_room = "Ярко-синий ореол вспыхнул вокруг $n1 и тут же угас.";
+      to_vict = "Волна ярко-синего света омыла вас с головы до ног.";
+      break;
+    case SPELL_GROUP_BLINK:
+    case SPELL_BLINK: af[0].location = APPLY_SPELL_BLINK;
+      af[0].modifier = 5 + GET_REMORT(ch) * 2 / 3.0;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      to_room = "$n начал$g мигать.";
+      to_vict = "Вы начали мигать.";
+      spellnum = SPELL_BLINK;
+      break;
+
+    case SPELL_MAGICSHIELD: af[0].location = APPLY_AC;
+      af[0].modifier = -GET_LEVEL(ch) * 10 / 6;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[1].location = APPLY_SAVING_REFLEX;
+      af[1].modifier = -GET_LEVEL(ch) / 5;
+      af[1].duration = af[0].duration;
+      af[2].location = APPLY_SAVING_STABILITY;
+      af[2].modifier = -GET_LEVEL(ch) / 5;
+      af[2].duration = af[0].duration;
+      accum_duration = TRUE;
+      to_room = "Сверкающий щит вспыхнул вокруг $n1 и угас.";
+      to_vict = "Сверкающий щит вспыхнул вокруг вас и угас.";
+      break;
+
+    case SPELL_NOFLEE: // "приковать противника"
+    case SPELL_INDRIKS_TEETH:
+    case SPELL_MASS_NOFLEE: af[0].battleflag = AF_BATTLEDEC;
+      savetype = SAVING_WILL;
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_BROKEN_CHAINS)
+          || (ch != victim && general_savingthrow(ch, victim, savetype, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 3, level, 4, 4, 0)) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_NOTELEPORT);
+      to_room = "$n0 теперь прикован$a к $N2.";
+      to_vict = "Вы не сможете покинуть $N3.";
+      break;
+
+    case SPELL_LIGHT:
+      if (!IS_NPC(ch) && !same_group(ch, victim)) {
+        send_to_char("Только на себя или одногруппника!\r\n", ch);
+        return 0;
+      }
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_HOLYLIGHT);
+      to_room = "$n0 начал$g светиться ярким светом.";
+      to_vict = "Вы засветились, освещая комнату.";
+      break;
+
+    case SPELL_DARKNESS:
+      if (!IS_NPC(ch) && !same_group(ch, victim)) {
+        send_to_char("Только на себя или одногруппника!\r\n", ch);
+        return 0;
+      }
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_HOLYDARK);
+      to_room = "$n0 погрузил$g комнату во мрак.";
+      to_vict = "Вы погрузили комнату в непроглядную тьму.";
+      break;
+    case SPELL_VAMPIRE: af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].location = APPLY_DAMROLL;
+      af[0].modifier = 0;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_VAMPIRE);
+      to_room = "Зрачки $n3 приобрели красный оттенок.";
+      to_vict = "Ваши зрачки приобрели красный оттенок.";
+      break;
+
+    case SPELL_EVILESS:
+      if (!IS_NPC(victim) || victim->get_master() != ch || !MOB_FLAGGED(victim, MOB_CORPSE)) {
+        //тихо уходим, т.к. заклинание массовое
+        break;
+      }
+      af[0].duration = pc_duration(victim, 10, GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].location = APPLY_DAMROLL;
+      af[0].modifier = 15 + (GET_REMORT(ch) > 8 ? (GET_REMORT(ch) - 8) : 0);
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
+      af[1].duration = af[0].duration;
+      af[1].location = APPLY_HITROLL;
+      af[1].modifier = 7 + (GET_REMORT(ch) > 8 ? (GET_REMORT(ch) - 8) : 0);;
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
+      af[2].duration = af[0].duration;
+      af[2].location = APPLY_HIT;
+      af[2].bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
+
+      // иначе, при рекасте, модификатор суммируется с текущим аффектом.
+      if (!AFF_FLAGGED(victim, EAffectFlag::AFF_EVILESS)) {
+        af[2].modifier = GET_REAL_MAX_HIT(victim);
+        // не очень красивый способ передать сигнал на лечение в mag_points
+        AFFECT_DATA<EApplyLocation> tmpaf;
+        tmpaf.type = SPELL_EVILESS;
+        tmpaf.duration = 1;
+        tmpaf.modifier = 0;
+        tmpaf.location = EApplyLocation::APPLY_NONE;
+        tmpaf.battleflag = 0;
+        tmpaf.bitvector = to_underlying(EAffectFlag::AFF_EVILESS);
+        affect_to_char(ch, tmpaf);
+      }
+      to_vict = "Черное облако покрыло вас.";
+      to_room = "Черное облако покрыло $n3 с головы до пят.";
+      break;
+
+    case SPELL_WC_OF_THUNDER:
+    case SPELL_ICESTORM:
+    case SPELL_EARTHFALL:
+    case SPELL_SHOCK: {
+      switch (spellnum) {
+        case SPELL_WC_OF_THUNDER: savetype = SAVING_WILL;
+          modi = GET_REAL_CON(ch) * 3 / 2;
+          break;
+        case SPELL_ICESTORM: savetype = SAVING_REFLEX;
+          modi = CALC_SUCCESS(modi, 30);
+          break;
+        case SPELL_EARTHFALL: savetype = SAVING_REFLEX;
+          modi = CALC_SUCCESS(modi, 95);
+          break;
+        case SPELL_SHOCK: savetype = SAVING_REFLEX;
+          if (GET_CLASS(ch) == CLASS_CLERIC) {
+            modi = CALC_SUCCESS(modi, 75);
+          } else {
+            modi = CALC_SUCCESS(modi, 25);
+          }
+          break;
+      }
+      if (WAITLESS(victim) || (!WAITLESS(ch) && general_savingthrow(ch, victim, savetype, modi))) {
+        success = FALSE;
+        break;
+      }
+      switch (spellnum) {
+        case SPELL_WC_OF_THUNDER: af[0].type = SPELL_DEAFNESS;
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
+          af[0].duration = complex_spell_modifier(ch, SPELL_DEAFNESS, GAPPLY_SPELL_EFFECT, af[0].duration);
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_DEAFNESS);
+          af[0].battleflag = AF_BATTLEDEC;
+          to_room = "$n0 оглох$q!";
+          to_vict = "Вы оглохли.";
+
+          if ((IS_NPC(victim)
+              && AFF_FLAGGED(victim, static_cast<EAffectFlag>(af[0].bitvector)))
+              || (ch != victim
+                  && affected_by_spell(victim, SPELL_DEAFNESS))) {
+            if (ch->in_room == IN_ROOM(victim))
+              send_to_char(NOEFFECT, ch);
+          } else {
+            affect_join(victim, af[0], accum_duration, FALSE, accum_affect, FALSE);
+            act(to_vict, FALSE, victim, 0, ch, TO_CHAR);
+            act(to_room, TRUE, victim, 0, ch, TO_ROOM | TO_ARENA_LISTEN);
+          }
+          break;
+
+        case SPELL_ICESTORM:
+        case SPELL_EARTHFALL: WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 2, 0, 0, 0, 0)) * koef_duration;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_MAGICSTOPFIGHT);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          to_room = "$n3 оглушило.";
+          to_vict = "Вас оглушило.";
+          spellnum = SPELL_MAGICBATTLE;
+          break;
+
+        case SPELL_SHOCK: WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 2, 0, 0, 0, 0)) * koef_duration;
+          af[0].bitvector = to_underlying(EAffectFlag::AFF_MAGICSTOPFIGHT);
+          af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+          to_room = "$n3 оглушило.";
+          to_vict = "Вас оглушило.";
+          spellnum = SPELL_MAGICBATTLE;
+          mag_affects(level, ch, victim, SPELL_BLINDNESS, SAVING_STABILITY);
+          break;
+      }
+      break;
+    }
 
 //Заклинание плач. Далим.
-	case SPELL_CRYING:
-		{
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_CRYING) || (ch != victim && general_savingthrow(ch, victim, savetype, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		af[0].location = APPLY_HIT;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 4, 0, 0, 0, 0)) * koef_duration;
-		af[0].modifier =
-			-1 * MAX(1,
-					 (MIN(29, GET_LEVEL(ch)) - MIN(24, GET_LEVEL(victim)) +
-					  GET_REMORT(ch) / 3) * GET_MAX_HIT(victim) / 100);
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_CRYING);
-		if (IS_NPC(victim))
-		{
-			af[1].location = APPLY_LIKES;
-			af[1].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 5, 0, 0, 0, 0));
-			af[1].modifier = -1 * MAX(1, ((level + 9) / 2 + 9 - GET_LEVEL(victim) / 2));
-			af[1].bitvector = to_underlying(EAffectFlag::AFF_CRYING);
-			af[1].battleflag = AF_BATTLEDEC;
-			to_room = "$n0 издал$g протяжный стон.";
-			break;
-		}
-		af[1].location = APPLY_CAST_SUCCESS;
-		af[1].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 5, 0, 0, 0, 0));
-		af[1].modifier = -1 * MAX(1, (level / 3 + GET_REMORT(ch) / 3 - GET_LEVEL(victim) / 10));
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_CRYING);
-		af[1].battleflag = AF_BATTLEDEC;
-		af[2].location = APPLY_MORALE;
-		af[2].duration = af[1].duration;
-		af[2].modifier = -1 * MAX(1, (level / 3 + GET_REMORT(ch) / 5 - GET_LEVEL(victim) / 5));
-		af[2].bitvector = to_underlying(EAffectFlag::AFF_CRYING);
-		af[2].battleflag = AF_BATTLEDEC;
-		to_room = "$n0 издал$g протяжный стон.";
-		to_vict = "Вы впали в уныние.";
-		break;
-		}
-		//Заклинания Забвение, Бремя времени. Далим.
-	case SPELL_OBLIVION:
-	case SPELL_BURDEN_OF_TIME:
-		{
-		if (WAITLESS(victim)
-				|| general_savingthrow(ch, victim, SAVING_REFLEX,
-									   CALC_SUCCESS(modi, (spellnum == SPELL_OBLIVION ? 40 : 90))))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		WAIT_STATE(victim, (level / 10 + 1) * PULSE_VIOLENCE);
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 3, 0, 0, 0, 0)) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_SLOW);
-		af[0].battleflag = AF_BATTLEDEC;
-		to_room = "Облако забвения окружило $n3.";
-		to_vict = "Ваш разум помутился.";
-		spellnum = SPELL_OBLIVION;
-		break;
-		}
+    case SPELL_CRYING: {
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_CRYING)
+          || (ch != victim && general_savingthrow(ch, victim, savetype, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      af[0].location = APPLY_HIT;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 4, 0, 0, 0, 0)) * koef_duration;
+      af[0].modifier =
+          -1 * MAX(1,
+                   (MIN(29, GET_LEVEL(ch)) - MIN(24, GET_LEVEL(victim)) +
+                       GET_REMORT(ch) / 3) * GET_MAX_HIT(victim) / 100);
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_CRYING);
+      if (IS_NPC(victim)) {
+        af[1].location = APPLY_LIKES;
+        af[1].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                    pc_duration(victim, 5, 0, 0, 0, 0));
+        af[1].modifier = -1 * MAX(1, ((level + 9) / 2 + 9 - GET_LEVEL(victim) / 2));
+        af[1].bitvector = to_underlying(EAffectFlag::AFF_CRYING);
+        af[1].battleflag = AF_BATTLEDEC;
+        to_room = "$n0 издал$g протяжный стон.";
+        break;
+      }
+      af[1].location = APPLY_CAST_SUCCESS;
+      af[1].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 5, 0, 0, 0, 0));
+      af[1].modifier = -1 * MAX(1, (level / 3 + GET_REMORT(ch) / 3 - GET_LEVEL(victim) / 10));
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_CRYING);
+      af[1].battleflag = AF_BATTLEDEC;
+      af[2].location = APPLY_MORALE;
+      af[2].duration = af[1].duration;
+      af[2].modifier = -1 * MAX(1, (level / 3 + GET_REMORT(ch) / 5 - GET_LEVEL(victim) / 5));
+      af[2].bitvector = to_underlying(EAffectFlag::AFF_CRYING);
+      af[2].battleflag = AF_BATTLEDEC;
+      to_room = "$n0 издал$g протяжный стон.";
+      to_vict = "Вы впали в уныние.";
+      break;
+    }
+      //Заклинания Забвение, Бремя времени. Далим.
+    case SPELL_OBLIVION:
+    case SPELL_BURDEN_OF_TIME: {
+      if (WAITLESS(victim)
+          || general_savingthrow(ch, victim, SAVING_REFLEX,
+                                 CALC_SUCCESS(modi, (spellnum == SPELL_OBLIVION ? 40 : 90)))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      WAIT_STATE(victim, (level / 10 + 1) * PULSE_VIOLENCE);
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 3, 0, 0, 0, 0)) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_SLOW);
+      af[0].battleflag = AF_BATTLEDEC;
+      to_room = "Облако забвения окружило $n3.";
+      to_vict = "Ваш разум помутился.";
+      spellnum = SPELL_OBLIVION;
+      break;
+    }
 
-	case SPELL_PEACEFUL:
-		{
-		if (AFF_FLAGGED(victim, EAffectFlag::AFF_PEACEFUL) || (IS_NPC(victim) && !AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM)) ||
-				(ch != victim && general_savingthrow(ch, victim, savetype, modi)))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		if (victim->get_fighting())
-		{
-			stop_fighting(victim, TRUE);
-			change_fighting(victim, TRUE);
-			WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
-		}
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 2, 0, 0, 0, 0)) * koef_duration;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_PEACEFUL);
-		to_room = "Взгляд $n1 потускнел, а сам он успокоился.";
-		to_vict = "Ваша душа очистилась от зла и странно успокоилась.";
-		break;
-		}
+    case SPELL_PEACEFUL: {
+      if (AFF_FLAGGED(victim, EAffectFlag::AFF_PEACEFUL)
+          || (IS_NPC(victim) && !AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM)) ||
+          (ch != victim && general_savingthrow(ch, victim, savetype, modi))) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      if (victim->get_fighting()) {
+        stop_fighting(victim, TRUE);
+        change_fighting(victim, TRUE);
+        WAIT_STATE(victim, 2 * PULSE_VIOLENCE);
+      }
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 2, 0, 0, 0, 0)) * koef_duration;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_PEACEFUL);
+      to_room = "Взгляд $n1 потускнел, а сам он успокоился.";
+      to_vict = "Ваша душа очистилась от зла и странно успокоилась.";
+      break;
+    }
 
-	case SPELL_STONEBONES:
-		{
-		if (GET_MOB_VNUM(victim) < MOB_SKELETON || GET_MOB_VNUM(victim) > LAST_NECRO_MOB)
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-		}
-		af[0].location = APPLY_ARMOUR;
-		af[0].duration = pc_duration(victim, 100, level, 1, 0, 0) * koef_duration;
-		af[0].modifier = level + 10 + GET_REMORT(ch) / 2;
-		af[1].location = APPLY_SAVING_STABILITY;
-		af[1].duration = af[0].duration;
-		af[1].modifier = level + 10 + GET_REMORT(ch) / 2;
-		accum_duration = TRUE;
-		to_vict = " ";
-		to_room = "Кости $n1 обрели твердость кремня.";
-		break;
-		}
+    case SPELL_STONEBONES: {
+      if (GET_MOB_VNUM(victim) < MOB_SKELETON || GET_MOB_VNUM(victim) > LAST_NECRO_MOB) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+      }
+      af[0].location = APPLY_ARMOUR;
+      af[0].duration = pc_duration(victim, 100, level, 1, 0, 0) * koef_duration;
+      af[0].modifier = level + 10 + GET_REMORT(ch) / 2;
+      af[1].location = APPLY_SAVING_STABILITY;
+      af[1].duration = af[0].duration;
+      af[1].modifier = level + 10 + GET_REMORT(ch) / 2;
+      accum_duration = TRUE;
+      to_vict = " ";
+      to_room = "Кости $n1 обрели твердость кремня.";
+      break;
+    }
 
-	case SPELL_FAILURE:
-	case SPELL_MASS_FAILURE:
-		{
-		savetype = SAVING_WILL;
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		af[0].location = APPLY_MORALE;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 2, level, 2, 0, 0)) * koef_duration;
-		af[0].modifier = -5 - (GET_LEVEL(ch) + GET_REMORT(ch)) / 2;
-		af[1].location = static_cast<EApplyLocation>(number(1, 6));
-		af[1].duration = af[0].duration;
-		af[1].modifier = - (GET_LEVEL(ch) + GET_REMORT(ch) * 3) / 15;
-		to_room = "Тяжелое бурое облако сгустилось над $n4.";
-		to_vict = "Тяжелые тучи сгустились над вами, и вы почувствовали, что удача покинула вас.";
-		break;
-		}
+    case SPELL_FAILURE:
+    case SPELL_MASS_FAILURE: {
+      savetype = SAVING_WILL;
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      af[0].location = APPLY_MORALE;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 2, level, 2, 0, 0)) * koef_duration;
+      af[0].modifier = -5 - (GET_LEVEL(ch) + GET_REMORT(ch)) / 2;
+      af[1].location = static_cast<EApplyLocation>(number(1, 6));
+      af[1].duration = af[0].duration;
+      af[1].modifier = -(GET_LEVEL(ch) + GET_REMORT(ch) * 3) / 15;
+      to_room = "Тяжелое бурое облако сгустилось над $n4.";
+      to_vict = "Тяжелые тучи сгустились над вами, и вы почувствовали, что удача покинула вас.";
+      break;
+    }
 
-	case SPELL_GLITTERDUST:
-		{
-		savetype = SAVING_REFLEX;
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi + 50))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
+    case SPELL_GLITTERDUST: {
+      savetype = SAVING_REFLEX;
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi + 50)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
 
-		if (affected_by_spell(victim, SPELL_INVISIBLE))
-		{
-			affect_from_char(victim, SPELL_INVISIBLE);
-		}
-		if (affected_by_spell(victim, SPELL_CAMOUFLAGE))
-		{
-			affect_from_char(victim, SPELL_CAMOUFLAGE);
-		}
-		if (affected_by_spell(victim, SPELL_HIDE))
-		{
-			affect_from_char(victim, SPELL_HIDE);
-		}
-		af[0].location = APPLY_SAVING_REFLEX;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 4, 0, 0, 0, 0)) * koef_duration;
-		af[0].modifier = (GET_LEVEL(ch) + GET_REMORT(ch)) / 3;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_GLITTERDUST);
-		accum_duration = TRUE;
-		accum_affect = TRUE;
-		to_room = "Облако ярко блестящей пыли накрыло $n3.";
-		to_vict = "Липкая блестящая пыль покрыла вас с головы до пят.";
-		break;
-		}
+      if (affected_by_spell(victim, SPELL_INVISIBLE)) {
+        affect_from_char(victim, SPELL_INVISIBLE);
+      }
+      if (affected_by_spell(victim, SPELL_CAMOUFLAGE)) {
+        affect_from_char(victim, SPELL_CAMOUFLAGE);
+      }
+      if (affected_by_spell(victim, SPELL_HIDE)) {
+        affect_from_char(victim, SPELL_HIDE);
+      }
+      af[0].location = APPLY_SAVING_REFLEX;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 4, 0, 0, 0, 0)) * koef_duration;
+      af[0].modifier = (GET_LEVEL(ch) + GET_REMORT(ch)) / 3;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_GLITTERDUST);
+      accum_duration = TRUE;
+      accum_affect = TRUE;
+      to_room = "Облако ярко блестящей пыли накрыло $n3.";
+      to_vict = "Липкая блестящая пыль покрыла вас с головы до пят.";
+      break;
+    }
 
-	case SPELL_SCREAM:
-		{
-		savetype = SAVING_STABILITY;
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_AFFRIGHT);
-		af[0].location = APPLY_SAVING_WILL;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 2, level, 2, 0, 0)) * koef_duration;
-		af[0].modifier = (2 * GET_LEVEL(ch) + GET_REMORT(ch)) / 4;
+    case SPELL_SCREAM: {
+      savetype = SAVING_STABILITY;
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_AFFRIGHT);
+      af[0].location = APPLY_SAVING_WILL;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 2, level, 2, 0, 0)) * koef_duration;
+      af[0].modifier = (2 * GET_LEVEL(ch) + GET_REMORT(ch)) / 4;
 
-		af[1].bitvector = to_underlying(EAffectFlag::AFF_AFFRIGHT);
-		af[1].location = APPLY_MORALE;
-		af[1].duration = af[0].duration;
-		af[1].modifier = -(GET_LEVEL(ch) + GET_REMORT(ch)) / 6;
+      af[1].bitvector = to_underlying(EAffectFlag::AFF_AFFRIGHT);
+      af[1].location = APPLY_MORALE;
+      af[1].duration = af[0].duration;
+      af[1].modifier = -(GET_LEVEL(ch) + GET_REMORT(ch)) / 6;
 
-		to_room = "$n0 побледнел$g и задрожал$g от страха.";
-		to_vict = "Страх сжал ваше сердце ледяными когтями.";
-		break;
-		}
+      to_room = "$n0 побледнел$g и задрожал$g от страха.";
+      to_vict = "Страх сжал ваше сердце ледяными когтями.";
+      break;
+    }
 
-	case SPELL_CATS_GRACE:
-		{
-		af[0].location = APPLY_DEX;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		if (ch == victim)
-			af[0].modifier = (level + 5) / 10;
-		else
-			af[0].modifier = (level + 10) / 15;
-		accum_duration = TRUE;
-		accum_affect = TRUE;
-		to_vict = "Ваши движения обрели невиданную ловкость.";
-		to_room = "Движения $n1 обрели невиданную ловкость.";
-		break;
-		}
+    case SPELL_CATS_GRACE: {
+      af[0].location = APPLY_DEX;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      if (ch == victim)
+        af[0].modifier = (level + 5) / 10;
+      else
+        af[0].modifier = (level + 10) / 15;
+      accum_duration = TRUE;
+      accum_affect = TRUE;
+      to_vict = "Ваши движения обрели невиданную ловкость.";
+      to_room = "Движения $n1 обрели невиданную ловкость.";
+      break;
+    }
 
-	case SPELL_BULL_BODY:
-		{
-		af[0].location = APPLY_CON;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0);
-		if (ch == victim)
-			af[0].modifier = (level + 5) / 10;
-		else
-			af[0].modifier = (level + 10) / 15;
-		accum_duration = TRUE;
-		accum_affect = TRUE;
-		to_vict = "Ваше тело налилось звериной мощью.";
-		to_room = "Плечи $n1 раздались вширь, а тело налилось звериной мощью.";
-		break;
-		}
+    case SPELL_BULL_BODY: {
+      af[0].location = APPLY_CON;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0);
+      if (ch == victim)
+        af[0].modifier = (level + 5) / 10;
+      else
+        af[0].modifier = (level + 10) / 15;
+      accum_duration = TRUE;
+      accum_affect = TRUE;
+      to_vict = "Ваше тело налилось звериной мощью.";
+      to_room = "Плечи $n1 раздались вширь, а тело налилось звериной мощью.";
+      break;
+    }
 
-	case SPELL_SNAKE_WISDOM:
-		{
-		af[0].location = APPLY_WIS;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].modifier = (level + 6) / 15;
-		accum_duration = TRUE;
-		accum_affect = TRUE;
-		to_vict = "Шелест змеиной чешуи коснулся вашего сознания, и вы стали мудрее.";
-		to_room = "$n спокойно и мудро посмотрел$g вокруг.";
-		break;
-		}
+    case SPELL_SNAKE_WISDOM: {
+      af[0].location = APPLY_WIS;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].modifier = (level + 6) / 15;
+      accum_duration = TRUE;
+      accum_affect = TRUE;
+      to_vict = "Шелест змеиной чешуи коснулся вашего сознания, и вы стали мудрее.";
+      to_room = "$n спокойно и мудро посмотрел$g вокруг.";
+      break;
+    }
 
-	case SPELL_GIMMICKRY:
-		{
-		af[0].location = APPLY_INT;
-		af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
-		af[0].modifier = (level + 6) / 15;
-		accum_duration = TRUE;
-		accum_affect = TRUE;
-		to_vict = "Вы почувствовали, что для вашего ума более нет преград.";
-		to_room = "$n хитро прищурил$u и поглядел$g по сторонам.";
-		break;
-		}
+    case SPELL_GIMMICKRY: {
+      af[0].location = APPLY_INT;
+      af[0].duration = pc_duration(victim, 20, SECS_PER_PLAYER_AFFECT * GET_REMORT(ch), 1, 0, 0) * koef_duration;
+      af[0].modifier = (level + 6) / 15;
+      accum_duration = TRUE;
+      accum_affect = TRUE;
+      to_vict = "Вы почувствовали, что для вашего ума более нет преград.";
+      to_room = "$n хитро прищурил$u и поглядел$g по сторонам.";
+      break;
+    }
 
-	case SPELL_WC_OF_MENACE:
-		{
-		savetype = SAVING_WILL;
-		modi = GET_REAL_CON(ch);
-		if (ch != victim && general_savingthrow(ch, victim, savetype, modi))
-		{
-			send_to_char(NOEFFECT, ch);
-			success = FALSE;
-			break;
-		}
-		af[0].location = APPLY_MORALE;
-		af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-						 pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
-		af[0].modifier = -dice((7 + level) / 8, 3);
-		to_vict = "Похоже, сегодня не ваш день.";
-		to_room = "Удача покинула $n3.";
-		break;
-		}
+    case SPELL_WC_OF_MENACE: {
+      savetype = SAVING_WILL;
+      modi = GET_REAL_CON(ch);
+      if (ch != victim && general_savingthrow(ch, victim, savetype, modi)) {
+        send_to_char(NOEFFECT, ch);
+        success = FALSE;
+        break;
+      }
+      af[0].location = APPLY_MORALE;
+      af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                  pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
+      af[0].modifier = -dice((7 + level) / 8, 3);
+      to_vict = "Похоже, сегодня не ваш день.";
+      to_room = "Удача покинула $n3.";
+      break;
+    }
 
-	case SPELL_WC_OF_MADNESS:
-		{
-		savetype = SAVING_STABILITY;
-		modi = GET_REAL_CON(ch) * 3 / 2;
-		if (ch == victim || !general_savingthrow(ch, victim, savetype, modi))
-		{
-			af[0].location = APPLY_INT;
-			af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-							 pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
-			af[0].modifier = -dice((7 + level) / 8, 2);
-			to_vict = "Вы потеряли рассудок.";
-			to_room = "$n0 потерял$g рассудок.";
+    case SPELL_WC_OF_MADNESS: {
+      savetype = SAVING_STABILITY;
+      modi = GET_REAL_CON(ch) * 3 / 2;
+      if (ch == victim || !general_savingthrow(ch, victim, savetype, modi)) {
+        af[0].location = APPLY_INT;
+        af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                    pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
+        af[0].modifier = -dice((7 + level) / 8, 2);
+        to_vict = "Вы потеряли рассудок.";
+        to_room = "$n0 потерял$g рассудок.";
 
-			savetype = SAVING_STABILITY;
-			modi = GET_REAL_CON(ch) * 2;
-			if (ch == victim || !general_savingthrow(ch, victim, savetype, modi))
-			{
-				af[1].location = APPLY_CAST_SUCCESS;
-				af[1].duration = af[0].duration;
-				af[1].modifier = -(dice((2 + level) / 3, 4) + dice(GET_REMORT(ch) / 2, 5));
+        savetype = SAVING_STABILITY;
+        modi = GET_REAL_CON(ch) * 2;
+        if (ch == victim || !general_savingthrow(ch, victim, savetype, modi)) {
+          af[1].location = APPLY_CAST_SUCCESS;
+          af[1].duration = af[0].duration;
+          af[1].modifier = -(dice((2 + level) / 3, 4) + dice(GET_REMORT(ch) / 2, 5));
 
-				af[2].location = APPLY_MANAREG;
-				af[2].duration = af[1].duration;
-				af[2].modifier = af[1].modifier;
-				to_vict = "Вы обезумели.";
-				to_room = "$n0 обезумел$g.";
-			}
-		}
-		else
-		{
-			savetype = SAVING_STABILITY;
-			modi = GET_REAL_CON(ch) * 2;
-			if (!general_savingthrow(ch, victim, savetype, modi))
-			{
-				af[0].location = APPLY_CAST_SUCCESS;
-				af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
-								 pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
-				af[0].modifier = -(dice((2 + level) / 3, 4) + dice(GET_REMORT(ch) / 2, 5));
+          af[2].location = APPLY_MANAREG;
+          af[2].duration = af[1].duration;
+          af[2].modifier = af[1].modifier;
+          to_vict = "Вы обезумели.";
+          to_room = "$n0 обезумел$g.";
+        }
+      } else {
+        savetype = SAVING_STABILITY;
+        modi = GET_REAL_CON(ch) * 2;
+        if (!general_savingthrow(ch, victim, savetype, modi)) {
+          af[0].location = APPLY_CAST_SUCCESS;
+          af[0].duration = calculate_resistance_coeff(victim, get_resist_type(spellnum),
+                                                      pc_duration(victim, 2, level + 3, 4, 6, 0)) * koef_duration;
+          af[0].modifier = -(dice((2 + level) / 3, 4) + dice(GET_REMORT(ch) / 2, 5));
 
-				af[1].location = APPLY_MANAREG;
-				af[1].duration = af[0].duration;
-				af[1].modifier = af[0].modifier;
-				to_vict = "Вас охватила паника.";
-				to_room = "$n0 начал$g сеять панику.";
-			}
-			else
-			{
-				send_to_char(NOEFFECT, ch);
-				success = FALSE;
-			}
-		}
-		update_spell = TRUE;
-		break;
-		}
+          af[1].location = APPLY_MANAREG;
+          af[1].duration = af[0].duration;
+          af[1].modifier = af[0].modifier;
+          to_vict = "Вас охватила паника.";
+          to_room = "$n0 начал$g сеять панику.";
+        } else {
+          send_to_char(NOEFFECT, ch);
+          success = FALSE;
+        }
+      }
+      update_spell = TRUE;
+      break;
+    }
 
-	case SPELL_WC_LUCK:
-		{
-		af[0].location = APPLY_MORALE;
-		af[0].modifier = MAX(1, ch->get_skill(SKILL_WARCRY) / 20.0);
-		af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		to_room = nullptr;
-		break;
-		}
+    case SPELL_WC_LUCK: {
+      af[0].location = APPLY_MORALE;
+      af[0].modifier = MAX(1, ch->get_skill(SKILL_WARCRY) / 20.0);
+      af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      to_room = nullptr;
+      break;
+    }
 
-	case SPELL_WC_EXPERIENSE:
-		{
-		af[0].location = APPLY_PERCENT_EXP;
-		af[0].modifier = MAX(1, ch->get_skill(SKILL_WARCRY) / 20.0);
-		af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		to_room = nullptr;
-		break;
-		}
+    case SPELL_WC_EXPERIENSE: {
+      af[0].location = APPLY_PERCENT_EXP;
+      af[0].modifier = MAX(1, ch->get_skill(SKILL_WARCRY) / 20.0);
+      af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      to_room = nullptr;
+      break;
+    }
 
-	case SPELL_WC_PHYSDAMAGE:
-		{
-		af[0].location = APPLY_PERCENT_DAM;
-		af[0].modifier = MAX(1, ch->get_skill(SKILL_WARCRY) / 20.0);
-		af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		to_room = nullptr;
-		break;
-		}
+    case SPELL_WC_PHYSDAMAGE: {
+      af[0].location = APPLY_PERCENT_DAM;
+      af[0].modifier = MAX(1, ch->get_skill(SKILL_WARCRY) / 20.0);
+      af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      to_room = nullptr;
+      break;
+    }
 
-	case SPELL_WC_OF_BATTLE:
-		{
-		af[0].location = APPLY_AC;
-		af[0].modifier = - (10 + MIN(20, 2 * GET_REMORT(ch)));
-		af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		to_room = nullptr;
-		break;
-		}
+    case SPELL_WC_OF_BATTLE: {
+      af[0].location = APPLY_AC;
+      af[0].modifier = -(10 + MIN(20, 2 * GET_REMORT(ch)));
+      af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      to_room = nullptr;
+      break;
+    }
 
-	case SPELL_WC_OF_DEFENSE:
-		{
-		af[0].location = APPLY_SAVING_CRITICAL;
-		af[0].modifier -= ch->get_skill(SKILL_WARCRY) / 10.0;
-		af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		af[1].location = APPLY_SAVING_REFLEX;
-		af[1].modifier -= ch->get_skill(SKILL_WARCRY) / 10;
-		af[1].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		af[2].location = APPLY_SAVING_STABILITY;
-		af[2].modifier -= ch->get_skill(SKILL_WARCRY) / 10;
-		af[2].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		af[3].location = APPLY_SAVING_WILL;
-		af[3].modifier -= ch->get_skill(SKILL_WARCRY) / 10;
-		af[3].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		//to_vict = nullptr;
-		to_room = nullptr;
-		break;
-		}
+    case SPELL_WC_OF_DEFENSE: {
+      af[0].location = APPLY_SAVING_CRITICAL;
+      af[0].modifier -= ch->get_skill(SKILL_WARCRY) / 10.0;
+      af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      af[1].location = APPLY_SAVING_REFLEX;
+      af[1].modifier -= ch->get_skill(SKILL_WARCRY) / 10;
+      af[1].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      af[2].location = APPLY_SAVING_STABILITY;
+      af[2].modifier -= ch->get_skill(SKILL_WARCRY) / 10;
+      af[2].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      af[3].location = APPLY_SAVING_WILL;
+      af[3].modifier -= ch->get_skill(SKILL_WARCRY) / 10;
+      af[3].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      //to_vict = nullptr;
+      to_room = nullptr;
+      break;
+    }
 
-	case SPELL_WC_OF_POWER:
-		{
-		af[0].location = APPLY_HIT;
-		af[0].modifier = MIN(200, (4 * ch->get_con() + ch->get_skill(SKILL_WARCRY)) / 2);
-		af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		to_vict = nullptr;
-		to_room = nullptr;
-		break;
-		}
+    case SPELL_WC_OF_POWER: {
+      af[0].location = APPLY_HIT;
+      af[0].modifier = MIN(200, (4 * ch->get_con() + ch->get_skill(SKILL_WARCRY)) / 2);
+      af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      to_vict = nullptr;
+      to_room = nullptr;
+      break;
+    }
 
-	case SPELL_WC_OF_BLESS:
-		{
-		af[0].location = APPLY_SAVING_STABILITY;
-		af[0].modifier = -(4 * ch->get_con() + ch->get_skill(SKILL_WARCRY)) / 24;
-		af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		af[1].location = APPLY_SAVING_WILL;
-		af[1].modifier = af[0].modifier;
-		af[1].duration = af[0].duration;
-		to_vict = nullptr;
-		to_room = nullptr;
-		break;
-		}
+    case SPELL_WC_OF_BLESS: {
+      af[0].location = APPLY_SAVING_STABILITY;
+      af[0].modifier = -(4 * ch->get_con() + ch->get_skill(SKILL_WARCRY)) / 24;
+      af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      af[1].location = APPLY_SAVING_WILL;
+      af[1].modifier = af[0].modifier;
+      af[1].duration = af[0].duration;
+      to_vict = nullptr;
+      to_room = nullptr;
+      break;
+    }
 
-	case SPELL_WC_OF_COURAGE:
-		{
-		af[0].location = APPLY_HITROLL;
-		af[0].modifier = (44 + ch->get_skill(SKILL_WARCRY)) / 45;
-		af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
-		af[1].location = APPLY_DAMROLL;
-		af[1].modifier = (29 + ch->get_skill(SKILL_WARCRY)) / 30;
-		af[1].duration = af[0].duration;
-		to_vict = nullptr;
-		to_room = nullptr;
-		break;
-		}
+    case SPELL_WC_OF_COURAGE: {
+      af[0].location = APPLY_HITROLL;
+      af[0].modifier = (44 + ch->get_skill(SKILL_WARCRY)) / 45;
+      af[0].duration = pc_duration(victim, 2, ch->get_skill(SKILL_WARCRY), 20, 10, 0) * koef_duration;
+      af[1].location = APPLY_DAMROLL;
+      af[1].modifier = (29 + ch->get_skill(SKILL_WARCRY)) / 30;
+      af[1].duration = af[0].duration;
+      to_vict = nullptr;
+      to_room = nullptr;
+      break;
+    }
 
-	case SPELL_ACONITUM_POISON:
-		af[0].location = APPLY_ACONITUM_POISON;
-		af[0].duration = 7;
-		af[0].modifier = level;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af[0].battleflag = AF_SAME_TIME;
-		to_vict = "Вы почувствовали себя отравленным.";
-		to_room = "$n позеленел$g от действия яда.";
-		break;
+    case SPELL_ACONITUM_POISON: af[0].location = APPLY_ACONITUM_POISON;
+      af[0].duration = 7;
+      af[0].modifier = level;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON);
+      af[0].battleflag = AF_SAME_TIME;
+      to_vict = "Вы почувствовали себя отравленным.";
+      to_room = "$n позеленел$g от действия яда.";
+      break;
 
-	case SPELL_SCOPOLIA_POISON:
-		af[0].location = APPLY_SCOPOLIA_POISON;
-		af[0].duration = 7;
-		af[0].modifier = 5;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON) | to_underlying(EAffectFlag::AFF_SCOPOLIA_POISON);
-		af[0].battleflag = AF_SAME_TIME;
-		to_vict = "Вы почувствовали себя отравленным.";
-		to_room = "$n позеленел$g от действия яда.";
-		break;
+    case SPELL_SCOPOLIA_POISON: af[0].location = APPLY_SCOPOLIA_POISON;
+      af[0].duration = 7;
+      af[0].modifier = 5;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON) | to_underlying(EAffectFlag::AFF_SCOPOLIA_POISON);
+      af[0].battleflag = AF_SAME_TIME;
+      to_vict = "Вы почувствовали себя отравленным.";
+      to_room = "$n позеленел$g от действия яда.";
+      break;
 
-	case SPELL_BELENA_POISON:
-		af[0].location = APPLY_BELENA_POISON;
-		af[0].duration = 7;
-		af[0].modifier = 5;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af[0].battleflag = AF_SAME_TIME;
-		to_vict = "Вы почувствовали себя отравленным.";
-		to_room = "$n позеленел$g от действия яда.";
-		break;
+    case SPELL_BELENA_POISON: af[0].location = APPLY_BELENA_POISON;
+      af[0].duration = 7;
+      af[0].modifier = 5;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON);
+      af[0].battleflag = AF_SAME_TIME;
+      to_vict = "Вы почувствовали себя отравленным.";
+      to_room = "$n позеленел$g от действия яда.";
+      break;
 
-	case SPELL_DATURA_POISON:
-		af[0].location = APPLY_DATURA_POISON;
-		af[0].duration = 7;
-		af[0].modifier = 5;
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON);
-		af[0].battleflag = AF_SAME_TIME;
-		to_vict = "Вы почувствовали себя отравленным.";
-		to_room = "$n позеленел$g от действия яда.";
-		break;
+    case SPELL_DATURA_POISON: af[0].location = APPLY_DATURA_POISON;
+      af[0].duration = 7;
+      af[0].modifier = 5;
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_POISON);
+      af[0].battleflag = AF_SAME_TIME;
+      to_vict = "Вы почувствовали себя отравленным.";
+      to_room = "$n позеленел$g от действия яда.";
+      break;
 
-	case SPELL_LACKY:
-		af[0].duration = pc_duration(victim, 6, 0, 0, 0, 0);
-		af[0].bitvector = to_underlying(EAffectFlag::AFF_LACKY);
-		//Polud пробный обработчик аффектов
-		af[0].handler.reset(new LackyAffectHandler());
-		af[0].type = SPELL_LACKY;
-		af[0].location = APPLY_HITROLL;
-		af[0].modifier = 0;
-		to_room = "$n вдохновенно выпятил$g грудь.";
-		to_vict = "Вы почувствовали вдохновение.";
-		break;
+    case SPELL_LACKY: af[0].duration = pc_duration(victim, 6, 0, 0, 0, 0);
+      af[0].bitvector = to_underlying(EAffectFlag::AFF_LACKY);
+      //Polud пробный обработчик аффектов
+      af[0].handler.reset(new LackyAffectHandler());
+      af[0].type = SPELL_LACKY;
+      af[0].location = APPLY_HITROLL;
+      af[0].modifier = 0;
+      to_room = "$n вдохновенно выпятил$g грудь.";
+      to_vict = "Вы почувствовали вдохновение.";
+      break;
 
-	case SPELL_ARROWS_FIRE:
-	case SPELL_ARROWS_WATER:
-	case SPELL_ARROWS_EARTH:
-	case SPELL_ARROWS_AIR:
-	case SPELL_ARROWS_DEATH:
-		{
-			//Додати обработчик
-			break;
-		}
+    case SPELL_ARROWS_FIRE:
+    case SPELL_ARROWS_WATER:
+    case SPELL_ARROWS_EARTH:
+    case SPELL_ARROWS_AIR:
+    case SPELL_ARROWS_DEATH: {
+      //Додати обработчик
+      break;
+    }
     case SPELL_PALADINE_INSPIRATION:
-        /*
+      /*
          * групповой спелл, развешивающий рандомные аффекты, к сожалению
          * не может быть применен по принципа "сгенерили рандом - и применили"
          * поэтому на каждого члена группы применяется свой аффект, а кастер еще и полечить может
          * */
 
-        if (ch == victim)
-            rnd = number(1,4);
-        else
-            rnd = number(1,3);
-        af[0].type = SPELL_PALADINE_INSPIRATION;
-        af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-        switch (rnd){
-            case 1:
-                af[0].location = APPLY_PERCENT_DAM;
-                af[0].duration = pc_duration(victim, 5, 0, 0, 0, 0);
-                af[0].modifier = GET_REMORT(ch) / 5 * 2 + GET_REMORT(ch);
-                break;
-            case 2:
-                af[0].location = APPLY_CAST_SUCCESS;
-                af[0].duration = pc_duration(victim, 3, 0, 0, 0, 0);
-                af[0].modifier = GET_REMORT(ch) / 5 * 2 + GET_REMORT(ch);
-                break;
-            case 3:
-                af[0].location = APPLY_MANAREG;
-                af[0].duration = pc_duration(victim, 10, 0, 0, 0, 0);
-                af[0].modifier = GET_REMORT(ch) / 5 * 2 + GET_REMORT(ch) * 5;
-                break;
-            case 4:
-                call_magic(ch, ch, nullptr, nullptr, SPELL_GROUP_HEAL, GET_LEVEL(ch));
-                break;
-            default:
-                break;
+      if (ch == victim)
+        rnd = number(1, 4);
+      else
+        rnd = number(1, 3);
+      af[0].type = SPELL_PALADINE_INSPIRATION;
+      af[0].battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+      switch (rnd) {
+        case 1:af[0].location = APPLY_PERCENT_DAM;
+          af[0].duration = pc_duration(victim, 5, 0, 0, 0, 0);
+          af[0].modifier = GET_REMORT(ch) / 5 * 2 + GET_REMORT(ch);
+          break;
+        case 2:af[0].location = APPLY_CAST_SUCCESS;
+          af[0].duration = pc_duration(victim, 3, 0, 0, 0, 0);
+          af[0].modifier = GET_REMORT(ch) / 5 * 2 + GET_REMORT(ch);
+          break;
+        case 3:af[0].location = APPLY_MANAREG;
+          af[0].duration = pc_duration(victim, 10, 0, 0, 0, 0);
+          af[0].modifier = GET_REMORT(ch) / 5 * 2 + GET_REMORT(ch) * 5;
+          break;
+        case 4:call_magic(ch, ch, nullptr, nullptr, SPELL_GROUP_HEAL, GET_LEVEL(ch));
+          break;
+        default:break;
+      }
+  }
+
+
+  //проверка на обкаст мобов, имеющих от рождения встроенный аффкект
+  //чтобы этот аффект не очистился, при спадении спелла
+  if (IS_NPC(victim) && success) {
+    for (i = 0; i < MAX_SPELL_AFFECTS && success; ++i) {
+      if (AFF_FLAGGED(&mob_proto[victim->get_rnum()], static_cast<EAffectFlag>(af[i].bitvector))) {
+        if (ch->in_room == IN_ROOM(victim)) {
+          send_to_char(NOEFFECT, ch);
         }
-	}
+        success = FALSE;
+      }
+    }
+  }
+  // позитивные аффекты - продлеваем, если они уже на цели
+  if (!SpINFO.violent && affected_by_spell(victim, spellnum) && success) {
+    update_spell = TRUE;
+  }
+  // вот такой оригинальный способ запретить рекасты негативных аффектов - через флаг апдейта
+  if ((ch != victim) && affected_by_spell(victim, spellnum) && success && (!update_spell)) {
+    if (ch->in_room == IN_ROOM(victim))
+      send_to_char(NOEFFECT, ch);
+    success = FALSE;
+  }
 
-
-	//проверка на обкаст мобов, имеющих от рождения встроенный аффкект
-	//чтобы этот аффект не очистился, при спадении спелла
-	if (IS_NPC(victim) && success){
-		for (i = 0; i < MAX_SPELL_AFFECTS && success; ++i) {
-			if (AFF_FLAGGED(&mob_proto[victim->get_rnum()], static_cast<EAffectFlag>(af[i].bitvector))) {
-				if (ch->in_room == IN_ROOM(victim)){
-					send_to_char(NOEFFECT, ch);
-				}
-				success = FALSE;
-			}
-		}
-	}
-	// позитивные аффекты - продлеваем, если они уже на цели
-	if (!SpINFO.violent && affected_by_spell(victim, spellnum) && success){
-		update_spell = TRUE;
-	}
-	// вот такой оригинальный способ запретить рекасты негативных аффектов - через флаг апдейта
-	if ((ch != victim) && affected_by_spell(victim, spellnum) && success && (!update_spell)) {
-		if (ch->in_room == IN_ROOM(victim))
-			send_to_char(NOEFFECT, ch);
-		success = FALSE;
-	}
-
-	for (i = 0; success && i < MAX_SPELL_AFFECTS; i++){
-		af[i].type = spellnum;
-		if (af[i].bitvector || af[i].location != APPLY_NONE){
-			af[i].duration = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_EFFECT, af[i].duration);
-			if (update_spell)
-				affect_join_fspell(victim, af[i]);
-			else
-				affect_join(victim, af[i], accum_duration, FALSE, accum_affect, FALSE);
-		}
-		// тут мы ездим по циклу 16 раз, хотя аффектов 1-3...
+  for (i = 0; success && i < MAX_SPELL_AFFECTS; i++) {
+    af[i].type = spellnum;
+    if (af[i].bitvector || af[i].location != APPLY_NONE) {
+      af[i].duration = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_EFFECT, af[i].duration);
+      if (update_spell)
+        affect_join_fspell(victim, af[i]);
+      else
+        affect_join(victim, af[i], accum_duration, FALSE, accum_affect, FALSE);
+    }
+    // тут мы ездим по циклу 16 раз, хотя аффектов 1-3...
 //		ch->send_to_TC(true, true, true, "Applied affect type %i\r\n", af[i].type);
-	}
+  }
 
-	if (success) {
-		// вот некрасиво же тут это делать...
-		if (spellnum == SPELL_POISON)
-			victim->Poisoner = GET_ID(ch);
-		if (to_vict != nullptr)
-			act(to_vict, FALSE, victim, 0, ch, TO_CHAR);
-		if (to_room != nullptr)
-			act(to_room, TRUE, victim, 0, ch, TO_ROOM | TO_ARENA_LISTEN);
-		return 1;
-	}
-	return 0;
+  if (success) {
+    // вот некрасиво же тут это делать...
+    if (spellnum == SPELL_POISON)
+      victim->Poisoner = GET_ID(ch);
+    if (to_vict != nullptr)
+      act(to_vict, FALSE, victim, 0, ch, TO_CHAR);
+    if (to_room != nullptr)
+      act(to_room, TRUE, victim, 0, ch, TO_ROOM | TO_ARENA_LISTEN);
+    return 1;
+  }
+  return 0;
 }
 
 
@@ -3025,1753 +2757,1572 @@ int mag_affects(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int
 
 // * These use act(), don't put the \r\n.
 const char *mag_summon_msgs[] =
-{
-	"\r\n",
-	"$n сделал$g несколько изящних пассов - вы почувствовали странное дуновение!",
-	"$n поднял$g труп!",
-	"$N появил$U из клубов голубого дыма!",
-	"$N появил$U из клубов зеленого дыма!",
-	"$N появил$U из клубов красного дыма!",
-	"$n сделал$g несколько изящных пассов - вас обдало порывом холодного ветра.",
-	"$n сделал$g несколько изящных пассов, от чего ваши волосы встали дыбом.",
-	"$n сделал$g несколько изящных пассов, обдав вас нестерпимым жаром.",
-	"$n сделал$g несколько изящных пассов, вызвав у вас приступ тошноты.",
-	"$n раздвоил$u!",
-	"$n оживил$g труп!",
-	"$n призвал$g защитника!",
-	"Огненный хранитель появился из вихря пламени!"
-};
+    {
+        "\r\n",
+        "$n сделал$g несколько изящних пассов - вы почувствовали странное дуновение!",
+        "$n поднял$g труп!",
+        "$N появил$U из клубов голубого дыма!",
+        "$N появил$U из клубов зеленого дыма!",
+        "$N появил$U из клубов красного дыма!",
+        "$n сделал$g несколько изящных пассов - вас обдало порывом холодного ветра.",
+        "$n сделал$g несколько изящных пассов, от чего ваши волосы встали дыбом.",
+        "$n сделал$g несколько изящных пассов, обдав вас нестерпимым жаром.",
+        "$n сделал$g несколько изящных пассов, вызвав у вас приступ тошноты.",
+        "$n раздвоил$u!",
+        "$n оживил$g труп!",
+        "$n призвал$g защитника!",
+        "Огненный хранитель появился из вихря пламени!"
+    };
 
 // * Keep the \r\n because these use send_to_char.
 const char *mag_summon_fail_msgs[] =
-{
-	"\r\n",
-	"Нет такого существа в мире.\r\n",
-	"Жаль, сорвалось...\r\n",
-	"Ничего.\r\n",
-	"Черт! Ничего не вышло.\r\n",
-	"Вы не смогли сделать этого!\r\n",
-	"Ваша магия провалилась.\r\n",
-	"У вас нет подходящего трупа!\r\n"
-};
+    {
+        "\r\n",
+        "Нет такого существа в мире.\r\n",
+        "Жаль, сорвалось...\r\n",
+        "Ничего.\r\n",
+        "Черт! Ничего не вышло.\r\n",
+        "Вы не смогли сделать этого!\r\n",
+        "Ваша магия провалилась.\r\n",
+        "У вас нет подходящего трупа!\r\n"
+    };
 
-int mag_summons(int level, CHAR_DATA * ch, OBJ_DATA * obj, int spellnum, int savetype)
-{
-	CHAR_DATA *tmp_mob, *mob = nullptr;
-	OBJ_DATA *tobj, *next_obj;
-	struct follow_type *k;
-	int pfail = 0, msg = 0, fmsg = 0, handle_corpse = FALSE, keeper = FALSE, cha_num = 0, modifier = 0;
-	mob_vnum mob_num;
+int mag_summons(int level, CHAR_DATA *ch, OBJ_DATA *obj, int spellnum, int savetype) {
+  CHAR_DATA *tmp_mob, *mob = nullptr;
+  OBJ_DATA *tobj, *next_obj;
+  struct follow_type *k;
+  int pfail = 0, msg = 0, fmsg = 0, handle_corpse = FALSE, keeper = FALSE, cha_num = 0, modifier = 0;
+  mob_vnum mob_num;
 
-	if (ch == nullptr)
-	{
-		return 0;
-	}
+  if (ch == nullptr) {
+    return 0;
+  }
 
-	switch (spellnum)
-	{
-	case SPELL_CLONE:
-		msg = 10;
-		fmsg = number(3, 5);	// Random fail message.
-		mob_num = MOB_DOUBLE;
-		pfail = 50 - GET_CAST_SUCCESS(ch) - GET_REMORT(ch) * 5;	// 50% failure, should be based on something later.
-		keeper = TRUE;
-		break;
+  switch (spellnum) {
+    case SPELL_CLONE: msg = 10;
+      fmsg = number(3, 5);    // Random fail message.
+      mob_num = MOB_DOUBLE;
+      pfail = 50 - GET_CAST_SUCCESS(ch) - GET_REMORT(ch) * 5;    // 50% failure, should be based on something later.
+      keeper = TRUE;
+      break;
 
-	case SPELL_SUMMON_KEEPER:
-		msg = 12;
-		fmsg = number(2, 6);
-		mob_num = MOB_KEEPER;
-		if (ch->get_fighting())
-			pfail = 50 - GET_CAST_SUCCESS(ch) - GET_REMORT(ch);
-		else
-			pfail = 0;
-		keeper = TRUE;
-		break;
+    case SPELL_SUMMON_KEEPER: msg = 12;
+      fmsg = number(2, 6);
+      mob_num = MOB_KEEPER;
+      if (ch->get_fighting())
+        pfail = 50 - GET_CAST_SUCCESS(ch) - GET_REMORT(ch);
+      else
+        pfail = 0;
+      keeper = TRUE;
+      break;
 
-	case SPELL_SUMMON_FIREKEEPER:
-		msg = 13;
-		fmsg = number(2, 6);
-		mob_num = MOB_FIREKEEPER;
-		if (ch->get_fighting())
-			pfail = 50 - GET_CAST_SUCCESS(ch) - GET_REMORT(ch);
-		else
-			pfail = 0;
-		keeper = TRUE;
-		break;
+    case SPELL_SUMMON_FIREKEEPER: msg = 13;
+      fmsg = number(2, 6);
+      mob_num = MOB_FIREKEEPER;
+      if (ch->get_fighting())
+        pfail = 50 - GET_CAST_SUCCESS(ch) - GET_REMORT(ch);
+      else
+        pfail = 0;
+      keeper = TRUE;
+      break;
 
-	case SPELL_ANIMATE_DEAD:
-		if (obj == nullptr || !IS_CORPSE(obj))
-		{
-			act(mag_summon_fail_msgs[7], FALSE, ch, 0, 0, TO_CHAR);
-			return 0;
-		}
-		mob_num = GET_OBJ_VAL(obj, 2);
-		if (mob_num <= 0)
-			mob_num = MOB_SKELETON;
-		else
-		{
-			const int real_mob_num = real_mobile(mob_num);
-			tmp_mob = (mob_proto + real_mob_num);
-			tmp_mob->set_normal_morph();
-			pfail = 10 + tmp_mob->get_con() * 2
-				- number(1, GET_LEVEL(ch)) - GET_CAST_SUCCESS(ch) - GET_REMORT(ch) * 5;
+    case SPELL_ANIMATE_DEAD:
+      if (obj == nullptr || !IS_CORPSE(obj)) {
+        act(mag_summon_fail_msgs[7], FALSE, ch, 0, 0, TO_CHAR);
+        return 0;
+      }
+      mob_num = GET_OBJ_VAL(obj, 2);
+      if (mob_num <= 0)
+        mob_num = MOB_SKELETON;
+      else {
+        const int real_mob_num = real_mobile(mob_num);
+        tmp_mob = (mob_proto + real_mob_num);
+        tmp_mob->set_normal_morph();
+        pfail = 10 + tmp_mob->get_con() * 2
+            - number(1, GET_LEVEL(ch)) - GET_CAST_SUCCESS(ch) - GET_REMORT(ch) * 5;
 
-			int corpse_mob_level = GET_LEVEL(mob_proto + real_mob_num);
-			if ( corpse_mob_level <= 5)
-			{
-				mob_num = MOB_SKELETON;
-			}
-			else if (corpse_mob_level <= 10)
-			{
-				mob_num = MOB_ZOMBIE;
-			}
-			else if (corpse_mob_level <= 15)
-			{
-				mob_num = MOB_BONEDOG;
-			}
-			else if (corpse_mob_level <= 20)
-			{
-				mob_num = MOB_BONEDRAGON;
-			}
-			else if (corpse_mob_level <= 25)
-			{
-				mob_num = MOB_BONESPIRIT;
-			}
-			else if (corpse_mob_level <= 34)
-			{
-				mob_num = MOB_NECROTANK;
-			}
-			else
-			{
-				int rnd = number(1,100);
-				mob_num = MOB_NECRODAMAGER;
-				if (rnd > 50) {
-					mob_num = MOB_NECROBREATHER;
-				}
-			}
+        int corpse_mob_level = GET_LEVEL(mob_proto + real_mob_num);
+        if (corpse_mob_level <= 5) {
+          mob_num = MOB_SKELETON;
+        } else if (corpse_mob_level <= 10) {
+          mob_num = MOB_ZOMBIE;
+        } else if (corpse_mob_level <= 15) {
+          mob_num = MOB_BONEDOG;
+        } else if (corpse_mob_level <= 20) {
+          mob_num = MOB_BONEDRAGON;
+        } else if (corpse_mob_level <= 25) {
+          mob_num = MOB_BONESPIRIT;
+        } else if (corpse_mob_level <= 34) {
+          mob_num = MOB_NECROTANK;
+        } else {
+          int rnd = number(1, 100);
+          mob_num = MOB_NECRODAMAGER;
+          if (rnd > 50) {
+            mob_num = MOB_NECROBREATHER;
+          }
+        }
 
-			// MOB_NECROCASTER disabled, cant cast
+        // MOB_NECROCASTER disabled, cant cast
 
-			if (GET_LEVEL(ch) + GET_REMORT(ch) + 4 < 15 && mob_num > MOB_ZOMBIE)
-			{
-				mob_num = MOB_ZOMBIE;
-			}
-			else if (GET_LEVEL(ch) + GET_REMORT(ch) + 4 < 25 && mob_num > MOB_BONEDOG)
-			{
-				mob_num = MOB_BONEDOG;
-			}
-			else if (GET_LEVEL(ch) + GET_REMORT(ch) + 4 < 32 && mob_num > MOB_BONEDRAGON)
-			{
-				mob_num = MOB_BONEDRAGON;
-			}
-		}
+        if (GET_LEVEL(ch) + GET_REMORT(ch) + 4 < 15 && mob_num > MOB_ZOMBIE) {
+          mob_num = MOB_ZOMBIE;
+        } else if (GET_LEVEL(ch) + GET_REMORT(ch) + 4 < 25 && mob_num > MOB_BONEDOG) {
+          mob_num = MOB_BONEDOG;
+        } else if (GET_LEVEL(ch) + GET_REMORT(ch) + 4 < 32 && mob_num > MOB_BONEDRAGON) {
+          mob_num = MOB_BONEDRAGON;
+        }
+      }
 
-		handle_corpse = TRUE;
-		msg = number(1, 9);
-		fmsg = number(2, 6);
-		break;
+      handle_corpse = TRUE;
+      msg = number(1, 9);
+      fmsg = number(2, 6);
+      break;
 
-	case SPELL_RESSURECTION:
-		if (obj == nullptr || !IS_CORPSE(obj))
-		{
-			act(mag_summon_fail_msgs[7], FALSE, ch, 0, 0, TO_CHAR);
-			return 0;
-		}
-		if ((mob_num = GET_OBJ_VAL(obj, 2)) <= 0)
-		{
-			send_to_char("Вы не можете поднять труп этого монстра!\r\n", ch);
-			return 0;
-		}
+    case SPELL_RESSURECTION:
+      if (obj == nullptr || !IS_CORPSE(obj)) {
+        act(mag_summon_fail_msgs[7], FALSE, ch, 0, 0, TO_CHAR);
+        return 0;
+      }
+      if ((mob_num = GET_OBJ_VAL(obj, 2)) <= 0) {
+        send_to_char("Вы не можете поднять труп этого монстра!\r\n", ch);
+        return 0;
+      }
 
-		handle_corpse = TRUE;
-		msg = 11;
-		fmsg = number(2, 6);
+      handle_corpse = TRUE;
+      msg = 11;
+      fmsg = number(2, 6);
 
-		tmp_mob = mob_proto + real_mobile(mob_num);
-		tmp_mob->set_normal_morph();
+      tmp_mob = mob_proto + real_mobile(mob_num);
+      tmp_mob->set_normal_morph();
 
-		pfail = 10 + tmp_mob->get_con() * 2
-			- number(1, GET_LEVEL(ch)) - GET_CAST_SUCCESS(ch) - GET_REMORT(ch) * 5;
-		break;
+      pfail = 10 + tmp_mob->get_con() * 2
+          - number(1, GET_LEVEL(ch)) - GET_CAST_SUCCESS(ch) - GET_REMORT(ch) * 5;
+      break;
 
-	default:
-		return 0;
-	}
+    default: return 0;
+  }
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM))
-	{
-		send_to_char("Вы слишком зависимы, чтобы искать себе последователей!\r\n", ch);
-		return 0;
-	}
-	// при перке помощь тьмы гораздо меньше шанс фейла
-	if (!IS_IMMORTAL(ch) && number(0, 101) < pfail && savetype)
-	{
-		if (can_use_feat(ch, HELPDARK_FEAT))
-		{
-			if (number(0, 3) == 0)
-			{
-				send_to_char(mag_summon_fail_msgs[fmsg], ch);
-				if (handle_corpse)
-					extract_obj(obj);
-				return 0;
-			}
-		}
-		else
-		{
-			send_to_char(mag_summon_fail_msgs[fmsg], ch);
-			if (handle_corpse)
-				extract_obj(obj);
-			return 0;
-		}
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)) {
+    send_to_char("Вы слишком зависимы, чтобы искать себе последователей!\r\n", ch);
+    return 0;
+  }
+  // при перке помощь тьмы гораздо меньше шанс фейла
+  if (!IS_IMMORTAL(ch) && number(0, 101) < pfail && savetype) {
+    if (can_use_feat(ch, HELPDARK_FEAT)) {
+      if (number(0, 3) == 0) {
+        send_to_char(mag_summon_fail_msgs[fmsg], ch);
+        if (handle_corpse)
+          extract_obj(obj);
+        return 0;
+      }
+    } else {
+      send_to_char(mag_summon_fail_msgs[fmsg], ch);
+      if (handle_corpse)
+        extract_obj(obj);
+      return 0;
+    }
+  }
 
-	if (!(mob = read_mobile(-mob_num, VIRTUAL)))
-	{
-		send_to_char("Вы точно не помните, как создать данного монстра.\r\n", ch);
-		return 0;
-	}
-	// очищаем умения у оживляемого моба
-	if (spellnum == SPELL_RESSURECTION)
-	{
-		clear_char_skills(mob);
-		// Меняем именование.
-		sprintf(buf2, "умертвие %s %s", GET_PAD(mob, 1), GET_NAME(mob));
-		mob->set_pc_name(buf2);
-		sprintf(buf2, "умертвие %s", GET_PAD(mob, 1));
-		mob->set_npc_name(buf2);
-		mob->player_data.long_descr = "";
-		sprintf(buf2, "умертвие %s", GET_PAD(mob, 1));
-		mob->player_data.PNames[0] = std::string(buf2);
-		sprintf(buf2, "умертвию %s", GET_PAD(mob, 1));
-		mob->player_data.PNames[2] = std::string(buf2);
-		sprintf(buf2, "умертвие %s", GET_PAD(mob, 1));
-		mob->player_data.PNames[3] = std::string(buf2);
-		sprintf(buf2, "умертвием %s", GET_PAD(mob, 1));
-		mob->player_data.PNames[4] = std::string(buf2);
-		sprintf(buf2, "умертвии %s", GET_PAD(mob, 1));
-		mob->player_data.PNames[5] = std::string(buf2);
-		sprintf(buf2, "умертвия %s", GET_PAD(mob, 1));
-		mob->player_data.PNames[1] = std::string(buf2);
-		mob->set_sex(ESex::SEX_NEUTRAL);
-		MOB_FLAGS(mob).set(MOB_RESURRECTED);	// added by Pereplut
-		// если есть фит ярость тьмы, то прибавляем к хп и дамролам
-		if (can_use_feat(ch, FURYDARK_FEAT))
-		{
-			GET_DR(mob) = GET_DR(mob) + GET_DR(mob) * 0.20;
-			GET_MAX_HIT(mob) = GET_MAX_HIT(mob) + GET_MAX_HIT(mob) * 0.20;
-			GET_HIT(mob) = GET_MAX_HIT(mob);
-			GET_HR(mob) = GET_HR(mob) + GET_HR(mob) * 0.20;
-		}
-	}
-	char_to_room(mob, ch->in_room);
-	if (!IS_IMMORTAL(ch) && (AFF_FLAGGED(mob, EAffectFlag::AFF_SANCTUARY) || MOB_FLAGGED(mob, MOB_PROTECT)))
-	{
-		send_to_char("Оживляемый был освящен Богами и противится этому!\r\n", ch);
-		extract_char(mob, FALSE);
-		return 0;
-	}
-	if (!IS_IMMORTAL(ch) && (GET_MOB_SPEC(mob) || MOB_FLAGGED(mob, MOB_NORESURRECTION) || MOB_FLAGGED(mob, MOB_AREA_ATTACK)))
-	{
-		send_to_char("Вы не можете обрести власть над этим созданием!\r\n", ch);
-		extract_char(mob, FALSE);
-		return 0;
-	}
-	if (!IS_IMMORTAL(ch) && AFF_FLAGGED(mob, EAffectFlag::AFF_SHIELD))
-	{
-		send_to_char("Боги защищают это существо даже после смерти.\r\n", ch);
-		extract_char(mob, FALSE);
-		return 0;
-	}
-	if (MOB_FLAGGED(mob, MOB_MOUNTING))
-	{
-		MOB_FLAGS(mob).unset(MOB_MOUNTING);
-	}
-	if (IS_HORSE(mob))
-	{
-		send_to_char("Это был боевой скакун, а не хухры-мухры.\r\n", ch);
-		extract_char(mob, FALSE);
-		return 0;
-	}
+  if (!(mob = read_mobile(-mob_num, VIRTUAL))) {
+    send_to_char("Вы точно не помните, как создать данного монстра.\r\n", ch);
+    return 0;
+  }
+  // очищаем умения у оживляемого моба
+  if (spellnum == SPELL_RESSURECTION) {
+    clear_char_skills(mob);
+    // Меняем именование.
+    sprintf(buf2, "умертвие %s %s", GET_PAD(mob, 1), GET_NAME(mob));
+    mob->set_pc_name(buf2);
+    sprintf(buf2, "умертвие %s", GET_PAD(mob, 1));
+    mob->set_npc_name(buf2);
+    mob->player_data.long_descr = "";
+    sprintf(buf2, "умертвие %s", GET_PAD(mob, 1));
+    mob->player_data.PNames[0] = std::string(buf2);
+    sprintf(buf2, "умертвию %s", GET_PAD(mob, 1));
+    mob->player_data.PNames[2] = std::string(buf2);
+    sprintf(buf2, "умертвие %s", GET_PAD(mob, 1));
+    mob->player_data.PNames[3] = std::string(buf2);
+    sprintf(buf2, "умертвием %s", GET_PAD(mob, 1));
+    mob->player_data.PNames[4] = std::string(buf2);
+    sprintf(buf2, "умертвии %s", GET_PAD(mob, 1));
+    mob->player_data.PNames[5] = std::string(buf2);
+    sprintf(buf2, "умертвия %s", GET_PAD(mob, 1));
+    mob->player_data.PNames[1] = std::string(buf2);
+    mob->set_sex(ESex::SEX_NEUTRAL);
+    MOB_FLAGS(mob).set(MOB_RESURRECTED);    // added by Pereplut
+    // если есть фит ярость тьмы, то прибавляем к хп и дамролам
+    if (can_use_feat(ch, FURYDARK_FEAT)) {
+      GET_DR(mob) = GET_DR(mob) + GET_DR(mob) * 0.20;
+      GET_MAX_HIT(mob) = GET_MAX_HIT(mob) + GET_MAX_HIT(mob) * 0.20;
+      GET_HIT(mob) = GET_MAX_HIT(mob);
+      GET_HR(mob) = GET_HR(mob) + GET_HR(mob) * 0.20;
+    }
+  }
+  char_to_room(mob, ch->in_room);
+  if (!IS_IMMORTAL(ch) && (AFF_FLAGGED(mob, EAffectFlag::AFF_SANCTUARY) || MOB_FLAGGED(mob, MOB_PROTECT))) {
+    send_to_char("Оживляемый был освящен Богами и противится этому!\r\n", ch);
+    extract_char(mob, FALSE);
+    return 0;
+  }
+  if (!IS_IMMORTAL(ch)
+      && (GET_MOB_SPEC(mob) || MOB_FLAGGED(mob, MOB_NORESURRECTION) || MOB_FLAGGED(mob, MOB_AREA_ATTACK))) {
+    send_to_char("Вы не можете обрести власть над этим созданием!\r\n", ch);
+    extract_char(mob, FALSE);
+    return 0;
+  }
+  if (!IS_IMMORTAL(ch) && AFF_FLAGGED(mob, EAffectFlag::AFF_SHIELD)) {
+    send_to_char("Боги защищают это существо даже после смерти.\r\n", ch);
+    extract_char(mob, FALSE);
+    return 0;
+  }
+  if (MOB_FLAGGED(mob, MOB_MOUNTING)) {
+    MOB_FLAGS(mob).unset(MOB_MOUNTING);
+  }
+  if (IS_HORSE(mob)) {
+    send_to_char("Это был боевой скакун, а не хухры-мухры.\r\n", ch);
+    extract_char(mob, FALSE);
+    return 0;
+  }
 
-	if (spellnum == SPELL_ANIMATE_DEAD && mob_num >= MOB_NECRODAMAGER && mob_num <= LAST_NECRO_MOB) {
-		// add 10% mob health by remort
-		mob->set_max_hit(mob->get_max_hit() * (1.0 + ch->get_remort() / 10.0));
-		mob->set_hit(mob->get_max_hit());
-		int player_charms_value = get_player_charms(ch, spellnum);
-		int mob_cahrms_value = get_reformed_charmice_hp(ch, mob, spellnum);
-		int damnodice = 1;
-		mob->mob_specials.damnodice = damnodice;
-		// look for count dice to maximize damage on player_charms_value. max 255.
-		while (player_charms_value > mob_cahrms_value && damnodice <= 255) {
-			damnodice++;
-			mob->mob_specials.damnodice = damnodice;
-			mob_cahrms_value = get_reformed_charmice_hp(ch, mob, spellnum);
-		}
-		damnodice--;
+  if (spellnum == SPELL_ANIMATE_DEAD && mob_num >= MOB_NECRODAMAGER && mob_num <= LAST_NECRO_MOB) {
+    // add 10% mob health by remort
+    mob->set_max_hit(mob->get_max_hit() * (1.0 + ch->get_remort() / 10.0));
+    mob->set_hit(mob->get_max_hit());
+    int player_charms_value = get_player_charms(ch, spellnum);
+    int mob_cahrms_value = get_reformed_charmice_hp(ch, mob, spellnum);
+    int damnodice = 1;
+    mob->mob_specials.damnodice = damnodice;
+    // look for count dice to maximize damage on player_charms_value. max 255.
+    while (player_charms_value > mob_cahrms_value && damnodice <= 255) {
+      damnodice++;
+      mob->mob_specials.damnodice = damnodice;
+      mob_cahrms_value = get_reformed_charmice_hp(ch, mob, spellnum);
+    }
+    damnodice--;
 
-		mob->mob_specials.damnodice = damnodice; // get prew damnodice for match with player_charms_value
-		if (damnodice == 255) {
-			// if damnodice == 255 mob damage not maximized. damsize too small
-			send_to_room("Темные искры пробежали по земле... И исчезли...", ch->in_room,0);
-		} else {
-			// mob damage maximazed.
-			send_to_room("Темные искры пробежали по земле. Кажется сама СМЕРТЬ наполняет это тело силой!", ch->in_room,0);
-		}
-	}
+    mob->mob_specials.damnodice = damnodice; // get prew damnodice for match with player_charms_value
+    if (damnodice == 255) {
+      // if damnodice == 255 mob damage not maximized. damsize too small
+      send_to_room("Темные искры пробежали по земле... И исчезли...", ch->in_room, 0);
+    } else {
+      // mob damage maximazed.
+      send_to_room("Темные искры пробежали по земле. Кажется сама СМЕРТЬ наполняет это тело силой!", ch->in_room, 0);
+    }
+  }
 
-	if (!check_charmee(ch, mob, spellnum))
-	{
-		extract_char(mob, FALSE);
-		if (handle_corpse)
-			extract_obj(obj);
-		return 0;
-	}
+  if (!check_charmee(ch, mob, spellnum)) {
+    extract_char(mob, FALSE);
+    if (handle_corpse)
+      extract_obj(obj);
+    return 0;
+  }
 
-	mob->set_exp(0);
-	IS_CARRYING_W(mob) = 0;
-	IS_CARRYING_N(mob) = 0;
-	mob->set_gold(0);
-	GET_GOLD_NoDs(mob) = 0;
-	GET_GOLD_SiDs(mob) = 0;
-	const auto days_from_full_moon =
-		(weather_info.moon_day < 14) ? (14 - weather_info.moon_day) : (weather_info.moon_day - 14);
-	const auto duration = pc_duration(mob, GET_REAL_WIS(ch) + number(0, days_from_full_moon), 0, 0, 0, 0);
-	AFFECT_DATA<EApplyLocation> af;
-	af.type = SPELL_CHARM;
-	af.duration = duration;
-	af.modifier = 0;
-	af.location = EApplyLocation::APPLY_NONE;
-	af.bitvector = to_underlying(EAffectFlag::AFF_CHARM);
-	af.battleflag = 0;
-	affect_to_char(mob, af);
-	if (keeper)
-	{
-		af.bitvector = to_underlying(EAffectFlag::AFF_HELPER);
-		affect_to_char(mob, af);
-		mob->set_skill(SKILL_RESCUE, 100);
-	}
+  mob->set_exp(0);
+  IS_CARRYING_W(mob) = 0;
+  IS_CARRYING_N(mob) = 0;
+  mob->set_gold(0);
+  GET_GOLD_NoDs(mob) = 0;
+  GET_GOLD_SiDs(mob) = 0;
+  const auto days_from_full_moon =
+      (weather_info.moon_day < 14) ? (14 - weather_info.moon_day) : (weather_info.moon_day - 14);
+  const auto duration = pc_duration(mob, GET_REAL_WIS(ch) + number(0, days_from_full_moon), 0, 0, 0, 0);
+  AFFECT_DATA<EApplyLocation> af;
+  af.type = SPELL_CHARM;
+  af.duration = duration;
+  af.modifier = 0;
+  af.location = EApplyLocation::APPLY_NONE;
+  af.bitvector = to_underlying(EAffectFlag::AFF_CHARM);
+  af.battleflag = 0;
+  affect_to_char(mob, af);
+  if (keeper) {
+    af.bitvector = to_underlying(EAffectFlag::AFF_HELPER);
+    affect_to_char(mob, af);
+    mob->set_skill(SKILL_RESCUE, 100);
+  }
 
-	MOB_FLAGS(mob).set(MOB_CORPSE);
-	if (spellnum == SPELL_CLONE) {
-		sprintf(buf2, "двойник %s %s", GET_PAD(ch, 1), GET_NAME(ch));
-		mob->set_pc_name(buf2);
-		sprintf(buf2, "двойник %s", GET_PAD(ch, 1));
-		mob->set_npc_name(buf2);
-		mob->player_data.long_descr = "";
-		sprintf(buf2, "двойник %s", GET_PAD(ch, 1));
-		mob->player_data.PNames[0] = std::string(buf2);
-		sprintf(buf2, "двойника %s", GET_PAD(ch, 1));
-		mob->player_data.PNames[1] = std::string(buf2);
-		sprintf(buf2, "двойнику %s", GET_PAD(ch, 1));
-		mob->player_data.PNames[2] = std::string(buf2);
-		sprintf(buf2, "двойника %s", GET_PAD(ch, 1));
-		mob->player_data.PNames[3] = std::string(buf2);
-		sprintf(buf2, "двойником %s", GET_PAD(ch, 1));
-		mob->player_data.PNames[4] = std::string(buf2);
-		sprintf(buf2, "двойнике %s", GET_PAD(ch, 1));
-		mob->player_data.PNames[5] = std::string(buf2);
+  MOB_FLAGS(mob).set(MOB_CORPSE);
+  if (spellnum == SPELL_CLONE) {
+    sprintf(buf2, "двойник %s %s", GET_PAD(ch, 1), GET_NAME(ch));
+    mob->set_pc_name(buf2);
+    sprintf(buf2, "двойник %s", GET_PAD(ch, 1));
+    mob->set_npc_name(buf2);
+    mob->player_data.long_descr = "";
+    sprintf(buf2, "двойник %s", GET_PAD(ch, 1));
+    mob->player_data.PNames[0] = std::string(buf2);
+    sprintf(buf2, "двойника %s", GET_PAD(ch, 1));
+    mob->player_data.PNames[1] = std::string(buf2);
+    sprintf(buf2, "двойнику %s", GET_PAD(ch, 1));
+    mob->player_data.PNames[2] = std::string(buf2);
+    sprintf(buf2, "двойника %s", GET_PAD(ch, 1));
+    mob->player_data.PNames[3] = std::string(buf2);
+    sprintf(buf2, "двойником %s", GET_PAD(ch, 1));
+    mob->player_data.PNames[4] = std::string(buf2);
+    sprintf(buf2, "двойнике %s", GET_PAD(ch, 1));
+    mob->player_data.PNames[5] = std::string(buf2);
 
-		mob->set_str(ch->get_str());
-		mob->set_dex(ch->get_dex());
-		mob->set_con(ch->get_con());
-		mob->set_wis(ch->get_wis());
-		mob->set_int(ch->get_int());
-		mob->set_cha(ch->get_cha());
+    mob->set_str(ch->get_str());
+    mob->set_dex(ch->get_dex());
+    mob->set_con(ch->get_con());
+    mob->set_wis(ch->get_wis());
+    mob->set_int(ch->get_int());
+    mob->set_cha(ch->get_cha());
 
-		mob->set_level(ch->get_level());
-		GET_HR(mob) = -20;
-		GET_AC(mob) = GET_AC(ch);
-		GET_DR(mob) = GET_DR(ch);
+    mob->set_level(ch->get_level());
+    GET_HR(mob) = -20;
+    GET_AC(mob) = GET_AC(ch);
+    GET_DR(mob) = GET_DR(ch);
 
-		GET_MAX_HIT(mob) = GET_MAX_HIT(ch);
-		GET_HIT(mob) = GET_MAX_HIT(ch);
-		mob->mob_specials.damnodice = 0;
-		mob->mob_specials.damsizedice = 0;
-		mob->set_gold(0);
-		GET_GOLD_NoDs(mob) = 0;
-		GET_GOLD_SiDs(mob) = 0;
-		mob->set_exp(0);
+    GET_MAX_HIT(mob) = GET_MAX_HIT(ch);
+    GET_HIT(mob) = GET_MAX_HIT(ch);
+    mob->mob_specials.damnodice = 0;
+    mob->mob_specials.damsizedice = 0;
+    mob->set_gold(0);
+    GET_GOLD_NoDs(mob) = 0;
+    GET_GOLD_SiDs(mob) = 0;
+    mob->set_exp(0);
 
-		GET_POS(mob) = POS_STANDING;
-		GET_DEFAULT_POS(mob) = POS_STANDING;
-		mob->set_sex(ESex::SEX_MALE);
+    GET_POS(mob) = POS_STANDING;
+    GET_DEFAULT_POS(mob) = POS_STANDING;
+    mob->set_sex(ESex::SEX_MALE);
 
-		mob->set_class(ch->get_class());
-		GET_WEIGHT(mob) = GET_WEIGHT(ch);
-		GET_HEIGHT(mob) = GET_HEIGHT(ch);
-		GET_SIZE(mob) = GET_SIZE(ch);
-		MOB_FLAGS(mob).set(MOB_CLONE);
-		MOB_FLAGS(mob).unset(MOB_MOUNTING);
-	}
-	act(mag_summon_msgs[msg], FALSE, ch, 0, mob, TO_ROOM | TO_ARENA_LISTEN);
+    mob->set_class(ch->get_class());
+    GET_WEIGHT(mob) = GET_WEIGHT(ch);
+    GET_HEIGHT(mob) = GET_HEIGHT(ch);
+    GET_SIZE(mob) = GET_SIZE(ch);
+    MOB_FLAGS(mob).set(MOB_CLONE);
+    MOB_FLAGS(mob).unset(MOB_MOUNTING);
+  }
+  act(mag_summon_msgs[msg], FALSE, ch, 0, mob, TO_ROOM | TO_ARENA_LISTEN);
 
-	ch->add_follower(mob);
-	if (spellnum == SPELL_CLONE)
-	{
-		// клоны теперь кастятся все вместе // ужасно некрасиво сделано
-		for (k = ch->followers; k; k = k->next)
-		{
-			if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_CHARM)
-				&& k->follower->get_master() == ch)
-			{
-				cha_num++;
-			}
-		}
-		cha_num = MAX(1, (GET_LEVEL(ch) + 4) / 5 - 2) - cha_num;
-		if (cha_num < 1)
-			return 0;
-		mag_summons(level, ch, obj, spellnum, 0);
-	}
-	if (spellnum == SPELL_ANIMATE_DEAD)
-	{
-		MOB_FLAGS(mob).set(MOB_RESURRECTED);
-		if (mob_num == MOB_SKELETON && can_use_feat(ch, LOYALASSIST_FEAT))
-			mob->set_skill(SKILL_RESCUE, 100);
+  ch->add_follower(mob);
+  if (spellnum == SPELL_CLONE) {
+    // клоны теперь кастятся все вместе // ужасно некрасиво сделано
+    for (k = ch->followers; k; k = k->next) {
+      if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_CHARM)
+          && k->follower->get_master() == ch) {
+        cha_num++;
+      }
+    }
+    cha_num = MAX(1, (GET_LEVEL(ch) + 4) / 5 - 2) - cha_num;
+    if (cha_num < 1)
+      return 0;
+    mag_summons(level, ch, obj, spellnum, 0);
+  }
+  if (spellnum == SPELL_ANIMATE_DEAD) {
+    MOB_FLAGS(mob).set(MOB_RESURRECTED);
+    if (mob_num == MOB_SKELETON && can_use_feat(ch, LOYALASSIST_FEAT))
+      mob->set_skill(SKILL_RESCUE, 100);
 
-		if (mob_num == MOB_BONESPIRIT && can_use_feat(ch, HAUNTINGSPIRIT_FEAT	))
-			mob->set_skill(SKILL_RESCUE, 120);
+    if (mob_num == MOB_BONESPIRIT && can_use_feat(ch, HAUNTINGSPIRIT_FEAT))
+      mob->set_skill(SKILL_RESCUE, 120);
 
-		// даем всем поднятым, ну наверное не будет чернок 75+ мудры вызывать зомби в щите.
-		float eff_wis = get_effective_wis(ch,spellnum);
-		if (eff_wis>=65)
-		{
-			// пока не даем, если надо включите
-			//af.bitvector = to_underlying(EAffectFlag::AFF_MAGICGLASS);
-			//affect_to_char(mob, af);
-		}
-		if (eff_wis>=75)
-		{
-			AFFECT_DATA<EApplyLocation> af;
-			af.type = SPELL_NO_SPELL;
-			af.duration = duration * (1+ GET_REMORT(ch));
-			af.modifier = 0;
-			af.location = EApplyLocation::APPLY_NONE;
-			af.bitvector = to_underlying(EAffectFlag::AFF_ICESHIELD);
-			af.battleflag = 0;
-			affect_to_char(mob, af);
-		}
+    // даем всем поднятым, ну наверное не будет чернок 75+ мудры вызывать зомби в щите.
+    float eff_wis = get_effective_wis(ch, spellnum);
+    if (eff_wis >= 65) {
+      // пока не даем, если надо включите
+      //af.bitvector = to_underlying(EAffectFlag::AFF_MAGICGLASS);
+      //affect_to_char(mob, af);
+    }
+    if (eff_wis >= 75) {
+      AFFECT_DATA<EApplyLocation> af;
+      af.type = SPELL_NO_SPELL;
+      af.duration = duration * (1 + GET_REMORT(ch));
+      af.modifier = 0;
+      af.location = EApplyLocation::APPLY_NONE;
+      af.bitvector = to_underlying(EAffectFlag::AFF_ICESHIELD);
+      af.battleflag = 0;
+      affect_to_char(mob, af);
+    }
 
-	}
+  }
 
-	if (spellnum == SPELL_SUMMON_KEEPER) {
-		// Svent TODO: не забыть перенести это в ability
-		mob->set_level(ch->get_level());
-        int rating  = (ch->get_skill(SKILL_LIGHT_MAGIC) + GET_REAL_CHA(ch))/2;
-		GET_MAX_HIT(mob) = GET_HIT(mob) = 50 + dice(10, 10) + rating*6;
-		mob->set_skill(SKILL_PUNCH, 10 + rating*1.5);
-		mob->set_skill(SKILL_RESCUE, 50 + rating);
-		mob->set_str(3+rating/5);
-		mob->set_dex(10+rating/5);
-		mob->set_con(10+rating/5);
-		GET_HR(mob) = rating/2 - 4;
-		GET_AC(mob) = 100 -  rating*2.65;
-	}
+  if (spellnum == SPELL_SUMMON_KEEPER) {
+    // Svent TODO: не забыть перенести это в ability
+    mob->set_level(ch->get_level());
+    int rating = (ch->get_skill(SKILL_LIGHT_MAGIC) + GET_REAL_CHA(ch)) / 2;
+    GET_MAX_HIT(mob) = GET_HIT(mob) = 50 + dice(10, 10) + rating * 6;
+    mob->set_skill(SKILL_PUNCH, 10 + rating * 1.5);
+    mob->set_skill(SKILL_RESCUE, 50 + rating);
+    mob->set_str(3 + rating / 5);
+    mob->set_dex(10 + rating / 5);
+    mob->set_con(10 + rating / 5);
+    GET_HR(mob) = rating / 2 - 4;
+    GET_AC(mob) = 100 - rating * 2.65;
+  }
 
-	if (spellnum == SPELL_SUMMON_FIREKEEPER) {
-		AFFECT_DATA<EApplyLocation> af;
-		af.type = SPELL_CHARM;
-		af.duration = duration;
-		af.modifier = 0;
-		af.location = EApplyLocation::APPLY_NONE;
-		af.battleflag = 0;
-		if (get_effective_cha(ch) >= 30)
-		{
-			af.bitvector = to_underlying(EAffectFlag::AFF_FIRESHIELD);
-			affect_to_char(mob, af);
-		}
-		else
-		{
-			af.bitvector = to_underlying(EAffectFlag::AFF_FIREAURA);
-			affect_to_char(mob, af);
-		}
+  if (spellnum == SPELL_SUMMON_FIREKEEPER) {
+    AFFECT_DATA<EApplyLocation> af;
+    af.type = SPELL_CHARM;
+    af.duration = duration;
+    af.modifier = 0;
+    af.location = EApplyLocation::APPLY_NONE;
+    af.battleflag = 0;
+    if (get_effective_cha(ch) >= 30) {
+      af.bitvector = to_underlying(EAffectFlag::AFF_FIRESHIELD);
+      affect_to_char(mob, af);
+    } else {
+      af.bitvector = to_underlying(EAffectFlag::AFF_FIREAURA);
+      affect_to_char(mob, af);
+    }
 
-		modifier = VPOSI((int)get_effective_cha(ch) - 20, 0, 30);
+    modifier = VPOSI((int) get_effective_cha(ch) - 20, 0, 30);
 
-		GET_DR(mob) = 10 + modifier * 3 / 2;
-		GET_NDD(mob) = 1;
-		GET_SDD(mob) = modifier / 5 + 1;
-		mob->mob_specials.ExtraAttack = 0;
+    GET_DR(mob) = 10 + modifier * 3 / 2;
+    GET_NDD(mob) = 1;
+    GET_SDD(mob) = modifier / 5 + 1;
+    mob->mob_specials.ExtraAttack = 0;
 
-		GET_MAX_HIT(mob) = GET_HIT(mob) = 300 + number(modifier * 12, modifier * 16);
-		mob->set_skill(SKILL_AWAKE, 50 + modifier * 2);
-		PRF_FLAGS(mob).set(PRF_AWAKE);
-	}
-	MOB_FLAGS(mob).set(MOB_NOTRAIN);
+    GET_MAX_HIT(mob) = GET_HIT(mob) = 300 + number(modifier * 12, modifier * 16);
+    mob->set_skill(SKILL_AWAKE, 50 + modifier * 2);
+    PRF_FLAGS(mob).set(PRF_AWAKE);
+  }
+  MOB_FLAGS(mob).set(MOB_NOTRAIN);
 
-	// А надо ли это вообще делать???
-	if (handle_corpse)
-	{
-		for (tobj = obj->get_contains(); tobj;)
-		{
-			next_obj = tobj->get_next_content();
-			obj_from_obj(tobj);
-			obj_to_room(tobj, ch->in_room);
-			if (!obj_decay(tobj) && tobj->get_in_room() != NOWHERE)
-			{
-				act("На земле остал$U лежать $o.", FALSE, ch, tobj, 0, TO_ROOM | TO_ARENA_LISTEN);
-			}
-			tobj = next_obj;
-		}
-		extract_obj(obj);
-	}
-	return 1;
+  // А надо ли это вообще делать???
+  if (handle_corpse) {
+    for (tobj = obj->get_contains(); tobj;) {
+      next_obj = tobj->get_next_content();
+      obj_from_obj(tobj);
+      obj_to_room(tobj, ch->in_room);
+      if (!obj_decay(tobj) && tobj->get_in_room() != NOWHERE) {
+        act("На земле остал$U лежать $o.", FALSE, ch, tobj, 0, TO_ROOM | TO_ARENA_LISTEN);
+      }
+      tobj = next_obj;
+    }
+    extract_obj(obj);
+  }
+  return 1;
 }
 
-int mag_points(int level, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int)
-{
-	int hit = 0; //если выставить больше нуля, то лечит
-	int move = 0; //если выставить больше нуля, то реген хп
-	bool extraHealing = false; //если true, то лечит сверх макс.хп
+int mag_points(int level, CHAR_DATA *ch, CHAR_DATA *victim, int spellnum, int) {
+  int hit = 0; //если выставить больше нуля, то лечит
+  int move = 0; //если выставить больше нуля, то реген хп
+  bool extraHealing = false; //если true, то лечит сверх макс.хп
 
-	if (victim == nullptr)	{
-		log("MAG_POINTS: Ошибка! Не указана цель, спелл spellnum: %d!\r\n", spellnum);
-		return 0;
-	}
+  if (victim == nullptr) {
+    log("MAG_POINTS: Ошибка! Не указана цель, спелл spellnum: %d!\r\n", spellnum);
+    return 0;
+  }
 
-	switch (spellnum)
-	{
-	case SPELL_CURE_LIGHT:
-		hit = dice(6, 3) + (level + 2) / 3;
-		send_to_char("Вы почувствовали себя немножко лучше.\r\n", victim);
-		break;
-	case SPELL_CURE_SERIOUS:
-		hit = dice(25, 2) + (level + 2) / 3;
-		send_to_char("Вы почувствовали себя намного лучше.\r\n", victim);
-		break;
-	case SPELL_CURE_CRITIC:
-		hit = dice(45, 2) + level;
-		send_to_char("Вы почувствовали себя значительно лучше.\r\n", victim);
-		break;
-	case SPELL_HEAL:
-	case SPELL_GROUP_HEAL:
-		hit = GET_REAL_MAX_HIT(victim) - GET_HIT(victim);
-		send_to_char("Вы почувствовали себя здоровым.\r\n", victim);
-		break;
-	case SPELL_PATRONAGE:
-		hit = (GET_LEVEL(victim) + GET_REMORT(victim)) * 2;
-		break;
-	case SPELL_WC_OF_POWER:
-		hit = MIN(200, (4 * ch->get_con() + ch->get_skill(SKILL_WARCRY)) / 2);
-		send_to_char("По вашему телу начала струиться живительная сила.\r\n", victim);
-		break;
-	case SPELL_EXTRA_HITS:
-		extraHealing = true;
-		hit = dice(10, level / 3) + level;
-		send_to_char("По вашему телу начала струиться живительная сила.\r\n", victim);
-		break;
-	case SPELL_EVILESS:
-	//лечим только умертвия-чармисы
-		if (!IS_NPC(victim) || victim->get_master() != ch || !MOB_FLAGGED(victim, MOB_CORPSE))
-			return 1;
-	//при рекасте - не лечим
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_EVILESS)){
-			hit = GET_REAL_MAX_HIT(victim) - GET_HIT(victim);
-			affect_from_char(ch, SPELL_EVILESS); //сбрасываем аффект с хозяина
-		}
-		break;
-	case SPELL_REFRESH:
-	case SPELL_GROUP_REFRESH:
-		move = GET_REAL_MAX_MOVE(victim) - GET_MOVE(victim);
-		send_to_char("Вы почувствовали себя полным сил.\r\n", victim);
-		break;
-	case SPELL_FULL:
-	case SPELL_COMMON_MEAL:
-		{
-			if (GET_COND(victim, THIRST) > 0)
-				GET_COND(victim, THIRST) = 0;
-			if (GET_COND(victim, FULL) > 0)
-				GET_COND(victim, FULL) = 0;
-			send_to_char("Вы полностью насытились.\r\n", victim);
-		}
-		break;
-	default:
-		log("MAG_POINTS: Ошибка! Передан не определенный лечащий спелл spellnum: %d!\r\n", spellnum);
-		return 0;
-		break;
-	}
+  switch (spellnum) {
+    case SPELL_CURE_LIGHT: hit = dice(6, 3) + (level + 2) / 3;
+      send_to_char("Вы почувствовали себя немножко лучше.\r\n", victim);
+      break;
+    case SPELL_CURE_SERIOUS: hit = dice(25, 2) + (level + 2) / 3;
+      send_to_char("Вы почувствовали себя намного лучше.\r\n", victim);
+      break;
+    case SPELL_CURE_CRITIC: hit = dice(45, 2) + level;
+      send_to_char("Вы почувствовали себя значительно лучше.\r\n", victim);
+      break;
+    case SPELL_HEAL:
+    case SPELL_GROUP_HEAL: hit = GET_REAL_MAX_HIT(victim) - GET_HIT(victim);
+      send_to_char("Вы почувствовали себя здоровым.\r\n", victim);
+      break;
+    case SPELL_PATRONAGE: hit = (GET_LEVEL(victim) + GET_REMORT(victim)) * 2;
+      break;
+    case SPELL_WC_OF_POWER: hit = MIN(200, (4 * ch->get_con() + ch->get_skill(SKILL_WARCRY)) / 2);
+      send_to_char("По вашему телу начала струиться живительная сила.\r\n", victim);
+      break;
+    case SPELL_EXTRA_HITS: extraHealing = true;
+      hit = dice(10, level / 3) + level;
+      send_to_char("По вашему телу начала струиться живительная сила.\r\n", victim);
+      break;
+    case SPELL_EVILESS:
+      //лечим только умертвия-чармисы
+      if (!IS_NPC(victim) || victim->get_master() != ch || !MOB_FLAGGED(victim, MOB_CORPSE))
+        return 1;
+      //при рекасте - не лечим
+      if (AFF_FLAGGED(ch, EAffectFlag::AFF_EVILESS)) {
+        hit = GET_REAL_MAX_HIT(victim) - GET_HIT(victim);
+        affect_from_char(ch, SPELL_EVILESS); //сбрасываем аффект с хозяина
+      }
+      break;
+    case SPELL_REFRESH:
+    case SPELL_GROUP_REFRESH: move = GET_REAL_MAX_MOVE(victim) - GET_MOVE(victim);
+      send_to_char("Вы почувствовали себя полным сил.\r\n", victim);
+      break;
+    case SPELL_FULL:
+    case SPELL_COMMON_MEAL: {
+      if (GET_COND(victim, THIRST) > 0)
+        GET_COND(victim, THIRST) = 0;
+      if (GET_COND(victim, FULL) > 0)
+        GET_COND(victim, FULL) = 0;
+      send_to_char("Вы полностью насытились.\r\n", victim);
+    }
+      break;
+    default: log("MAG_POINTS: Ошибка! Передан не определенный лечащий спелл spellnum: %d!\r\n", spellnum);
+      return 0;
+      break;
+  }
 
-	hit = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_EFFECT, hit);
+  hit = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_EFFECT, hit);
 
-	if (hit && victim->get_fighting() && ch != victim){
-		if (!pk_agro_action(ch, victim->get_fighting()))
-			return 0;
-	}
-	// лечение
-	if (GET_HIT(victim) < MAX_HITS && hit != 0) {
-		// просто лечим
-		if (!extraHealing  &&  GET_HIT(victim) < GET_REAL_MAX_HIT(victim))
-			GET_HIT(victim) = MIN(GET_HIT(victim) + hit, GET_REAL_MAX_HIT(victim));
-		// добавляем фикс.хиты сверх максимума
-		if (extraHealing) {
-			// если макс.хп отрицательные - доводим до 1
-			if (GET_REAL_MAX_HIT(victim) <= 0)
-				GET_HIT(victim) = MAX(GET_HIT(victim), MIN(GET_HIT(victim) + hit, 1));
-			else
-			// лимит в треть от макс.хп сверху
-				GET_HIT(victim) = MAX(GET_HIT(victim),
-									MIN(GET_HIT(victim) + hit,
-										GET_REAL_MAX_HIT(victim) + GET_REAL_MAX_HIT(victim) * 33 / 100));
-		}
-	}
-	if (move != 0 && GET_MOVE(victim) < GET_REAL_MAX_MOVE(victim))
-		GET_MOVE(victim) = MIN(GET_MOVE(victim) + move, GET_REAL_MAX_MOVE(victim));
-	update_pos(victim);
+  if (hit && victim->get_fighting() && ch != victim) {
+    if (!pk_agro_action(ch, victim->get_fighting()))
+      return 0;
+  }
+  // лечение
+  if (GET_HIT(victim) < MAX_HITS && hit != 0) {
+    // просто лечим
+    if (!extraHealing && GET_HIT(victim) < GET_REAL_MAX_HIT(victim))
+      GET_HIT(victim) = MIN(GET_HIT(victim) + hit, GET_REAL_MAX_HIT(victim));
+    // добавляем фикс.хиты сверх максимума
+    if (extraHealing) {
+      // если макс.хп отрицательные - доводим до 1
+      if (GET_REAL_MAX_HIT(victim) <= 0)
+        GET_HIT(victim) = MAX(GET_HIT(victim), MIN(GET_HIT(victim) + hit, 1));
+      else
+        // лимит в треть от макс.хп сверху
+        GET_HIT(victim) = MAX(GET_HIT(victim),
+                              MIN(GET_HIT(victim) + hit,
+                                  GET_REAL_MAX_HIT(victim) + GET_REAL_MAX_HIT(victim) * 33 / 100));
+    }
+  }
+  if (move != 0 && GET_MOVE(victim) < GET_REAL_MAX_MOVE(victim))
+    GET_MOVE(victim) = MIN(GET_MOVE(victim) + move, GET_REAL_MAX_MOVE(victim));
+  update_pos(victim);
 
-	return 1;
+  return 1;
 }
 
-inline bool NODISPELL(const AFFECT_DATA<EApplyLocation>::shared_ptr& affect)
-{
-	return !affect
-		|| !spell_info[affect->type].name
-		|| *spell_info[affect->type].name == '!'
-		|| affect->bitvector == to_underlying(EAffectFlag::AFF_CHARM)
-		|| affect->type == SPELL_CHARM
-		|| affect->type == SPELL_QUEST
-		|| affect->type == SPELL_FASCINATION
-		|| affect->type == SPELL_PATRONAGE
-		|| affect->type == SPELL_SOLOBONUS
-		|| affect->type == SPELL_EVILESS;
+inline bool NODISPELL(const AFFECT_DATA<EApplyLocation>::shared_ptr &affect) {
+  return !affect
+      || !spell_info[affect->type].name
+      || *spell_info[affect->type].name == '!'
+      || affect->bitvector == to_underlying(EAffectFlag::AFF_CHARM)
+      || affect->type == SPELL_CHARM
+      || affect->type == SPELL_QUEST
+      || affect->type == SPELL_FASCINATION
+      || affect->type == SPELL_PATRONAGE
+      || affect->type == SPELL_SOLOBONUS
+      || affect->type == SPELL_EVILESS;
 }
 
-int mag_unaffects(int/* level*/, CHAR_DATA * ch, CHAR_DATA * victim, int spellnum, int/* type*/)
-{
-	int spell = 0, remove = 0;
-	const char *to_vict = nullptr, *to_room = nullptr;
+int mag_unaffects(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, int spellnum, int/* type*/) {
+  int spell = 0, remove = 0;
+  const char *to_vict = nullptr, *to_room = nullptr;
 
-	if (victim == nullptr)
-	{
-		return 0;
-	}
+  if (victim == nullptr) {
+    return 0;
+  }
 
-	switch (spellnum)
-	{
-	case SPELL_CURE_BLIND:
-		spell = SPELL_BLINDNESS;
-		to_vict = "К вам вернулась способность видеть.";
-		to_room = "$n прозрел$g.";
-		break;
-	case SPELL_REMOVE_POISON:
-		spell = SPELL_POISON;
-		to_vict = "Тепло заполнило ваше тело.";
-		to_room = "$n выглядит лучше.";
-		break;
-	case SPELL_CURE_PLAQUE:
-		spell = SPELL_PLAQUE;
-		to_vict = "Лихорадка прекратилась.";
-		break;
-	case SPELL_REMOVE_CURSE:
-		spell = SPELL_CURSE;
-		to_vict = "Боги вернули вам свое покровительство.";
-		break;
-	case SPELL_REMOVE_HOLD:
-		spell = SPELL_HOLD;
-		to_vict = "К вам вернулась способность двигаться.";
-		break;
-	case SPELL_REMOVE_SILENCE:
-		spell = SPELL_SILENCE;
-		to_vict = "К вам вернулась способность разговаривать.";
-		break;
-	case SPELL_REMOVE_DEAFNESS:
-		spell = SPELL_DEAFNESS;
-		to_vict = "К вам вернулась способность слышать.";
-		break;
-	case SPELL_DISPELL_MAGIC:
-		if (!IS_NPC(ch)
-			&& !same_group(ch, victim))
-		{
-			send_to_char("Только на себя или одногруппника!\r\n", ch);
+  switch (spellnum) {
+    case SPELL_CURE_BLIND: spell = SPELL_BLINDNESS;
+      to_vict = "К вам вернулась способность видеть.";
+      to_room = "$n прозрел$g.";
+      break;
+    case SPELL_REMOVE_POISON: spell = SPELL_POISON;
+      to_vict = "Тепло заполнило ваше тело.";
+      to_room = "$n выглядит лучше.";
+      break;
+    case SPELL_CURE_PLAQUE: spell = SPELL_PLAQUE;
+      to_vict = "Лихорадка прекратилась.";
+      break;
+    case SPELL_REMOVE_CURSE: spell = SPELL_CURSE;
+      to_vict = "Боги вернули вам свое покровительство.";
+      break;
+    case SPELL_REMOVE_HOLD: spell = SPELL_HOLD;
+      to_vict = "К вам вернулась способность двигаться.";
+      break;
+    case SPELL_REMOVE_SILENCE: spell = SPELL_SILENCE;
+      to_vict = "К вам вернулась способность разговаривать.";
+      break;
+    case SPELL_REMOVE_DEAFNESS: spell = SPELL_DEAFNESS;
+      to_vict = "К вам вернулась способность слышать.";
+      break;
+    case SPELL_DISPELL_MAGIC:
+      if (!IS_NPC(ch)
+          && !same_group(ch, victim)) {
+        send_to_char("Только на себя или одногруппника!\r\n", ch);
 
-			return 0;
-		}
+        return 0;
+      }
 
-		{
-			const auto affects_count = victim->affected.size();
-			if (0 == affects_count)
-			{
-				send_to_char(NOEFFECT, ch);
-				return 0;
-			}
+      {
+        const auto affects_count = victim->affected.size();
+        if (0 == affects_count) {
+          send_to_char(NOEFFECT, ch);
+          return 0;
+        }
 
-			spell = 1;
-			const auto rspell = number(1, static_cast<int>(affects_count));
-			auto affect_i = victim->affected.begin();
-			while (spell < rspell)
-			{
-				++affect_i;
-				++spell;
-			}
+        spell = 1;
+        const auto rspell = number(1, static_cast<int>(affects_count));
+        auto affect_i = victim->affected.begin();
+        while (spell < rspell) {
+          ++affect_i;
+          ++spell;
+        }
 
-			if (NODISPELL(*affect_i))
-			{
-				send_to_char(NOEFFECT, ch);
+        if (NODISPELL(*affect_i)) {
+          send_to_char(NOEFFECT, ch);
 
-				return 0;
-			}
+          return 0;
+        }
 
-			spell = (*affect_i)->type;
-		}
+        spell = (*affect_i)->type;
+      }
 
-		remove = TRUE;
-		break;
+      remove = TRUE;
+      break;
 
-	default:
-		log("SYSERR: unknown spellnum %d passed to mag_unaffects.", spellnum);
-		return 0;
-	}
+    default: log("SYSERR: unknown spellnum %d passed to mag_unaffects.", spellnum);
+      return 0;
+  }
 
-	if (spellnum == SPELL_REMOVE_POISON && !affected_by_spell(victim, spell))
-	{
-		if (affected_by_spell(victim, SPELL_ACONITUM_POISON))
-			spell = SPELL_ACONITUM_POISON;
-		else if (affected_by_spell(victim, SPELL_SCOPOLIA_POISON))
-			spell = SPELL_SCOPOLIA_POISON;
-		else if (affected_by_spell(victim, SPELL_BELENA_POISON))
-			spell = SPELL_BELENA_POISON;
-		else if (affected_by_spell(victim, SPELL_DATURA_POISON))
-			spell = SPELL_DATURA_POISON;
-	}
+  if (spellnum == SPELL_REMOVE_POISON && !affected_by_spell(victim, spell)) {
+    if (affected_by_spell(victim, SPELL_ACONITUM_POISON))
+      spell = SPELL_ACONITUM_POISON;
+    else if (affected_by_spell(victim, SPELL_SCOPOLIA_POISON))
+      spell = SPELL_SCOPOLIA_POISON;
+    else if (affected_by_spell(victim, SPELL_BELENA_POISON))
+      spell = SPELL_BELENA_POISON;
+    else if (affected_by_spell(victim, SPELL_DATURA_POISON))
+      spell = SPELL_DATURA_POISON;
+  }
 
-	if (!affected_by_spell(victim, spell))
-	{
-		if (spellnum != SPELL_HEAL)	// 'cure blindness' message.
-			send_to_char(NOEFFECT, ch);
-		return 0;
-	}
-	spellnum = spell;
-	if (ch != victim && !remove)
-	{
-		if (IS_SET(SpINFO.routines, NPC_AFFECT_NPC))
-		{
-			if (!pk_agro_action(ch, victim))
-				return 0;
-		}
-		else if (IS_SET(SpINFO.routines, NPC_AFFECT_PC) && victim->get_fighting())
-		{
-			if (!pk_agro_action(ch, victim->get_fighting()))
-				return 0;
-		}
-	}
+  if (!affected_by_spell(victim, spell)) {
+    if (spellnum != SPELL_HEAL)    // 'cure blindness' message.
+      send_to_char(NOEFFECT, ch);
+    return 0;
+  }
+  spellnum = spell;
+  if (ch != victim && !remove) {
+    if (IS_SET(SpINFO.routines, NPC_AFFECT_NPC)) {
+      if (!pk_agro_action(ch, victim))
+        return 0;
+    } else if (IS_SET(SpINFO.routines, NPC_AFFECT_PC) && victim->get_fighting()) {
+      if (!pk_agro_action(ch, victim->get_fighting()))
+        return 0;
+    }
+  }
 //Polud затычка для закла !удалить яд!. По хорошему нужно его переделать с параметром - тип удаляемого яда
-	if (spell == SPELL_POISON)
-	{
-		affect_from_char(victim, SPELL_ACONITUM_POISON);
-		affect_from_char(victim, SPELL_DATURA_POISON);
-		affect_from_char(victim, SPELL_SCOPOLIA_POISON);
-		affect_from_char(victim, SPELL_BELENA_POISON);
-	}
-	affect_from_char(victim, spell);
-	if (to_vict != nullptr)
-		act(to_vict, FALSE, victim, 0, ch, TO_CHAR);
-	if (to_room != nullptr)
-		act(to_room, TRUE, victim, 0, ch, TO_ROOM | TO_ARENA_LISTEN);
+  if (spell == SPELL_POISON) {
+    affect_from_char(victim, SPELL_ACONITUM_POISON);
+    affect_from_char(victim, SPELL_DATURA_POISON);
+    affect_from_char(victim, SPELL_SCOPOLIA_POISON);
+    affect_from_char(victim, SPELL_BELENA_POISON);
+  }
+  affect_from_char(victim, spell);
+  if (to_vict != nullptr)
+    act(to_vict, FALSE, victim, 0, ch, TO_CHAR);
+  if (to_room != nullptr)
+    act(to_room, TRUE, victim, 0, ch, TO_ROOM | TO_ARENA_LISTEN);
 
-	return 1;
+  return 1;
 }
 
-int mag_alter_objs(int/* level*/, CHAR_DATA * ch, OBJ_DATA * obj, int spellnum, int/* savetype*/)
-{
-	const char *to_char = nullptr;
+int mag_alter_objs(int/* level*/, CHAR_DATA *ch, OBJ_DATA *obj, int spellnum, int/* savetype*/) {
+  const char *to_char = nullptr;
 
-	if (obj == nullptr)
-	{
-		return 0;
-	}
+  if (obj == nullptr) {
+    return 0;
+  }
 
-	if (obj->get_extra_flag(EExtraFlag::ITEM_NOALTER))
-	{
-		act("$o устойчив$A к вашей магии.", TRUE, ch, obj, 0, TO_CHAR);
-		return 0;
-	}
+  if (obj->get_extra_flag(EExtraFlag::ITEM_NOALTER)) {
+    act("$o устойчив$A к вашей магии.", TRUE, ch, obj, 0, TO_CHAR);
+    return 0;
+  }
 
-	switch (spellnum)
-	{
-	case SPELL_BLESS:
-		if (!obj->get_extra_flag(EExtraFlag::ITEM_BLESS)
-			&& (GET_OBJ_WEIGHT(obj) <= 5 * GET_LEVEL(ch)))
-		{
-			obj->set_extra_flag(EExtraFlag::ITEM_BLESS);
-			if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP))
-			{
-				obj->unset_extraflag(EExtraFlag::ITEM_NODROP);
-				if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)
-				{
-					obj->inc_val(2);
-				}
-			}
-			obj->add_maximum(MAX(GET_OBJ_MAX(obj) >> 2, 1));
-			obj->set_current_durability(GET_OBJ_MAX(obj));
-			to_char = "$o вспыхнул$G голубым светом и тут же погас$Q.";
-			obj->add_timed_spell(SPELL_BLESS, -1);
-		}
-		break;
+  switch (spellnum) {
+    case SPELL_BLESS:
+      if (!obj->get_extra_flag(EExtraFlag::ITEM_BLESS)
+          && (GET_OBJ_WEIGHT(obj) <= 5 * GET_LEVEL(ch))) {
+        obj->set_extra_flag(EExtraFlag::ITEM_BLESS);
+        if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
+          obj->unset_extraflag(EExtraFlag::ITEM_NODROP);
+          if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON) {
+            obj->inc_val(2);
+          }
+        }
+        obj->add_maximum(MAX(GET_OBJ_MAX(obj) >> 2, 1));
+        obj->set_current_durability(GET_OBJ_MAX(obj));
+        to_char = "$o вспыхнул$G голубым светом и тут же погас$Q.";
+        obj->add_timed_spell(SPELL_BLESS, -1);
+      }
+      break;
 
-	case SPELL_CURSE:
-		if (!obj->get_extra_flag(EExtraFlag::ITEM_NODROP))
-		{
-			obj->set_extra_flag(EExtraFlag::ITEM_NODROP);
-			if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)
-			{
-				if (GET_OBJ_VAL(obj, 2) > 0)
-				{
-					obj->dec_val(2);
-				}
-			}
-			else if (ObjSystem::is_armor_type(obj))
-			{
-				if (GET_OBJ_VAL(obj, 0) > 0)
-				{
-					obj->dec_val(0);
-				}
-				if (GET_OBJ_VAL(obj, 1) > 0)
-				{
-					obj->dec_val(1);
-				}
-			}
-			to_char = "$o вспыхнул$G красным светом и тут же погас$Q.";
-		}
-		break;
+    case SPELL_CURSE:
+      if (!obj->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
+        obj->set_extra_flag(EExtraFlag::ITEM_NODROP);
+        if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON) {
+          if (GET_OBJ_VAL(obj, 2) > 0) {
+            obj->dec_val(2);
+          }
+        } else if (ObjSystem::is_armor_type(obj)) {
+          if (GET_OBJ_VAL(obj, 0) > 0) {
+            obj->dec_val(0);
+          }
+          if (GET_OBJ_VAL(obj, 1) > 0) {
+            obj->dec_val(1);
+          }
+        }
+        to_char = "$o вспыхнул$G красным светом и тут же погас$Q.";
+      }
+      break;
 
-	case SPELL_INVISIBLE:
-		if (!obj->get_extra_flag(EExtraFlag::ITEM_NOINVIS)
-			&& !obj->get_extra_flag(EExtraFlag::ITEM_INVISIBLE))
-		{
-			obj->set_extra_flag(EExtraFlag::ITEM_INVISIBLE);
-			to_char = "$o растворил$U в пустоте.";
-		}
-		break;
+    case SPELL_INVISIBLE:
+      if (!obj->get_extra_flag(EExtraFlag::ITEM_NOINVIS)
+          && !obj->get_extra_flag(EExtraFlag::ITEM_INVISIBLE)) {
+        obj->set_extra_flag(EExtraFlag::ITEM_INVISIBLE);
+        to_char = "$o растворил$U в пустоте.";
+      }
+      break;
 
-	case SPELL_POISON:
-		if (!GET_OBJ_VAL(obj, 3)
-			&& (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON
-				|| GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_FOUNTAIN
-				|| GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_FOOD))
-		{
-			obj->set_val(3, 1);
-			to_char = "$o отравлен$G.";
-		}
-		break;
+    case SPELL_POISON:
+      if (!GET_OBJ_VAL(obj, 3)
+          && (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON
+              || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_FOUNTAIN
+              || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_FOOD)) {
+        obj->set_val(3, 1);
+        to_char = "$o отравлен$G.";
+      }
+      break;
 
-	case SPELL_REMOVE_CURSE:
-		if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP))
-		{
-			obj->unset_extraflag(EExtraFlag::ITEM_NODROP);
-			if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)
-			{
-				obj->inc_val(2);
-			}
-			to_char = "$o вспыхнул$G розовым светом и тут же погас$Q.";
-		}
-		break;
+    case SPELL_REMOVE_CURSE:
+      if (obj->get_extra_flag(EExtraFlag::ITEM_NODROP)) {
+        obj->unset_extraflag(EExtraFlag::ITEM_NODROP);
+        if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON) {
+          obj->inc_val(2);
+        }
+        to_char = "$o вспыхнул$G розовым светом и тут же погас$Q.";
+      }
+      break;
 
-	case SPELL_ENCHANT_WEAPON:
-	{
-		if (ch == nullptr || obj == nullptr)
-		{
-			return 0;
-		}
+    case SPELL_ENCHANT_WEAPON: {
+      if (ch == nullptr || obj == nullptr) {
+        return 0;
+      }
 
-		// Either already enchanted or not a weapon.
-		if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON)
-		{
-			to_char = "Еще раз ударьтесь головой об стену, авось зрение вернется...";
-			break;
-		}
-		else if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_MAGIC))
-		{
-			to_char = "Вам не под силу зачаровать магическую вещь.";
-			break;
-		}
+      // Either already enchanted or not a weapon.
+      if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON) {
+        to_char = "Еще раз ударьтесь головой об стену, авось зрение вернется...";
+        break;
+      } else if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_MAGIC)) {
+        to_char = "Вам не под силу зачаровать магическую вещь.";
+        break;
+      }
 
-		if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_SETSTUFF))
-		{
-			send_to_char(ch, "Сетовый предмет не может быть заколдован.\r\n");
-			break;
-		}
+      if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_SETSTUFF)) {
+        send_to_char(ch, "Сетовый предмет не может быть заколдован.\r\n");
+        break;
+      }
 
-		auto reagobj = GET_EQ(ch, WEAR_HOLD);
-		if (reagobj
-			&& (get_obj_in_list_vnum(GlobalDrop::MAGIC1_ENCHANT_VNUM, reagobj)
-				|| get_obj_in_list_vnum(GlobalDrop::MAGIC2_ENCHANT_VNUM, reagobj)
-				|| get_obj_in_list_vnum(GlobalDrop::MAGIC3_ENCHANT_VNUM, reagobj)))
-		{
-			// у нас имеется доп символ для зачарования
-			obj->set_enchant(ch->get_skill(SKILL_LIGHT_MAGIC), reagobj);
-			material_component_processing(ch, reagobj->get_rnum(), spellnum); //может неправильный вызов
-		}
-		else
-		{
-			obj->set_enchant(ch->get_skill(SKILL_LIGHT_MAGIC));
-		}
-		if (GET_RELIGION(ch) == RELIGION_MONO)
-		{
-			to_char = "$o вспыхнул$G на миг голубым светом и тут же потух$Q.";
-		}
-		else if (GET_RELIGION(ch) == RELIGION_POLY)
-		{
-			to_char = "$o вспыхнул$G на миг красным светом и тут же потух$Q.";
-		}
-		else
-		{
-			to_char = "$o вспыхнул$G на миг желтым светом и тут же потух$Q.";
-		}
-		break;
-	}
-	case SPELL_REMOVE_POISON:
-		if (GET_OBJ_RNUM(obj)<0)
-		{
-			to_char = "Ничего не случилось.";
-			char buf[100];
-			sprintf(buf, "неизвестный прототип объекта : %s (VNUM=%d)",	GET_OBJ_PNAME(obj, 0).c_str(), obj->get_vnum());
-			mudlog(buf, BRF, LVL_BUILDER, SYSLOG, 1);
-			break;
-		}
-		if (obj_proto[GET_OBJ_RNUM(obj)]->get_val(3) > 1 && GET_OBJ_VAL(obj, 3) == 1)
-		{
-			to_char = "Содержимое $o1 протухло и не поддается магии.";
-			break;
-		}
-		if ((GET_OBJ_VAL(obj, 3) == 1)
-			&& ((GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON)
-				|| GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_FOUNTAIN
-				|| GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_FOOD))
-		{
-			obj->set_val(3, 0);
-			to_char = "$o стал$G вполне пригодным к применению.";
-		}
-		break;
+      auto reagobj = GET_EQ(ch, WEAR_HOLD);
+      if (reagobj
+          && (get_obj_in_list_vnum(GlobalDrop::MAGIC1_ENCHANT_VNUM, reagobj)
+              || get_obj_in_list_vnum(GlobalDrop::MAGIC2_ENCHANT_VNUM, reagobj)
+              || get_obj_in_list_vnum(GlobalDrop::MAGIC3_ENCHANT_VNUM, reagobj))) {
+        // у нас имеется доп символ для зачарования
+        obj->set_enchant(ch->get_skill(SKILL_LIGHT_MAGIC), reagobj);
+        material_component_processing(ch, reagobj->get_rnum(), spellnum); //может неправильный вызов
+      } else {
+        obj->set_enchant(ch->get_skill(SKILL_LIGHT_MAGIC));
+      }
+      if (GET_RELIGION(ch) == RELIGION_MONO) {
+        to_char = "$o вспыхнул$G на миг голубым светом и тут же потух$Q.";
+      } else if (GET_RELIGION(ch) == RELIGION_POLY) {
+        to_char = "$o вспыхнул$G на миг красным светом и тут же потух$Q.";
+      } else {
+        to_char = "$o вспыхнул$G на миг желтым светом и тут же потух$Q.";
+      }
+      break;
+    }
+    case SPELL_REMOVE_POISON:
+      if (GET_OBJ_RNUM(obj) < 0) {
+        to_char = "Ничего не случилось.";
+        char buf[100];
+        sprintf(buf, "неизвестный прототип объекта : %s (VNUM=%d)", GET_OBJ_PNAME(obj, 0).c_str(), obj->get_vnum());
+        mudlog(buf, BRF, LVL_BUILDER, SYSLOG, 1);
+        break;
+      }
+      if (obj_proto[GET_OBJ_RNUM(obj)]->get_val(3) > 1 && GET_OBJ_VAL(obj, 3) == 1) {
+        to_char = "Содержимое $o1 протухло и не поддается магии.";
+        break;
+      }
+      if ((GET_OBJ_VAL(obj, 3) == 1)
+          && ((GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON)
+              || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_FOUNTAIN
+              || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_FOOD)) {
+        obj->set_val(3, 0);
+        to_char = "$o стал$G вполне пригодным к применению.";
+      }
+      break;
 
-	case SPELL_FLY:
-		obj->add_timed_spell(SPELL_FLY, -1);
-		obj->set_extra_flag(EExtraFlag::ITEM_FLYING);
-		to_char = "$o вспыхнул$G зеленоватым светом и тут же погас$Q.";
-		break;
+    case SPELL_FLY: obj->add_timed_spell(SPELL_FLY, -1);
+      obj->set_extra_flag(EExtraFlag::ITEM_FLYING);
+      to_char = "$o вспыхнул$G зеленоватым светом и тут же погас$Q.";
+      break;
 
-	case SPELL_ACID:
-		alterate_object(obj, number(GET_LEVEL(ch) * 2, GET_LEVEL(ch) * 4), 100);
-		break;
+    case SPELL_ACID: alterate_object(obj, number(GET_LEVEL(ch) * 2, GET_LEVEL(ch) * 4), 100);
+      break;
 
-	case SPELL_REPAIR:
-		obj->set_current_durability(GET_OBJ_MAX(obj));
-		to_char = "Вы полностью восстановили $o3.";
-		break;
+    case SPELL_REPAIR: obj->set_current_durability(GET_OBJ_MAX(obj));
+      to_char = "Вы полностью восстановили $o3.";
+      break;
 
-	case SPELL_TIMER_REPAIR:
-		if (GET_OBJ_RNUM(obj) != NOTHING)
-		{
-			obj->set_current_durability(GET_OBJ_MAX(obj));
-			obj->set_timer(obj_proto.at(GET_OBJ_RNUM(obj))->get_timer());
-			to_char = "Вы полностью восстановили $o3.";
-			log("%s used magic repair", GET_NAME(ch));
-		}
-		else
-		{
-			return 0;
-		}
-		break;
+    case SPELL_TIMER_REPAIR:
+      if (GET_OBJ_RNUM(obj) != NOTHING) {
+        obj->set_current_durability(GET_OBJ_MAX(obj));
+        obj->set_timer(obj_proto.at(GET_OBJ_RNUM(obj))->get_timer());
+        to_char = "Вы полностью восстановили $o3.";
+        log("%s used magic repair", GET_NAME(ch));
+      } else {
+        return 0;
+      }
+      break;
 
-	case SPELLS_RESTORATION:
-		{
-			if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_MAGIC)
-				&& (GET_OBJ_RNUM(obj) != NOTHING))
-			{
-				if (obj_proto.at(GET_OBJ_RNUM(obj))->get_extra_flag(EExtraFlag::ITEM_MAGIC))
-				{
-					return 0;
-				}
-				obj->unset_enchant();
-			}
-			else
-			{
-				return 0;
-			}
-			to_char = "$o осветил$U на миг внутренним светом и тут же потух$Q.";
-		}
-		break;
+    case SPELLS_RESTORATION: {
+      if (OBJ_FLAGGED(obj, EExtraFlag::ITEM_MAGIC)
+          && (GET_OBJ_RNUM(obj) != NOTHING)) {
+        if (obj_proto.at(GET_OBJ_RNUM(obj))->get_extra_flag(EExtraFlag::ITEM_MAGIC)) {
+          return 0;
+        }
+        obj->unset_enchant();
+      } else {
+        return 0;
+      }
+      to_char = "$o осветил$U на миг внутренним светом и тут же потух$Q.";
+    }
+      break;
 
-	case SPELL_LIGHT:
-		obj->add_timed_spell(SPELL_LIGHT, -1);
-		obj->set_extra_flag(EExtraFlag::ITEM_GLOW);
-		to_char = "$o засветил$U ровным зеленоватым светом.";
-		break;
+    case SPELL_LIGHT: obj->add_timed_spell(SPELL_LIGHT, -1);
+      obj->set_extra_flag(EExtraFlag::ITEM_GLOW);
+      to_char = "$o засветил$U ровным зеленоватым светом.";
+      break;
 
-	case SPELL_DARKNESS:
-		if (obj->timed_spell().check_spell(SPELL_LIGHT))
-		{
-			obj->del_timed_spell(SPELL_LIGHT, true);
-			return 1;
-		}
-		break;
-	} // switch
+    case SPELL_DARKNESS:
+      if (obj->timed_spell().check_spell(SPELL_LIGHT)) {
+        obj->del_timed_spell(SPELL_LIGHT, true);
+        return 1;
+      }
+      break;
+  } // switch
 
-	if (to_char == nullptr)
-	{
-		send_to_char(NOEFFECT, ch);
-	}
-	else
-	{
-		act(to_char, TRUE, ch, obj, 0, TO_CHAR);
-	}
+  if (to_char == nullptr) {
+    send_to_char(NOEFFECT, ch);
+  } else {
+    act(to_char, TRUE, ch, obj, 0, TO_CHAR);
+  }
 
-	return 1;
+  return 1;
 }
 
-int mag_creations(int/* level*/, CHAR_DATA * ch, int spellnum)
-{
-	obj_vnum z;
+int mag_creations(int/* level*/, CHAR_DATA *ch, int spellnum) {
+  obj_vnum z;
 
-	if (ch == nullptr)
-	{
-		return 0;
-	}
-	// level = MAX(MIN(level, LVL_IMPL), 1); - Hm, not used.
+  if (ch == nullptr) {
+    return 0;
+  }
+  // level = MAX(MIN(level, LVL_IMPL), 1); - Hm, not used.
 
-	switch (spellnum)
-	{
-	case SPELL_CREATE_FOOD:
-		z = START_BREAD;
-		break;
+  switch (spellnum) {
+    case SPELL_CREATE_FOOD: z = START_BREAD;
+      break;
 
-	case SPELL_CREATE_LIGHT:
-		z = CREATE_LIGHT;
-		break;
+    case SPELL_CREATE_LIGHT: z = CREATE_LIGHT;
+      break;
 
-	default:
-		send_to_char("Spell unimplemented, it would seem.\r\n", ch);
-		return 0;
-		break;
-	}
+    default: send_to_char("Spell unimplemented, it would seem.\r\n", ch);
+      return 0;
+      break;
+  }
 
-	const auto tobj = world_objects.create_from_prototype_by_vnum(z);
-	if (!tobj)
-	{
-		send_to_char("Что-то не видно образа для создания.\r\n", ch);
-		log("SYSERR: spell_creations, spell %d, obj %d: obj not found", spellnum, z);
-		return 0;
-	}
+  const auto tobj = world_objects.create_from_prototype_by_vnum(z);
+  if (!tobj) {
+    send_to_char("Что-то не видно образа для создания.\r\n", ch);
+    log("SYSERR: spell_creations, spell %d, obj %d: obj not found", spellnum, z);
+    return 0;
+  }
 
-	act("$n создал$g $o3.", FALSE, ch, tobj.get(), 0, TO_ROOM | TO_ARENA_LISTEN);
-	act("Вы создали $o3.", FALSE, ch, tobj.get(), 0, TO_CHAR);
-	load_otrigger(tobj.get());
+  act("$n создал$g $o3.", FALSE, ch, tobj.get(), 0, TO_ROOM | TO_ARENA_LISTEN);
+  act("Вы создали $o3.", FALSE, ch, tobj.get(), 0, TO_CHAR);
+  load_otrigger(tobj.get());
 
-	if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch))
-	{
-		send_to_char("Вы не сможете унести столько предметов.\r\n", ch);
-		obj_to_room(tobj.get(), ch->in_room);
-		obj_decay(tobj.get());
-	}
-	else if (IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(tobj) > CAN_CARRY_W(ch))
-	{
-		send_to_char("Вы не сможете унести такой вес.\r\n", ch);
-		obj_to_room(tobj.get(), ch->in_room);
-		obj_decay(tobj.get());
-	}
-	else
-	{
-		obj_to_char(tobj.get(), ch);
-	}
+  if (IS_CARRYING_N(ch) >= CAN_CARRY_N(ch)) {
+    send_to_char("Вы не сможете унести столько предметов.\r\n", ch);
+    obj_to_room(tobj.get(), ch->in_room);
+    obj_decay(tobj.get());
+  } else if (IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(tobj) > CAN_CARRY_W(ch)) {
+    send_to_char("Вы не сможете унести такой вес.\r\n", ch);
+    obj_to_room(tobj.get(), ch->in_room);
+    obj_decay(tobj.get());
+  } else {
+    obj_to_char(tobj.get(), ch);
+  }
 
-	return 1;
+  return 1;
 }
 
-int mag_manual(int level, CHAR_DATA * caster, CHAR_DATA * cvict, OBJ_DATA * ovict, int spellnum, int/* savetype*/)
-{
-	switch (spellnum)
-	{
-	case SPELL_GROUP_RECALL:
-	case SPELL_WORD_OF_RECALL:
-		MANUAL_SPELL(spell_recall);
-		break;
-	case SPELL_TELEPORT:
-		MANUAL_SPELL(spell_teleport);
-		break;
-	case SPELL_CONTROL_WEATHER:
-		MANUAL_SPELL(spell_control_weather);
-		break;
-	case SPELL_CREATE_WATER:
-		MANUAL_SPELL(spell_create_water);
-		break;
-	case SPELL_LOCATE_OBJECT:
-		MANUAL_SPELL(spell_locate_object);
-		break;
-	case SPELL_SUMMON:
-		MANUAL_SPELL(spell_summon);
-		break;
-	case SPELL_PORTAL:
-		MANUAL_SPELL(spell_portal);
-		break;
-	case SPELL_CREATE_WEAPON:
-		MANUAL_SPELL(spell_create_weapon);
-		break;
-	case SPELL_RELOCATE:
-		MANUAL_SPELL(spell_relocate);
-		break;
-	case SPELL_CHARM:
-		MANUAL_SPELL(spell_charm);
-		break;
-	case SPELL_ENERGY_DRAIN:
-		MANUAL_SPELL(spell_energydrain);
-		break;
-	case SPELL_MASS_FEAR:
-	case SPELL_FEAR:
-		MANUAL_SPELL(spell_fear);
-		break;
-	case SPELL_SACRIFICE:
-		MANUAL_SPELL(spell_sacrifice);
-		break;
-	case SPELL_IDENTIFY:
-		MANUAL_SPELL(spell_identify);
-		break;
-	case SPELL_HOLYSTRIKE:
-		MANUAL_SPELL(spell_holystrike);
-		break;
-	case SPELL_ANGEL:
-		MANUAL_SPELL(spell_angel);
-		break;
-	case SPELL_VAMPIRE:
-		MANUAL_SPELL(spell_vampire);
-		break;
-	case SPELL_MENTAL_SHADOW:
-		MANUAL_SPELL(spell_mental_shadow);
-		break;
-	default:
-		return 0;
-		break;
-	}
-	return 1;
+int mag_manual(int level, CHAR_DATA *caster, CHAR_DATA *cvict, OBJ_DATA *ovict, int spellnum, int/* savetype*/) {
+  switch (spellnum) {
+    case SPELL_GROUP_RECALL:
+    case SPELL_WORD_OF_RECALL: MANUAL_SPELL(spell_recall);
+      break;
+    case SPELL_TELEPORT: MANUAL_SPELL(spell_teleport);
+      break;
+    case SPELL_CONTROL_WEATHER: MANUAL_SPELL(spell_control_weather);
+      break;
+    case SPELL_CREATE_WATER: MANUAL_SPELL(spell_create_water);
+      break;
+    case SPELL_LOCATE_OBJECT: MANUAL_SPELL(spell_locate_object);
+      break;
+    case SPELL_SUMMON: MANUAL_SPELL(spell_summon);
+      break;
+    case SPELL_PORTAL: MANUAL_SPELL(spell_portal);
+      break;
+    case SPELL_CREATE_WEAPON: MANUAL_SPELL(spell_create_weapon);
+      break;
+    case SPELL_RELOCATE: MANUAL_SPELL(spell_relocate);
+      break;
+    case SPELL_CHARM: MANUAL_SPELL(spell_charm);
+      break;
+    case SPELL_ENERGY_DRAIN: MANUAL_SPELL(spell_energydrain);
+      break;
+    case SPELL_MASS_FEAR:
+    case SPELL_FEAR: MANUAL_SPELL(spell_fear);
+      break;
+    case SPELL_SACRIFICE: MANUAL_SPELL(spell_sacrifice);
+      break;
+    case SPELL_IDENTIFY: MANUAL_SPELL(spell_identify);
+      break;
+    case SPELL_HOLYSTRIKE: MANUAL_SPELL(spell_holystrike);
+      break;
+    case SPELL_ANGEL: MANUAL_SPELL(spell_angel);
+      break;
+    case SPELL_VAMPIRE: MANUAL_SPELL(spell_vampire);
+      break;
+    case SPELL_MENTAL_SHADOW: MANUAL_SPELL(spell_mental_shadow);
+      break;
+    default: return 0;
+      break;
+  }
+  return 1;
 }
 
 //******************************************************************************
 //******************************************************************************
 //******************************************************************************
 
-int check_mobile_list(CHAR_DATA * ch)
-{
-	for (const auto& vict : character_list)
-	{
-		if (vict.get() == ch)
-		{
-			return (TRUE);
-		}
-	}
+int check_mobile_list(CHAR_DATA *ch) {
+  for (const auto &vict : character_list) {
+    if (vict.get() == ch) {
+      return (TRUE);
+    }
+  }
 
-	return (FALSE);
+  return (FALSE);
 }
 
-void cast_reaction(CHAR_DATA * victim, CHAR_DATA * caster, int spellnum)
-{
-	if (caster == victim)
-		return;
+void cast_reaction(CHAR_DATA *victim, CHAR_DATA *caster, int spellnum) {
+  if (caster == victim)
+    return;
 
-	if (!check_mobile_list(victim) || !SpINFO.violent)
-		return;
+  if (!check_mobile_list(victim) || !SpINFO.violent)
+    return;
 
-	if (AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM) ||
-			AFF_FLAGGED(victim, EAffectFlag::AFF_SLEEP) ||
-			AFF_FLAGGED(victim, EAffectFlag::AFF_BLIND) ||
-			AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT) ||
-			AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT) || AFF_FLAGGED(victim, EAffectFlag::AFF_HOLD) || IS_HORSE(victim))
-		return;
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM) ||
+      AFF_FLAGGED(victim, EAffectFlag::AFF_SLEEP) ||
+      AFF_FLAGGED(victim, EAffectFlag::AFF_BLIND) ||
+      AFF_FLAGGED(victim, EAffectFlag::AFF_STOPFIGHT) ||
+      AFF_FLAGGED(victim, EAffectFlag::AFF_MAGICSTOPFIGHT) || AFF_FLAGGED(victim, EAffectFlag::AFF_HOLD)
+      || IS_HORSE(victim))
+    return;
 
-	if (IS_NPC(caster)
-			&& GET_MOB_RNUM(caster) == real_mobile(DG_CASTER_PROXY))
-		return;
+  if (IS_NPC(caster)
+      && GET_MOB_RNUM(caster) == real_mobile(DG_CASTER_PROXY))
+    return;
 
-	if (CAN_SEE(victim, caster) && MAY_ATTACK(victim) && IN_ROOM(victim) == IN_ROOM(caster))
-	{
-		if (IS_NPC(victim))
-			attack_best(victim, caster);
-		else
-			hit(victim, caster, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
-	}
-	else if (CAN_SEE(victim, caster) && !IS_NPC(caster) && IS_NPC(victim) && MOB_FLAGGED(victim, MOB_MEMORY))
-	{
-		mobRemember(victim, caster);
-	}
+  if (CAN_SEE(victim, caster) && MAY_ATTACK(victim) && IN_ROOM(victim) == IN_ROOM(caster)) {
+    if (IS_NPC(victim))
+      attack_best(victim, caster);
+    else
+      hit(victim, caster, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
+  } else if (CAN_SEE(victim, caster) && !IS_NPC(caster) && IS_NPC(victim) && MOB_FLAGGED(victim, MOB_MEMORY)) {
+    mobRemember(victim, caster);
+  }
 
-	if (caster->purged())
-	{
-		return;
-	}
-	if (!CAN_SEE(victim, caster) && (GET_REAL_INT(victim) > 25 || GET_REAL_INT(victim) > number(10, 25)))
-	{
-		if (!AFF_FLAGGED(victim, EAffectFlag::AFF_DETECT_INVIS)
-				&& GET_SPELL_MEM(victim, SPELL_DETECT_INVIS) > 0)
-			cast_spell(victim, victim, 0, 0, SPELL_DETECT_INVIS,  SPELL_DETECT_INVIS);
-		else if (!AFF_FLAGGED(victim, EAffectFlag::AFF_SENSE_LIFE)
-				 && GET_SPELL_MEM(victim, SPELL_SENSE_LIFE) > 0)
-			cast_spell(victim, victim, 0, 0, SPELL_SENSE_LIFE, SPELL_SENSE_LIFE);
-		else if (!AFF_FLAGGED(victim, EAffectFlag::AFF_INFRAVISION)
-				 && GET_SPELL_MEM(victim, SPELL_LIGHT) > 0)
-			cast_spell(victim, victim, 0, 0, SPELL_LIGHT, SPELL_LIGHT);
-	}
+  if (caster->purged()) {
+    return;
+  }
+  if (!CAN_SEE(victim, caster) && (GET_REAL_INT(victim) > 25 || GET_REAL_INT(victim) > number(10, 25))) {
+    if (!AFF_FLAGGED(victim, EAffectFlag::AFF_DETECT_INVIS)
+        && GET_SPELL_MEM(victim, SPELL_DETECT_INVIS) > 0)
+      cast_spell(victim, victim, 0, 0, SPELL_DETECT_INVIS, SPELL_DETECT_INVIS);
+    else if (!AFF_FLAGGED(victim, EAffectFlag::AFF_SENSE_LIFE)
+        && GET_SPELL_MEM(victim, SPELL_SENSE_LIFE) > 0)
+      cast_spell(victim, victim, 0, 0, SPELL_SENSE_LIFE, SPELL_SENSE_LIFE);
+    else if (!AFF_FLAGGED(victim, EAffectFlag::AFF_INFRAVISION)
+        && GET_SPELL_MEM(victim, SPELL_LIGHT) > 0)
+      cast_spell(victim, victim, 0, 0, SPELL_LIGHT, SPELL_LIGHT);
+  }
 }
 
 // Применение заклинания к одной цели
 //---------------------------------------------------------
-int mag_single_target(int level, CHAR_DATA * caster, CHAR_DATA * cvict, OBJ_DATA * ovict, int spellnum, int savetype)
-{
-	/*
+int mag_single_target(int level, CHAR_DATA *caster, CHAR_DATA *cvict, OBJ_DATA *ovict, int spellnum, int savetype) {
+  /*
 	if (IS_SET(SpINFO.routines, 0)){
 			send_to_char(NOEFFECT, caster);
 			return (-1);
 	}
 	*/
 
-	//туповато конечно, но подобные проверки тут как счупалцьа перепутаны
-	//и чтоб сделать по человечески надо треть пары модулей перелопатить
-	if (cvict && (caster != cvict))
-		if  (IS_GOD(cvict) || (((GET_LEVEL(cvict) / 2) > (GET_LEVEL(caster) + (GET_REMORT(caster) / 2))) && !IS_NPC(caster))) // при разнице уровня более чем в 2 раза закл фэйл
-		{
-			send_to_char(NOEFFECT, caster);
-			return (-1);
-		}
+  //туповато конечно, но подобные проверки тут как счупалцьа перепутаны
+  //и чтоб сделать по человечески надо треть пары модулей перелопатить
+  if (cvict && (caster != cvict))
+    if (IS_GOD(cvict) || (((GET_LEVEL(cvict) / 2) > (GET_LEVEL(caster) + (GET_REMORT(caster) / 2)))
+        && !IS_NPC(caster))) // при разнице уровня более чем в 2 раза закл фэйл
+    {
+      send_to_char(NOEFFECT, caster);
+      return (-1);
+    }
 
-	if (IS_SET(SpINFO.routines, MAG_WARCRY) && cvict && IS_UNDEAD(cvict))
-		return 1;
+  if (IS_SET(SpINFO.routines, MAG_WARCRY) && cvict && IS_UNDEAD(cvict))
+    return 1;
 
-	if (IS_SET(SpINFO.routines, MAG_DAMAGE))
-		if (mag_damage(level, caster, cvict, spellnum, savetype) == -1)
-			return (-1);	// Successful and target died, don't cast again.
+  if (IS_SET(SpINFO.routines, MAG_DAMAGE))
+    if (mag_damage(level, caster, cvict, spellnum, savetype) == -1)
+      return (-1);    // Successful and target died, don't cast again.
 
-	if (IS_SET(SpINFO.routines, MAG_AFFECTS))
-		mag_affects(level, caster, cvict, spellnum, savetype);
+  if (IS_SET(SpINFO.routines, MAG_AFFECTS))
+    mag_affects(level, caster, cvict, spellnum, savetype);
 
-	if (IS_SET(SpINFO.routines, MAG_UNAFFECTS))
-		mag_unaffects(level, caster, cvict, spellnum, savetype);
+  if (IS_SET(SpINFO.routines, MAG_UNAFFECTS))
+    mag_unaffects(level, caster, cvict, spellnum, savetype);
 
-	if (IS_SET(SpINFO.routines, MAG_POINTS))
-		mag_points(level, caster, cvict, spellnum, savetype);
+  if (IS_SET(SpINFO.routines, MAG_POINTS))
+    mag_points(level, caster, cvict, spellnum, savetype);
 
-	if (IS_SET(SpINFO.routines, MAG_ALTER_OBJS))
-		mag_alter_objs(level, caster, ovict, spellnum, savetype);
+  if (IS_SET(SpINFO.routines, MAG_ALTER_OBJS))
+    mag_alter_objs(level, caster, ovict, spellnum, savetype);
 
-	if (IS_SET(SpINFO.routines, MAG_SUMMONS))
-		mag_summons(level, caster, ovict, spellnum, 1);	// savetype =1 -- ВРЕМЕННО, показатель что фэйлить надо
+  if (IS_SET(SpINFO.routines, MAG_SUMMONS))
+    mag_summons(level, caster, ovict, spellnum, 1);    // savetype =1 -- ВРЕМЕННО, показатель что фэйлить надо
 
-	if (IS_SET(SpINFO.routines, MAG_CREATIONS))
-		mag_creations(level, caster, spellnum);
+  if (IS_SET(SpINFO.routines, MAG_CREATIONS))
+    mag_creations(level, caster, spellnum);
 
-	if (IS_SET(SpINFO.routines, MAG_MANUAL))
-		mag_manual(level, caster, cvict, ovict, spellnum, savetype);
+  if (IS_SET(SpINFO.routines, MAG_MANUAL))
+    mag_manual(level, caster, cvict, ovict, spellnum, savetype);
 
-	cast_reaction(cvict, caster, spellnum);
-	return 1;
+  cast_reaction(cvict, caster, spellnum);
+  return 1;
 }
 
-typedef struct
-{
-	int spell;
-	const char *to_char;
-	const char *to_room;
-	const char *to_vict;
-	float castSuccessPercentDecay;
-	int skillDivisor;
-	int diceSize;
-	int minTargetsAmount;
-	int maxTargetsAmount;
-	int freeTargets;
-	int castLevelDecay;
+typedef struct {
+  int spell;
+  const char *to_char;
+  const char *to_room;
+  const char *to_vict;
+  float castSuccessPercentDecay;
+  int skillDivisor;
+  int diceSize;
+  int minTargetsAmount;
+  int maxTargetsAmount;
+  int freeTargets;
+  int castLevelDecay;
 } spl_message;
 
 // Svent TODO Перенести эту порнографию в спеллпарсер
 const spl_message mag_messages[] =
-{
-    {SPELL_PALADINE_INSPIRATION, // групповой
-    "Ваш точный удар воодушевил и придал новых сил!",
-    "Точный удар $n1 воодушевил и придал новых сил!",
-            nullptr,
-    0.0, 20, 2, 1, 20, 3, 0},
-    {SPELL_EVILESS,
-	 "Вы запросили помощи у Чернобога. Долг перед темными силами стал чуточку больше..",
-	 "Внезапно появившееся чёрное облако скрыло $n3 на мгновение от вашего взгляда.",
-	 nullptr,
-	 0.0, 20, 2, 1, 20, 3, 0},
-	{SPELL_MASS_BLINDNESS,
-	 "У вас над головой возникла яркая вспышка, которая ослепила все живое.",
-	 "Вдруг над головой $n1 возникла яркая вспышка.",
-	 "Вы невольно взглянули на вспышку света, вызванную $n4, и ваши глаза заслезились.",
-	 0.05, 20, 2, 5, 20, 3, 2},
-	{SPELL_MASS_HOLD,
-	 "Вы сжали зубы от боли, когда из вашего тела вырвалось множество невидимых каменных лучей.",
-	 nullptr,
-	 "В вас попал каменный луч, исходящий от $n1.",
-	 0.05, 20, 2, 5, 20, 3, 2},
-	{SPELL_MASS_CURSE,
-	 "Медленно оглянувшись, вы прошептали древние слова.",
-	 nullptr,
-	 "$n злобно посмотрел$g на вас и начал$g шептать древние слова.",
-	 0.05, 20, 3, 5, 20, 3, 2},
-	{SPELL_MASS_SILENCE,
-	 "Поведя вокруг грозным взглядом, вы заставили всех замолчать.",
-	 nullptr,
-	 "Вы встретились взглядом с $n4, и у вас появилось ощущение, что горлу чего-то не хватает.",
-	 0.05, 20, 2, 5, 20, 3, 2},
-	{SPELL_DEAFNESS,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.05, 10, 3, 5, 20, 3, 2},
-	{SPELL_MASS_DEAFNESS,
-	 "Вы нахмурились, склонив голову, и громкий хлопок сотряс воздух.",
-	 "Как только $n0 склонил$g голову, раздался оглушающий хлопок.",
-	 nullptr,
-	 0.05, 10, 3, 5, 20, 3, 2},
-	{SPELL_MASS_SLOW,
-	 "Положив ладони на землю, вы вызвали цепкие корни,\r\nопутавшие существ, стоящих рядом с вами.",
-	 nullptr,
-	 "$n вызвал$g цепкие корни, опутавшие ваши ноги.",
-	 0.05, 10, 3, 5, 20, 3, 2},
-	{SPELL_ARMAGEDDON,
-	 "Вы сплели руки в замысловатом жесте, и все потускнело!",
-	 "$n сплел$g руки в замысловатом жесте, и все потускнело!",
-	 nullptr,
-	 0.05, 25, 2, 5, 20, 3, 2},
-	{SPELL_EARTHQUAKE,
-	 "Вы опустили руки, и земля начала дрожать вокруг вас!",
-	 "$n опустил$g руки, и земля задрожала!",
-	 nullptr,
-	 0.05, 25, 2, 5, 20, 5, 2},
-	{SPELL_THUNDERSTONE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.05, 25, 2, 3, 15, 3, 4},
-	{SPELL_CONE_OF_COLD,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.05, 40, 2, 2, 5, 5, 4},
-	{SPELL_ACID,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.05, 20, 2, 3, 8, 4, 4},
-	{SPELL_LIGHTNING_BOLT,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.05, 15, 3, 3, 6, 4, 4},
-	{SPELL_CALL_LIGHTNING,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.05, 15, 3, 3, 5, 4, 4},
-	{SPELL_WHIRLWIND,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.05, 40, 1, 1, 3, 3, 4},
-	{SPELL_DAMAGE_SERIOUS,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.05, 20, 3, 1, 6, 6, 4},
-	{SPELL_FIREBLAST,
-	 "Вы вызвали потоки подземного пламени!",
-	 "$n0 вызвал$g потоки пламени из глубин земли!",
-	 nullptr,
-	 0.05, 20, 2, 5, 20, 3, 3},
-	{SPELL_ICESTORM,
-	 "Вы воздели руки к небу, и тысячи мелких льдинок хлынули вниз!",
-	 "$n воздел$g руки к небу, и тысячи мелких льдинок хлынули вниз!",
-	 nullptr,
-	 0.05, 30, 2, 5, 20, 3, 4},
-	{SPELL_DUSTSTORM,
-	 "Вы взмахнули руками и вызвали огромное пылевое облако,\r\nскрывшее все вокруг.",
-	 "Вас поглотила пылевая буря, вызванная $n4.",
-	 nullptr,
-	 0.05, 15, 2, 5, 20, 3, 2},
-	{SPELL_MASS_FEAR,
-	 "Вы оглядели комнату устрашающим взглядом, заставив всех содрогнуться.",
-	 "$n0 оглядел$g комнату устрашающим взглядом.",
-	 nullptr,
-	 0.05, 15, 2, 5, 20, 3, 3},
-	{SPELL_GLITTERDUST,
-	 "Вы слегка прищелкнули пальцами, и вокруг сгустилось облако блестящей пыли.",
-	 "$n0 сотворил$g облако блестящей пыли, медленно осевшее на землю.",
-	 nullptr,
-	 0.05, 15, 3, 5, 20, 5, 3},
-	{SPELL_SONICWAVE,
-	 "Вы оттолкнули от себя воздух руками, и он плотным кольцом стремительно двинулся во все стороны!",
-	 "$n махнул$g руками, и огромное кольцо сжатого воздуха распостранилось во все стороны!",
-	 nullptr,
-	 0.05, 20, 2, 5, 20, 3, 3},
-	{SPELL_CHAIN_LIGHTNING,
-	 "Вы подняли руки к небу и оно осветилось яркими вспышками!",
-	 "$n поднял$g руки к небу и оно осветилось яркими вспышками!",
-	 nullptr,
-	 0.05, 10, 3, 1, 8, 1, 5},
-	{SPELL_EARTHFALL,
-	 "Вы высоко подбросили комок земли и он, увеличиваясь на глазах, обрушился вниз.",
-	 "$n высоко подбросил$g комок земли, который, увеличиваясь на глазах, стал падать вниз.",
-	 nullptr,
-	 0.05, 20, 2, 1, 3, 1, 8},
-	{SPELL_SHOCK,
-	 "Яркая вспышка слетела с кончиков ваших пальцев и с оглушительным грохотом взорвалась в воздухе.",
-	 "Выпущенная $n1 яркая вспышка с оглушительным грохотом взорвалась в воздухе.",
-	 nullptr,
-	 0.05, 35, 2, 1, 4, 2, 8},
-	{SPELL_BURDEN_OF_TIME,
-	 "Вы скрестили руки на груди, вызвав яркую вспышку синего света.",
-	 "$n0 скрестил$g руки на груди, вызвав яркую вспышку синего света.",
-	 nullptr,
-	 0.05, 20, 2, 5, 20, 3, 8},
-	{SPELL_FAILURE,
-	 "Вы простерли руки над головой, вызвав череду раскатов грома.",
-	 "$n0 вызвал$g череду раскатов грома, заставивших все вокруг содрогнуться.",
-	 nullptr,
-	 0.05, 15, 2, 1, 5, 3, 8},
-	{SPELL_SCREAM,
-	 "Вы испустили кошмарный вопль, едва не разорвавший вам горло.",
-	 "$n0 испустил$g кошмарный вопль, отдавшийся в вашей душе замогильным холодом.",
-	 nullptr,
-	 0.05, 40, 3, 1, 8, 3, 5},
-	{SPELL_BURNING_HANDS,
-	 "С ваших ладоней сорвался поток жаркого пламени.",
-	 "$n0 испустил$g поток жаркого багрового пламени!",
-	 nullptr,
-	 0.05, 20, 2, 5, 20, 3, 7},
-	{SPELL_COLOR_SPRAY,
-	 "Из ваших рук вылетел сноп ледяных стрел.",
-	 "$n0 метнул$g во врагов сноп ледяных стрел.",
-	 nullptr,
-	 0.05, 30, 2, 1, 5, 3, 7},
-	{SPELL_WC_OF_CHALLENGE,
-	 nullptr,
-	 "Вы не стерпели насмешки, и бросились на $n1!",
-	 nullptr,
-	 0.01, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_MENACE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.01, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_RAGE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.01, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_MADNESS,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.01, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_THUNDER,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.01, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_DEFENSE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.01, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_HEAL,
-	 "Вы подняли голову вверх и ощутили яркий свет, ласково бегущий по вашему телу.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.01, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_ARMOR,
-	 "Вы создали защитную сферу, которая окутала вас и пространство рядом с вами.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_RECALL,
-	 "Вы выкрикнули заклинание и хлопнули в ладоши.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_STRENGTH,
-	 "Вы призвали мощь Вселенной.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_BLESS,
-	 "Прикрыв глаза, вы прошептали таинственную молитву.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_HASTE,
-	 "Разведя руки в стороны, вы ощутили всю мощь стихии ветра.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_FLY,
-	 "Ваше заклинание вызвало белое облако, которое разделилось, подхватывая вас и товарищей.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_INVISIBLE,
-	 "Вы вызвали прозрачный туман, поглотивший все дружественное вам.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_MAGICGLASS,
-	 "Вы произнесли несколько резких слов, и все вокруг засеребрилось.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_SANCTUARY,
-	 "Вы подняли руки к небу и произнесли священную молитву.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_PRISMATICAURA,
-	 "Силы духа, призванные вами, окутали вас и окружающих голубоватым сиянием.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_FIRE_AURA,
-	 "Силы огня пришли к вам на помощь и защитили вас.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_AIR_AURA,
-	 "Силы воздуха пришли к вам на помощь и защитили вас.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_ICE_AURA,
-	 "Силы холода пришли к вам на помощь и защитили вас.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_REFRESH,
-	 "Ваша магия наполнила воздух зеленоватым сиянием.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_DEFENSE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_BATTLE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_POWER,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_BLESS,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_OF_COURAGE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_SIGHT_OF_DARKNESS,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GENERAL_SINCERITY,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_MAGICAL_GAZE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_ALL_SEEING_EYE,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_EYE_OF_GODS,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_BREATHING_AT_DEPTH,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GENERAL_RECOVERY,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_COMMON_MEAL,
-	 "Вы услышали гомон невидимых лакеев, готовящих трапезу.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_STONE_WALL,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_SNAKE_EYES,
-	 nullptr,
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_EARTH_AURA,
-	 "Земля одарила вас своей защитой.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_PROT_FROM_EVIL,
-	 "Сила света подавила в вас страх к тьме.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_BLINK,
-	 "Очертания вас и соратников замерцали в такт биения сердца, став прозрачней.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_CLOUDLY,
-	 "Пелена тумана окутала вас и окружющих, скрыв очертания.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_GROUP_AWARNESS,
-	 "Произнесенные слова обострили ваши чувства и внимательность ваших соратников.\r\n",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_EXPERIENSE,
-	 "Вы приготовились к обретению нового опыта.",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_LUCK,
-	 "Вы ощутили, что вам улыбнулась удача.",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_WC_PHYSDAMAGE,
-	 "Боевой клич придал вам сил!",
-	 nullptr,
-	 nullptr,
-	 0.0, 20, 2, 5, 20, 3, 0},
-	{SPELL_MASS_FAILURE,
-	 "Вняв вашему призыву, Змей Велес коснулся недобрым взглядом ваших супостатов.\r\n",
-	 nullptr,
-	 "$n провыл$g несколько странно звучащих слов и от тяжелого взгляда из-за края мира у вас подкосились ноги.",
-	 0.03, 25, 2, 3, 15, 4, 6},
-	{SPELL_MASS_NOFLEE,
-	 "Вы соткали магические тенета, опутавшие ваших врагов.\r\n",
-	 nullptr,
-	 "$n что-то прошептал$g, странно скрючив пальцы, и взлетевшие откуда ни возьмись ловчие сети опутали вас",
-	 0.03, 25, 2, 3, 15, 5, 6},
-	{ -1, nullptr, nullptr, nullptr, 0.01, 1, 1, 1, 1, 1, 0}
-};
+    {
+        {SPELL_PALADINE_INSPIRATION, // групповой
+         "Ваш точный удар воодушевил и придал новых сил!",
+         "Точный удар $n1 воодушевил и придал новых сил!",
+         nullptr,
+         0.0, 20, 2, 1, 20, 3, 0},
+        {SPELL_EVILESS,
+         "Вы запросили помощи у Чернобога. Долг перед темными силами стал чуточку больше..",
+         "Внезапно появившееся чёрное облако скрыло $n3 на мгновение от вашего взгляда.",
+         nullptr,
+         0.0, 20, 2, 1, 20, 3, 0},
+        {SPELL_MASS_BLINDNESS,
+         "У вас над головой возникла яркая вспышка, которая ослепила все живое.",
+         "Вдруг над головой $n1 возникла яркая вспышка.",
+         "Вы невольно взглянули на вспышку света, вызванную $n4, и ваши глаза заслезились.",
+         0.05, 20, 2, 5, 20, 3, 2},
+        {SPELL_MASS_HOLD,
+         "Вы сжали зубы от боли, когда из вашего тела вырвалось множество невидимых каменных лучей.",
+         nullptr,
+         "В вас попал каменный луч, исходящий от $n1.",
+         0.05, 20, 2, 5, 20, 3, 2},
+        {SPELL_MASS_CURSE,
+         "Медленно оглянувшись, вы прошептали древние слова.",
+         nullptr,
+         "$n злобно посмотрел$g на вас и начал$g шептать древние слова.",
+         0.05, 20, 3, 5, 20, 3, 2},
+        {SPELL_MASS_SILENCE,
+         "Поведя вокруг грозным взглядом, вы заставили всех замолчать.",
+         nullptr,
+         "Вы встретились взглядом с $n4, и у вас появилось ощущение, что горлу чего-то не хватает.",
+         0.05, 20, 2, 5, 20, 3, 2},
+        {SPELL_DEAFNESS,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.05, 10, 3, 5, 20, 3, 2},
+        {SPELL_MASS_DEAFNESS,
+         "Вы нахмурились, склонив голову, и громкий хлопок сотряс воздух.",
+         "Как только $n0 склонил$g голову, раздался оглушающий хлопок.",
+         nullptr,
+         0.05, 10, 3, 5, 20, 3, 2},
+        {SPELL_MASS_SLOW,
+         "Положив ладони на землю, вы вызвали цепкие корни,\r\nопутавшие существ, стоящих рядом с вами.",
+         nullptr,
+         "$n вызвал$g цепкие корни, опутавшие ваши ноги.",
+         0.05, 10, 3, 5, 20, 3, 2},
+        {SPELL_ARMAGEDDON,
+         "Вы сплели руки в замысловатом жесте, и все потускнело!",
+         "$n сплел$g руки в замысловатом жесте, и все потускнело!",
+         nullptr,
+         0.05, 25, 2, 5, 20, 3, 2},
+        {SPELL_EARTHQUAKE,
+         "Вы опустили руки, и земля начала дрожать вокруг вас!",
+         "$n опустил$g руки, и земля задрожала!",
+         nullptr,
+         0.05, 25, 2, 5, 20, 5, 2},
+        {SPELL_THUNDERSTONE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.05, 25, 2, 3, 15, 3, 4},
+        {SPELL_CONE_OF_COLD,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.05, 40, 2, 2, 5, 5, 4},
+        {SPELL_ACID,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.05, 20, 2, 3, 8, 4, 4},
+        {SPELL_LIGHTNING_BOLT,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.05, 15, 3, 3, 6, 4, 4},
+        {SPELL_CALL_LIGHTNING,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.05, 15, 3, 3, 5, 4, 4},
+        {SPELL_WHIRLWIND,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.05, 40, 1, 1, 3, 3, 4},
+        {SPELL_DAMAGE_SERIOUS,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.05, 20, 3, 1, 6, 6, 4},
+        {SPELL_FIREBLAST,
+         "Вы вызвали потоки подземного пламени!",
+         "$n0 вызвал$g потоки пламени из глубин земли!",
+         nullptr,
+         0.05, 20, 2, 5, 20, 3, 3},
+        {SPELL_ICESTORM,
+         "Вы воздели руки к небу, и тысячи мелких льдинок хлынули вниз!",
+         "$n воздел$g руки к небу, и тысячи мелких льдинок хлынули вниз!",
+         nullptr,
+         0.05, 30, 2, 5, 20, 3, 4},
+        {SPELL_DUSTSTORM,
+         "Вы взмахнули руками и вызвали огромное пылевое облако,\r\nскрывшее все вокруг.",
+         "Вас поглотила пылевая буря, вызванная $n4.",
+         nullptr,
+         0.05, 15, 2, 5, 20, 3, 2},
+        {SPELL_MASS_FEAR,
+         "Вы оглядели комнату устрашающим взглядом, заставив всех содрогнуться.",
+         "$n0 оглядел$g комнату устрашающим взглядом.",
+         nullptr,
+         0.05, 15, 2, 5, 20, 3, 3},
+        {SPELL_GLITTERDUST,
+         "Вы слегка прищелкнули пальцами, и вокруг сгустилось облако блестящей пыли.",
+         "$n0 сотворил$g облако блестящей пыли, медленно осевшее на землю.",
+         nullptr,
+         0.05, 15, 3, 5, 20, 5, 3},
+        {SPELL_SONICWAVE,
+         "Вы оттолкнули от себя воздух руками, и он плотным кольцом стремительно двинулся во все стороны!",
+         "$n махнул$g руками, и огромное кольцо сжатого воздуха распостранилось во все стороны!",
+         nullptr,
+         0.05, 20, 2, 5, 20, 3, 3},
+        {SPELL_CHAIN_LIGHTNING,
+         "Вы подняли руки к небу и оно осветилось яркими вспышками!",
+         "$n поднял$g руки к небу и оно осветилось яркими вспышками!",
+         nullptr,
+         0.05, 10, 3, 1, 8, 1, 5},
+        {SPELL_EARTHFALL,
+         "Вы высоко подбросили комок земли и он, увеличиваясь на глазах, обрушился вниз.",
+         "$n высоко подбросил$g комок земли, который, увеличиваясь на глазах, стал падать вниз.",
+         nullptr,
+         0.05, 20, 2, 1, 3, 1, 8},
+        {SPELL_SHOCK,
+         "Яркая вспышка слетела с кончиков ваших пальцев и с оглушительным грохотом взорвалась в воздухе.",
+         "Выпущенная $n1 яркая вспышка с оглушительным грохотом взорвалась в воздухе.",
+         nullptr,
+         0.05, 35, 2, 1, 4, 2, 8},
+        {SPELL_BURDEN_OF_TIME,
+         "Вы скрестили руки на груди, вызвав яркую вспышку синего света.",
+         "$n0 скрестил$g руки на груди, вызвав яркую вспышку синего света.",
+         nullptr,
+         0.05, 20, 2, 5, 20, 3, 8},
+        {SPELL_FAILURE,
+         "Вы простерли руки над головой, вызвав череду раскатов грома.",
+         "$n0 вызвал$g череду раскатов грома, заставивших все вокруг содрогнуться.",
+         nullptr,
+         0.05, 15, 2, 1, 5, 3, 8},
+        {SPELL_SCREAM,
+         "Вы испустили кошмарный вопль, едва не разорвавший вам горло.",
+         "$n0 испустил$g кошмарный вопль, отдавшийся в вашей душе замогильным холодом.",
+         nullptr,
+         0.05, 40, 3, 1, 8, 3, 5},
+        {SPELL_BURNING_HANDS,
+         "С ваших ладоней сорвался поток жаркого пламени.",
+         "$n0 испустил$g поток жаркого багрового пламени!",
+         nullptr,
+         0.05, 20, 2, 5, 20, 3, 7},
+        {SPELL_COLOR_SPRAY,
+         "Из ваших рук вылетел сноп ледяных стрел.",
+         "$n0 метнул$g во врагов сноп ледяных стрел.",
+         nullptr,
+         0.05, 30, 2, 1, 5, 3, 7},
+        {SPELL_WC_OF_CHALLENGE,
+         nullptr,
+         "Вы не стерпели насмешки, и бросились на $n1!",
+         nullptr,
+         0.01, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_MENACE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.01, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_RAGE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.01, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_MADNESS,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.01, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_THUNDER,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.01, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_DEFENSE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.01, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_HEAL,
+         "Вы подняли голову вверх и ощутили яркий свет, ласково бегущий по вашему телу.\r\n",
+         nullptr,
+         nullptr,
+         0.01, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_ARMOR,
+         "Вы создали защитную сферу, которая окутала вас и пространство рядом с вами.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_RECALL,
+         "Вы выкрикнули заклинание и хлопнули в ладоши.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_STRENGTH,
+         "Вы призвали мощь Вселенной.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_BLESS,
+         "Прикрыв глаза, вы прошептали таинственную молитву.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_HASTE,
+         "Разведя руки в стороны, вы ощутили всю мощь стихии ветра.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_FLY,
+         "Ваше заклинание вызвало белое облако, которое разделилось, подхватывая вас и товарищей.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_INVISIBLE,
+         "Вы вызвали прозрачный туман, поглотивший все дружественное вам.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_MAGICGLASS,
+         "Вы произнесли несколько резких слов, и все вокруг засеребрилось.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_SANCTUARY,
+         "Вы подняли руки к небу и произнесли священную молитву.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_PRISMATICAURA,
+         "Силы духа, призванные вами, окутали вас и окружающих голубоватым сиянием.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_FIRE_AURA,
+         "Силы огня пришли к вам на помощь и защитили вас.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_AIR_AURA,
+         "Силы воздуха пришли к вам на помощь и защитили вас.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_ICE_AURA,
+         "Силы холода пришли к вам на помощь и защитили вас.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_REFRESH,
+         "Ваша магия наполнила воздух зеленоватым сиянием.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_DEFENSE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_BATTLE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_POWER,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_BLESS,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_OF_COURAGE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_SIGHT_OF_DARKNESS,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GENERAL_SINCERITY,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_MAGICAL_GAZE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_ALL_SEEING_EYE,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_EYE_OF_GODS,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_BREATHING_AT_DEPTH,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GENERAL_RECOVERY,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_COMMON_MEAL,
+         "Вы услышали гомон невидимых лакеев, готовящих трапезу.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_STONE_WALL,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_SNAKE_EYES,
+         nullptr,
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_EARTH_AURA,
+         "Земля одарила вас своей защитой.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_PROT_FROM_EVIL,
+         "Сила света подавила в вас страх к тьме.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_BLINK,
+         "Очертания вас и соратников замерцали в такт биения сердца, став прозрачней.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_CLOUDLY,
+         "Пелена тумана окутала вас и окружющих, скрыв очертания.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_GROUP_AWARNESS,
+         "Произнесенные слова обострили ваши чувства и внимательность ваших соратников.\r\n",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_EXPERIENSE,
+         "Вы приготовились к обретению нового опыта.",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_LUCK,
+         "Вы ощутили, что вам улыбнулась удача.",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_WC_PHYSDAMAGE,
+         "Боевой клич придал вам сил!",
+         nullptr,
+         nullptr,
+         0.0, 20, 2, 5, 20, 3, 0},
+        {SPELL_MASS_FAILURE,
+         "Вняв вашему призыву, Змей Велес коснулся недобрым взглядом ваших супостатов.\r\n",
+         nullptr,
+         "$n провыл$g несколько странно звучащих слов и от тяжелого взгляда из-за края мира у вас подкосились ноги.",
+         0.03, 25, 2, 3, 15, 4, 6},
+        {SPELL_MASS_NOFLEE,
+         "Вы соткали магические тенета, опутавшие ваших врагов.\r\n",
+         nullptr,
+         "$n что-то прошептал$g, странно скрючив пальцы, и взлетевшие откуда ни возьмись ловчие сети опутали вас",
+         0.03, 25, 2, 3, 15, 5, 6},
+        {-1, nullptr, nullptr, nullptr, 0.01, 1, 1, 1, 1, 1, 0}
+    };
 
 int findIndexOfSpellMsg(int spellNumber) {
-	int i = 0;
-	for (; mag_messages[i].spell != -1; ++i) {
-		if (mag_messages[i].spell == spellNumber) {
-			return i;
-		}
-	}
-	return i;
+  int i = 0;
+  for (; mag_messages[i].spell != -1; ++i) {
+    if (mag_messages[i].spell == spellNumber) {
+      return i;
+    }
+  }
+  return i;
 }
 
-int trySendCastMessages(CHAR_DATA* ch, CHAR_DATA* victim, ROOM_DATA* room, int spellnum) {
-	int msgIndex = findIndexOfSpellMsg(spellnum);
-	if (mag_messages[msgIndex].spell < 0) {
-		sprintf(buf, "ERROR: Нет сообщений в mag_messages для заклинания с номером %d.", spellnum);
-		mudlog(buf, BRF, LVL_BUILDER, SYSLOG, TRUE);
-		return msgIndex;
-	}
-	if (room && world[ch->in_room] == room) {
-		if (multi_cast_say(ch)) {
-			if (mag_messages[msgIndex].to_char != nullptr) {
-                // вот тут надо воткнуть проверку на группу.
-				act(mag_messages[msgIndex].to_char, FALSE, ch, 0, victim, TO_CHAR);
-			}
-			if (mag_messages[msgIndex].to_room != nullptr) {
-				act(mag_messages[msgIndex].to_room, FALSE, ch, 0, victim, TO_ROOM | TO_ARENA_LISTEN);
-			}
-		}
-	}
-	return msgIndex;
+int trySendCastMessages(CHAR_DATA *ch, CHAR_DATA *victim, ROOM_DATA *room, int spellnum) {
+  int msgIndex = findIndexOfSpellMsg(spellnum);
+  if (mag_messages[msgIndex].spell < 0) {
+    sprintf(buf, "ERROR: Нет сообщений в mag_messages для заклинания с номером %d.", spellnum);
+    mudlog(buf, BRF, LVL_BUILDER, SYSLOG, TRUE);
+    return msgIndex;
+  }
+  if (room && world[ch->in_room] == room) {
+    if (multi_cast_say(ch)) {
+      if (mag_messages[msgIndex].to_char != nullptr) {
+        // вот тут надо воткнуть проверку на группу.
+        act(mag_messages[msgIndex].to_char, FALSE, ch, 0, victim, TO_CHAR);
+      }
+      if (mag_messages[msgIndex].to_room != nullptr) {
+        act(mag_messages[msgIndex].to_room, FALSE, ch, 0, victim, TO_ROOM | TO_ARENA_LISTEN);
+      }
+    }
+  }
+  return msgIndex;
 };
 
-int calculateAmountTargetsOfSpell(const CHAR_DATA* ch, const int& msgIndex, const int& spellnum) {
-	int amount = ch->get_skill(get_magic_skill_number_by_spell(spellnum));
-	amount = dice(amount/mag_messages[msgIndex].skillDivisor, mag_messages[msgIndex].diceSize);
-	return mag_messages[msgIndex].minTargetsAmount + MIN(amount, mag_messages[msgIndex].maxTargetsAmount);
+int calculateAmountTargetsOfSpell(const CHAR_DATA *ch, const int &msgIndex, const int &spellnum) {
+  int amount = ch->get_skill(get_magic_skill_number_by_spell(spellnum));
+  amount = dice(amount / mag_messages[msgIndex].skillDivisor, mag_messages[msgIndex].diceSize);
+  return mag_messages[msgIndex].minTargetsAmount + MIN(amount, mag_messages[msgIndex].maxTargetsAmount);
 }
 
-int callMagicToArea(CHAR_DATA* ch, CHAR_DATA* victim, ROOM_DATA* room, int spellnum, int level) {
-	if (ch == nullptr || IN_ROOM(ch) == NOWHERE) {
-		return 0;
-	}
+int callMagicToArea(CHAR_DATA *ch, CHAR_DATA *victim, ROOM_DATA *room, int spellnum, int level) {
+  if (ch == nullptr || IN_ROOM(ch) == NOWHERE) {
+    return 0;
+  }
 
-	ActionTargeting::FoesRosterType roster{ch, victim, [](CHAR_DATA*, CHAR_DATA* target) {return !IS_HORSE(target);}};
-	int msgIndex = trySendCastMessages(ch, victim, room, spellnum);
-	int targetsAmount = calculateAmountTargetsOfSpell(ch, msgIndex, spellnum);
-	int targetsCounter = 1;
-	float castDecay = 0.0;
-	int levelDecay = 0;
-	if (can_use_feat(ch, MULTI_CAST_FEAT)) {
-		castDecay = mag_messages[msgIndex].castSuccessPercentDecay*0.6;
-		levelDecay = MAX(MIN(1, mag_messages[msgIndex].castLevelDecay), mag_messages[msgIndex].castLevelDecay - 1);
-	} else {
-		castDecay = mag_messages[msgIndex].castSuccessPercentDecay;
-		levelDecay = mag_messages[msgIndex].castLevelDecay;
-	}
-	const int CASTER_CAST_SUCCESS = GET_CAST_SUCCESS(ch);
+  ActionTargeting::FoesRosterType roster{ch, victim, [](CHAR_DATA *, CHAR_DATA *target) { return !IS_HORSE(target); }};
+  int msgIndex = trySendCastMessages(ch, victim, room, spellnum);
+  int targetsAmount = calculateAmountTargetsOfSpell(ch, msgIndex, spellnum);
+  int targetsCounter = 1;
+  float castDecay = 0.0;
+  int levelDecay = 0;
+  if (can_use_feat(ch, MULTI_CAST_FEAT)) {
+    castDecay = mag_messages[msgIndex].castSuccessPercentDecay * 0.6;
+    levelDecay = MAX(MIN(1, mag_messages[msgIndex].castLevelDecay), mag_messages[msgIndex].castLevelDecay - 1);
+  } else {
+    castDecay = mag_messages[msgIndex].castSuccessPercentDecay;
+    levelDecay = mag_messages[msgIndex].castLevelDecay;
+  }
+  const int CASTER_CAST_SUCCESS = GET_CAST_SUCCESS(ch);
 
-	for (const auto& target : roster) {
-		if (mag_messages[msgIndex].to_vict != nullptr && target->desc) {
-			act(mag_messages[msgIndex].to_vict, FALSE, ch, 0, target, TO_VICT);
-		}
-		mag_single_target(level, ch, target, nullptr, spellnum, SAVING_STABILITY);
-		if (ch->purged()) {
-			return 1;
-		}
-		if (!IS_NPC(ch)) {
-			++targetsCounter;
-			if (targetsCounter > mag_messages[msgIndex].freeTargets) {
-				int tax = CASTER_CAST_SUCCESS*castDecay*(targetsCounter - mag_messages[msgIndex].freeTargets);
-				GET_CAST_SUCCESS(ch) = MAX(-200, CASTER_CAST_SUCCESS - tax);
-				level = MAX(1, level - levelDecay);
-				if (PRF_FLAGGED(ch, PRF_TESTER)) {
-					send_to_char(ch, "&GМакс. целей: %d, Каст: %d, Уровень заклинания: %d.&n\r\n", targetsAmount, GET_CAST_SUCCESS(ch), level);
-				}
-			};
-		};
-		if (targetsCounter >= targetsAmount) {
-			break;
-		}
-	}
+  for (const auto &target : roster) {
+    if (mag_messages[msgIndex].to_vict != nullptr && target->desc) {
+      act(mag_messages[msgIndex].to_vict, FALSE, ch, 0, target, TO_VICT);
+    }
+    mag_single_target(level, ch, target, nullptr, spellnum, SAVING_STABILITY);
+    if (ch->purged()) {
+      return 1;
+    }
+    if (!IS_NPC(ch)) {
+      ++targetsCounter;
+      if (targetsCounter > mag_messages[msgIndex].freeTargets) {
+        int tax = CASTER_CAST_SUCCESS * castDecay * (targetsCounter - mag_messages[msgIndex].freeTargets);
+        GET_CAST_SUCCESS(ch) = MAX(-200, CASTER_CAST_SUCCESS - tax);
+        level = MAX(1, level - levelDecay);
+        if (PRF_FLAGGED(ch, PRF_TESTER)) {
+          send_to_char(ch,
+                       "&GМакс. целей: %d, Каст: %d, Уровень заклинания: %d.&n\r\n",
+                       targetsAmount,
+                       GET_CAST_SUCCESS(ch),
+                       level);
+        }
+      };
+    };
+    if (targetsCounter >= targetsAmount) {
+      break;
+    }
+  }
 
-	GET_CAST_SUCCESS(ch) = CASTER_CAST_SUCCESS;
-	return 1;
+  GET_CAST_SUCCESS(ch) = CASTER_CAST_SUCCESS;
+  return 1;
 }
 
 // Применение заклинания к группе в комнате
 //---------------------------------------------------------
-int callMagicToGroup(int level, CHAR_DATA * ch, int spellnum)
-{
-	if (ch == nullptr) {
-		return 0;
-	}
+int callMagicToGroup(int level, CHAR_DATA *ch, int spellnum) {
+  if (ch == nullptr) {
+    return 0;
+  }
 
-	trySendCastMessages(ch, nullptr, world[IN_ROOM(ch)], spellnum);
+  trySendCastMessages(ch, nullptr, world[IN_ROOM(ch)], spellnum);
 
-	ActionTargeting::FriendsRosterType roster{ch, ch};
-	roster.flip();
-	for (const auto target : roster) {
-		mag_single_target(level, ch, target, nullptr, spellnum, SAVING_STABILITY);
-	}
-	return 1;
+  ActionTargeting::FriendsRosterType roster{ch, ch};
+  roster.flip();
+  for (const auto target : roster) {
+    mag_single_target(level, ch, target, nullptr, spellnum, SAVING_STABILITY);
+  }
+  return 1;
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/magic.utils.cpp
+++ b/src/magic.utils.cpp
@@ -50,154 +50,130 @@ char cast_argument[MAX_STRING_LENGTH];
 extern int what_sky;
 
 // local functions
-void say_spell(CHAR_DATA * ch, int spellnum, CHAR_DATA * tch, OBJ_DATA * tobj);
+void say_spell(CHAR_DATA *ch, int spellnum, CHAR_DATA *tch, OBJ_DATA *tobj);
 int get_zone_rooms(int, int *, int *);
 
-int spell_create_level(const CHAR_DATA* ch, int spellnum)
-{
-	int required_level = spell_create[spellnum].runes.min_caster_level;
+int spell_create_level(const CHAR_DATA *ch, int spellnum) {
+  int required_level = spell_create[spellnum].runes.min_caster_level;
 
-	if (required_level >= LVL_GOD)
-		return required_level;
-	if (can_use_feat(ch, SECRET_RUNES_FEAT)) {
-		int remort = ch->get_remort();
-		required_level -= MIN(8, MAX(0, ((remort - 8)/3)*2 + (remort > 7 && remort < 11 ? 1 : 0)));
-	}
+  if (required_level >= LVL_GOD)
+    return required_level;
+  if (can_use_feat(ch, SECRET_RUNES_FEAT)) {
+    int remort = ch->get_remort();
+    required_level -= MIN(8, MAX(0, ((remort - 8) / 3) * 2 + (remort > 7 && remort < 11 ? 1 : 0)));
+  }
 
-	return MAX(1, required_level);
+  return MAX(1, required_level);
 }
 
 // say_spell erodes buf, buf1, buf2
-void say_spell(CHAR_DATA * ch, int spellnum, CHAR_DATA * tch, OBJ_DATA * tobj)
-{
-	char lbuf[256];
-	const char *say_to_self, *say_to_other, *say_to_obj_vis, *say_to_something,
-	*helpee_vict, *damagee_vict, *format;
-	int  religion;
+void say_spell(CHAR_DATA *ch, int spellnum, CHAR_DATA *tch, OBJ_DATA *tobj) {
+  char lbuf[256];
+  const char *say_to_self, *say_to_other, *say_to_obj_vis, *say_to_something,
+      *helpee_vict, *damagee_vict, *format;
+  int religion;
 
+  *buf = '\0';
+  strcpy(lbuf, SpINFO.syn);
+  // Say phrase ?
+  if (cast_phrase[spellnum][GET_RELIGION(ch)] == nullptr) {
+    sprintf(buf, "[ERROR]: say_spell: для спелла %d не объявлена cast_phrase", spellnum);
+    mudlog(buf, CMP, LVL_GOD, SYSLOG, TRUE);
+    return;
+  }
+  if (IS_NPC(ch)) {
+    switch (GET_RACE(ch)) {
+      case NPC_RACE_EVIL_SPIRIT:
+      case NPC_RACE_GHOST:
+      case NPC_RACE_HUMAN:
+      case NPC_RACE_ZOMBIE:
+      case NPC_RACE_SPIRIT: religion = number(RELIGION_POLY, RELIGION_MONO);
+        if (*cast_phrase[spellnum][religion] != '\n')
+          strcpy(buf, cast_phrase[spellnum][religion]);
+        say_to_self = "$n пробормотал$g : '%s'.";
+        say_to_other = "$n взглянул$g на $N3 и бросил$g : '%s'.";
+        say_to_obj_vis = "$n глянул$g на $o3 и произнес$q : '%s'.";
+        say_to_something = "$n произнес$q : '%s'.";
+        damagee_vict = "$n зыркнул$g на вас и проревел$g : '%s'.";
+        helpee_vict = "$n улыбнул$u вам и произнес$q : '%s'.";
+        break;
+      default: say_to_self = "$n издал$g непонятный звук.";
+        say_to_other = "$n издал$g непонятный звук.";
+        say_to_obj_vis = "$n издал$g непонятный звук.";
+        say_to_something = "$n издал$g непонятный звук.";
+        damagee_vict = "$n издал$g непонятный звук.";
+        helpee_vict = "$n издал$g непонятный звук.";
+    }
+  } else {
+    //если включен режим без повторов (подавление ехо) не показываем
+    if (PRF_FLAGGED(ch, PRF_NOREPEAT)) {
+      if (!ch->get_fighting()) //если персонаж не в бою, шлем строчку, если в бою ничего не шлем
+        send_to_char(OK, ch);
+    } else {
+      if (IS_SET(SpINFO.routines, MAG_WARCRY))
+        sprintf(buf, "Вы выкрикнули \"%s%s%s\".\r\n",
+                SpINFO.violent ? CCIRED(ch, C_NRM) : CCIGRN(ch, C_NRM), SpINFO.name, CCNRM(ch, C_NRM));
+      else
+        sprintf(buf, "Вы произнесли заклинание \"%s%s%s\".\r\n",
+                SpINFO.violent ? CCIRED(ch, C_NRM) : CCIGRN(ch, C_NRM), SpINFO.name, CCNRM(ch, C_NRM));
+      send_to_char(buf, ch);
+    }
+    if (*cast_phrase[spellnum][GET_RELIGION(ch)] != '\n')
+      strcpy(buf, cast_phrase[spellnum][GET_RELIGION(ch)]);
+    say_to_self = "$n прикрыл$g глаза и прошептал$g : '%s'.";
+    say_to_other = "$n взглянул$g на $N3 и произнес$q : '%s'.";
+    say_to_obj_vis = "$n посмотрел$g на $o3 и произнес$q : '%s'.";
+    say_to_something = "$n произнес$q : '%s'.";
+    damagee_vict = "$n зыркнул$g на вас и произнес$q : '%s'.";
+    helpee_vict = "$n подмигнул$g вам и произнес$q : '%s'.";
+  }
 
-	*buf = '\0';
-	strcpy(lbuf, SpINFO.syn);
-	// Say phrase ?
-	if (cast_phrase[spellnum][GET_RELIGION(ch)] == nullptr){
-		sprintf(buf, "[ERROR]: say_spell: для спелла %d не объявлена cast_phrase", spellnum);
-		mudlog(buf, CMP, LVL_GOD, SYSLOG, TRUE);
-		return;
-	}
-	if (IS_NPC(ch)) {
-		switch (GET_RACE(ch)) {
-		case NPC_RACE_EVIL_SPIRIT:
-		case NPC_RACE_GHOST:
-		case NPC_RACE_HUMAN:
-		case NPC_RACE_ZOMBIE:
-		case NPC_RACE_SPIRIT:
-			religion = number(RELIGION_POLY, RELIGION_MONO);
-			if (*cast_phrase[spellnum][religion] != '\n')
-				strcpy(buf, cast_phrase[spellnum][religion]);
-			say_to_self = "$n пробормотал$g : '%s'.";
-			say_to_other = "$n взглянул$g на $N3 и бросил$g : '%s'.";
-			say_to_obj_vis = "$n глянул$g на $o3 и произнес$q : '%s'.";
-			say_to_something = "$n произнес$q : '%s'.";
-			damagee_vict = "$n зыркнул$g на вас и проревел$g : '%s'.";
-			helpee_vict = "$n улыбнул$u вам и произнес$q : '%s'.";
-			break;
-		default:
-			say_to_self = "$n издал$g непонятный звук.";
-			say_to_other = "$n издал$g непонятный звук.";
-			say_to_obj_vis = "$n издал$g непонятный звук.";
-			say_to_something = "$n издал$g непонятный звук.";
-			damagee_vict = "$n издал$g непонятный звук.";
-			helpee_vict = "$n издал$g непонятный звук.";
-		}
-	}
-	else {
-		//если включен режим без повторов (подавление ехо) не показываем
-		if (PRF_FLAGGED(ch, PRF_NOREPEAT)) {
-			if (!ch->get_fighting()) //если персонаж не в бою, шлем строчку, если в бою ничего не шлем
-				send_to_char(OK, ch);
-		}
-		else {
-			if (IS_SET(SpINFO.routines, MAG_WARCRY))
-				sprintf(buf, "Вы выкрикнули \"%s%s%s\".\r\n",
-					SpINFO.violent ? CCIRED(ch, C_NRM) : CCIGRN(ch, C_NRM), SpINFO.name, CCNRM(ch, C_NRM));
-			else
-				sprintf(buf, "Вы произнесли заклинание \"%s%s%s\".\r\n",
-					SpINFO.violent ? CCIRED(ch, C_NRM) : CCIGRN(ch, C_NRM), SpINFO.name, CCNRM(ch, C_NRM));
-			send_to_char(buf, ch);
-		}
-		if (*cast_phrase[spellnum][GET_RELIGION(ch)] != '\n')
-			strcpy(buf, cast_phrase[spellnum][GET_RELIGION(ch)]);
-		say_to_self = "$n прикрыл$g глаза и прошептал$g : '%s'.";
-		say_to_other = "$n взглянул$g на $N3 и произнес$q : '%s'.";
-		say_to_obj_vis = "$n посмотрел$g на $o3 и произнес$q : '%s'.";
-		say_to_something = "$n произнес$q : '%s'.";
-		damagee_vict = "$n зыркнул$g на вас и произнес$q : '%s'.";
-		helpee_vict = "$n подмигнул$g вам и произнес$q : '%s'.";
-	}
+  if (tch != NULL && IN_ROOM(tch) == ch->in_room) {
+    if (tch == ch) {
+      format = say_to_self;
+    } else {
+      format = say_to_other;
+    }
+  } else if (tobj != NULL && (tobj->get_in_room() == ch->in_room || tobj->get_carried_by() == ch)) {
+    format = say_to_obj_vis;
+  } else {
+    format = say_to_something;
+  }
 
-	if (tch != NULL && IN_ROOM(tch) == ch->in_room)
-	{
-		if (tch == ch)
-		{
-			format = say_to_self;
-		}
-		else
-		{
-			format = say_to_other;
-		}
-	}
-	else if (tobj != NULL && (tobj->get_in_room() == ch->in_room || tobj->get_carried_by() == ch))
-	{
-		format = say_to_obj_vis;
-	}
-	else
-	{
-		format = say_to_something;
-	}
+  sprintf(buf1, format, spell_name(spellnum));
+  sprintf(buf2, format, buf);
 
-	sprintf(buf1, format, spell_name(spellnum));
-	sprintf(buf2, format, buf);
+  for (const auto i : world[ch->in_room]->people) {
+    if (i == ch
+        || i == tch
+        || !i->desc
+        || !AWAKE(i)
+        || AFF_FLAGGED(i, EAffectFlag::AFF_DEAFNESS)) {
+      continue;
+    }
 
-	for (const auto i : world[ch->in_room]->people)
-	{
-		if (i == ch
-			|| i == tch
-			|| !i->desc
-			|| !AWAKE(i)
-			|| AFF_FLAGGED(i, EAffectFlag::AFF_DEAFNESS))
-		{
-			continue;
-		}
+    if (IS_SET(GET_SPELL_TYPE(i, spellnum), SPELL_KNOW | SPELL_TEMP)) {
+      perform_act(buf1, ch, tobj, tch, i);
+    } else {
+      perform_act(buf2, ch, tobj, tch, i);
+    }
+  }
 
-		if (IS_SET(GET_SPELL_TYPE(i, spellnum), SPELL_KNOW | SPELL_TEMP))
-		{
-			perform_act(buf1, ch, tobj, tch, i);
-		}
-		else
-		{
-			perform_act(buf2, ch, tobj, tch, i);
-		}
-	}
+  act(buf1, 1, ch, tobj, tch, TO_ARENA_LISTEN);
 
-	act(buf1, 1, ch, tobj, tch, TO_ARENA_LISTEN);
-
-	if (tch != NULL
-		&& tch != ch
-		&& IN_ROOM(tch) == ch->in_room
-		&& !AFF_FLAGGED(tch, EAffectFlag::AFF_DEAFNESS))
-	{
-		if (SpINFO.violent)
-		{
-			sprintf(buf1, damagee_vict,
-				IS_SET(GET_SPELL_TYPE(tch, spellnum), SPELL_KNOW | SPELL_TEMP) ? spell_name(spellnum) : buf);
-		}
-		else
-		{
-			sprintf(buf1, helpee_vict,
-				IS_SET(GET_SPELL_TYPE(tch, spellnum), SPELL_KNOW | SPELL_TEMP) ? spell_name(spellnum) : buf);
-		}
-		act(buf1, FALSE, ch, NULL, tch, TO_VICT);
-	}
+  if (tch != NULL
+      && tch != ch
+      && IN_ROOM(tch) == ch->in_room
+      && !AFF_FLAGGED(tch, EAffectFlag::AFF_DEAFNESS)) {
+    if (SpINFO.violent) {
+      sprintf(buf1, damagee_vict,
+              IS_SET(GET_SPELL_TYPE(tch, spellnum), SPELL_KNOW | SPELL_TEMP) ? spell_name(spellnum) : buf);
+    } else {
+      sprintf(buf1, helpee_vict,
+              IS_SET(GET_SPELL_TYPE(tch, spellnum), SPELL_KNOW | SPELL_TEMP) ? spell_name(spellnum) : buf);
+    }
+    act(buf1, FALSE, ch, NULL, tch, TO_VICT);
+  }
 }
 
 /*
@@ -206,219 +182,187 @@ void say_spell(CHAR_DATA * ch, int spellnum, CHAR_DATA * tch, OBJ_DATA * tobj)
  * this because you can guarantee > 0 and <= TOP_SPELL_DEFINE.
  */
 
-template <typename T>
-void fix_name(T& name)
-{
-	size_t pos = 0;
-	while ('\0' != name[pos] && pos < MAX_STRING_LENGTH)
-	{
-		if (('.' == name[pos]) || ('_' == name[pos]))
-		{
-			name[pos] = ' ';
-		}
-		++pos;
-	}
+template<typename T>
+void fix_name(T &name) {
+  size_t pos = 0;
+  while ('\0' != name[pos] && pos < MAX_STRING_LENGTH) {
+    if (('.' == name[pos]) || ('_' == name[pos])) {
+      name[pos] = ' ';
+    }
+    ++pos;
+  }
 }
 
-void fix_name_feat(char *name)
-{
-	fix_name(name);
+void fix_name_feat(char *name) {
+  fix_name(name);
 }
 
-ESkill find_skill_num(const char *name)
-{
-	int ok;
-	char const *temp, *temp2;
-	char first[256], first2[256];
+ESkill find_skill_num(const char *name) {
+  int ok;
+  char const *temp, *temp2;
+  char first[256], first2[256];
 
-	for (const auto index : AVAILABLE_SKILLS)
-	{
-		if (is_abbrev(name, skill_info[index].name))
-		{
-			return (index);
-		}
+  for (const auto index : AVAILABLE_SKILLS) {
+    if (is_abbrev(name, skill_info[index].name)) {
+      return (index);
+    }
 
-		ok = TRUE;
-		// It won't be changed, but other uses of this function elsewhere may.
-		temp = any_one_arg(skill_info[index].name, first);
-		temp2 = any_one_arg(name, first2);
-		while (*first && *first2 && ok)
-		{
-			if (!is_abbrev(first2, first))
-			{
-				ok = FALSE;
-			}
-			temp = any_one_arg(temp, first);
-			temp2 = any_one_arg(temp2, first2);
-		}
+    ok = TRUE;
+    // It won't be changed, but other uses of this function elsewhere may.
+    temp = any_one_arg(skill_info[index].name, first);
+    temp2 = any_one_arg(name, first2);
+    while (*first && *first2 && ok) {
+      if (!is_abbrev(first2, first)) {
+        ok = FALSE;
+      }
+      temp = any_one_arg(temp, first);
+      temp2 = any_one_arg(temp2, first2);
+    }
 
-		if (ok && !*first2)
-		{
-			return (index);
-		}
-	}
+    if (ok && !*first2) {
+      return (index);
+    }
+  }
 
-	return SKILL_INVALID;
+  return SKILL_INVALID;
 }
 
-int find_spell_num(const char *name)
-{
-	int index, ok;
-	int use_syn = 0;
-	char const *temp, *temp2, *realname;
-	char first[256], first2[256];
+int find_spell_num(const char *name) {
+  int index, ok;
+  int use_syn = 0;
+  char const *temp, *temp2, *realname;
+  char first[256], first2[256];
 
-	use_syn = (((ubyte) * name <= (ubyte) 'z')
-			   && ((ubyte) * name >= (ubyte) 'a'))
-			  || (((ubyte) * name <= (ubyte) 'Z') && ((ubyte) * name >= (ubyte) 'A'));
+  use_syn = (((ubyte) *name <= (ubyte) 'z')
+      && ((ubyte) *name >= (ubyte) 'a'))
+      || (((ubyte) *name <= (ubyte) 'Z') && ((ubyte) *name >= (ubyte) 'A'));
 
-	for (index = 1; index <= TOP_SPELL_DEFINE; index++)
-	{
-		realname = (use_syn) ? spell_info[index].syn : spell_info[index].name;
+  for (index = 1; index <= TOP_SPELL_DEFINE; index++) {
+    realname = (use_syn) ? spell_info[index].syn : spell_info[index].name;
 
-		if (!realname || !*realname)
-			continue;
-		if (is_abbrev(name, realname))
-			return (index);
-		ok = TRUE;
-		// It won't be changed, but other uses of this function elsewhere may.
-		temp = any_one_arg(realname, first);
-		temp2 = any_one_arg(name, first2);
-		while (*first && *first2 && ok)
-		{
-			if (!is_abbrev(first2, first))
-				ok = FALSE;
-			temp = any_one_arg(temp, first);
-			temp2 = any_one_arg(temp2, first2);
-		}
-		if (ok && !*first2)
-			return (index);
+    if (!realname || !*realname)
+      continue;
+    if (is_abbrev(name, realname))
+      return (index);
+    ok = TRUE;
+    // It won't be changed, but other uses of this function elsewhere may.
+    temp = any_one_arg(realname, first);
+    temp2 = any_one_arg(name, first2);
+    while (*first && *first2 && ok) {
+      if (!is_abbrev(first2, first))
+        ok = FALSE;
+      temp = any_one_arg(temp, first);
+      temp2 = any_one_arg(temp2, first2);
+    }
+    if (ok && !*first2)
+      return (index);
 
-	}
-	return (-1);
+  }
+  return (-1);
 }
 
-ESkill fix_name_and_find_skill_num(char *name)
-{
-	fix_name(name);
-	return find_skill_num(name);
+ESkill fix_name_and_find_skill_num(char *name) {
+  fix_name(name);
+  return find_skill_num(name);
 }
 
-ESkill fix_name_and_find_skill_num(std::string& name)
-{
-	fix_name(name);
-	return find_skill_num(name.c_str());
+ESkill fix_name_and_find_skill_num(std::string &name) {
+  fix_name(name);
+  return find_skill_num(name.c_str());
 }
 
-int fix_name_and_find_spell_num(char *name)
-{
-	fix_name(name);
-	return find_spell_num(name);
+int fix_name_and_find_spell_num(char *name) {
+  fix_name(name);
+  return find_spell_num(name);
 }
 
-int fix_name_and_find_spell_num(std::string& name)
-{
-	fix_name(name);
-	return find_spell_num(name.c_str());
+int fix_name_and_find_spell_num(std::string &name) {
+  fix_name(name);
+  return find_spell_num(name.c_str());
 }
 
-int may_cast_in_nomagic(CHAR_DATA * caster, CHAR_DATA* /*victim*/, int spellnum)
-{
-	// More than 33 level - may cast always
-	if (IS_GRGOD(caster) || IS_SET(SpINFO.routines, MAG_WARCRY))
-		return TRUE;
-	if (IS_NPC(caster) && !(AFF_FLAGGED(caster, EAffectFlag::AFF_CHARM) || MOB_FLAGGED(caster, MOB_ANGEL)))
-		return TRUE;
+int may_cast_in_nomagic(CHAR_DATA *caster, CHAR_DATA * /*victim*/, int spellnum) {
+  // More than 33 level - may cast always
+  if (IS_GRGOD(caster) || IS_SET(SpINFO.routines, MAG_WARCRY))
+    return TRUE;
+  if (IS_NPC(caster) && !(AFF_FLAGGED(caster, EAffectFlag::AFF_CHARM) || MOB_FLAGGED(caster, MOB_ANGEL)))
+    return TRUE;
 
-	return FALSE;
+  return FALSE;
 }
-
 
 // может ли кастер зачитать заклинание?
-int may_cast_here(CHAR_DATA * caster, CHAR_DATA * victim, int spellnum)
-{
-	int ignore;
+int may_cast_here(CHAR_DATA *caster, CHAR_DATA *victim, int spellnum) {
+  int ignore;
 
-	//  More than 33 level - may cast always
-	if (IS_GRGOD(caster))
-	{
-		return TRUE;
-	}
+  //  More than 33 level - may cast always
+  if (IS_GRGOD(caster)) {
+    return TRUE;
+  }
 
-	if (ROOM_FLAGGED(IN_ROOM(caster), ROOM_NOBATTLE) && SpINFO.violent)
-	{
-		return FALSE;
-	}
+  if (ROOM_FLAGGED(IN_ROOM(caster), ROOM_NOBATTLE) && SpINFO.violent) {
+    return FALSE;
+  }
 
-	// не в мирке можно кастовать все что угодно
-	if (!ROOM_FLAGGED(IN_ROOM(caster), ROOM_PEACEFUL))
-	{
-		return TRUE;
-	}
+  // не в мирке можно кастовать все что угодно
+  if (!ROOM_FLAGGED(IN_ROOM(caster), ROOM_PEACEFUL)) {
+    return TRUE;
+  }
 
-	// Проверяю, что закл имеет одну из допустимых комбинаций параметров
-	ignore = IS_SET(SpINFO.targets, TAR_IGNORE)
-		|| IS_SET(SpINFO.routines, MAG_MASSES)
-		|| IS_SET(SpINFO.routines, MAG_GROUPS);
+  // Проверяю, что закл имеет одну из допустимых комбинаций параметров
+  ignore = IS_SET(SpINFO.targets, TAR_IGNORE)
+      || IS_SET(SpINFO.routines, MAG_MASSES)
+      || IS_SET(SpINFO.routines, MAG_GROUPS);
 
-	// цели нет
-	if (!ignore && !victim)
-	{
-		return TRUE;
-	}
+  // цели нет
+  if (!ignore && !victim) {
+    return TRUE;
+  }
 
-	if (ignore && !IS_SET(SpINFO.routines, MAG_MASSES) && !IS_SET(SpINFO.routines, MAG_GROUPS))
-	{
-		if (SpINFO.violent)
-		{
-			return FALSE;	// нельзя злые кастовать
-		}
-		// если игнорируется цель, то должен быть GROUP или MASS
-		// в противном случае на цель кастовать нельзя
-		return victim == 0 ? TRUE : FALSE;
-	}
-	// остальные комбинации не проверяю
+  if (ignore && !IS_SET(SpINFO.routines, MAG_MASSES) && !IS_SET(SpINFO.routines, MAG_GROUPS)) {
+    if (SpINFO.violent) {
+      return FALSE;    // нельзя злые кастовать
+    }
+    // если игнорируется цель, то должен быть GROUP или MASS
+    // в противном случае на цель кастовать нельзя
+    return victim == 0 ? TRUE : FALSE;
+  }
+  // остальные комбинации не проверяю
 
-	// индивидуальная цель
-	ignore = victim
-		&& (IS_SET(SpINFO.targets, TAR_CHAR_ROOM)
-			|| IS_SET(SpINFO.targets, TAR_CHAR_WORLD))
-		&& !IS_SET(SpINFO.routines, MAG_AREAS);
+  // индивидуальная цель
+  ignore = victim
+      && (IS_SET(SpINFO.targets, TAR_CHAR_ROOM)
+          || IS_SET(SpINFO.targets, TAR_CHAR_WORLD))
+      && !IS_SET(SpINFO.routines, MAG_AREAS);
 
-	// начинаю проверять условия каста
-	// Для добрых заклинаний - проверка на противника цели
-	// Для злых заклинаний - проверка на цель
-	for (const auto ch_vict : world[caster->in_room]->people)
-	{
-		if (IS_IMMORTAL(ch_vict))
-			continue;	// имморталы на этот процесс не влияют
-		if (!HERE(ch_vict))
-			continue;	// лд не участвуют
-		if (SpINFO.violent && same_group(caster, ch_vict))
-			continue;	// на согрупника кастовться не будет
-		if (ignore && ch_vict != victim)
-			continue;	// только по 1 чару, и не текущему
-		// ch_vict может стать потунциальной жертвой
-		if (SpINFO.violent)
-		{
-			if (!may_kill_here(caster, ch_vict, NoArgument))
-			{
-				return 0;
-			}
-		}
-		else
-		{
-			if (!may_kill_here(caster, ch_vict->get_fighting(), NoArgument))
-			{
-				return 0;
-			}
-		}
-	}
+  // начинаю проверять условия каста
+  // Для добрых заклинаний - проверка на противника цели
+  // Для злых заклинаний - проверка на цель
+  for (const auto ch_vict : world[caster->in_room]->people) {
+    if (IS_IMMORTAL(ch_vict))
+      continue;    // имморталы на этот процесс не влияют
+    if (!HERE(ch_vict))
+      continue;    // лд не участвуют
+    if (SpINFO.violent && same_group(caster, ch_vict))
+      continue;    // на согрупника кастовться не будет
+    if (ignore && ch_vict != victim)
+      continue;    // только по 1 чару, и не текущему
+    // ch_vict может стать потунциальной жертвой
+    if (SpINFO.violent) {
+      if (!may_kill_here(caster, ch_vict, NoArgument)) {
+        return 0;
+      }
+    } else {
+      if (!may_kill_here(caster, ch_vict->get_fighting(), NoArgument)) {
+        return 0;
+      }
+    }
+  }
 
-	// check_pkill вызвать не могу, т.к. имя жертвы безвозвратно утеряно
+  // check_pkill вызвать не могу, т.к. имя жертвы безвозвратно утеряно
 
-	// Ура! Можно
-	return (TRUE);
+  // Ура! Можно
+  return (TRUE);
 }
 
 /*
@@ -428,222 +372,203 @@ int may_cast_here(CHAR_DATA * caster, CHAR_DATA * victim, int spellnum)
  * This is also the entry point for non-spoken or unrestricted spells.
  * Spellnum 0 is legal but silently ignored here, to make callers simpler.
  */
-int call_magic(CHAR_DATA * caster, CHAR_DATA * cvict, OBJ_DATA * ovict, ROOM_DATA *rvict, int spellnum, int level) {
+int call_magic(CHAR_DATA *caster, CHAR_DATA *cvict, OBJ_DATA *ovict, ROOM_DATA *rvict, int spellnum, int level) {
 
-	if (spellnum < 1 || spellnum > TOP_SPELL_DEFINE)
-		return (0);
+  if (spellnum < 1 || spellnum > TOP_SPELL_DEFINE)
+    return (0);
 
-	if (caster && cvict) {
-		cast_mtrigger(cvict, caster, spellnum);
-	}
+  if (caster && cvict) {
+    cast_mtrigger(cvict, caster, spellnum);
+  }
 
-	if (ROOM_FLAGGED(IN_ROOM(caster), ROOM_NOMAGIC) && !may_cast_in_nomagic(caster, cvict, spellnum)) {
-		send_to_char("Ваша магия потерпела неудачу и развеялась по воздуху.\r\n", caster);
-		act("Магия $n1 потерпела неудачу и развеялась по воздуху.", FALSE, caster, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		return 0;
-	}
+  if (ROOM_FLAGGED(IN_ROOM(caster), ROOM_NOMAGIC) && !may_cast_in_nomagic(caster, cvict, spellnum)) {
+    send_to_char("Ваша магия потерпела неудачу и развеялась по воздуху.\r\n", caster);
+    act("Магия $n1 потерпела неудачу и развеялась по воздуху.", FALSE, caster, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+    return 0;
+  }
 
-	if (!may_cast_here(caster, cvict, spellnum)) {
-		if (IS_SET(SpINFO.routines, MAG_WARCRY)) {
-			send_to_char("Ваш громовой глас сотряс воздух, но ничего не произошло!\r\n", caster);
-			act("Вы вздрогнули от неожиданного крика, но ничего не произошло.", FALSE, caster, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		} else {
-			send_to_char("Ваша магия обратилась всего лишь в яркую вспышку!\r\n", caster);
-			act("Яркая вспышка на миг осветила комнату, и тут же погасла.", FALSE, caster, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-		}
-		return 0;
-	}
+  if (!may_cast_here(caster, cvict, spellnum)) {
+    if (IS_SET(SpINFO.routines, MAG_WARCRY)) {
+      send_to_char("Ваш громовой глас сотряс воздух, но ничего не произошло!\r\n", caster);
+      act("Вы вздрогнули от неожиданного крика, но ничего не произошло.",
+          FALSE,
+          caster,
+          0,
+          0,
+          TO_ROOM | TO_ARENA_LISTEN);
+    } else {
+      send_to_char("Ваша магия обратилась всего лишь в яркую вспышку!\r\n", caster);
+      act("Яркая вспышка на миг осветила комнату, и тут же погасла.", FALSE, caster, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+    }
+    return 0;
+  }
 
-	if (SpellUsage::isActive)
-		SpellUsage::AddSpellStat(GET_CLASS(caster), spellnum);
+  if (SpellUsage::isActive)
+    SpellUsage::AddSpellStat(GET_CLASS(caster), spellnum);
 
-	if (IS_SET(SpINFO.routines, MAG_AREAS) || IS_SET(SpINFO.routines, MAG_MASSES))
-		return callMagicToArea(caster, cvict, rvict, spellnum, level);
+  if (IS_SET(SpINFO.routines, MAG_AREAS) || IS_SET(SpINFO.routines, MAG_MASSES))
+    return callMagicToArea(caster, cvict, rvict, spellnum, level);
 
-	if (IS_SET(SpINFO.routines, MAG_GROUPS))
-		return callMagicToGroup(level, caster, spellnum);
+  if (IS_SET(SpINFO.routines, MAG_GROUPS))
+    return callMagicToGroup(level, caster, spellnum);
 
-	if (IS_SET(SpINFO.routines, MAG_ROOM))
-		return RoomSpells::imposeSpellToRoom(level, caster, rvict, spellnum);
+  if (IS_SET(SpINFO.routines, MAG_ROOM))
+    return RoomSpells::imposeSpellToRoom(level, caster, rvict, spellnum);
 
-	return mag_single_target(level, caster, cvict, ovict, spellnum, SAVING_STABILITY);
+  return mag_single_target(level, caster, cvict, ovict, spellnum, SAVING_STABILITY);
 }
 
-const char *what_sky_type[] = { "пасмурно",
-								"cloudless",
-								"облачно",
-								"cloudy",
-								"дождь",
-								"raining",
-								"ясно",
-								"lightning",
-								"\n"
-							  };
+const char *what_sky_type[] = {"пасмурно",
+                               "cloudless",
+                               "облачно",
+                               "cloudy",
+                               "дождь",
+                               "raining",
+                               "ясно",
+                               "lightning",
+                               "\n"
+};
 
-const char *what_weapon[] = { "плеть",
-							  "whip",
-							  "дубина",
-							  "club",
-							  "\n"
-							};
+const char *what_weapon[] = {"плеть",
+                             "whip",
+                             "дубина",
+                             "club",
+                             "\n"
+};
 
 /**
 * Поиск предмета для каста локейта (без учета видимости для чара и с поиском
 * как в основном списке, так и в личных хранилищах с почтой).
 */
-OBJ_DATA *find_obj_for_locate(CHAR_DATA *ch, const char *name)
-{
+OBJ_DATA *find_obj_for_locate(CHAR_DATA *ch, const char *name) {
 //	OBJ_DATA *obj = ObjectAlias::locate_object(name);
-	OBJ_DATA *obj = get_obj_vis_for_locate(ch, name);
-	if (!obj)
-	{
-		obj = Depot::locate_object(name);
-		if (!obj)
-		{
-			obj = Parcel::locate_object(name);
-		}
-	}
-	return obj;
+  OBJ_DATA *obj = get_obj_vis_for_locate(ch, name);
+  if (!obj) {
+    obj = Depot::locate_object(name);
+    if (!obj) {
+      obj = Parcel::locate_object(name);
+    }
+  }
+  return obj;
 }
 
-int find_cast_target(int spellnum, const char *t, CHAR_DATA * ch, CHAR_DATA ** tch, OBJ_DATA ** tobj, ROOM_DATA ** troom)
-{
-	*tch = NULL;
-	*tobj = NULL;
-	*troom = world[ch->in_room];
-	if (spellnum == SPELL_CONTROL_WEATHER)
-	{
-		if ((what_sky = search_block(t, what_sky_type, FALSE)) < 0)
-		{
-			send_to_char("Не указан тип погоды.\r\n", ch);
-			return FALSE;
-		}
-		else
-			what_sky >>= 1;
-	}
+int find_cast_target(int spellnum, const char *t, CHAR_DATA *ch, CHAR_DATA **tch, OBJ_DATA **tobj, ROOM_DATA **troom) {
+  *tch = NULL;
+  *tobj = NULL;
+  *troom = world[ch->in_room];
+  if (spellnum == SPELL_CONTROL_WEATHER) {
+    if ((what_sky = search_block(t, what_sky_type, FALSE)) < 0) {
+      send_to_char("Не указан тип погоды.\r\n", ch);
+      return FALSE;
+    } else
+      what_sky >>= 1;
+  }
 
-	if (spellnum == SPELL_CREATE_WEAPON)
-	{
-		if ((what_sky = search_block(t, what_weapon, FALSE)) < 0)
-		{
-			send_to_char("Не указан тип оружия.\r\n", ch);
-			return FALSE;
-		}
-		else
-			what_sky = 5 + (what_sky >> 1);
-	}
+  if (spellnum == SPELL_CREATE_WEAPON) {
+    if ((what_sky = search_block(t, what_weapon, FALSE)) < 0) {
+      send_to_char("Не указан тип оружия.\r\n", ch);
+      return FALSE;
+    } else
+      what_sky = 5 + (what_sky >> 1);
+  }
 
-	strcpy(cast_argument, t);
+  strcpy(cast_argument, t);
 
-	if (IS_SET(SpINFO.targets, TAR_ROOM_THIS))
-		return TRUE;
-	if (IS_SET(SpINFO.targets, TAR_IGNORE))
-		return TRUE;
-	else if (*t)
-	{
-		if (IS_SET(SpINFO.targets, TAR_CHAR_ROOM))
-		{
-			if ((*tch = get_char_vis(ch, t, FIND_CHAR_ROOM)) != NULL)
-			{
-				if (SpINFO.violent && !check_pkill(ch, *tch, t))
-					return FALSE;
-				return TRUE;
-			}
-		}
+  if (IS_SET(SpINFO.targets, TAR_ROOM_THIS))
+    return TRUE;
+  if (IS_SET(SpINFO.targets, TAR_IGNORE))
+    return TRUE;
+  else if (*t) {
+    if (IS_SET(SpINFO.targets, TAR_CHAR_ROOM)) {
+      if ((*tch = get_char_vis(ch, t, FIND_CHAR_ROOM)) != NULL) {
+        if (SpINFO.violent && !check_pkill(ch, *tch, t))
+          return FALSE;
+        return TRUE;
+      }
+    }
 
-		if (IS_SET(SpINFO.targets, TAR_CHAR_WORLD)) {
-			if ((*tch = get_char_vis(ch, t, FIND_CHAR_WORLD)) != NULL) {
-				// чтобы мобов не чекали
-				if (IS_NPC(ch) || !IS_NPC(*tch)) {
-					if (SpINFO.violent && !check_pkill(ch, *tch, t)) {
-						return FALSE;
-					}
-					return TRUE;
-				}
-				if (!IS_NPC(ch)) {
-					struct follow_type *k, *k_next;
-					int tnum = 1, fnum = 0; // ищем одноимённые цели
-					char tmpname[MAX_INPUT_LENGTH];
-					char *tmp = tmpname;
-					strcpy(tmp, t);
-					tnum = get_number(&tmp); // возвращает 1, если первая цель
-					for (k = ch->followers; k; k = k_next) {
-						k_next = k->next;
-						if (isname(tmp, k->follower->get_pc_name())) {
-							if (++fnum == tnum) {// нашли!!
-								*tch = k->follower;
-								return TRUE;
-							}
-						}
-					}
-				}
-			}
-		}
+    if (IS_SET(SpINFO.targets, TAR_CHAR_WORLD)) {
+      if ((*tch = get_char_vis(ch, t, FIND_CHAR_WORLD)) != NULL) {
+        // чтобы мобов не чекали
+        if (IS_NPC(ch) || !IS_NPC(*tch)) {
+          if (SpINFO.violent && !check_pkill(ch, *tch, t)) {
+            return FALSE;
+          }
+          return TRUE;
+        }
+        if (!IS_NPC(ch)) {
+          struct follow_type *k, *k_next;
+          int tnum = 1, fnum = 0; // ищем одноимённые цели
+          char tmpname[MAX_INPUT_LENGTH];
+          char *tmp = tmpname;
+          strcpy(tmp, t);
+          tnum = get_number(&tmp); // возвращает 1, если первая цель
+          for (k = ch->followers; k; k = k_next) {
+            k_next = k->next;
+            if (isname(tmp, k->follower->get_pc_name())) {
+              if (++fnum == tnum) {// нашли!!
+                *tch = k->follower;
+                return TRUE;
+              }
+            }
+          }
+        }
+      }
+    }
 
-		if (IS_SET(SpINFO.targets, TAR_OBJ_INV))
-			if ((*tobj = get_obj_in_list_vis(ch, t, ch->carrying)) != NULL)
-				return TRUE;
+    if (IS_SET(SpINFO.targets, TAR_OBJ_INV))
+      if ((*tobj = get_obj_in_list_vis(ch, t, ch->carrying)) != NULL)
+        return TRUE;
 
-		if (IS_SET(SpINFO.targets, TAR_OBJ_EQUIP))
-		{
-			int tmp;
-			if ((*tobj = get_object_in_equip_vis(ch, t, ch->equipment, &tmp)) != NULL)
-				return TRUE;
-		}
+    if (IS_SET(SpINFO.targets, TAR_OBJ_EQUIP)) {
+      int tmp;
+      if ((*tobj = get_object_in_equip_vis(ch, t, ch->equipment, &tmp)) != NULL)
+        return TRUE;
+    }
 
-		if (IS_SET(SpINFO.targets, TAR_OBJ_ROOM))
-			if ((*tobj = get_obj_in_list_vis(ch, t, world[ch->in_room]->contents)) != NULL)
-				return TRUE;
+    if (IS_SET(SpINFO.targets, TAR_OBJ_ROOM))
+      if ((*tobj = get_obj_in_list_vis(ch, t, world[ch->in_room]->contents)) != NULL)
+        return TRUE;
 
-		if (IS_SET(SpINFO.targets, TAR_OBJ_WORLD))
-		{
+    if (IS_SET(SpINFO.targets, TAR_OBJ_WORLD)) {
 //			if ((*tobj = get_obj_vis(ch, t)) != NULL)
 //				return TRUE;
-			if (spellnum == SPELL_LOCATE_OBJECT)
-			{
-				*tobj = find_obj_for_locate(ch, t);
-			}
-			else
-			{
-				*tobj = get_obj_vis(ch, t);
-			}
-			if (*tobj)
-			{
-				return true;
-			}
-		}
-	}
-	else
-	{
-		if (IS_SET(SpINFO.targets, TAR_FIGHT_SELF))
-			if (ch->get_fighting() != NULL)
-			{
-				*tch = ch;
-				return TRUE;
-			}
-		if (IS_SET(SpINFO.targets, TAR_FIGHT_VICT))
-			if (ch->get_fighting() != NULL)
-			{
-				*tch = ch->get_fighting();
-				return TRUE;
-			}
-		if (IS_SET(SpINFO.targets, TAR_CHAR_ROOM) && !SpINFO.violent)
-		{
-			*tch = ch;
-			return TRUE;
-		}
-	}
-	// TODO: добавить обработку TAR_ROOM_DIR и TAR_ROOM_WORLD
-	if (IS_SET(SpINFO.routines, MAG_WARCRY))
-		sprintf(buf, "И на %s же вы хотите так громко крикнуть?\r\n",
-				IS_SET(SpINFO.targets, TAR_OBJ_ROOM | TAR_OBJ_INV | TAR_OBJ_WORLD | TAR_OBJ_EQUIP)
-				? "ЧТО" : "КОГО");
-	else
-		sprintf(buf, "На %s Вы хотите ЭТО колдовать?\r\n",
-				IS_SET(SpINFO.targets, TAR_OBJ_ROOM | TAR_OBJ_INV | TAR_OBJ_WORLD | TAR_OBJ_EQUIP)
-				? "ЧТО" : "КОГО");
-	send_to_char(buf, ch);
-	return FALSE;
+      if (spellnum == SPELL_LOCATE_OBJECT) {
+        *tobj = find_obj_for_locate(ch, t);
+      } else {
+        *tobj = get_obj_vis(ch, t);
+      }
+      if (*tobj) {
+        return true;
+      }
+    }
+  } else {
+    if (IS_SET(SpINFO.targets, TAR_FIGHT_SELF))
+      if (ch->get_fighting() != NULL) {
+        *tch = ch;
+        return TRUE;
+      }
+    if (IS_SET(SpINFO.targets, TAR_FIGHT_VICT))
+      if (ch->get_fighting() != NULL) {
+        *tch = ch->get_fighting();
+        return TRUE;
+      }
+    if (IS_SET(SpINFO.targets, TAR_CHAR_ROOM) && !SpINFO.violent) {
+      *tch = ch;
+      return TRUE;
+    }
+  }
+  // TODO: добавить обработку TAR_ROOM_DIR и TAR_ROOM_WORLD
+  if (IS_SET(SpINFO.routines, MAG_WARCRY))
+    sprintf(buf, "И на %s же вы хотите так громко крикнуть?\r\n",
+            IS_SET(SpINFO.targets, TAR_OBJ_ROOM | TAR_OBJ_INV | TAR_OBJ_WORLD | TAR_OBJ_EQUIP)
+            ? "ЧТО" : "КОГО");
+  else
+    sprintf(buf, "На %s Вы хотите ЭТО колдовать?\r\n",
+            IS_SET(SpINFO.targets, TAR_OBJ_ROOM | TAR_OBJ_INV | TAR_OBJ_WORLD | TAR_OBJ_EQUIP)
+            ? "ЧТО" : "КОГО");
+  send_to_char(buf, ch);
+  return FALSE;
 }
 
 /*
@@ -654,191 +579,175 @@ int find_cast_target(int spellnum, const char *t, CHAR_DATA * ch, CHAR_DATA ** t
  * Entry point for NPC casts.  Recommended entry point for spells cast
  * by NPCs via specprocs.
  */
-int cast_spell(CHAR_DATA * ch, CHAR_DATA * tch, OBJ_DATA * tobj, ROOM_DATA * troom, int spellnum, int spell_subst)
-{
-	int ignore;
-	ESkill skillnum = SKILL_INVALID;
+int cast_spell(CHAR_DATA *ch, CHAR_DATA *tch, OBJ_DATA *tobj, ROOM_DATA *troom, int spellnum, int spell_subst) {
+  int ignore;
+  ESkill skillnum = SKILL_INVALID;
 
-	if (spellnum < 0 || spellnum > TOP_SPELL_DEFINE){
-		log("SYSERR: cast_spell trying to call spellnum %d/%d.\n", spellnum, TOP_SPELL_DEFINE);
-		return (0);
-	}
+  if (spellnum < 0 || spellnum > TOP_SPELL_DEFINE) {
+    log("SYSERR: cast_spell trying to call spellnum %d/%d.\n", spellnum, TOP_SPELL_DEFINE);
+    return (0);
+  }
 //проверка на алайнмент мобов
 
-	if (tch && ch){
-		if (IS_MOB(tch) && IS_MOB(ch) && !SAME_ALIGN(ch, tch) && !SpINFO.violent)
-			return (0);
-	}
+  if (tch && ch) {
+    if (IS_MOB(tch) && IS_MOB(ch) && !SAME_ALIGN(ch, tch) && !SpINFO.violent)
+      return (0);
+  }
 
-	if (!troom)
-		// Вызвали с пустой комнатой значит будем кастить тут
-		troom = world[ch->in_room];
+  if (!troom)
+    // Вызвали с пустой комнатой значит будем кастить тут
+    troom = world[ch->in_room];
 
-	if (GET_POS(ch) < SpINFO.min_position) {
-		switch (GET_POS(ch))
-		{
-		case POS_SLEEPING:
-			send_to_char("Вы спите и не могете думать больше ни о чем.\r\n", ch);
-			break;
-		case POS_RESTING:
-			send_to_char("Вы расслаблены и отдыхаете. И далась вам эта магия?\r\n", ch);
-			break;
-		case POS_SITTING:
-			send_to_char("Похоже, в этой позе Вы много не наколдуете.\r\n", ch);
-			break;
-		case POS_FIGHTING:
-			send_to_char("Невозможно! Вы сражаетесь! Это вам не шухры-мухры.\r\n", ch);
-			break;
-		default:
-			send_to_char("Вам вряд ли это удастся.\r\n", ch);
-			break;
-		}
-		return (0);
-	}
+  if (GET_POS(ch) < SpINFO.min_position) {
+    switch (GET_POS(ch)) {
+      case POS_SLEEPING: send_to_char("Вы спите и не могете думать больше ни о чем.\r\n", ch);
+        break;
+      case POS_RESTING: send_to_char("Вы расслаблены и отдыхаете. И далась вам эта магия?\r\n", ch);
+        break;
+      case POS_SITTING: send_to_char("Похоже, в этой позе Вы много не наколдуете.\r\n", ch);
+        break;
+      case POS_FIGHTING: send_to_char("Невозможно! Вы сражаетесь! Это вам не шухры-мухры.\r\n", ch);
+        break;
+      default: send_to_char("Вам вряд ли это удастся.\r\n", ch);
+        break;
+    }
+    return (0);
+  }
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) && ch->get_master() == tch)	{
-		send_to_char("Вы не посмеете поднять руку на вашего повелителя!\r\n", ch);
-		return (0);
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) && ch->get_master() == tch) {
+    send_to_char("Вы не посмеете поднять руку на вашего повелителя!\r\n", ch);
+    return (0);
+  }
 
-	if (tch != ch && !IS_IMMORTAL(ch) && IS_SET(SpINFO.targets, TAR_SELF_ONLY)) {
-		send_to_char("Вы можете колдовать это только на себя!\r\n", ch);
-		return (0);
-	}
+  if (tch != ch && !IS_IMMORTAL(ch) && IS_SET(SpINFO.targets, TAR_SELF_ONLY)) {
+    send_to_char("Вы можете колдовать это только на себя!\r\n", ch);
+    return (0);
+  }
 
-	if (tch == ch && IS_SET(SpINFO.targets, TAR_NOT_SELF)) {
-		send_to_char("Колдовать? ЭТО? На себя?! Да вы с ума сошли!\r\n", ch);
-		return (0);
-	}
+  if (tch == ch && IS_SET(SpINFO.targets, TAR_NOT_SELF)) {
+    send_to_char("Колдовать? ЭТО? На себя?! Да вы с ума сошли!\r\n", ch);
+    return (0);
+  }
 
-	if ((!tch || IN_ROOM(tch) == NOWHERE) && !tobj && !troom &&
-			IS_SET(SpINFO.targets,
-				   TAR_CHAR_ROOM | TAR_CHAR_WORLD | TAR_FIGHT_SELF | TAR_FIGHT_VICT
-				   | TAR_OBJ_INV | TAR_OBJ_ROOM | TAR_OBJ_WORLD | TAR_OBJ_EQUIP | TAR_ROOM_THIS
-				   | TAR_ROOM_DIR))
-	{
-		send_to_char("Цель заклинания не доступна.\r\n", ch);
-		return (0);
-	}
+  if ((!tch || IN_ROOM(tch) == NOWHERE) && !tobj && !troom &&
+      IS_SET(SpINFO.targets,
+             TAR_CHAR_ROOM | TAR_CHAR_WORLD | TAR_FIGHT_SELF | TAR_FIGHT_VICT
+                 | TAR_OBJ_INV | TAR_OBJ_ROOM | TAR_OBJ_WORLD | TAR_OBJ_EQUIP | TAR_ROOM_THIS
+                 | TAR_ROOM_DIR)) {
+    send_to_char("Цель заклинания не доступна.\r\n", ch);
+    return (0);
+  }
 
-	if (tch && ch && IN_ROOM(tch) != ch->in_room) {
-		if (!IS_SET(SpINFO.targets, TAR_CHAR_WORLD)) {
-			send_to_char("Цель заклинания недоступна.\r\n", ch);
-			return (0);
-		}
-	}
+  if (tch && ch && IN_ROOM(tch) != ch->in_room) {
+    if (!IS_SET(SpINFO.targets, TAR_CHAR_WORLD)) {
+      send_to_char("Цель заклинания недоступна.\r\n", ch);
+      return (0);
+    }
+  }
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_PEACEFUL)){
-		ignore = IS_SET(SpINFO.targets, TAR_IGNORE) ||
-				 IS_SET(SpINFO.routines, MAG_MASSES) || IS_SET(SpINFO.routines, MAG_GROUPS);
-		if (ignore)  { // индивидуальная цель
-			if (SpINFO.violent) {
-				send_to_char("Ваша душа полна смирения, и вы не желаете творить зло.\r\n", ch);
-				return FALSE;	// нельзя злые кастовать
-			}
-		}
-		for (const auto ch_vict : world[ch->in_room]->people) {
-			if (SpINFO.violent) {
-				if (ch_vict == tch) {
-					send_to_char("Ваша душа полна смирения, и вы не желаете творить зло.\r\n", ch);
-					return FALSE;
-				}
-			}
-			else {
-				if (ch_vict == tch && !same_group(ch, ch_vict)) {
-					send_to_char("Ваша душа полна смирения, и вы не желаете творить зло.\r\n", ch);
-					return FALSE;
-				}
-			}
-		}
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_PEACEFUL)) {
+    ignore = IS_SET(SpINFO.targets, TAR_IGNORE) ||
+        IS_SET(SpINFO.routines, MAG_MASSES) || IS_SET(SpINFO.routines, MAG_GROUPS);
+    if (ignore) { // индивидуальная цель
+      if (SpINFO.violent) {
+        send_to_char("Ваша душа полна смирения, и вы не желаете творить зло.\r\n", ch);
+        return FALSE;    // нельзя злые кастовать
+      }
+    }
+    for (const auto ch_vict : world[ch->in_room]->people) {
+      if (SpINFO.violent) {
+        if (ch_vict == tch) {
+          send_to_char("Ваша душа полна смирения, и вы не желаете творить зло.\r\n", ch);
+          return FALSE;
+        }
+      } else {
+        if (ch_vict == tch && !same_group(ch, ch_vict)) {
+          send_to_char("Ваша душа полна смирения, и вы не желаете творить зло.\r\n", ch);
+          return FALSE;
+        }
+      }
+    }
+  }
 
-	skillnum = get_magic_skill_number_by_spell(spellnum);
-	if (skillnum != SKILL_INVALID && skillnum != SKILL_UNDEF) {
-		train_skill(ch, skillnum, skill_info[skillnum].max_percent, tch);
-	}
-	// Комнату тут в say_spell не обрабатываем - будет сказал "что-то"
-	say_spell(ch, spellnum, tch, tobj);
-	// Уменьшаем кол-во заклов в меме
-	if (GET_SPELL_MEM(ch, spell_subst) > 0)
-		GET_SPELL_MEM(ch, spell_subst)--;
-	else
-		GET_SPELL_MEM(ch, spell_subst) = 0;
-	// если включен автомем
-	if (!IS_NPC(ch) && !IS_IMMORTAL(ch) && PRF_FLAGGED(ch, PRF_AUTOMEM))
-		MemQ_remember(ch, spell_subst);
-	// если НПЦ - уменьшаем его макс.количество кастуемых спеллов
-	if (IS_NPC(ch))
-		GET_CASTER(ch) -= (IS_SET(spell_info[spellnum].routines, NPC_CALCULATE) ? 1 : 0);
-	if (!IS_NPC(ch))
-		affect_total(ch);
+  skillnum = get_magic_skill_number_by_spell(spellnum);
+  if (skillnum != SKILL_INVALID && skillnum != SKILL_UNDEF) {
+    train_skill(ch, skillnum, true, tch);
+  }
+  // Комнату тут в say_spell не обрабатываем - будет сказал "что-то"
+  say_spell(ch, spellnum, tch, tobj);
+  // Уменьшаем кол-во заклов в меме
+  if (GET_SPELL_MEM(ch, spell_subst) > 0) {
+    GET_SPELL_MEM(ch, spell_subst)--;
+  } else {
+    GET_SPELL_MEM(ch, spell_subst) = 0;
+  }
+  // если включен автомем
+  if (!IS_NPC(ch) && !IS_IMMORTAL(ch) && PRF_FLAGGED(ch, PRF_AUTOMEM)) {
+    MemQ_remember(ch, spell_subst);
+  }
+  // если НПЦ - уменьшаем его макс.количество кастуемых спеллов
+  if (IS_NPC(ch)) {
+    GET_CASTER(ch) -= (IS_SET(spell_info[spellnum].routines, NPC_CALCULATE) ? 1 : 0);
+  }
+  if (!IS_NPC(ch)) {
+    affect_total(ch);
+  }
 
-	return (call_magic(ch, tch, tobj, troom, spellnum, GET_LEVEL(ch)));
+  return (call_magic(ch, tch, tobj, troom, spellnum, GET_LEVEL(ch)));
 }
 
-int spell_use_success(CHAR_DATA * ch, CHAR_DATA * victim, int casting_type, int spellnum)
-{
-	int prob = 100;
-	int skill;
-	if (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE))
-	{
-		return TRUE;
-	}
+int spell_use_success(CHAR_DATA *ch, CHAR_DATA *victim, int casting_type, int spellnum) {
+  int prob = 100;
+  int skill;
+  if (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, GF_GODSLIKE)) {
+    return TRUE;
+  }
 
-	switch (casting_type)
-	{
-	case SAVING_STABILITY:
-	case SAVING_NONE:
-		prob = wis_bonus(GET_REAL_WIS(ch), WIS_FAILS) + GET_CAST_SUCCESS(ch);
+  switch (casting_type) {
+    case SAVING_STABILITY:
+    case SAVING_NONE: prob = wis_bonus(GET_REAL_WIS(ch), WIS_FAILS) + GET_CAST_SUCCESS(ch);
 
-		if ((IS_MAGE(ch) && ch->in_room != NOWHERE && ROOM_FLAGGED(ch->in_room, ROOM_MAGE))
-			|| (IS_CLERIC(ch) && ch->in_room != NOWHERE && ROOM_FLAGGED(ch->in_room, ROOM_CLERIC))
-			|| (IS_PALADINE(ch) && ch->in_room != NOWHERE && ROOM_FLAGGED(ch->in_room, ROOM_PALADINE))
-			|| (IS_MERCHANT(ch) && ch->in_room != NOWHERE && ROOM_FLAGGED(ch->in_room, ROOM_MERCHANT)))
-		{
-			prob += 10;
-		}
+      if ((IS_MAGE(ch) && ch->in_room != NOWHERE && ROOM_FLAGGED(ch->in_room, ROOM_MAGE))
+          || (IS_CLERIC(ch) && ch->in_room != NOWHERE && ROOM_FLAGGED(ch->in_room, ROOM_CLERIC))
+          || (IS_PALADINE(ch) && ch->in_room != NOWHERE && ROOM_FLAGGED(ch->in_room, ROOM_PALADINE))
+          || (IS_MERCHANT(ch) && ch->in_room != NOWHERE && ROOM_FLAGGED(ch->in_room, ROOM_MERCHANT))) {
+        prob += 10;
+      }
 
-		if (IS_MAGE(ch) && equip_in_metall(ch))
-		{
-			prob -= 50;
-		}
-		break;
-	}
+      if (IS_MAGE(ch) && equip_in_metall(ch)) {
+        prob -= 50;
+      }
+      break;
+  }
 
-	if (equip_in_metall(ch) && !can_use_feat(ch, COMBAT_CASTING_FEAT))
-	{
-		prob -= 50;
-	}
+  if (equip_in_metall(ch) && !can_use_feat(ch, COMBAT_CASTING_FEAT)) {
+    prob -= 50;
+  }
 
-	prob = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_SUCCESS, prob);
-	if (GET_GOD_FLAG(ch, GF_GODSCURSE) ||
-		(SpINFO.violent && victim && GET_GOD_FLAG(victim, GF_GODSLIKE)) ||
-		(!SpINFO.violent && victim && GET_GOD_FLAG(victim, GF_GODSCURSE)))
-	{
-		prob -= 50;
-	}
+  prob = complex_spell_modifier(ch, spellnum, GAPPLY_SPELL_SUCCESS, prob);
+  if (GET_GOD_FLAG(ch, GF_GODSCURSE) ||
+      (SpINFO.violent && victim && GET_GOD_FLAG(victim, GF_GODSLIKE)) ||
+      (!SpINFO.violent && victim && GET_GOD_FLAG(victim, GF_GODSCURSE))) {
+    prob -= 50;
+  }
 
-	if ((SpINFO.violent && victim && GET_GOD_FLAG(victim, GF_GODSCURSE)) ||
-		(!SpINFO.violent && victim && GET_GOD_FLAG(victim, GF_GODSLIKE)))
-	{
-		prob += 50;
-	}
+  if ((SpINFO.violent && victim && GET_GOD_FLAG(victim, GF_GODSCURSE)) ||
+      (!SpINFO.violent && victim && GET_GOD_FLAG(victim, GF_GODSLIKE))) {
+    prob += 50;
+  }
 
-	if (IS_NPC(ch) && (GET_LEVEL(ch) >= STRONG_MOB_LEVEL))
-	{
-		prob += GET_LEVEL(ch) - 20;
-	}
+  if (IS_NPC(ch) && (GET_LEVEL(ch) >= STRONG_MOB_LEVEL)) {
+    prob += GET_LEVEL(ch) - 20;
+  }
 
-	const ESkill skill_number = get_magic_skill_number_by_spell(spellnum);
-	if (skill_number > 0)
-	{
-		skill = ch->get_skill(skill_number) / 20;
-		prob += skill;
-	}
-	//prob*=ch->get_cond_penalty(P_CAST);
-	// умения магии дают + к успеху колдовства
-	return (prob > number(0, 100));
+  const ESkill skill_number = get_magic_skill_number_by_spell(spellnum);
+  if (skill_number > 0) {
+    skill = ch->get_skill(skill_number) / 20;
+    prob += skill;
+  }
+  //prob*=ch->get_cond_penalty(P_CAST);
+  // умения магии дают + к успеху колдовства
+  return (prob > number(0, 100));
 }
 
 

--- a/src/magic.utils.cpp
+++ b/src/magic.utils.cpp
@@ -671,7 +671,7 @@ int cast_spell(CHAR_DATA *ch, CHAR_DATA *tch, OBJ_DATA *tobj, ROOM_DATA *troom, 
 
   skillnum = get_magic_skill_number_by_spell(spellnum);
   if (skillnum != SKILL_INVALID && skillnum != SKILL_UNDEF) {
-    train_skill(ch, skillnum, true, tch);
+    TrainSkill(ch, skillnum, true, tch);
   }
   // Комнату тут в say_spell не обрабатываем - будет сказал "что-то"
   say_spell(ch, spellnum, tch, tobj);

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -41,7 +41,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 
-void show_string(DESCRIPTOR_DATA * d, char *input);
+void show_string(DESCRIPTOR_DATA *d, char *input);
 
 #define PARSE_FORMAT      0
 #define PARSE_REPLACE     1
@@ -58,31 +58,30 @@ extern const char *unused_spellname;
 // local functions
 void smash_tilde(char *str);
 void do_skillset(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
-char *next_page(char *str, CHAR_DATA * ch);
-int count_pages(char *str, CHAR_DATA * ch);
-void paginate_string(char *str, DESCRIPTOR_DATA * d);
+char *next_page(char *str, CHAR_DATA *ch);
+int count_pages(char *str, CHAR_DATA *ch);
+void paginate_string(char *str, DESCRIPTOR_DATA *d);
 
 const char *string_fields[] =
-{
-	"name",
-	"short",
-	"long",
-	"description",
-	"title",
-	"delete-description",
-	"\n"
-};
-
+    {
+        "name",
+        "short",
+        "long",
+        "description",
+        "title",
+        "delete-description",
+        "\n"
+    };
 
 // maximum length for text field x+1
 int length[] =
-{
-	15,
-	60,
-	256,
-	240,
-	60
-};
+    {
+        15,
+        60,
+        256,
+        240,
+        60
+    };
 
 
 // ************************************************************************
@@ -96,16 +95,15 @@ int length[] =
  * function around because other MUD packages use it, like mudFTP.
  *   -gg 9/9/98
  */
-void smash_tilde(char *str)
-{
-	/*
-	 * Erase any ~'s inserted by people in the editor.  This prevents anyone
-	 * using online creation from causing parse errors in the world files.
-	 * Derived from an idea by Sammy <samedi@dhc.net> (who happens to like
-	 * his tildes thank you very much.), -gg 2/20/98
-	 */
-	while ((str = strchr(str, '~')) != NULL)
-		* str = ' ';
+void smash_tilde(char *str) {
+  /*
+   * Erase any ~'s inserted by people in the editor.  This prevents anyone
+   * using online creation from causing parse errors in the world files.
+   * Derived from an idea by Sammy <samedi@dhc.net> (who happens to like
+   * his tildes thank you very much.), -gg 2/20/98
+   */
+  while ((str = strchr(str, '~')) != NULL)
+    *str = ' ';
 }
 
 /*
@@ -115,1167 +113,946 @@ void smash_tilde(char *str)
  * else you may want through it.  The improved editor patch when updated
  * could use it to pass the old text buffer, for instance.
  */
-void string_write(DESCRIPTOR_DATA * d, const AbstractStringWriter::shared_ptr& writer, size_t len, int mailto, void *data)
-{
-	if (d->character && !IS_NPC(d->character))
-	{
-		PLR_FLAGS(d->character).set(PLR_WRITING);
-	}
+void string_write(DESCRIPTOR_DATA *d,
+                  const AbstractStringWriter::shared_ptr &writer,
+                  size_t len,
+                  int mailto,
+                  void *data) {
+  if (d->character && !IS_NPC(d->character)) {
+    PLR_FLAGS(d->character).set(PLR_WRITING);
+  }
 
-	if (data)
-	{
-		mudlog("SYSERR: string_write: I don't understand special data.", BRF, LVL_IMMORT, SYSLOG, TRUE);
-	}
+  if (data) {
+    mudlog("SYSERR: string_write: I don't understand special data.", BRF, LVL_IMMORT, SYSLOG, TRUE);
+  }
 
-	d->writer = writer;
-	d->max_str = len;
-	d->mail_to = mailto;
+  d->writer = writer;
+  d->max_str = len;
+  d->mail_to = mailto;
 }
-
 
 // * Handle some editor commands.
-void parse_action(int command, char *string, DESCRIPTOR_DATA * d)
-{
-	int indent = 0, rep_all = 0, flags = 0, replaced;
-	int j = 0;
-	int i, line_low, line_high;
-	char *s, *t;
-	//log("[PA] Start %d(%s)", command, string);
-	switch (command)
-	{
-	case PARSE_HELP:
-		sprintf(buf,
-				"Формат команд редактора: /<letter>\r\n\r\n"
-				"/a         -  прекратить редактирование\r\n"
-				"/c         -  очистить буфер\r\n"
-				"/d#,       -  удалить строку #\r\n"
-				"/e# <text> -  заменить строку # на текст <text>\r\n"
-				"/f         -  форматировать текст\r\n"
-				"/fi        -  indented formatting of text\r\n"
-				"/h         -  отобразить список команд (помощь)\r\n"
-				"/i# <text> -  вставить <text> после строки #\r\n"
-				"/l         -  пролистать буфер\r\n"
-				"/n         -  пролистать буфер с номерами строк\r\n"
-				"/r 'a' 'b' -  заменить первое вхождение текста <a> в буфере на текст <b>\r\n"
-				"/ra 'a' 'b'-  заменить все вхождения текста <a> в буфере на текст <b>\r\n"
-				"              Формат: /r[a] 'шаблон' 'на_что_меняем'\r\n" "/s         -  сохранить текст\r\n");
-		SEND_TO_Q(buf, d);
-		break;
+void parse_action(int command, char *string, DESCRIPTOR_DATA *d) {
+  int indent = 0, rep_all = 0, flags = 0, replaced;
+  int j = 0;
+  int i, line_low, line_high;
+  char *s, *t;
+  //log("[PA] Start %d(%s)", command, string);
+  switch (command) {
+    case PARSE_HELP:
+      sprintf(buf,
+              "Формат команд редактора: /<letter>\r\n\r\n"
+              "/a         -  прекратить редактирование\r\n"
+              "/c         -  очистить буфер\r\n"
+              "/d#,       -  удалить строку #\r\n"
+              "/e# <text> -  заменить строку # на текст <text>\r\n"
+              "/f         -  форматировать текст\r\n"
+              "/fi        -  indented formatting of text\r\n"
+              "/h         -  отобразить список команд (помощь)\r\n"
+              "/i# <text> -  вставить <text> после строки #\r\n"
+              "/l         -  пролистать буфер\r\n"
+              "/n         -  пролистать буфер с номерами строк\r\n"
+              "/r 'a' 'b' -  заменить первое вхождение текста <a> в буфере на текст <b>\r\n"
+              "/ra 'a' 'b'-  заменить все вхождения текста <a> в буфере на текст <b>\r\n"
+              "              Формат: /r[a] 'шаблон' 'на_что_меняем'\r\n" "/s         -  сохранить текст\r\n");
+      SEND_TO_Q(buf, d);
+      break;
 
-	case PARSE_FORMAT:
-		while (isalpha(string[j]) && j < 2)
-		{
-			switch (string[j])
-			{
-			case 'i':
-				if (!indent)
-				{
-					indent = TRUE;
-					flags += FORMAT_INDENT;
-				}
-				break;
-			default:
-				break;
-			}
-			j++;
-		}
+    case PARSE_FORMAT:
+      while (isalpha(string[j]) && j < 2) {
+        switch (string[j]) {
+          case 'i':
+            if (!indent) {
+              indent = TRUE;
+              flags += FORMAT_INDENT;
+            }
+            break;
+          default: break;
+        }
+        j++;
+      }
 
-		format_text(d->writer, flags, d, d->max_str);
+      format_text(d->writer, flags, d, d->max_str);
 
-		sprintf(buf, "Текст отформатирован %s\r\n", (indent ? "WITH INDENT." : "."));
-		SEND_TO_Q(buf, d);
-		break;
+      sprintf(buf, "Текст отформатирован %s\r\n", (indent ? "WITH INDENT." : "."));
+      SEND_TO_Q(buf, d);
+      break;
 
-	case PARSE_REPLACE:
-		while (isalpha(string[j]) && j < 2)
-		{
-			switch (string[j])
-			{
-			case 'a':
-				if (!indent)
-					rep_all = 1;
-				break;
-			default:
-				break;
-			}
-			j++;
-		}
-		if ((s = strtok(string, "'")) == NULL)
-		{
-			SEND_TO_Q("Неверный формат.\r\n", d);
-			return;
-		}
-		else if ((s = strtok(NULL, "'")) == NULL)
-		{
-			SEND_TO_Q("Шаблон должен быть заключен в апострофы.\r\n", d);
-			return;
-		}
-		else if ((t = strtok(NULL, "'")) == NULL)
-		{
-			SEND_TO_Q("No replacement string.\r\n", d);
-			return;
-		}
-		else if ((t = strtok(NULL, "'")) == NULL)
-		{
-			SEND_TO_Q("Замещающая строка должна быть заключена в апострофы.\r\n", d);
-			return;
-		}
-		else
-		{
-			size_t total_len = strlen(t) + strlen(d->writer->get_string()) - strlen(s);
-			if (total_len <= d->max_str)
-			{
-				replaced = replace_str(d->writer, s, t, rep_all, static_cast<int>(d->max_str));
-				if (replaced > 0)
-				{
-					sprintf(buf, "Заменено вхождений '%s' на '%s' - %d.\r\n", s, t, replaced);
-					SEND_TO_Q(buf, d);
-				}
-				else if (replaced == 0)
-				{
-					sprintf(buf, "Шаблон '%s' не найден.\r\n", s);
-					SEND_TO_Q(buf, d);
-				}
-				else
-				{
-					SEND_TO_Q("ОШИБКА: При попытке замены буфер переполнен - прервано.\r\n", d);
-				}
-			}
-			else
-			{
-				SEND_TO_Q("Нет свободного места для завершения команды.\r\n", d);
-			}
-		}
-		break;
+    case PARSE_REPLACE:
+      while (isalpha(string[j]) && j < 2) {
+        switch (string[j]) {
+          case 'a':
+            if (!indent)
+              rep_all = 1;
+            break;
+          default: break;
+        }
+        j++;
+      }
+      if ((s = strtok(string, "'")) == NULL) {
+        SEND_TO_Q("Неверный формат.\r\n", d);
+        return;
+      } else if ((s = strtok(NULL, "'")) == NULL) {
+        SEND_TO_Q("Шаблон должен быть заключен в апострофы.\r\n", d);
+        return;
+      } else if ((t = strtok(NULL, "'")) == NULL) {
+        SEND_TO_Q("No replacement string.\r\n", d);
+        return;
+      } else if ((t = strtok(NULL, "'")) == NULL) {
+        SEND_TO_Q("Замещающая строка должна быть заключена в апострофы.\r\n", d);
+        return;
+      } else {
+        size_t total_len = strlen(t) + strlen(d->writer->get_string()) - strlen(s);
+        if (total_len <= d->max_str) {
+          replaced = replace_str(d->writer, s, t, rep_all, static_cast<int>(d->max_str));
+          if (replaced > 0) {
+            sprintf(buf, "Заменено вхождений '%s' на '%s' - %d.\r\n", s, t, replaced);
+            SEND_TO_Q(buf, d);
+          } else if (replaced == 0) {
+            sprintf(buf, "Шаблон '%s' не найден.\r\n", s);
+            SEND_TO_Q(buf, d);
+          } else {
+            SEND_TO_Q("ОШИБКА: При попытке замены буфер переполнен - прервано.\r\n", d);
+          }
+        } else {
+          SEND_TO_Q("Нет свободного места для завершения команды.\r\n", d);
+        }
+      }
+      break;
 
-	case PARSE_DELETE:
-		switch (sscanf(string, " %d - %d ", &line_low, &line_high))
-		{
-		case 0:
-			SEND_TO_Q("Вы должны указать номер строки или диапазон для удаления.\r\n", d);
-			return;
-		case 1:
-			line_high = line_low;
-			break;
-		case 2:
-			if (line_high < line_low)
-			{
-				SEND_TO_Q("Неверный диапазон.\r\n", d);
-				return;
-			}
-			break;
-		}
+    case PARSE_DELETE:
+      switch (sscanf(string, " %d - %d ", &line_low, &line_high)) {
+        case 0: SEND_TO_Q("Вы должны указать номер строки или диапазон для удаления.\r\n", d);
+          return;
+        case 1: line_high = line_low;
+          break;
+        case 2:
+          if (line_high < line_low) {
+            SEND_TO_Q("Неверный диапазон.\r\n", d);
+            return;
+          }
+          break;
+      }
 
-		i = 1;
-		{
-			char* buffer = str_dup(d->writer->get_string());
-			std::shared_ptr<char> guard(buffer, free);
-			s = buffer;
-			if (s == nullptr)
-			{
-				SEND_TO_Q("Буфер пуст.\r\n", d);
-				return;
-			}
-			else if (line_low > 0)
-			{
-				unsigned int total_len = 1;
-				while (s && (i < line_low))
-				{
-					if ((s = strchr(s, '\n')) != NULL)
-					{
-						i++;
-						s++;
-					}
-				}
-				if ((i < line_low) || (s == NULL))
-				{
-					SEND_TO_Q("Строка(и) вне диапазона - проигнорировано.\r\n", d);
-					return;
-				}
-				t = s;
-				while (s && (i < line_high))
-				{
-					if ((s = strchr(s, '\n')) != NULL)
-					{
-						i++;
-						total_len++;
-						s++;
-					}
-				}
-				if ((s) && ((s = strchr(s, '\n')) != NULL))
-				{
-					s++;
-					while (*s != '\0')
-					{
-						*(t++) = *(s++);
-					}
-				}
-				else
-				{
-					total_len--;
-				}
-				*t = '\0';
-				d->writer->set_string(buffer);
+      i = 1;
+      {
+        char *buffer = str_dup(d->writer->get_string());
+        std::shared_ptr<char> guard(buffer, free);
+        s = buffer;
+        if (s == nullptr) {
+          SEND_TO_Q("Буфер пуст.\r\n", d);
+          return;
+        } else if (line_low > 0) {
+          unsigned int total_len = 1;
+          while (s && (i < line_low)) {
+            if ((s = strchr(s, '\n')) != NULL) {
+              i++;
+              s++;
+            }
+          }
+          if ((i < line_low) || (s == NULL)) {
+            SEND_TO_Q("Строка(и) вне диапазона - проигнорировано.\r\n", d);
+            return;
+          }
+          t = s;
+          while (s && (i < line_high)) {
+            if ((s = strchr(s, '\n')) != NULL) {
+              i++;
+              total_len++;
+              s++;
+            }
+          }
+          if ((s) && ((s = strchr(s, '\n')) != NULL)) {
+            s++;
+            while (*s != '\0') {
+              *(t++) = *(s++);
+            }
+          } else {
+            total_len--;
+          }
+          *t = '\0';
+          d->writer->set_string(buffer);
 
-				sprintf(buf, "%u line%sdeleted.\r\n", total_len, ((total_len != 1) ? "s " : " "));
-				SEND_TO_Q(buf, d);
-			}
-			else
-			{
-				SEND_TO_Q("Отрицательный или нулевой номер строки для удаления.\r\n", d);
-				return;
-			}
-		}
-		break;
+          sprintf(buf, "%u line%sdeleted.\r\n", total_len, ((total_len != 1) ? "s " : " "));
+          SEND_TO_Q(buf, d);
+        } else {
+          SEND_TO_Q("Отрицательный или нулевой номер строки для удаления.\r\n", d);
+          return;
+        }
+      }
+      break;
 
-	case PARSE_LIST_NORM:
-		// * Note: Rv's buf, buf1, buf2, and arg variables are defined to 32k so
-		// * they are probly ok for what to do here.
-		*buf = '\0';
-		if (*string != '\0')
-			switch (sscanf(string, " %d - %d ", &line_low, &line_high))
-			{
-			case 0:
-				line_low = 1;
-				line_high = 999999;
-				break;
-			case 1:
-				line_high = line_low;
-				break;
-			}
-		else
-		{
-			line_low = 1;
-			line_high = 999999;
-		}
+    case PARSE_LIST_NORM:
+      // * Note: Rv's buf, buf1, buf2, and arg variables are defined to 32k so
+      // * they are probly ok for what to do here.
+      *buf = '\0';
+      if (*string != '\0')
+        switch (sscanf(string, " %d - %d ", &line_low, &line_high)) {
+          case 0: line_low = 1;
+            line_high = 999999;
+            break;
+          case 1: line_high = line_low;
+            break;
+        }
+      else {
+        line_low = 1;
+        line_high = 999999;
+      }
 
-		if (line_low < 1)
-		{
-			SEND_TO_Q("Начальный номер отрицательный или 0.\r\n", d);
-			return;
-		}
-		else if (line_high < line_low)
-		{
-			SEND_TO_Q("Неверный диапазон.\r\n", d);
-			return;
-		}
-		*buf = '\0';
-		if ((line_high < 999999) || (line_low > 1))
-			sprintf(buf, "Текущий диапазон [%d - %d]:\r\n", line_low, line_high);
-		i = 1;
-		{
-			const char* pos = d->writer->get_string();
+      if (line_low < 1) {
+        SEND_TO_Q("Начальный номер отрицательный или 0.\r\n", d);
+        return;
+      } else if (line_high < line_low) {
+        SEND_TO_Q("Неверный диапазон.\r\n", d);
+        return;
+      }
+      *buf = '\0';
+      if ((line_high < 999999) || (line_low > 1))
+        sprintf(buf, "Текущий диапазон [%d - %d]:\r\n", line_low, line_high);
+      i = 1;
+      {
+        const char *pos = d->writer->get_string();
 
-			unsigned int total_len = 0;
-			while (pos && (i < line_low))
-			{
-				if ((pos = strchr(pos, '\n')) != NULL)
-				{
-					i++;
-					pos++;
-				}
-			}
+        unsigned int total_len = 0;
+        while (pos && (i < line_low)) {
+          if ((pos = strchr(pos, '\n')) != NULL) {
+            i++;
+            pos++;
+          }
+        }
 
-			if ((i < line_low) || (pos == NULL))
-			{
-				SEND_TO_Q("Строка(и) вне диапазона - проигнорировано.\r\n", d);
-				return;
-			}
+        if ((i < line_low) || (pos == NULL)) {
+          SEND_TO_Q("Строка(и) вне диапазона - проигнорировано.\r\n", d);
+          return;
+        }
 
-			const char* beginning = pos;
-			while (pos && (i <= line_high))
-			{
-				if ((pos = strchr(pos, '\n')) != NULL)
-				{
-					i++;
-					total_len++;
-					pos++;
-				}
-			}
+        const char *beginning = pos;
+        while (pos && (i <= line_high)) {
+          if ((pos = strchr(pos, '\n')) != NULL) {
+            i++;
+            total_len++;
+            pos++;
+          }
+        }
 
-			if (pos)
-			{
-				strncat(buf, beginning, pos - beginning);
-			}
-			else
-			{
-				strcat(buf, beginning);
-			}
+        if (pos) {
+          strncat(buf, beginning, pos - beginning);
+        } else {
+          strcat(buf, beginning);
+        }
 
-			page_string(d, buf, TRUE);
-		}
+        page_string(d, buf, TRUE);
+      }
 
-		break;
+      break;
 
-	case PARSE_LIST_NUM:
-		// * Note: Rv's buf, buf1, buf2, and arg variables are defined to 32k so
-		// * they are probly ok for what to do here.
-		*buf = '\0';
-		if (*string != '\0')
-		{
-			switch (sscanf(string, " %d - %d ", &line_low, &line_high))
-			{
-			case 0:
-				line_low = 1;
-				line_high = 999999;
-				break;
-			case 1:
-				line_high = line_low;
-				break;
-			}
-		}
-		else
-		{
-			line_low = 1;
-			line_high = 999999;
-		}
+    case PARSE_LIST_NUM:
+      // * Note: Rv's buf, buf1, buf2, and arg variables are defined to 32k so
+      // * they are probly ok for what to do here.
+      *buf = '\0';
+      if (*string != '\0') {
+        switch (sscanf(string, " %d - %d ", &line_low, &line_high)) {
+          case 0: line_low = 1;
+            line_high = 999999;
+            break;
+          case 1: line_high = line_low;
+            break;
+        }
+      } else {
+        line_low = 1;
+        line_high = 999999;
+      }
 
-		if (line_low < 1)
-		{
-			SEND_TO_Q("Номер строки должен быть больше 0.\r\n", d);
-			return;
-		}
-		if (line_high < line_low)
-		{
-			SEND_TO_Q("Неверный диапазон.\r\n", d);
-			return;
-		}
-		*buf = '\0';
-		i = 1;
-		{
-			const char* pos = d->writer->get_string();
-			unsigned int total_len = 0;
+      if (line_low < 1) {
+        SEND_TO_Q("Номер строки должен быть больше 0.\r\n", d);
+        return;
+      }
+      if (line_high < line_low) {
+        SEND_TO_Q("Неверный диапазон.\r\n", d);
+        return;
+      }
+      *buf = '\0';
+      i = 1;
+      {
+        const char *pos = d->writer->get_string();
+        unsigned int total_len = 0;
 
-			while (pos && (i < line_low))
-			{
-				if ((pos = strchr(pos, '\n')) != NULL)
-				{
-					i++;
-					pos++;
-				}
-			}
+        while (pos && (i < line_low)) {
+          if ((pos = strchr(pos, '\n')) != NULL) {
+            i++;
+            pos++;
+          }
+        }
 
-			if ((i < line_low) || (pos == NULL))
-			{
-				SEND_TO_Q("Строка(и) вне диапазона - проигнорировано.\r\n", d);
-				return;
-			}
+        if ((i < line_low) || (pos == NULL)) {
+          SEND_TO_Q("Строка(и) вне диапазона - проигнорировано.\r\n", d);
+          return;
+        }
 
-			const char* beginning = pos;
-			while (pos && (i <= line_high))
-			{
-				if ((pos = strchr(pos, '\n')) != NULL)
-				{
-					i++;
-					total_len++;
-					pos++;
-					sprintf(buf, "%s%4d:\r\n", buf, (i - 1));
-					strncat(buf, beginning, pos - beginning);
-					beginning = pos;
-				}
-			}
+        const char *beginning = pos;
+        while (pos && (i <= line_high)) {
+          if ((pos = strchr(pos, '\n')) != NULL) {
+            i++;
+            total_len++;
+            pos++;
+            sprintf(buf, "%s%4d:\r\n", buf, (i - 1));
+            strncat(buf, beginning, pos - beginning);
+            beginning = pos;
+          }
+        }
 
-			if (pos && beginning)
-			{
-				strncat(buf, beginning, pos - beginning);
-			}
-			else if (beginning)
-			{
-				strcat(buf, beginning);
-			}
-		}
+        if (pos && beginning) {
+          strncat(buf, beginning, pos - beginning);
+        } else if (beginning) {
+          strcat(buf, beginning);
+        }
+      }
 
-		page_string(d, buf, TRUE);
-		break;
+      page_string(d, buf, TRUE);
+      break;
 
-	case PARSE_INSERT:
-		half_chop(string, buf, buf2);
-		if (*buf == '\0')
-		{
-			SEND_TO_Q("Вы должны указать номер строки, после которой вставить текст.\r\n", d);
-			return;
-		}
-		line_low = atoi(buf);
-		strcat(buf2, "\r\n");
+    case PARSE_INSERT: half_chop(string, buf, buf2);
+      if (*buf == '\0') {
+        SEND_TO_Q("Вы должны указать номер строки, после которой вставить текст.\r\n", d);
+        return;
+      }
+      line_low = atoi(buf);
+      strcat(buf2, "\r\n");
 
-		i = 1;
-		*buf = '\0';
-		{
-			const char* pos = d->writer->get_string();
-			const char* beginning = pos;
-			if (pos == NULL)
-			{
-				SEND_TO_Q("Буфер пуст - ничего не вставлено.\r\n", d);
-				return;
-			}
-			if (line_low > 0)
-			{
-				while (pos && (i < line_low))
-				{
-					if ((pos = strchr(pos, '\n')) != NULL)
-					{
-						i++;
-						pos++;
-					}
-				}
-				if ((i < line_low) || (pos == NULL))
-				{
-					SEND_TO_Q("Номер строки вне диапазона - прервано.\r\n", d);
-					return;
-				}
-				if ((pos - beginning + strlen(buf2) + strlen(pos) + 3) > d->max_str)
-				{
-					SEND_TO_Q("Превышение размеров буфера - прервано.\r\n", d);
-					return;
-				}
-				if (beginning && (*beginning != '\0'))
-				{
-					strncat(buf, beginning, pos - beginning);
-				}
-				strcat(buf, buf2);
-				if (*pos != '\0')
-				{
-					strcat(buf, pos);
-				}
-				d->writer->set_string(buf);
-				SEND_TO_Q("Строка вставлена.\r\n", d);
-			}
-			else
-			{
-				SEND_TO_Q("Номер строки должен быть больше 0.\r\n", d);
-				return;
-			}
-		}
-		break;
+      i = 1;
+      *buf = '\0';
+      {
+        const char *pos = d->writer->get_string();
+        const char *beginning = pos;
+        if (pos == NULL) {
+          SEND_TO_Q("Буфер пуст - ничего не вставлено.\r\n", d);
+          return;
+        }
+        if (line_low > 0) {
+          while (pos && (i < line_low)) {
+            if ((pos = strchr(pos, '\n')) != NULL) {
+              i++;
+              pos++;
+            }
+          }
+          if ((i < line_low) || (pos == NULL)) {
+            SEND_TO_Q("Номер строки вне диапазона - прервано.\r\n", d);
+            return;
+          }
+          if ((pos - beginning + strlen(buf2) + strlen(pos) + 3) > d->max_str) {
+            SEND_TO_Q("Превышение размеров буфера - прервано.\r\n", d);
+            return;
+          }
+          if (beginning && (*beginning != '\0')) {
+            strncat(buf, beginning, pos - beginning);
+          }
+          strcat(buf, buf2);
+          if (*pos != '\0') {
+            strcat(buf, pos);
+          }
+          d->writer->set_string(buf);
+          SEND_TO_Q("Строка вставлена.\r\n", d);
+        } else {
+          SEND_TO_Q("Номер строки должен быть больше 0.\r\n", d);
+          return;
+        }
+      }
+      break;
 
-	case PARSE_EDIT:
-		half_chop(string, buf, buf2);
-		if (*buf == '\0')
-		{
-			SEND_TO_Q("Вы должны указать номер строки изменяемого текста.\r\n", d);
-			return;
-		}
-		line_low = atoi(buf);
-		strcat(buf2, "\r\n");
+    case PARSE_EDIT: half_chop(string, buf, buf2);
+      if (*buf == '\0') {
+        SEND_TO_Q("Вы должны указать номер строки изменяемого текста.\r\n", d);
+        return;
+      }
+      line_low = atoi(buf);
+      strcat(buf2, "\r\n");
 
-		i = 1;
-		*buf = '\0';
-		{
-			const char* s = d->writer->get_string();
-			const char* beginning = s;
-			if (s == nullptr)
-			{
-				SEND_TO_Q("Буфер пуст - изменения не проведены.\r\n", d);
-				return;
-			}
+      i = 1;
+      *buf = '\0';
+      {
+        const char *s = d->writer->get_string();
+        const char *beginning = s;
+        if (s == nullptr) {
+          SEND_TO_Q("Буфер пуст - изменения не проведены.\r\n", d);
+          return;
+        }
 
-			if (line_low > 0)
-			{	// Loop through the text counting \\n characters until we get to the line/
-				while (s && (i < line_low))
-				{
-					if ((s = strchr(s, '\n')) != NULL)
-					{
-						i++;
-						s++;
-					}
-				}
+        if (line_low > 0) {    // Loop through the text counting \\n characters until we get to the line/
+          while (s && (i < line_low)) {
+            if ((s = strchr(s, '\n')) != NULL) {
+              i++;
+              s++;
+            }
+          }
 
-				// * Make sure that there was a THAT line in the text.
-				if ((i < line_low) || (s == NULL))
-				{
-					SEND_TO_Q("Строка вне диапазона - прервано.\r\n", d);
-					return;
-				}
+          // * Make sure that there was a THAT line in the text.
+          if ((i < line_low) || (s == NULL)) {
+            SEND_TO_Q("Строка вне диапазона - прервано.\r\n", d);
+            return;
+          }
 
-				// If s is the same as *d->str that means I'm at the beginning of the
-				// message text and I don't need to put that into the changed buffer.
-				if (s != beginning)
-				{	// First things first .. we get this part into the buffer.
-					// Put the first 'good' half of the text into storage.
-					strncat(buf, beginning, s - beginning);
-				}
-				// Put the new 'good' line into place.
-				strcat(buf, buf2);
-				if ((s = strchr(s, '\n')) != NULL)
-				{
-					/*
-					* This means that we are at the END of the line, we want out of
-					* there, but we want s to point to the beginning of the line
-					* AFTER the line we want edited
-					*/
-					s++;
-					// * Now put the last 'good' half of buffer into storage.
-					strcat(buf, s);
-				}
+          // If s is the same as *d->str that means I'm at the beginning of the
+          // message text and I don't need to put that into the changed buffer.
+          if (s != beginning) {    // First things first .. we get this part into the buffer.
+            // Put the first 'good' half of the text into storage.
+            strncat(buf, beginning, s - beginning);
+          }
+          // Put the new 'good' line into place.
+          strcat(buf, buf2);
+          if ((s = strchr(s, '\n')) != NULL) {
+            /*
+            * This means that we are at the END of the line, we want out of
+            * there, but we want s to point to the beginning of the line
+            * AFTER the line we want edited
+            */
+            s++;
+            // * Now put the last 'good' half of buffer into storage.
+            strcat(buf, s);
+          }
 
-				// * Check for buffer overflow.
-				if (strlen(buf) > d->max_str)
-				{
-					SEND_TO_Q("Превышение максимального размера буфера - прервано.\r\n", d);
-					return;
-				}
+          // * Check for buffer overflow.
+          if (strlen(buf) > d->max_str) {
+            SEND_TO_Q("Превышение максимального размера буфера - прервано.\r\n", d);
+            return;
+          }
 
-				// * Change the size of the REAL buffer to fit the new text.
-				d->writer->set_string(buf);
-				SEND_TO_Q("Строка изменена.\r\n", d);
-			}
-			else
-			{
-				SEND_TO_Q("Номер строки должен быть больше 0.\r\n", d);
-				return;
-			}
-		}
-		break;
+          // * Change the size of the REAL buffer to fit the new text.
+          d->writer->set_string(buf);
+          SEND_TO_Q("Строка изменена.\r\n", d);
+        } else {
+          SEND_TO_Q("Номер строки должен быть больше 0.\r\n", d);
+          return;
+        }
+      }
+      break;
 
-	default:
-		SEND_TO_Q("Неверная опция.\r\n", d);
-		mudlog("SYSERR: invalid command passed to parse_action", BRF, LVL_IMPL, SYSLOG, TRUE);
-		return;
-	}
-	//log("[PA] Stop");
+    default: SEND_TO_Q("Неверная опция.\r\n", d);
+      mudlog("SYSERR: invalid command passed to parse_action", BRF, LVL_IMPL, SYSLOG, TRUE);
+      return;
+  }
+  //log("[PA] Stop");
 }
 
-
-
-
 // Add user input to the 'current' string (as defined by d->str) //
-void string_add(DESCRIPTOR_DATA * d, char *str)
-{
-	int terminator = 0, action = 0;
-	int i = 2, j = 0;
-	char actions[MAX_INPUT_LENGTH];
+void string_add(DESCRIPTOR_DATA *d, char *str) {
+  int terminator = 0, action = 0;
+  int i = 2, j = 0;
+  char actions[MAX_INPUT_LENGTH];
 
-	// determine if this is the terminal string, and truncate if so //
-	// changed to only accept '@' at the beginning of line - J. Elson 1/17/94 //
-	// Changed to accept '/<letter>' style editing commands - instead //
-	//   of solitary '@' to end. - M. Scott 10/15/96 //
+  // determine if this is the terminal string, and truncate if so //
+  // changed to only accept '@' at the beginning of line - J. Elson 1/17/94 //
+  // Changed to accept '/<letter>' style editing commands - instead //
+  //   of solitary '@' to end. - M. Scott 10/15/96 //
 
-	delete_doubledollar(str);
+  delete_doubledollar(str);
 
 #if 0
-	// Removed old handling of '@' character, put #if 1 to re-enable it. //
-	if ((terminator = (*str == '@')))
-		* str = '\0';
+  // Removed old handling of '@' character, put #if 1 to re-enable it. //
+  if ((terminator = (*str == '@')))
+      * str = '\0';
 #endif
 
-	// почту логировать как-то не оно
-	if (d->character && !PLR_FLAGGED(d->character, PLR_MAILING))
-		log("[SA] <%s> adds string '%s'", GET_NAME(d->character), str);
+  // почту логировать как-то не оно
+  if (d->character && !PLR_FLAGGED(d->character, PLR_MAILING))
+    log("[SA] <%s> adds string '%s'", GET_NAME(d->character), str);
 
-	smash_tilde(str);
-	if (!d->writer)
-	{
-		return;
-	}
+  smash_tilde(str);
+  if (!d->writer) {
+    return;
+  }
 
-	if ((action = (*str == '/')))
-	{
-		while (str[i] != '\0')
-		{
-			actions[j] = str[i];
-			i++;
-			j++;
-		}
-		actions[j] = '\0';
-		*str = '\0';
-		switch (str[1])
-		{
-		case 'a':
-			terminator = 2;	// Working on an abort message, //
-			break;
-		case 'c':
-			if (d->writer->get_string())
-			{
-				d->writer->clear();
-				SEND_TO_Q("Буфер очищен.\r\n", d);
-			}
-			else
-				SEND_TO_Q("Буфер пуст.\r\n", d);
-			break;
-		case 'd':
-			parse_action(PARSE_DELETE, actions, d);
-			break;
-		case 'e':
-			parse_action(PARSE_EDIT, actions, d);
-			break;
-		case 'f':
-			if (d->writer->get_string())
-			{
-				parse_action(PARSE_FORMAT, actions, d);
-			}
-			else
-			{
-				SEND_TO_Q("Буфер пуст.\r\n", d);
-			}
-			break;
-		case 'i':
-			if (d->writer->get_string())
-			{
-				parse_action(PARSE_INSERT, actions, d);
-			}
-			else
-			{
-				SEND_TO_Q("Буфер пуст.\r\n", d);
-			}
-			break;
-		case 'h':
-			parse_action(PARSE_HELP, actions, d);
-			break;
-		case 'l':
-			if (d->writer->get_string())
-			{
-				parse_action(PARSE_LIST_NORM, actions, d);
-			}
-			else
-			{
-				SEND_TO_Q("Буфер пуст.\r\n", d);
-			}
-			break;
-		case 'n':
-			if (d->writer->get_string())
-			{
-				parse_action(PARSE_LIST_NUM, actions, d);
-			}
-			else
-			{
-				SEND_TO_Q("Буфер пуст.\r\n", d);
-			}
-			break;
-		case 'r':
-			parse_action(PARSE_REPLACE, actions, d);
-			break;
-		case 's':
-			terminator = 1;
-			*str = '\0';
-			break;
-		default:
-			SEND_TO_Q("Интересный выбор. Я о нем подумаю...\r\n", d);
-			break;
-		}
-	}
+  if ((action = (*str == '/'))) {
+    while (str[i] != '\0') {
+      actions[j] = str[i];
+      i++;
+      j++;
+    }
+    actions[j] = '\0';
+    *str = '\0';
+    switch (str[1]) {
+      case 'a': terminator = 2;    // Working on an abort message, //
+        break;
+      case 'c':
+        if (d->writer->get_string()) {
+          d->writer->clear();
+          SEND_TO_Q("Буфер очищен.\r\n", d);
+        } else
+          SEND_TO_Q("Буфер пуст.\r\n", d);
+        break;
+      case 'd': parse_action(PARSE_DELETE, actions, d);
+        break;
+      case 'e': parse_action(PARSE_EDIT, actions, d);
+        break;
+      case 'f':
+        if (d->writer->get_string()) {
+          parse_action(PARSE_FORMAT, actions, d);
+        } else {
+          SEND_TO_Q("Буфер пуст.\r\n", d);
+        }
+        break;
+      case 'i':
+        if (d->writer->get_string()) {
+          parse_action(PARSE_INSERT, actions, d);
+        } else {
+          SEND_TO_Q("Буфер пуст.\r\n", d);
+        }
+        break;
+      case 'h': parse_action(PARSE_HELP, actions, d);
+        break;
+      case 'l':
+        if (d->writer->get_string()) {
+          parse_action(PARSE_LIST_NORM, actions, d);
+        } else {
+          SEND_TO_Q("Буфер пуст.\r\n", d);
+        }
+        break;
+      case 'n':
+        if (d->writer->get_string()) {
+          parse_action(PARSE_LIST_NUM, actions, d);
+        } else {
+          SEND_TO_Q("Буфер пуст.\r\n", d);
+        }
+        break;
+      case 'r': parse_action(PARSE_REPLACE, actions, d);
+        break;
+      case 's': terminator = 1;
+        *str = '\0';
+        break;
+      default: SEND_TO_Q("Интересный выбор. Я о нем подумаю...\r\n", d);
+        break;
+    }
+  }
 
-	if (!d->writer->get_string())
-	{
-		if (strlen(str) + 3 > d->max_str)
-		{
-			send_to_char("Слишком длинная строка - усечена.\r\n", d->character.get());
-			strcpy(&str[d->max_str - 3], "\r\n");
-			d->writer->set_string(str);
-		}
-		else if (CON_WRITE_MOD == STATE(d) && strlen(str) + 3 > 80)
-		{
-			send_to_char("Слишком длинная строка - усечена.\r\n", d->character.get());
-			str[80 - 3] = '\0';
-			d->writer->set_string(str);
-		}
-		else
-		{
-			d->writer->set_string(str);
-		}
-	}
-	else
-	{
-		if (CON_WRITE_MOD == STATE(d) && strlen(str) + 3 > 80)
-		{
-			send_to_char("Слишком длинная строка - усечена.\r\n", d->character.get());
-			str[80 - 3] = '\0';
-		}
+  if (!d->writer->get_string()) {
+    if (strlen(str) + 3 > d->max_str) {
+      send_to_char("Слишком длинная строка - усечена.\r\n", d->character.get());
+      strcpy(&str[d->max_str - 3], "\r\n");
+      d->writer->set_string(str);
+    } else if (CON_WRITE_MOD == STATE(d) && strlen(str) + 3 > 80) {
+      send_to_char("Слишком длинная строка - усечена.\r\n", d->character.get());
+      str[80 - 3] = '\0';
+      d->writer->set_string(str);
+    } else {
+      d->writer->set_string(str);
+    }
+  } else {
+    if (CON_WRITE_MOD == STATE(d) && strlen(str) + 3 > 80) {
+      send_to_char("Слишком длинная строка - усечена.\r\n", d->character.get());
+      str[80 - 3] = '\0';
+    }
 
-		if (strlen(str) + d->writer->length() + 3 > d->max_str)  	// \r\n\0 //
-		{
-			send_to_char(d->character.get(),
-				"Слишком длинное послание > %lu симв. Последняя строка проигнорирована.\r\n",
-				d->max_str - 3);
-			action = TRUE;
-		}
-		else
-		{
-			d->writer->append_string(str);
-		}
-	}
+    if (strlen(str) + d->writer->length() + 3 > d->max_str)    // \r\n\0 //
+    {
+      send_to_char(d->character.get(),
+                   "Слишком длинное послание > %lu симв. Последняя строка проигнорирована.\r\n",
+                   d->max_str - 3);
+      action = TRUE;
+    } else {
+      d->writer->append_string(str);
+    }
+  }
 
-	if (terminator)
-	{	// OLC Edits
-		extern void oedit_disp_menu(DESCRIPTOR_DATA * d);
-		extern void oedit_disp_extradesc_menu(DESCRIPTOR_DATA * d);
-		extern void redit_disp_menu(DESCRIPTOR_DATA * d);
-		extern void redit_disp_extradesc_menu(DESCRIPTOR_DATA * d);
-		extern void redit_disp_exit_menu(DESCRIPTOR_DATA * d);
-		extern void medit_disp_menu(DESCRIPTOR_DATA * d);
-		extern void trigedit_disp_menu(DESCRIPTOR_DATA * d);
+  if (terminator) {    // OLC Edits
+    extern void oedit_disp_menu(DESCRIPTOR_DATA *d);
+    extern void oedit_disp_extradesc_menu(DESCRIPTOR_DATA *d);
+    extern void redit_disp_menu(DESCRIPTOR_DATA *d);
+    extern void redit_disp_extradesc_menu(DESCRIPTOR_DATA *d);
+    extern void redit_disp_exit_menu(DESCRIPTOR_DATA *d);
+    extern void medit_disp_menu(DESCRIPTOR_DATA *d);
+    extern void trigedit_disp_menu(DESCRIPTOR_DATA *d);
 
 #if defined(OASIS_MPROG)
-		extern void medit_change_mprog(DESCRIPTOR_DATA * d);
+    extern void medit_change_mprog(DESCRIPTOR_DATA * d);
 
-		if (STATE(d) == CON_MEDIT)
-		{
-			switch (OLC_MODE(d))
-			{
-			case MEDIT_D_DESC:
-				medit_disp_menu(d);
-				break;
-			case MEDIT_MPROG_COMLIST:
-				medit_change_mprog(d);
-				break;
-			}
-		}
+    if (STATE(d) == CON_MEDIT)
+    {
+        switch (OLC_MODE(d))
+        {
+        case MEDIT_D_DESC:
+            medit_disp_menu(d);
+            break;
+        case MEDIT_MPROG_COMLIST:
+            medit_change_mprog(d);
+            break;
+        }
+    }
 #endif
 
-		// * Here we check for the abort option and reset the pointers.
-		if ((terminator == 2) && ((STATE(d) == CON_REDIT) || (STATE(d) == CON_MEDIT) || (STATE(d) == CON_OEDIT) || (STATE(d) == CON_TRIGEDIT) || (STATE(d) == CON_EXDESC)))  	//log("[SA] 2s");
-		{
-			if (d->backstr)
-			{
-				d->writer->set_string(d->backstr);
-				free(d->backstr);
-			}
-			else
-			{
-				d->writer->clear();
-			}
-			d->backstr = nullptr;
-			d->writer.reset();
-		}
-		// * This fix causes the editor to NULL out empty messages -- M. Scott
-		// * Fixed to fix the fix for empty fixed messages. -- gg
-		else if (d->writer
-			&& d->writer->get_string()
-			&& '\0' == *d->writer->get_string())
-		{
-			d->writer->set_string("\r\n");
-		}
+    // * Here we check for the abort option and reset the pointers.
+    if ((terminator == 2)
+        && ((STATE(d) == CON_REDIT) || (STATE(d) == CON_MEDIT) || (STATE(d) == CON_OEDIT) || (STATE(d) == CON_TRIGEDIT)
+            || (STATE(d) == CON_EXDESC)))    //log("[SA] 2s");
+    {
+      if (d->backstr) {
+        d->writer->set_string(d->backstr);
+        free(d->backstr);
+      } else {
+        d->writer->clear();
+      }
+      d->backstr = nullptr;
+      d->writer.reset();
+    }
+      // * This fix causes the editor to NULL out empty messages -- M. Scott
+      // * Fixed to fix the fix for empty fixed messages. -- gg
+    else if (d->writer
+        && d->writer->get_string()
+        && '\0' == *d->writer->get_string()) {
+      d->writer->set_string("\r\n");
+    }
 
-		if (STATE(d) == CON_MEDIT)
-			medit_disp_menu(d);
+    if (STATE(d) == CON_MEDIT)
+      medit_disp_menu(d);
 
-		if (STATE(d) == CON_TRIGEDIT)
-			trigedit_disp_menu(d);
+    if (STATE(d) == CON_TRIGEDIT)
+      trigedit_disp_menu(d);
 
-		if (STATE(d) == CON_OEDIT)
-		{
-			switch (OLC_MODE(d))
-			{
-			case OEDIT_ACTDESC:
-				oedit_disp_menu(d);
-				break;
-			case OEDIT_EXTRADESC_DESCRIPTION:
-				oedit_disp_extradesc_menu(d);
-				break;
-			}
-		}
-		else if (STATE(d) == CON_REDIT)
-		{
-			switch (OLC_MODE(d))
-			{
-			case REDIT_DESC:
-				redit_disp_menu(d);
-				break;
-			case REDIT_EXIT_DESCRIPTION:
-				redit_disp_exit_menu(d);
-				break;
-			case REDIT_EXTRADESC_DESCRIPTION:
-				redit_disp_extradesc_menu(d);
-				break;
-			}
-		}
-		else if (STATE(d) == CON_WRITEBOARD)
-		{
-			// добавление сообщения на доску
-			if (terminator == 1
-				&& d->writer->get_string()
-				&& !d->board.expired())
-			{
-				auto board = d->board.lock();
-				d->message->date = time(0);
-				d->message->text = d->writer->get_string();
-				// для новостных отступов ну и вообще мож все так сейвить, посмотрим
-				if (board->get_type() == Boards::NEWS_BOARD
-					|| board->get_type() == Boards::GODNEWS_BOARD)
-				{
-					format_news_message(d->message->text);
-				}
-				board->write_message(d->message);
-				Boards::Static::new_message_notify(board);
-				SEND_TO_Q("Спасибо за ваши излияния души, послание сохранено.\r\n", d);
-			}
-			else
-			{
-				SEND_TO_Q("Редактирование прервано.\r\n", d);
-			}
-			d->message.reset();
-			d->board.reset();
-			if (d->writer)
-			{
-				d->writer->clear();
-				d->writer.reset();
-			}
-			d->connected = CON_PLAYING;
-		}
-		else if (STATE(d) == CON_WRITE_MOD)
-		{
-			// писали клановое сообщение дня
-			if (terminator == 1
-				&& d->writer->get_string())
-			{
-				std::string body = d->writer->get_string();
-				boost::trim(body);
-				if (body.empty())
-				{
-					CLAN(d->character)->write_mod(body);
-					send_to_char("Сообщение удалено.\r\n", d->character.get());
-				}
-				else
-				{
-					// за время редактирования могли лишиться привилегии/клана
-					if (d->character
-						&& CLAN(d->character)
-						&& CLAN(d->character)->CheckPrivilege(
-							CLAN_MEMBER(d->character)->rank_num,
-							ClanSystem::MAY_CLAN_MOD))
-					{
-						std::string head = boost::str(boost::format
-							("Сообщение дружины (автор %1%):\r\n")
-							% GET_NAME(d->character));
-						// отступ (копи-паст из CON_WRITEBOARD выше)
-						format_news_message(body);
-						head += body;
+    if (STATE(d) == CON_OEDIT) {
+      switch (OLC_MODE(d)) {
+        case OEDIT_ACTDESC: oedit_disp_menu(d);
+          break;
+        case OEDIT_EXTRADESC_DESCRIPTION: oedit_disp_extradesc_menu(d);
+          break;
+      }
+    } else if (STATE(d) == CON_REDIT) {
+      switch (OLC_MODE(d)) {
+        case REDIT_DESC: redit_disp_menu(d);
+          break;
+        case REDIT_EXIT_DESCRIPTION: redit_disp_exit_menu(d);
+          break;
+        case REDIT_EXTRADESC_DESCRIPTION: redit_disp_extradesc_menu(d);
+          break;
+      }
+    } else if (STATE(d) == CON_WRITEBOARD) {
+      // добавление сообщения на доску
+      if (terminator == 1
+          && d->writer->get_string()
+          && !d->board.expired()) {
+        auto board = d->board.lock();
+        d->message->date = time(0);
+        d->message->text = d->writer->get_string();
+        // для новостных отступов ну и вообще мож все так сейвить, посмотрим
+        if (board->get_type() == Boards::NEWS_BOARD
+            || board->get_type() == Boards::GODNEWS_BOARD) {
+          format_news_message(d->message->text);
+        }
+        board->write_message(d->message);
+        Boards::Static::new_message_notify(board);
+        SEND_TO_Q("Спасибо за ваши излияния души, послание сохранено.\r\n", d);
+      } else {
+        SEND_TO_Q("Редактирование прервано.\r\n", d);
+      }
+      d->message.reset();
+      d->board.reset();
+      if (d->writer) {
+        d->writer->clear();
+        d->writer.reset();
+      }
+      d->connected = CON_PLAYING;
+    } else if (STATE(d) == CON_WRITE_MOD) {
+      // писали клановое сообщение дня
+      if (terminator == 1
+          && d->writer->get_string()) {
+        std::string body = d->writer->get_string();
+        boost::trim(body);
+        if (body.empty()) {
+          CLAN(d->character)->write_mod(body);
+          send_to_char("Сообщение удалено.\r\n", d->character.get());
+        } else {
+          // за время редактирования могли лишиться привилегии/клана
+          if (d->character
+              && CLAN(d->character)
+              && CLAN(d->character)->CheckPrivilege(
+                  CLAN_MEMBER(d->character)->rank_num,
+                  ClanSystem::MAY_CLAN_MOD)) {
+            std::string head = boost::str(boost::format
+                                              ("Сообщение дружины (автор %1%):\r\n")
+                                              % GET_NAME(d->character));
+            // отступ (копи-паст из CON_WRITEBOARD выше)
+            format_news_message(body);
+            head += body;
 
-						CLAN(d->character)->write_mod(head);
-						SEND_TO_Q("Сообщение добавлено.\r\n", d);
-					}
-					else
-					{
-						SEND_TO_Q("Ошибочка вышла...\r\n", d);
-					}
-				}
-			}
-			else
-			{
-				SEND_TO_Q("Сообщение прервано.\r\n", d);
-			}
+            CLAN(d->character)->write_mod(head);
+            SEND_TO_Q("Сообщение добавлено.\r\n", d);
+          } else {
+            SEND_TO_Q("Ошибочка вышла...\r\n", d);
+          }
+        }
+      } else {
+        SEND_TO_Q("Сообщение прервано.\r\n", d);
+      }
 
-			if (d->writer)
-			{
-				d->writer->clear();
-				d->writer.reset();
-			}
-			d->connected = CON_PLAYING;
-		}
-		else if (!d->connected && (PLR_FLAGGED(d->character, PLR_MAILING)))
-		{
-			if ((terminator == 1) && d->writer->get_string())
-			{
-				mail::add(d->mail_to, d->character->get_uid(), d->writer->get_string());
-				SEND_TO_Q("Ближайшей оказией я отправлю ваше письмо адресату!\r\n", d);
-				if (DescByUID(d->mail_to))
-				{
-					mail::add_notice(d->mail_to);
-				}
-			}
-			else
-				SEND_TO_Q("Письмо удалено.\r\n", d);
-			//log("[SA] 5s");
-			d->mail_to = 0;
-			if (d->writer)
-			{
-				d->writer->clear();
-				d->writer.reset();
-			}
-		}
-		else if (STATE(d) == CON_EXDESC)  	//log("[SA] 7s");
-		{
-			if (terminator != 1)
-			{
-				SEND_TO_Q("Создание описания прервано.\r\n", d);
-			}
-			SEND_TO_Q(MENU, d);
-			d->connected = CON_MENU;
-			//log("[SA] 7f");
-		}
-		else if (!d->connected && d->character && !IS_NPC(d->character))
-		{
-			if (terminator == 1)  	//log("[SA] 8s");
-			{
-				if (d->writer)
-				{
-					d->writer->clear();
-					d->writer.reset();
-				}
-			}
-			else  	//log("[SA] 9s");
-			{
-				if (d->backstr)
-				{
-					d->writer->set_string(d->backstr);
-					free(d->backstr);
-					d->backstr = nullptr;
-				}
-				else
-				{
-					d->writer->clear();
-				}
+      if (d->writer) {
+        d->writer->clear();
+        d->writer.reset();
+      }
+      d->connected = CON_PLAYING;
+    } else if (!d->connected && (PLR_FLAGGED(d->character, PLR_MAILING))) {
+      if ((terminator == 1) && d->writer->get_string()) {
+        mail::add(d->mail_to, d->character->get_uid(), d->writer->get_string());
+        SEND_TO_Q("Ближайшей оказией я отправлю ваше письмо адресату!\r\n", d);
+        if (DescByUID(d->mail_to)) {
+          mail::add_notice(d->mail_to);
+        }
+      } else
+        SEND_TO_Q("Письмо удалено.\r\n", d);
+      //log("[SA] 5s");
+      d->mail_to = 0;
+      if (d->writer) {
+        d->writer->clear();
+        d->writer.reset();
+      }
+    } else if (STATE(d) == CON_EXDESC)    //log("[SA] 7s");
+    {
+      if (terminator != 1) {
+        SEND_TO_Q("Создание описания прервано.\r\n", d);
+      }
+      SEND_TO_Q(MENU, d);
+      d->connected = CON_MENU;
+      //log("[SA] 7f");
+    } else if (!d->connected && d->character && !IS_NPC(d->character)) {
+      if (terminator == 1)    //log("[SA] 8s");
+      {
+        if (d->writer) {
+          d->writer->clear();
+          d->writer.reset();
+        }
+      } else    //log("[SA] 9s");
+      {
+        if (d->backstr) {
+          d->writer->set_string(d->backstr);
+          free(d->backstr);
+          d->backstr = nullptr;
+        } else {
+          d->writer->clear();
+        }
 
-				SEND_TO_Q("Сообщение прервано.\r\n", d);
-			}
-		}
+        SEND_TO_Q("Сообщение прервано.\r\n", d);
+      }
+    }
 
-		if (d->character && !IS_NPC(d->character))
-		{
-			PLR_FLAGS(d->character).unset(PLR_WRITING);
+    if (d->character && !IS_NPC(d->character)) {
+      PLR_FLAGS(d->character).unset(PLR_WRITING);
 
-			PLR_FLAGS(d->character).unset(PLR_MAILING);
-		}
-		if (d->backstr)
-		{
-			free(d->backstr);
-			d->backstr = nullptr;
-		}
+      PLR_FLAGS(d->character).unset(PLR_MAILING);
+    }
+    if (d->backstr) {
+      free(d->backstr);
+      d->backstr = nullptr;
+    }
 
-		d->writer.reset();
-	}
-	else if (!action)
-	{
-		d->writer->append_string("\r\n");
-	}
+    d->writer.reset();
+  } else if (!action) {
+    d->writer->append_string("\r\n");
+  }
 }
 
 // ***********************************************************************
 // * Set of character features                                           *
 // ***********************************************************************
 
-void do_featset(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	CHAR_DATA *vict;
-	char name[MAX_INPUT_LENGTH], buf2[128];
-	char buf[MAX_INPUT_LENGTH], help[MAX_STRING_LENGTH];
-	int feat = -1, value, i, qend;
+void do_featset(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *vict;
+  char name[MAX_INPUT_LENGTH], buf2[128];
+  char buf[MAX_INPUT_LENGTH], help[MAX_STRING_LENGTH];
+  int feat = -1, value, i, qend;
 
-	argument = one_argument(argument, name);
+  argument = one_argument(argument, name);
 
-	if (!*name)  		// no arguments. print an informative text //
-	{
-		send_to_char("Формат: featset <игрок> '<способность>' <значение>\r\n", ch);
-		strcpy(help, "Возможные способности:\r\n");
-		for (qend = 0, i = 1; i < MAX_FEATS; i++)
-		{
-			if (feat_info[i].type == UNUSED_FTYPE)	// This is valid. //
-				continue;
-			sprintf(help + strlen(help), "%30s", feat_info[i].name);
-			if (qend++ % 3 == 2)
-			{
-				strcat(help, "\r\n");
-				send_to_char(help, ch);
-				*help = '\0';
-			}
-		}
-		if (*help)
-			send_to_char(help, ch);
-		send_to_char("\r\n", ch);
-		return;
-	}
+  if (!*name)        // no arguments. print an informative text //
+  {
+    send_to_char("Формат: featset <игрок> '<способность>' <значение>\r\n", ch);
+    strcpy(help, "Возможные способности:\r\n");
+    for (qend = 0, i = 1; i < MAX_FEATS; i++) {
+      if (feat_info[i].type == UNUSED_FTYPE)    // This is valid. //
+        continue;
+      sprintf(help + strlen(help), "%30s", feat_info[i].name);
+      if (qend++ % 3 == 2) {
+        strcat(help, "\r\n");
+        send_to_char(help, ch);
+        *help = '\0';
+      }
+    }
+    if (*help)
+      send_to_char(help, ch);
+    send_to_char("\r\n", ch);
+    return;
+  }
 
-	if (!(vict = get_char_vis(ch, name, FIND_CHAR_WORLD)))
-	{
-		send_to_char(NOPERSON, ch);
-		return;
-	}
-	skip_spaces(&argument);
+  if (!(vict = get_char_vis(ch, name, FIND_CHAR_WORLD))) {
+    send_to_char(NOPERSON, ch);
+    return;
+  }
+  skip_spaces(&argument);
 
-	// If there is no chars in argument //
-	if (!*argument)
-	{
-		send_to_char("Пропущено название способности.\r\n", ch);
-		return;
-	}
-	if (*argument != '\'')
-	{
-		send_to_char("Название способности надо заключить в символы : ''\r\n", ch);
-		return;
-	}
-	// Locate the last quote and lowercase the magic words (if any) //
+  // If there is no chars in argument //
+  if (!*argument) {
+    send_to_char("Пропущено название способности.\r\n", ch);
+    return;
+  }
+  if (*argument != '\'') {
+    send_to_char("Название способности надо заключить в символы : ''\r\n", ch);
+    return;
+  }
+  // Locate the last quote and lowercase the magic words (if any) //
 
-	for (qend = 1; argument[qend] && argument[qend] != '\''; qend++)
-		argument[qend] = LOWER(argument[qend]);
+  for (qend = 1; argument[qend] && argument[qend] != '\''; qend++)
+    argument[qend] = LOWER(argument[qend]);
 
-	if (argument[qend] != '\'')
-	{
-		send_to_char("Название способности должно быть заключено в символы : ''\r\n", ch);
-		return;
-	}
-	strcpy(help, (argument + 1));
-	help[qend - 1] = '\0';
+  if (argument[qend] != '\'') {
+    send_to_char("Название способности должно быть заключено в символы : ''\r\n", ch);
+    return;
+  }
+  strcpy(help, (argument + 1));
+  help[qend - 1] = '\0';
 
-	if ((feat = find_feat_num(help)) <= 0)
-	{
-		send_to_char("Неизвестная способность.\r\n", ch);
-		return;
-	}
+  if ((feat = find_feat_num(help)) <= 0) {
+    send_to_char("Неизвестная способность.\r\n", ch);
+    return;
+  }
 
-	argument += qend + 1;	// skip to next parameter //
-	argument = one_argument(argument, buf);
+  argument += qend + 1;    // skip to next parameter //
+  argument = one_argument(argument, buf);
 
-	if (!*buf)
-	{
-		send_to_char("Не указан числовой параметр (0 или 1).\r\n", ch);
-		return;
-	}
-	value = atoi(buf);
-	if (value < 0 || value > 1)
-	{
-		send_to_char("Допустимые значения: 0 (снять), 1 (установить).\r\n", ch);
-		return;
-	}
+  if (!*buf) {
+    send_to_char("Не указан числовой параметр (0 или 1).\r\n", ch);
+    return;
+  }
+  value = atoi(buf);
+  if (value < 0 || value > 1) {
+    send_to_char("Допустимые значения: 0 (снять), 1 (установить).\r\n", ch);
+    return;
+  }
 
-	if (IS_NPC(vict))
-	{
-		send_to_char("Вы не можете добавить способность NPC, используйте OLC.\r\n", ch);
-		return;
-	}
+  if (IS_NPC(vict)) {
+    send_to_char("Вы не можете добавить способность NPC, используйте OLC.\r\n", ch);
+    return;
+  }
 
-
-	sprintf(buf2, "%s changed %s's %s to '%s'.", GET_NAME(ch), GET_NAME(vict),
-			feat_info[feat].name, value ? "enabled" : "disabled");
-	mudlog(buf2, BRF, -1, SYSLOG, TRUE);
-	imm_log("%s", buf2);
-	if (feat >= 0 && feat < MAX_FEATS)
-	{
-		if (value)
-			SET_FEAT(vict, feat);
-		else
-			UNSET_FEAT(vict, feat);
-	}
-	sprintf(buf2, "Вы изменили для %s '%s' на '%s'.\r\n", GET_PAD(vict, 1),
-			feat_info[feat].name, value ? "доступно" : "недоступно");
-	if (!can_get_feat(vict, feat) && value == 1)
-		send_to_char("Эта способность не доступна данному персонажу и будет удалена при повторном входе в игру.\r\n", ch);
-	send_to_char(buf2, ch);
+  sprintf(buf2, "%s changed %s's %s to '%s'.", GET_NAME(ch), GET_NAME(vict),
+          feat_info[feat].name, value ? "enabled" : "disabled");
+  mudlog(buf2, BRF, -1, SYSLOG, TRUE);
+  imm_log("%s", buf2);
+  if (feat >= 0 && feat < MAX_FEATS) {
+    if (value)
+      SET_FEAT(vict, feat);
+    else
+      UNSET_FEAT(vict, feat);
+  }
+  sprintf(buf2, "Вы изменили для %s '%s' на '%s'.\r\n", GET_PAD(vict, 1),
+          feat_info[feat].name, value ? "доступно" : "недоступно");
+  if (!can_get_feat(vict, feat) && value == 1)
+    send_to_char("Эта способность не доступна данному персонажу и будет удалена при повторном входе в игру.\r\n", ch);
+  send_to_char(buf2, ch);
 }
 
 // **********************************************************************
 // *  Modification of character skills                                  *
 // **********************************************************************
 
-void do_skillset(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	CHAR_DATA *vict;
-	char name[MAX_INPUT_LENGTH], buf2[128];
-	char buf[MAX_INPUT_LENGTH], help[MAX_STRING_LENGTH];
-	int spell = -1, value, i, qend;
-	ESkill skill = SKILL_INVALID;
+void do_skillset(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *vict;
+  char name[MAX_INPUT_LENGTH], buf2[128];
+  char buf[MAX_INPUT_LENGTH], help[MAX_STRING_LENGTH];
+  int spell = -1, value, i, qend;
+  ESkill skill = SKILL_INVALID;
 
-	argument = one_argument(argument, name);
+  argument = one_argument(argument, name);
 
-	// * No arguments. print an informative text.
-	if (!*name)  		// no arguments. print an informative text
-	{
-		send_to_char("Формат: skillset <игрок> '<умение/заклинание>' <значение>\r\n", ch);
-		strcpy(help, "Возможные умения:\r\n");
-		for (qend = 0, i = 0; i <= TOP_SPELL_DEFINE; i++)
-		{
-			if (spell_info[i].name == unused_spellname)	// This is valid.
-				continue;
-			sprintf(help + strlen(help), "%18s", spell_info[i].name);
-			if (qend++ % 4 == 3)
-			{
-				strcat(help, "\r\n");
-				send_to_char(help, ch);
-				*help = '\0';
-			}
-		}
-		if (*help)
-			send_to_char(help, ch);
-		send_to_char("\r\n", ch);
-		return;
-	}
+  // * No arguments. print an informative text.
+  if (!*name)        // no arguments. print an informative text
+  {
+    send_to_char("Формат: skillset <игрок> '<умение/заклинание>' <значение>\r\n", ch);
+    strcpy(help, "Возможные умения:\r\n");
+    for (qend = 0, i = 0; i <= TOP_SPELL_DEFINE; i++) {
+      if (spell_info[i].name == unused_spellname)    // This is valid.
+        continue;
+      sprintf(help + strlen(help), "%18s", spell_info[i].name);
+      if (qend++ % 4 == 3) {
+        strcat(help, "\r\n");
+        send_to_char(help, ch);
+        *help = '\0';
+      }
+    }
+    if (*help)
+      send_to_char(help, ch);
+    send_to_char("\r\n", ch);
+    return;
+  }
 
-	if (!(vict = get_char_vis(ch, name, FIND_CHAR_WORLD)))
-	{
-		send_to_char(NOPERSON, ch);
-		return;
-	}
-	skip_spaces(&argument);
+  if (!(vict = get_char_vis(ch, name, FIND_CHAR_WORLD))) {
+    send_to_char(NOPERSON, ch);
+    return;
+  }
+  skip_spaces(&argument);
 
-	// If there is no chars in argument
-	if (!*argument)
-	{
-		send_to_char("Пропущено название умения.\r\n", ch);
-		return;
-	}
-	if (*argument != '\'')
-	{
-		send_to_char("Умение надо заключить в символы : ''\r\n", ch);
-		return;
-	}
-	// Locate the last quote and lowercase the magic words (if any)
+  // If there is no chars in argument
+  if (!*argument) {
+    send_to_char("Пропущено название умения.\r\n", ch);
+    return;
+  }
+  if (*argument != '\'') {
+    send_to_char("Умение надо заключить в символы : ''\r\n", ch);
+    return;
+  }
+  // Locate the last quote and lowercase the magic words (if any)
 
-	for (qend = 1; argument[qend] && argument[qend] != '\''; qend++)
-	{
-		argument[qend] = LOWER(argument[qend]);
-	}
+  for (qend = 1; argument[qend] && argument[qend] != '\''; qend++) {
+    argument[qend] = LOWER(argument[qend]);
+  }
 
-	if (argument[qend] != '\'')
-	{
-		send_to_char("Умение должно быть заключено в символы : ''\r\n", ch);
-		return;
-	}
-	strcpy(help, (argument + 1));
-	help[qend - 1] = '\0';
+  if (argument[qend] != '\'') {
+    send_to_char("Умение должно быть заключено в символы : ''\r\n", ch);
+    return;
+  }
+  strcpy(help, (argument + 1));
+  help[qend - 1] = '\0';
 
-	if (SKILL_INVALID == (skill = fix_name_and_find_skill_num(help)))
-	{
-		spell = fix_name_and_find_spell_num(help);
-	}
+  if (SKILL_INVALID == (skill = fix_name_and_find_skill_num(help))) {
+    spell = fix_name_and_find_spell_num(help);
+  }
 
-	if (SKILL_INVALID == skill
-        && spell < 0)
-	{
-		send_to_char("Неизвестное умение/заклинание.\r\n", ch);
-		return;
-	}
-	argument += qend + 1;	// skip to next parameter
-	argument = one_argument(argument, buf);
+  if (SKILL_INVALID == skill
+      && spell < 0) {
+    send_to_char("Неизвестное умение/заклинание.\r\n", ch);
+    return;
+  }
+  argument += qend + 1;    // skip to next parameter
+  argument = one_argument(argument, buf);
 
-	if (!*buf)
-	{
-		send_to_char("Пропущен уровень умения.\r\n", ch);
-		return;
-	}
-	value = atoi(buf);
-	if (value < 0)
-	{
-		send_to_char("Минимальное значение умения 0.\r\n", ch);
-		return;
-	}
-	if (!is_magic_skill(skill) && value > 200)
-	{
-		send_to_char("Максимальное значение умения 200.\r\n", ch);
-		return;
-	}
-	if (IS_NPC(vict))
-	{
-		send_to_char("Вы не можете добавить умение для мобов.\r\n", ch);
-		return;
-	}
+  if (!*buf) {
+    send_to_char("Пропущен уровень умения.\r\n", ch);
+    return;
+  }
+  value = atoi(buf);
+  if (value < 0) {
+    send_to_char("Минимальное значение умения 0.\r\n", ch);
+    return;
+  }
+  if (IS_NPC(vict)) {
+    send_to_char("Вы не можете добавить умение для мобов.\r\n", ch);
+    return;
+  }
+  if (value > skill_info[skill].cap) {
+    send_to_char("Превышено максимально возможное значение умения.\r\n", ch);
+    value = skill_info[skill].cap;
+  }
 
-	// * find_skill_num() guarantees a valid spell_info[] index, or -1, and we
-	// * checked for the -1 above so we are safe here.
-	sprintf(buf2, "%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict),
-		spell >= 0 ? spell_info[spell].name : skill_info[skill].name, value);
-	mudlog(buf2, BRF, -1, SYSLOG, TRUE);
-	imm_log("%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict),
-		spell >= 0 ? spell_info[spell].name : skill_info[skill].name, value);
-	if (spell >= 0 && spell <= MAX_SPELLS)
-	{
-		GET_SPELL_TYPE(vict, spell) = value;
-	}
-	else if (SKILL_INVALID != skill
-		&& skill <= MAX_SKILL_NUM)
-	{
-		vict->set_skill(skill, value);
-	}
-	sprintf(buf2, "Вы изменили для %s '%s' на %d.\r\n", GET_PAD(vict, 1),
-		spell >= 0 ? spell_info[spell].name : skill_info[skill].name, value);
-	send_to_char(buf2, ch);
+  // * find_skill_num() guarantees a valid spell_info[] index, or -1, and we
+  // * checked for the -1 above so we are safe here.
+  sprintf(buf2, "%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict),
+          spell >= 0 ? spell_info[spell].name : skill_info[skill].name, value);
+  mudlog(buf2, BRF, -1, SYSLOG, TRUE);
+  imm_log("%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict),
+          spell >= 0 ? spell_info[spell].name : skill_info[skill].name, value);
+  if (spell >= 0 && spell <= MAX_SPELLS) {
+    GET_SPELL_TYPE(vict, spell) = value;
+  } else if (SKILL_INVALID != skill
+      && skill <= MAX_SKILL_NUM) {
+    vict->set_skill(skill, value);
+  }
+  sprintf(buf2, "Вы изменили для %s '%s' на %d.\r\n", GET_PAD(vict, 1),
+          spell >= 0 ? spell_info[spell].name : skill_info[skill].name, value);
+  send_to_char(buf2, ch);
 }
 
 
@@ -1289,251 +1066,205 @@ void do_skillset(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
 
 // * Traverse down the string until the begining of the next page has been
 // * reached.  Return NULL if this is the last page of the string.
-char *next_page(char *str, CHAR_DATA * ch)
-{
-	int col = 1, line = 1, spec_code = FALSE;
-	const char *color;
+char *next_page(char *str, CHAR_DATA *ch) {
+  int col = 1, line = 1, spec_code = FALSE;
+  const char *color;
 
-	for (;; str++)  	// If end of string, return NULL. //
-	{
-		if (*str == '\0')
-			return (NULL);
+  for (;; str++)    // If end of string, return NULL. //
+  {
+    if (*str == '\0')
+      return (NULL);
 
-		// If we're at the start of the next page, return this fact. //
-		else if (STRING_WIDTH(ch) && line > STRING_WIDTH(ch))
-			return (str);
+      // If we're at the start of the next page, return this fact. //
+    else if (STRING_WIDTH(ch) && line > STRING_WIDTH(ch))
+      return (str);
 
-		// Check for the begining of an ANSI color code block. //
-		else if (*str == '$' && !strncmp(str + 1, "COLOR", 5))
-		{
-			if (!ch)
-				color = KNRM;
-			else
-				switch (*(str + 6))
-				{
-				case 'N':
-					color = clr((ch), (C_NRM)) ? KIDRK : KNRM;
-					break;
-				case 'n':
-					color = clr((ch), (C_NRM)) ? KNRM : KNRM;
-					break;
-				case 'R':
-					color = clr((ch), (C_NRM)) ? KIRED : KNRM;
-					break;
-				case 'r':
-					color = clr((ch), (C_NRM)) ? KRED : KNRM;
-					break;
-				case 'G':
-					color = clr((ch), (C_NRM)) ? KIGRN : KNRM;
-					break;
-				case 'g':
-					color = clr((ch), (C_NRM)) ? KGRN : KNRM;
-					break;
-				case 'Y':
-					color = clr((ch), (C_NRM)) ? KIYEL : KNRM;
-					break;
-				case 'y':
-					color = clr((ch), (C_NRM)) ? KYEL : KNRM;
-					break;
-				case 'B':
-					color = clr((ch), (C_NRM)) ? KIBLU : KNRM;
-					break;
-				case 'b':
-					color = clr((ch), (C_NRM)) ? KBLU : KNRM;
-					break;
-				case 'M':
-					color = clr((ch), (C_NRM)) ? KIMAG : KNRM;
-					break;
-				case 'm':
-					color = clr((ch), (C_NRM)) ? KMAG : KNRM;
-					break;
-				case 'C':
-					color = clr((ch), (C_NRM)) ? KICYN : KNRM;
-					break;
-				case 'c':
-					color = clr((ch), (C_NRM)) ? KCYN : KNRM;
-					break;
-				case 'W':
-					color = clr((ch), (C_NRM)) ? KIDRK : KNRM;
-					break;
-				case 'w':
-					color = clr((ch), (C_NRM)) ? KWHT : KNRM;
-					break;
-				default:
-					color = KNRM;
-				}
-			strncpy(str, color, strlen(color));
-			str += (strlen(color) - 1);
-		}
-		else if (*str == '\x1B' && !spec_code)
-			spec_code = TRUE;
+      // Check for the begining of an ANSI color code block. //
+    else if (*str == '$' && !strncmp(str + 1, "COLOR", 5)) {
+      if (!ch)
+        color = KNRM;
+      else
+        switch (*(str + 6)) {
+          case 'N': color = clr((ch), (C_NRM)) ? KIDRK : KNRM;
+            break;
+          case 'n': color = clr((ch), (C_NRM)) ? KNRM : KNRM;
+            break;
+          case 'R': color = clr((ch), (C_NRM)) ? KIRED : KNRM;
+            break;
+          case 'r': color = clr((ch), (C_NRM)) ? KRED : KNRM;
+            break;
+          case 'G': color = clr((ch), (C_NRM)) ? KIGRN : KNRM;
+            break;
+          case 'g': color = clr((ch), (C_NRM)) ? KGRN : KNRM;
+            break;
+          case 'Y': color = clr((ch), (C_NRM)) ? KIYEL : KNRM;
+            break;
+          case 'y': color = clr((ch), (C_NRM)) ? KYEL : KNRM;
+            break;
+          case 'B': color = clr((ch), (C_NRM)) ? KIBLU : KNRM;
+            break;
+          case 'b': color = clr((ch), (C_NRM)) ? KBLU : KNRM;
+            break;
+          case 'M': color = clr((ch), (C_NRM)) ? KIMAG : KNRM;
+            break;
+          case 'm': color = clr((ch), (C_NRM)) ? KMAG : KNRM;
+            break;
+          case 'C': color = clr((ch), (C_NRM)) ? KICYN : KNRM;
+            break;
+          case 'c': color = clr((ch), (C_NRM)) ? KCYN : KNRM;
+            break;
+          case 'W': color = clr((ch), (C_NRM)) ? KIDRK : KNRM;
+            break;
+          case 'w': color = clr((ch), (C_NRM)) ? KWHT : KNRM;
+            break;
+          default: color = KNRM;
+        }
+      strncpy(str, color, strlen(color));
+      str += (strlen(color) - 1);
+    } else if (*str == '\x1B' && !spec_code)
+      spec_code = TRUE;
 
-		// Check for the end of an ANSI color code block. //
-		else if (*str == 'm' && spec_code)
-			spec_code = FALSE;
+      // Check for the end of an ANSI color code block. //
+    else if (*str == 'm' && spec_code)
+      spec_code = FALSE;
 
-		// Check for everything else. //
-		else if (!spec_code)  	// Carriage return puts us in column one. //
-		{
-			if (*str == '\r')
-				col = 1;
-			// Newline puts us on the next line. //
-			else if (*str == '\n')
-				line++;
+      // Check for everything else. //
+    else if (!spec_code)    // Carriage return puts us in column one. //
+    {
+      if (*str == '\r')
+        col = 1;
+        // Newline puts us on the next line. //
+      else if (*str == '\n')
+        line++;
 
-			// * We need to check here and see if we are over the page width,
-			// * and if so, compensate by going to the begining of the next line.
-			else if (STRING_LENGTH(ch) && ++col > STRING_LENGTH(ch))
-			{
-				col = 1;
-				line++;
-			}
-		}
-	}
+        // * We need to check here and see if we are over the page width,
+        // * and if so, compensate by going to the begining of the next line.
+      else if (STRING_LENGTH(ch) && ++col > STRING_LENGTH(ch)) {
+        col = 1;
+        line++;
+      }
+    }
+  }
 }
-
 
 // Function that returns the number of pages in the string.
-int count_pages(char *str, CHAR_DATA * ch)
-{
-	int pages;
+int count_pages(char *str, CHAR_DATA *ch) {
+  int pages;
 
-	for (pages = 1; (str = next_page(str, ch)); pages++);
-	return (pages);
+  for (pages = 1; (str = next_page(str, ch)); pages++);
+  return (pages);
 }
-
 
 /* This function assigns all the pointers for showstr_vector for the
  * page_string function, after showstr_vector has been allocated and
  * showstr_count set.
  */
-void paginate_string(char *str, DESCRIPTOR_DATA * d)
-{
-	int i;
+void paginate_string(char *str, DESCRIPTOR_DATA *d) {
+  int i;
 
-	if (d->showstr_count)
-	{
-		*(d->showstr_vector) = str;
-	}
+  if (d->showstr_count) {
+    *(d->showstr_vector) = str;
+  }
 
-	for (i = 1; i < d->showstr_count && str; i++)
-	{
-		str = d->showstr_vector[i] = next_page(str, d->character.get());
-	}
+  for (i = 1; i < d->showstr_count && str; i++) {
+    str = d->showstr_vector[i] = next_page(str, d->character.get());
+  }
 
-	d->showstr_page = 0;
+  d->showstr_page = 0;
 }
 
 // The call that gets the paging ball rolling...
-void page_string(DESCRIPTOR_DATA * d, char *str, int keep_internal)
-{
-	if (!d)
-		return;
+void page_string(DESCRIPTOR_DATA *d, char *str, int keep_internal) {
+  if (!d)
+    return;
 
-	if (!str || !*str)
-	{
-		send_to_char("", d->character.get());
-		return;
-	}
-	d->showstr_count = count_pages(str, d->character.get());
-	CREATE(d->showstr_vector, d->showstr_count);
+  if (!str || !*str) {
+    send_to_char("", d->character.get());
+    return;
+  }
+  d->showstr_count = count_pages(str, d->character.get());
+  CREATE(d->showstr_vector, d->showstr_count);
 
-	if (keep_internal)
-	{
-		d->showstr_head = str_dup(str);
-		paginate_string(d->showstr_head, d);
-	}
-	else
-	{
-		paginate_string(str, d);
-	}
+  if (keep_internal) {
+    d->showstr_head = str_dup(str);
+    paginate_string(d->showstr_head, d);
+  } else {
+    paginate_string(str, d);
+  }
 
-	buf2[0] = '\0';
-	show_string(d, buf2);
+  buf2[0] = '\0';
+  show_string(d, buf2);
 }
 
 // TODO типа временно для стрингов
-void page_string(DESCRIPTOR_DATA * d, const std::string& buf)
-{
-	// TODO: при keep_internal == true (а в 99% случаев так оно есть)
-	// получаем дальше в page_string повторный str_dup.
-	// как бы собраться с силами и переписать все это :/
-	char *str = str_dup(buf.c_str());
-	page_string(d, str, true);
-	free(str);
+void page_string(DESCRIPTOR_DATA *d, const std::string &buf) {
+  // TODO: при keep_internal == true (а в 99% случаев так оно есть)
+  // получаем дальше в page_string повторный str_dup.
+  // как бы собраться с силами и переписать все это :/
+  char *str = str_dup(buf.c_str());
+  page_string(d, str, true);
+  free(str);
 }
 
 // The call that displays the next page.
-void show_string(DESCRIPTOR_DATA * d, char *input)
-{
-	char buffer[MAX_STRING_LENGTH];
-	int diff;
+void show_string(DESCRIPTOR_DATA *d, char *input) {
+  char buffer[MAX_STRING_LENGTH];
+  int diff;
 
-	any_one_arg(input, buf);
+  any_one_arg(input, buf);
 
-	//* Q is for quit. :)
-	if (LOWER(*buf) == 'q' || LOWER(*buf) == 'к')
-	{
-		free(d->showstr_vector);
-		d->showstr_count = 0;
-		if (d->showstr_head)
-		{
-			free(d->showstr_head);
-			d->showstr_head = NULL;
-		}
-		print_con_prompt(d);
-		return;
-	}
-	// R is for refresh, so back up one page internally so we can display
-	// it again.
-	else if (LOWER(*buf) == 'r' || LOWER(*buf) == 'п')
-	{
-		d->showstr_page = MAX(0, d->showstr_page - 1);
-	}
-	// B is for back, so back up two pages internally so we can display the
-	// correct page here.
-	else if (LOWER(*buf) == 'b' || LOWER(*buf) == 'н')
-	{
-		d->showstr_page = MAX(0, d->showstr_page - 2);
-	}
-	// Feature to 'goto' a page.  Just type the number of the page and you
-	// are there!
-	else if (a_isdigit(*buf))
-	{
-		d->showstr_page = MAX(0, MIN(atoi(buf) - 1, d->showstr_count - 1));
-	}
-
-	else if (*buf)
-	{
-		send_to_char("Листать : <RETURN>, Q<К>онец, R<П>овтор, B<Н>азад, или номер страницы.\r\n", d->character.get());
-		return;
-	}
-	// If we're displaying the last page, just send it to the character, and
-	// then free up the space we used.
-	if (d->showstr_page + 1 >= d->showstr_count)
-	{
-		send_to_char(d->showstr_vector[d->showstr_page], d->character.get());
-		free(d->showstr_vector);
-		d->showstr_vector = nullptr;
-		d->showstr_count = 0;
-		if (d->showstr_head)
-		{
-			free(d->showstr_head);
-			d->showstr_head = NULL;
-		}
-		print_con_prompt(d);
-	}
-	// Or if we have more to show....
-	else
-	{
-		diff = d->showstr_vector[d->showstr_page + 1] - d->showstr_vector[d->showstr_page];
-		if (diff >= MAX_STRING_LENGTH)
-			diff = MAX_STRING_LENGTH - 1;
-		strncpy(buffer, d->showstr_vector[d->showstr_page], diff);
-		buffer[diff] = '\0';
-		send_to_char(buffer, d->character.get());
-		d->showstr_page++;
-	}
+  //* Q is for quit. :)
+  if (LOWER(*buf) == 'q' || LOWER(*buf) == 'к') {
+    free(d->showstr_vector);
+    d->showstr_count = 0;
+    if (d->showstr_head) {
+      free(d->showstr_head);
+      d->showstr_head = NULL;
+    }
+    print_con_prompt(d);
+    return;
+  }
+    // R is for refresh, so back up one page internally so we can display
+    // it again.
+  else if (LOWER(*buf) == 'r' || LOWER(*buf) == 'п') {
+    d->showstr_page = MAX(0, d->showstr_page - 1);
+  }
+    // B is for back, so back up two pages internally so we can display the
+    // correct page here.
+  else if (LOWER(*buf) == 'b' || LOWER(*buf) == 'н') {
+    d->showstr_page = MAX(0, d->showstr_page - 2);
+  }
+    // Feature to 'goto' a page.  Just type the number of the page and you
+    // are there!
+  else if (a_isdigit(*buf)) {
+    d->showstr_page = MAX(0, MIN(atoi(buf) - 1, d->showstr_count - 1));
+  } else if (*buf) {
+    send_to_char("Листать : <RETURN>, Q<К>онец, R<П>овтор, B<Н>азад, или номер страницы.\r\n", d->character.get());
+    return;
+  }
+  // If we're displaying the last page, just send it to the character, and
+  // then free up the space we used.
+  if (d->showstr_page + 1 >= d->showstr_count) {
+    send_to_char(d->showstr_vector[d->showstr_page], d->character.get());
+    free(d->showstr_vector);
+    d->showstr_vector = nullptr;
+    d->showstr_count = 0;
+    if (d->showstr_head) {
+      free(d->showstr_head);
+      d->showstr_head = NULL;
+    }
+    print_con_prompt(d);
+  }
+    // Or if we have more to show....
+  else {
+    diff = d->showstr_vector[d->showstr_page + 1] - d->showstr_vector[d->showstr_page];
+    if (diff >= MAX_STRING_LENGTH)
+      diff = MAX_STRING_LENGTH - 1;
+    strncpy(buffer, d->showstr_vector[d->showstr_page], diff);
+    buffer[diff] = '\0';
+    send_to_char(buffer, d->character.get());
+    d->showstr_page++;
+  }
 }
 
 ///
@@ -1543,16 +1274,13 @@ void show_string(DESCRIPTOR_DATA * d, char *input)
 /// 2) после последней страницы не ждать втихую нажатия от игрока, а вывести меню текущего CON_STATE
 /// 3) напечатать тоже самое при выходе из пролистывания через Q/К
 ///
-void print_con_prompt(DESCRIPTOR_DATA *d)
-{
-	if (d->showstr_count)
-	{
-		return;
-	}
-	if (STATE(d) == CON_RESET_STATS)
-	{
-		genchar_disp_menu(d->character.get());
-	}
+void print_con_prompt(DESCRIPTOR_DATA *d) {
+  if (d->showstr_count) {
+    return;
+  }
+  if (STATE(d) == CON_RESET_STATS) {
+    genchar_disp_menu(d->character.get());
+  }
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/poison.cpp
+++ b/src/poison.cpp
@@ -214,8 +214,8 @@ bool weap_poison_vict(CHAR_DATA *ch, CHAR_DATA *vict, int spell_num)
 // * Крит при отравлении с пушек.
 void weap_crit_poison(CHAR_DATA *ch, CHAR_DATA *vict, int/* spell_num*/) {
     AFFECT_DATA<EApplyLocation> af;
-	int percent = number(1, skill_info[SKILL_POISONED].max_percent * 3);
-	int prob = calculate_skill(ch, SKILL_POISONED, vict);
+	int percent = number(1, skill_info[SKILL_POISONED].fail_percent * 3);
+	int prob = CalcCurrentSkill(ch, SKILL_POISONED, vict);
 	if (prob >= percent) {
 		switch (number(1, 5)) {
 		case 1:
@@ -368,7 +368,7 @@ void try_weap_poison(CHAR_DATA *ch, CHAR_DATA *vict, int spell_num)
 	if (number(1, 200) <= 25
 		|| (!GET_AF_BATTLE(vict, EAF_FIRST_POISON) && !AFF_FLAGGED(vict, EAffectFlag::AFF_POISON)))
 	{
-		improve_skill(ch, SKILL_POISONED, TRUE, vict);
+      ImproveSkill(ch, SKILL_POISONED, TRUE, vict);
 		if (weap_poison_vict(ch, vict, spell_num))
 		{
 			if (spell_num == SPELL_ACONITUM_POISON)

--- a/src/skills.cpp
+++ b/src/skills.cpp
@@ -46,388 +46,316 @@
 
 extern struct message_list fight_messages[MAX_MESSAGES];
 
-class WeapForAct
-{
-public:
-	enum WeapType
-	{
-		EWT_UNDEFINED,
-		EWT_PROTOTYPE_SHARED_PTR,
-		EWT_OBJECT_RAW_PTR,	// Anton Gorev (09/28/2016): We need to get rid of raw pointers in the future
-		EWT_STRING
-	};
+class WeapForAct {
+ public:
+  enum WeapType {
+    EWT_UNDEFINED,
+    EWT_PROTOTYPE_SHARED_PTR,
+    EWT_OBJECT_RAW_PTR,    // Anton Gorev (09/28/2016): We need to get rid of raw pointers in the future
+    EWT_STRING
+  };
 
-	class WeaponTypeException : public std::exception
-	{
-	public:
-		explicit WeaponTypeException(const char* what) : m_what(what) {}
+  class WeaponTypeException : public std::exception {
+   public:
+    explicit WeaponTypeException(const char *what) : m_what(what) {}
 
-		virtual const char* what() const throw() { return m_what.c_str(); }
+    virtual const char *what() const throw() { return m_what.c_str(); }
 
-	private:
-		std::string m_what;
-	};
+   private:
+    std::string m_what;
+  };
 
-	WeapForAct() : m_type(EWT_UNDEFINED), m_prototype_raw_ptr(nullptr) {}
-	WeapForAct(const WeapForAct& from);
-	void set_damage_string(const int damage);
-	WeapForAct& operator=(const CObjectPrototype::shared_ptr& prototype_shared_ptr);
-	WeapForAct& operator=(OBJ_DATA* prototype_raw_ptr);
+  WeapForAct() : m_type(EWT_UNDEFINED), m_prototype_raw_ptr(nullptr) {}
+  WeapForAct(const WeapForAct &from);
+  void set_damage_string(const int damage);
+  WeapForAct &operator=(const CObjectPrototype::shared_ptr &prototype_shared_ptr);
+  WeapForAct &operator=(OBJ_DATA *prototype_raw_ptr);
 
-	auto type() const { return m_type; }
-	const auto& get_prototype_shared_ptr() const;
-	auto get_prototype_raw_ptr() const;
-	const auto get_object_ptr() const;
-	const auto& get_string() const;
+  auto type() const { return m_type; }
+  const auto &get_prototype_shared_ptr() const;
+  auto get_prototype_raw_ptr() const;
+  const auto get_object_ptr() const;
+  const auto &get_string() const;
 
-private:
-	using kick_type_t = std::vector<const char*>;
+ private:
+  using kick_type_t = std::vector<const char *>;
 
-	WeapForAct& operator=(const WeapForAct&);
+  WeapForAct &operator=(const WeapForAct &);
 
-	bool check_type(const WeapType type) const { return check_type(type, true); }
-	bool check_type(const WeapType type, const bool raise_exception) const;
+  bool check_type(const WeapType type) const { return check_type(type, true); }
+  bool check_type(const WeapType type, const bool raise_exception) const;
 
-	WeapType m_type;
-	OBJ_DATA::shared_ptr m_prototype_shared_ptr;
-	OBJ_DATA* m_prototype_raw_ptr;
-	std::string m_string;
+  WeapType m_type;
+  OBJ_DATA::shared_ptr m_prototype_shared_ptr;
+  OBJ_DATA *m_prototype_raw_ptr;
+  std::string m_string;
 
-	static const kick_type_t s_kick_type;	// Anton Gorev (09/28/2016): As I know, it is a duplicate. We need to reuse kick types from other place.
+  static const kick_type_t
+      s_kick_type;    // Anton Gorev (09/28/2016): As I know, it is a duplicate. We need to reuse kick types from other place.
 };
 
-WeapForAct::WeapForAct(const WeapForAct& from) :
-	m_type(from.m_type),
-	m_prototype_shared_ptr(from.m_prototype_shared_ptr),
-	m_prototype_raw_ptr(from.m_prototype_raw_ptr),
-	m_string(from.m_string)
-{
+WeapForAct::WeapForAct(const WeapForAct &from) :
+    m_type(from.m_type),
+    m_prototype_shared_ptr(from.m_prototype_shared_ptr),
+    m_prototype_raw_ptr(from.m_prototype_raw_ptr),
+    m_string(from.m_string) {
 }
 
 //inline bool has_skill(...) const { return 0 < get_skill(skill); }
 
 void WeapForAct::set_damage_string(const int damage) {
-	m_type = EWT_STRING;
-	if (damage <= 5) {
-		m_string = s_kick_type[0];
-	}
-	else if (damage <= 11) {
-		m_string = s_kick_type[1];
-	}
-	else if (damage <= 26) {
-		m_string = s_kick_type[2];
-	}
-	else if (damage <= 35) {
-		m_string = s_kick_type[3];
-	}
-	else if (damage <= 45) {
-		m_string = s_kick_type[4];
-	}
-	else if (damage <= 56) {
-		m_string = s_kick_type[5];
-	}
-	else if (damage <= 96) {
-		m_string = s_kick_type[6];
-	}
-	else if (damage <= 136) {
-		m_string = s_kick_type[7];
-	}
-	else if (damage <= 176) {
-		m_string = s_kick_type[8];
-	}
-	else if (damage <= 216) {
-		m_string = s_kick_type[9];
-	}
-	else if (damage <= 256) {
-		m_string = s_kick_type[10];
-	}
-	else if (damage <= 296) {
-		m_string = s_kick_type[11];
-	}
-	else if (damage <= 400) {
-		m_string = s_kick_type[12];
-	}
-	else if (damage <= 800) {
-		m_string = s_kick_type[13];
-	}
-	else {
-		m_string = s_kick_type[14];
-	}
+  m_type = EWT_STRING;
+  if (damage <= 5) {
+    m_string = s_kick_type[0];
+  } else if (damage <= 11) {
+    m_string = s_kick_type[1];
+  } else if (damage <= 26) {
+    m_string = s_kick_type[2];
+  } else if (damage <= 35) {
+    m_string = s_kick_type[3];
+  } else if (damage <= 45) {
+    m_string = s_kick_type[4];
+  } else if (damage <= 56) {
+    m_string = s_kick_type[5];
+  } else if (damage <= 96) {
+    m_string = s_kick_type[6];
+  } else if (damage <= 136) {
+    m_string = s_kick_type[7];
+  } else if (damage <= 176) {
+    m_string = s_kick_type[8];
+  } else if (damage <= 216) {
+    m_string = s_kick_type[9];
+  } else if (damage <= 256) {
+    m_string = s_kick_type[10];
+  } else if (damage <= 296) {
+    m_string = s_kick_type[11];
+  } else if (damage <= 400) {
+    m_string = s_kick_type[12];
+  } else if (damage <= 800) {
+    m_string = s_kick_type[13];
+  } else {
+    m_string = s_kick_type[14];
+  }
 }
 
-const auto& WeapForAct::get_prototype_shared_ptr() const
-{
-	check_type(EWT_PROTOTYPE_SHARED_PTR);
-	return m_prototype_shared_ptr;
+const auto &WeapForAct::get_prototype_shared_ptr() const {
+  check_type(EWT_PROTOTYPE_SHARED_PTR);
+  return m_prototype_shared_ptr;
 }
 
-auto WeapForAct::get_prototype_raw_ptr() const
-{
-	check_type(EWT_OBJECT_RAW_PTR);
-	return m_prototype_raw_ptr;
+auto WeapForAct::get_prototype_raw_ptr() const {
+  check_type(EWT_OBJECT_RAW_PTR);
+  return m_prototype_raw_ptr;
 }
 
-const auto WeapForAct::get_object_ptr() const
-{
-	if (check_type(EWT_OBJECT_RAW_PTR, false))
-	{
-		return m_prototype_raw_ptr;
-	}
-	else if (check_type(EWT_PROTOTYPE_SHARED_PTR, false))
-	{
-		return m_prototype_shared_ptr.get();
-	}
+const auto WeapForAct::get_object_ptr() const {
+  if (check_type(EWT_OBJECT_RAW_PTR, false)) {
+    return m_prototype_raw_ptr;
+  } else if (check_type(EWT_PROTOTYPE_SHARED_PTR, false)) {
+    return m_prototype_shared_ptr.get();
+  }
 
-	std::stringstream ss;
-	ss << "Requested object ptr but actual weapon type is [" << m_type << "]";
-	throw WeaponTypeException(ss.str().c_str());
+  std::stringstream ss;
+  ss << "Requested object ptr but actual weapon type is [" << m_type << "]";
+  throw WeaponTypeException(ss.str().c_str());
 }
 
-const auto& WeapForAct::get_string() const
-{
-	check_type(EWT_STRING);
-	return m_string;
+const auto &WeapForAct::get_string() const {
+  check_type(EWT_STRING);
+  return m_string;
 }
 
-bool WeapForAct::check_type(const WeapType type, const bool raise_exception) const
-{
-	if (type != m_type)
-	{
-		if (raise_exception)
-		{
-			std::stringstream ss;
-			ss << "Type of weapon [" << m_type << "] does not match to expected [" << type << "]";
-			throw WeaponTypeException(ss.str().c_str());
-		}
+bool WeapForAct::check_type(const WeapType type, const bool raise_exception) const {
+  if (type != m_type) {
+    if (raise_exception) {
+      std::stringstream ss;
+      ss << "Type of weapon [" << m_type << "] does not match to expected [" << type << "]";
+      throw WeaponTypeException(ss.str().c_str());
+    }
 
-		return false;
-	}
+    return false;
+  }
 
-	return true;
+  return true;
 }
 
-WeapForAct& WeapForAct::operator=(OBJ_DATA* prototype_raw_ptr)
-{
-	m_type = EWT_OBJECT_RAW_PTR;
-	m_prototype_raw_ptr = prototype_raw_ptr;
-	return *this;
+WeapForAct &WeapForAct::operator=(OBJ_DATA *prototype_raw_ptr) {
+  m_type = EWT_OBJECT_RAW_PTR;
+  m_prototype_raw_ptr = prototype_raw_ptr;
+  return *this;
 }
 
-WeapForAct& WeapForAct::operator=(const CObjectPrototype::shared_ptr& prototype_shared_ptr)
-{
-	m_type = EWT_PROTOTYPE_SHARED_PTR;
-	m_prototype_shared_ptr.reset();
-	if (prototype_shared_ptr)
-	{
-		m_prototype_shared_ptr.reset(new OBJ_DATA(*prototype_shared_ptr));
-	}
-	return *this;
+WeapForAct &WeapForAct::operator=(const CObjectPrototype::shared_ptr &prototype_shared_ptr) {
+  m_type = EWT_PROTOTYPE_SHARED_PTR;
+  m_prototype_shared_ptr.reset();
+  if (prototype_shared_ptr) {
+    m_prototype_shared_ptr.reset(new OBJ_DATA(*prototype_shared_ptr));
+  }
+  return *this;
 }
 
 const WeapForAct::kick_type_t WeapForAct::s_kick_type =
 // силы пинка. полностью соответствуют наносимым поврждениям обычного удара
-{
-	"легонько ",		//  1..5
-	"слегка ",		// 6..11
-	"",			// 12..26
-	"сильно ",		// 27..35
-	"очень сильно ",	// 36..45
-	"чрезвычайно сильно ",	// 46..55
-	"БОЛЬНО ",		// 56..96
-	"ОЧЕНЬ БОЛЬНО ",	// 97..136
-	"ЧРЕЗВЫЧАЙНО БОЛЬНО ",	// 137..176
-	"НЕВЫНОСИМО БОЛЬНО ",	// 177..216
-	"ЖЕСТОКО ",	// 217..256
-	"УЖАСНО ",// 257..296
-	"УБИЙСТВЕННО ",	 // 297..400
-	"ИЗУВЕРСКИ ", // 400+
-	"СМЕРТЕЛЬНО " // 800+
+    {
+        "легонько ",        //  1..5
+        "слегка ",        // 6..11
+        "",            // 12..26
+        "сильно ",        // 27..35
+        "очень сильно ",    // 36..45
+        "чрезвычайно сильно ",    // 46..55
+        "БОЛЬНО ",        // 56..96
+        "ОЧЕНЬ БОЛЬНО ",    // 97..136
+        "ЧРЕЗВЫЧАЙНО БОЛЬНО ",    // 137..176
+        "НЕВЫНОСИМО БОЛЬНО ",    // 177..216
+        "ЖЕСТОКО ",    // 217..256
+        "УЖАСНО ",// 257..296
+        "УБИЙСТВЕННО ",     // 297..400
+        "ИЗУВЕРСКИ ", // 400+
+        "СМЕРТЕЛЬНО " // 800+
+    };
+
+struct brief_shields {
+  brief_shields(CHAR_DATA *ch_, CHAR_DATA *vict_, const WeapForAct &weap_, std::string add_);
+
+  void act_to_char(const char *msg);
+  void act_to_vict(const char *msg);
+  void act_to_room(const char *msg);
+
+  void act_with_exception_handling(const char *msg, int type) const;
+
+  CHAR_DATA *ch;
+  CHAR_DATA *vict;
+  WeapForAct weap;
+  std::string add;
+  // флаг отражаемого дамага, который надо глушить в режиме PRF_BRIEF_SHIELDS
+  bool reflect;
+
+ private:
+  void act_no_add(const char *msg, int type);
+  void act_add(const char *msg, int type);
 };
 
-struct brief_shields
-{
-	brief_shields(CHAR_DATA* ch_, CHAR_DATA* vict_, const WeapForAct& weap_, std::string add_);
-
-	void act_to_char(const char *msg);
-	void act_to_vict(const char *msg);
-	void act_to_room(const char *msg);
-
-	void act_with_exception_handling(const char *msg, int type) const;
-
-	CHAR_DATA* ch;
-	CHAR_DATA* vict;
-	WeapForAct weap;
-	std::string add;
-	// флаг отражаемого дамага, который надо глушить в режиме PRF_BRIEF_SHIELDS
-	bool reflect;
-
-private:
-	void act_no_add(const char *msg, int type);
-	void act_add(const char *msg, int type);
-};
-
-brief_shields::brief_shields(CHAR_DATA* ch_, CHAR_DATA* vict_, const WeapForAct& weap_, std::string add_) : ch(ch_), vict(vict_), weap(weap_), add(add_), reflect(false)
-{
+brief_shields::brief_shields(CHAR_DATA *ch_, CHAR_DATA *vict_, const WeapForAct &weap_, std::string add_)
+    : ch(ch_), vict(vict_), weap(weap_), add(add_), reflect(false) {
 }
 
-void brief_shields::act_to_char(const char *msg)
-{
-	if (!reflect
-		|| (reflect
-			&& !PRF_FLAGGED(ch, PRF_BRIEF_SHIELDS)))
-	{
-		if (!add.empty()
-			&& PRF_FLAGGED(ch, PRF_BRIEF_SHIELDS))
-		{
-			act_add(msg, TO_CHAR);
-		}
-		else
-		{
-			act_no_add(msg, TO_CHAR);
-		}
-	}
+void brief_shields::act_to_char(const char *msg) {
+  if (!reflect
+      || (reflect
+          && !PRF_FLAGGED(ch, PRF_BRIEF_SHIELDS))) {
+    if (!add.empty()
+        && PRF_FLAGGED(ch, PRF_BRIEF_SHIELDS)) {
+      act_add(msg, TO_CHAR);
+    } else {
+      act_no_add(msg, TO_CHAR);
+    }
+  }
 }
 
-void brief_shields::act_to_vict(const char *msg)
-{
-	if (!reflect
-		|| (reflect
-			&& !PRF_FLAGGED(vict, PRF_BRIEF_SHIELDS)))
-	{
-		if (!add.empty()
-			&& PRF_FLAGGED(vict, PRF_BRIEF_SHIELDS))
-		{
-			act_add(msg, TO_VICT | TO_SLEEP);
-		}
-		else
-		{
-			act_no_add(msg, TO_VICT | TO_SLEEP);
-		}
-	}
+void brief_shields::act_to_vict(const char *msg) {
+  if (!reflect
+      || (reflect
+          && !PRF_FLAGGED(vict, PRF_BRIEF_SHIELDS))) {
+    if (!add.empty()
+        && PRF_FLAGGED(vict, PRF_BRIEF_SHIELDS)) {
+      act_add(msg, TO_VICT | TO_SLEEP);
+    } else {
+      act_no_add(msg, TO_VICT | TO_SLEEP);
+    }
+  }
 }
 
-void brief_shields::act_to_room(const char *msg)
-{
-	if (add.empty())
-	{
-		if (reflect)
-		{
-			act_no_add(msg, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
-		}
-		else
-		{
-			act_no_add(msg, TO_NOTVICT | TO_ARENA_LISTEN);
-		}
-	}
-	else
-	{
-		act_no_add(msg, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
-		if (!reflect)
-		{
-			act_add(msg, TO_NOTVICT | TO_ARENA_LISTEN | TO_BRIEF_SHIELDS);
-		}
-	}
+void brief_shields::act_to_room(const char *msg) {
+  if (add.empty()) {
+    if (reflect) {
+      act_no_add(msg, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
+    } else {
+      act_no_add(msg, TO_NOTVICT | TO_ARENA_LISTEN);
+    }
+  } else {
+    act_no_add(msg, TO_NOTVICT | TO_ARENA_LISTEN | TO_NO_BRIEF_SHIELDS);
+    if (!reflect) {
+      act_add(msg, TO_NOTVICT | TO_ARENA_LISTEN | TO_BRIEF_SHIELDS);
+    }
+  }
 }
 
-void brief_shields::act_with_exception_handling(const char* msg, const int type) const
-{
-	try
-	{
-		const auto weapon_type = weap.type();
-		switch (weapon_type)
-		{
-		case WeapForAct::EWT_STRING:
-			act(msg, FALSE, ch, nullptr, vict, type, weap.get_string());
-			break;
+void brief_shields::act_with_exception_handling(const char *msg, const int type) const {
+  try {
+    const auto weapon_type = weap.type();
+    switch (weapon_type) {
+      case WeapForAct::EWT_STRING: act(msg, FALSE, ch, nullptr, vict, type, weap.get_string());
+        break;
 
-		case WeapForAct::EWT_OBJECT_RAW_PTR:
-		case WeapForAct::EWT_PROTOTYPE_SHARED_PTR:
-			act(msg, FALSE, ch, weap.get_object_ptr(), vict, type);
-			break;
+      case WeapForAct::EWT_OBJECT_RAW_PTR:
+      case WeapForAct::EWT_PROTOTYPE_SHARED_PTR: act(msg, FALSE, ch, weap.get_object_ptr(), vict, type);
+        break;
 
-		default:
-			act(msg, FALSE, ch, nullptr, vict, type);
-		}
-	}
-	catch (const WeapForAct::WeaponTypeException& e)
-	{
-		mudlog(e.what(), BRF, LVL_BUILDER, ERRLOG, TRUE);
-	}
+      default: act(msg, FALSE, ch, nullptr, vict, type);
+    }
+  }
+  catch (const WeapForAct::WeaponTypeException &e) {
+    mudlog(e.what(), BRF, LVL_BUILDER, ERRLOG, TRUE);
+  }
 }
 
-void brief_shields::act_no_add(const char *msg, int type)
-{
-	act_with_exception_handling(msg, type);
+void brief_shields::act_no_add(const char *msg, int type) {
+  act_with_exception_handling(msg, type);
 }
 
-void brief_shields::act_add(const char *msg, int type)
-{
-	char buf_[MAX_INPUT_LENGTH];
-	snprintf(buf_, sizeof(buf_), "%s%s", msg, add.c_str());
-	act_with_exception_handling(buf_, type);
+void brief_shields::act_add(const char *msg, int type) {
+  char buf_[MAX_INPUT_LENGTH];
+  snprintf(buf_, sizeof(buf_), "%s%s", msg, add.c_str());
+  act_with_exception_handling(buf_, type);
 }
 
-const WeapForAct init_weap(CHAR_DATA *ch, int dam, int attacktype)
-{
-	// Нижеследующий код повергает в ужас
-	WeapForAct weap;
-	int weap_i = 0;
+const WeapForAct init_weap(CHAR_DATA *ch, int dam, int attacktype) {
+  // Нижеследующий код повергает в ужас
+  WeapForAct weap;
+  int weap_i = 0;
 
-	switch (attacktype)
-	{
-	case SKILL_BACKSTAB + TYPE_HIT:
-		weap = GET_EQ(ch, WEAR_WIELD);
-		if (!weap.get_prototype_raw_ptr())
-		{
-			weap_i = real_object(DUMMY_KNIGHT);
-			if (0 <= weap_i)
-			{
-				weap = obj_proto[weap_i];
-			}
-		}
-		break;
+  switch (attacktype) {
+    case SKILL_BACKSTAB + TYPE_HIT: weap = GET_EQ(ch, WEAR_WIELD);
+      if (!weap.get_prototype_raw_ptr()) {
+        weap_i = real_object(DUMMY_KNIGHT);
+        if (0 <= weap_i) {
+          weap = obj_proto[weap_i];
+        }
+      }
+      break;
 
-	case SKILL_THROW + TYPE_HIT:
-		weap = GET_EQ(ch, WEAR_WIELD);
-		if (!weap.get_prototype_raw_ptr())
-		{
-			weap_i = real_object(DUMMY_KNIGHT);
-			if (0 <= weap_i)
-			{
-				weap = obj_proto[weap_i];
-			}
-		}
-		break;
+    case SKILL_THROW + TYPE_HIT: weap = GET_EQ(ch, WEAR_WIELD);
+      if (!weap.get_prototype_raw_ptr()) {
+        weap_i = real_object(DUMMY_KNIGHT);
+        if (0 <= weap_i) {
+          weap = obj_proto[weap_i];
+        }
+      }
+      break;
 
-	case SKILL_BASH + TYPE_HIT:
-		weap = GET_EQ(ch, WEAR_SHIELD);
-		if (!weap.get_prototype_raw_ptr())
-		{
-			weap_i = real_object(DUMMY_SHIELD);
-			if (0 <= weap_i)
-			{
-				weap = obj_proto[weap_i];
-			}
-		}
-		break;
+    case SKILL_BASH + TYPE_HIT: weap = GET_EQ(ch, WEAR_SHIELD);
+      if (!weap.get_prototype_raw_ptr()) {
+        weap_i = real_object(DUMMY_SHIELD);
+        if (0 <= weap_i) {
+          weap = obj_proto[weap_i];
+        }
+      }
+      break;
 
-	case SKILL_KICK + TYPE_HIT:
-		// weap - текст силы удара
-		weap.set_damage_string(dam);
-		break;
+    case SKILL_KICK + TYPE_HIT:
+      // weap - текст силы удара
+      weap.set_damage_string(dam);
+      break;
 
-	case TYPE_HIT:
-		break;
+    case TYPE_HIT: break;
 
-	default:
-		weap_i = real_object(DUMMY_WEAPON);
-		if (0 <= weap_i)
-		{
-			weap = obj_proto[weap_i];
-		}
-	}
+    default: weap_i = real_object(DUMMY_WEAPON);
+      if (0 <= weap_i) {
+        weap = obj_proto[weap_i];
+      }
+  }
 
-	return weap;
+  return weap;
 }
 
 typedef std::map<ESkill, std::string> ESkill_name_by_value_t;
@@ -435,1343 +363,1202 @@ typedef std::map<const std::string, ESkill> ESkill_value_by_name_t;
 ESkill_name_by_value_t ESkill_name_by_value;
 ESkill_value_by_name_t ESkill_value_by_name;
 
-void init_ESkill_ITEM_NAMES()
-{
-	ESkill_name_by_value.clear();
-	ESkill_value_by_name.clear();
+void init_ESkill_ITEM_NAMES() {
+  ESkill_name_by_value.clear();
+  ESkill_value_by_name.clear();
 
-	ESkill_name_by_value[ESkill::SKILL_GLOBAL_COOLDOWN] = "SKILL_GLOBAL_COOLDOWN";
-	ESkill_name_by_value[ESkill::SKILL_PROTECT] = "SKILL_PROTECT";
-	ESkill_name_by_value[ESkill::SKILL_TOUCH] = "SKILL_TOUCH";
-	ESkill_name_by_value[ESkill::SKILL_SHIT] = "SKILL_SHIT";
-	ESkill_name_by_value[ESkill::SKILL_MIGHTHIT] = "SKILL_MIGHTHIT";
-	ESkill_name_by_value[ESkill::SKILL_STUPOR] = "SKILL_STUPOR";
-	ESkill_name_by_value[ESkill::SKILL_POISONED] = "SKILL_POISONED";
-	ESkill_name_by_value[ESkill::SKILL_SENSE] = "SKILL_SENSE";
-	ESkill_name_by_value[ESkill::SKILL_HORSE] = "SKILL_HORSE";
-	ESkill_name_by_value[ESkill::SKILL_HIDETRACK] = "SKILL_HIDETRACK";
-	ESkill_name_by_value[ESkill::SKILL_RELIGION] = "SKILL_RELIGION";
-	ESkill_name_by_value[ESkill::SKILL_MAKEFOOD] = "SKILL_MAKEFOOD";
-	ESkill_name_by_value[ESkill::SKILL_MULTYPARRY] = "SKILL_MULTYPARRY";
-	ESkill_name_by_value[ESkill::SKILL_TRANSFORMWEAPON] = "SKILL_TRANSFORMWEAPON";
-	ESkill_name_by_value[ESkill::SKILL_LEADERSHIP] = "SKILL_LEADERSHIP";
-	ESkill_name_by_value[ESkill::SKILL_PUNCTUAL] = "SKILL_PUNCTUAL";
-	ESkill_name_by_value[ESkill::SKILL_AWAKE] = "SKILL_AWAKE";
-	ESkill_name_by_value[ESkill::SKILL_IDENTIFY] = "SKILL_IDENTIFY";
-	ESkill_name_by_value[ESkill::SKILL_HEARING] = "SKILL_HEARING";
-	ESkill_name_by_value[ESkill::SKILL_CREATE_POTION] = "SKILL_CREATE_POTION";
-	ESkill_name_by_value[ESkill::SKILL_CREATE_SCROLL] = "SKILL_CREATE_SCROLL";
-	ESkill_name_by_value[ESkill::SKILL_CREATE_WAND] = "SKILL_CREATE_WAND";
-	ESkill_name_by_value[ESkill::SKILL_LOOK_HIDE] = "SKILL_LOOK_HIDE";
-	ESkill_name_by_value[ESkill::SKILL_ARMORED] = "SKILL_ARMORED";
-	ESkill_name_by_value[ESkill::SKILL_DRUNKOFF] = "SKILL_DRUNKOFF";
-	ESkill_name_by_value[ESkill::SKILL_AID] = "SKILL_AID";
-	ESkill_name_by_value[ESkill::SKILL_FIRE] = "SKILL_FIRE";
-	ESkill_name_by_value[ESkill::SKILL_CREATEBOW] = "SKILL_CREATEBOW";
-	ESkill_name_by_value[ESkill::SKILL_THROW] = "SKILL_THROW";
-	ESkill_name_by_value[ESkill::SKILL_BACKSTAB] = "SKILL_BACKSTAB";
-	ESkill_name_by_value[ESkill::SKILL_BASH] = "SKILL_BASH";
-	ESkill_name_by_value[ESkill::SKILL_HIDE] = "SKILL_HIDE";
-	ESkill_name_by_value[ESkill::SKILL_KICK] = "SKILL_KICK";
-	ESkill_name_by_value[ESkill::SKILL_PICK_LOCK] = "SKILL_PICK_LOCK";
-	ESkill_name_by_value[ESkill::SKILL_PUNCH] = "SKILL_PUNCH";
-	ESkill_name_by_value[ESkill::SKILL_RESCUE] = "SKILL_RESCUE";
-	ESkill_name_by_value[ESkill::SKILL_SNEAK] = "SKILL_SNEAK";
-	ESkill_name_by_value[ESkill::SKILL_STEAL] = "SKILL_STEAL";
-	ESkill_name_by_value[ESkill::SKILL_TRACK] = "SKILL_TRACK";
-	ESkill_name_by_value[ESkill::SKILL_CLUBS] = "SKILL_CLUBS";
-	ESkill_name_by_value[ESkill::SKILL_AXES] = "SKILL_AXES";
-	ESkill_name_by_value[ESkill::SKILL_LONGS] = "SKILL_LONGS";
-	ESkill_name_by_value[ESkill::SKILL_SHORTS] = "SKILL_SHORTS";
-	ESkill_name_by_value[ESkill::SKILL_NONSTANDART] = "SKILL_NONSTANDART";
-	ESkill_name_by_value[ESkill::SKILL_BOTHHANDS] = "SKILL_BOTHHANDS";
-	ESkill_name_by_value[ESkill::SKILL_PICK] = "SKILL_PICK";
-	ESkill_name_by_value[ESkill::SKILL_SPADES] = "SKILL_SPADES";
-	ESkill_name_by_value[ESkill::SKILL_SATTACK] = "SKILL_SATTACK";
-	ESkill_name_by_value[ESkill::SKILL_DISARM] = "SKILL_DISARM";
-	ESkill_name_by_value[ESkill::SKILL_PARRY] = "SKILL_PARRY";
-	ESkill_name_by_value[ESkill::SKILL_HEAL] = "SKILL_HEAL";
-	ESkill_name_by_value[ESkill::SKILL_MORPH] = "SKILL_MORPH";
-	ESkill_name_by_value[ESkill::SKILL_BOWS] = "SKILL_BOWS";
-	ESkill_name_by_value[ESkill::SKILL_ADDSHOT] = "SKILL_ADDSHOT";
-	ESkill_name_by_value[ESkill::SKILL_CAMOUFLAGE] = "SKILL_CAMOUFLAGE";
-	ESkill_name_by_value[ESkill::SKILL_DEVIATE] = "SKILL_DEVIATE";
-	ESkill_name_by_value[ESkill::SKILL_BLOCK] = "SKILL_BLOCK";
-	ESkill_name_by_value[ESkill::SKILL_LOOKING] = "SKILL_LOOKING";
-	ESkill_name_by_value[ESkill::SKILL_CHOPOFF] = "SKILL_CHOPOFF";
-	ESkill_name_by_value[ESkill::SKILL_REPAIR] = "SKILL_REPAIR";
-	ESkill_name_by_value[ESkill::SKILL_UPGRADE] = "SKILL_UPGRADE";
-	ESkill_name_by_value[ESkill::SKILL_COURAGE] = "SKILL_COURAGE";
-	ESkill_name_by_value[ESkill::SKILL_MANADRAIN] = "SKILL_MANADRAIN";
-	ESkill_name_by_value[ESkill::SKILL_NOPARRYHIT] = "SKILL_NOPARRYHIT";
-	ESkill_name_by_value[ESkill::SKILL_TOWNPORTAL] = "SKILL_TOWNPORTAL";
-	ESkill_name_by_value[ESkill::SKILL_MAKE_STAFF] = "SKILL_MAKE_STAFF";
-	ESkill_name_by_value[ESkill::SKILL_MAKE_BOW] = "SKILL_MAKE_BOW";
-	ESkill_name_by_value[ESkill::SKILL_MAKE_WEAPON] = "SKILL_MAKE_WEAPON";
-	ESkill_name_by_value[ESkill::SKILL_MAKE_ARMOR] = "SKILL_MAKE_ARMOR";
-	ESkill_name_by_value[ESkill::SKILL_MAKE_JEWEL] = "SKILL_MAKE_JEWEL";
-	ESkill_name_by_value[ESkill::SKILL_MAKE_WEAR] = "SKILL_MAKE_WEAR";
-	ESkill_name_by_value[ESkill::SKILL_MAKE_POTION] = "SKILL_MAKE_POTION";
-	ESkill_name_by_value[ESkill::SKILL_DIG] = "SKILL_DIG";
-	ESkill_name_by_value[ESkill::SKILL_INSERTGEM] = "SKILL_INSERTGEM";
-	ESkill_name_by_value[ESkill::SKILL_WARCRY] = "SKILL_WARCRY";
-	ESkill_name_by_value[ESkill::SKILL_TURN_UNDEAD] = "SKILL_TURN_UNDEAD";
-	ESkill_name_by_value[ESkill::SKILL_IRON_WIND] = "SKILL_IRON_WIND";
-	ESkill_name_by_value[ESkill::SKILL_STRANGLE] = "SKILL_STRANGLE";
-	ESkill_name_by_value[ESkill::SKILL_AIR_MAGIC] = "SKILL_AIR_MAGIC";
-	ESkill_name_by_value[ESkill::SKILL_FIRE_MAGIC] = "SKILL_FIRE_MAGIC";
-	ESkill_name_by_value[ESkill::SKILL_WATER_MAGIC] = "SKILL_WATER_MAGIC";
-	ESkill_name_by_value[ESkill::SKILL_EARTH_MAGIC] = "SKILL_EARTH_MAGIC";
-	ESkill_name_by_value[ESkill::SKILL_LIGHT_MAGIC] = "SKILL_LIGHT_MAGIC";
-	ESkill_name_by_value[ESkill::SKILL_DARK_MAGIC] = "SKILL_DARK_MAGIC";
-	ESkill_name_by_value[ESkill::SKILL_MIND_MAGIC] = "SKILL_MIND_MAGIC";
-	ESkill_name_by_value[ESkill::SKILL_LIFE_MAGIC] = "SKILL_LIFE_MAGIC";
-	ESkill_name_by_value[ESkill::SKILL_MAKE_AMULET] = "SKILL_MAKE_AMULET";
+  ESkill_name_by_value[ESkill::SKILL_GLOBAL_COOLDOWN] = "SKILL_GLOBAL_COOLDOWN";
+  ESkill_name_by_value[ESkill::SKILL_PROTECT] = "SKILL_PROTECT";
+  ESkill_name_by_value[ESkill::SKILL_TOUCH] = "SKILL_TOUCH";
+  ESkill_name_by_value[ESkill::SKILL_SHIT] = "SKILL_SHIT";
+  ESkill_name_by_value[ESkill::SKILL_MIGHTHIT] = "SKILL_MIGHTHIT";
+  ESkill_name_by_value[ESkill::SKILL_STUPOR] = "SKILL_STUPOR";
+  ESkill_name_by_value[ESkill::SKILL_POISONED] = "SKILL_POISONED";
+  ESkill_name_by_value[ESkill::SKILL_SENSE] = "SKILL_SENSE";
+  ESkill_name_by_value[ESkill::SKILL_HORSE] = "SKILL_HORSE";
+  ESkill_name_by_value[ESkill::SKILL_HIDETRACK] = "SKILL_HIDETRACK";
+  ESkill_name_by_value[ESkill::SKILL_RELIGION] = "SKILL_RELIGION";
+  ESkill_name_by_value[ESkill::SKILL_MAKEFOOD] = "SKILL_MAKEFOOD";
+  ESkill_name_by_value[ESkill::SKILL_MULTYPARRY] = "SKILL_MULTYPARRY";
+  ESkill_name_by_value[ESkill::SKILL_TRANSFORMWEAPON] = "SKILL_TRANSFORMWEAPON";
+  ESkill_name_by_value[ESkill::SKILL_LEADERSHIP] = "SKILL_LEADERSHIP";
+  ESkill_name_by_value[ESkill::SKILL_PUNCTUAL] = "SKILL_PUNCTUAL";
+  ESkill_name_by_value[ESkill::SKILL_AWAKE] = "SKILL_AWAKE";
+  ESkill_name_by_value[ESkill::SKILL_IDENTIFY] = "SKILL_IDENTIFY";
+  ESkill_name_by_value[ESkill::SKILL_HEARING] = "SKILL_HEARING";
+  ESkill_name_by_value[ESkill::SKILL_CREATE_POTION] = "SKILL_CREATE_POTION";
+  ESkill_name_by_value[ESkill::SKILL_CREATE_SCROLL] = "SKILL_CREATE_SCROLL";
+  ESkill_name_by_value[ESkill::SKILL_CREATE_WAND] = "SKILL_CREATE_WAND";
+  ESkill_name_by_value[ESkill::SKILL_LOOK_HIDE] = "SKILL_LOOK_HIDE";
+  ESkill_name_by_value[ESkill::SKILL_ARMORED] = "SKILL_ARMORED";
+  ESkill_name_by_value[ESkill::SKILL_DRUNKOFF] = "SKILL_DRUNKOFF";
+  ESkill_name_by_value[ESkill::SKILL_AID] = "SKILL_AID";
+  ESkill_name_by_value[ESkill::SKILL_FIRE] = "SKILL_FIRE";
+  ESkill_name_by_value[ESkill::SKILL_CREATEBOW] = "SKILL_CREATEBOW";
+  ESkill_name_by_value[ESkill::SKILL_THROW] = "SKILL_THROW";
+  ESkill_name_by_value[ESkill::SKILL_BACKSTAB] = "SKILL_BACKSTAB";
+  ESkill_name_by_value[ESkill::SKILL_BASH] = "SKILL_BASH";
+  ESkill_name_by_value[ESkill::SKILL_HIDE] = "SKILL_HIDE";
+  ESkill_name_by_value[ESkill::SKILL_KICK] = "SKILL_KICK";
+  ESkill_name_by_value[ESkill::SKILL_PICK_LOCK] = "SKILL_PICK_LOCK";
+  ESkill_name_by_value[ESkill::SKILL_PUNCH] = "SKILL_PUNCH";
+  ESkill_name_by_value[ESkill::SKILL_RESCUE] = "SKILL_RESCUE";
+  ESkill_name_by_value[ESkill::SKILL_SNEAK] = "SKILL_SNEAK";
+  ESkill_name_by_value[ESkill::SKILL_STEAL] = "SKILL_STEAL";
+  ESkill_name_by_value[ESkill::SKILL_TRACK] = "SKILL_TRACK";
+  ESkill_name_by_value[ESkill::SKILL_CLUBS] = "SKILL_CLUBS";
+  ESkill_name_by_value[ESkill::SKILL_AXES] = "SKILL_AXES";
+  ESkill_name_by_value[ESkill::SKILL_LONGS] = "SKILL_LONGS";
+  ESkill_name_by_value[ESkill::SKILL_SHORTS] = "SKILL_SHORTS";
+  ESkill_name_by_value[ESkill::SKILL_NONSTANDART] = "SKILL_NONSTANDART";
+  ESkill_name_by_value[ESkill::SKILL_BOTHHANDS] = "SKILL_BOTHHANDS";
+  ESkill_name_by_value[ESkill::SKILL_PICK] = "SKILL_PICK";
+  ESkill_name_by_value[ESkill::SKILL_SPADES] = "SKILL_SPADES";
+  ESkill_name_by_value[ESkill::SKILL_SATTACK] = "SKILL_SATTACK";
+  ESkill_name_by_value[ESkill::SKILL_DISARM] = "SKILL_DISARM";
+  ESkill_name_by_value[ESkill::SKILL_PARRY] = "SKILL_PARRY";
+  ESkill_name_by_value[ESkill::SKILL_HEAL] = "SKILL_HEAL";
+  ESkill_name_by_value[ESkill::SKILL_MORPH] = "SKILL_MORPH";
+  ESkill_name_by_value[ESkill::SKILL_BOWS] = "SKILL_BOWS";
+  ESkill_name_by_value[ESkill::SKILL_ADDSHOT] = "SKILL_ADDSHOT";
+  ESkill_name_by_value[ESkill::SKILL_CAMOUFLAGE] = "SKILL_CAMOUFLAGE";
+  ESkill_name_by_value[ESkill::SKILL_DEVIATE] = "SKILL_DEVIATE";
+  ESkill_name_by_value[ESkill::SKILL_BLOCK] = "SKILL_BLOCK";
+  ESkill_name_by_value[ESkill::SKILL_LOOKING] = "SKILL_LOOKING";
+  ESkill_name_by_value[ESkill::SKILL_CHOPOFF] = "SKILL_CHOPOFF";
+  ESkill_name_by_value[ESkill::SKILL_REPAIR] = "SKILL_REPAIR";
+  ESkill_name_by_value[ESkill::SKILL_UPGRADE] = "SKILL_UPGRADE";
+  ESkill_name_by_value[ESkill::SKILL_COURAGE] = "SKILL_COURAGE";
+  ESkill_name_by_value[ESkill::SKILL_MANADRAIN] = "SKILL_MANADRAIN";
+  ESkill_name_by_value[ESkill::SKILL_NOPARRYHIT] = "SKILL_NOPARRYHIT";
+  ESkill_name_by_value[ESkill::SKILL_TOWNPORTAL] = "SKILL_TOWNPORTAL";
+  ESkill_name_by_value[ESkill::SKILL_MAKE_STAFF] = "SKILL_MAKE_STAFF";
+  ESkill_name_by_value[ESkill::SKILL_MAKE_BOW] = "SKILL_MAKE_BOW";
+  ESkill_name_by_value[ESkill::SKILL_MAKE_WEAPON] = "SKILL_MAKE_WEAPON";
+  ESkill_name_by_value[ESkill::SKILL_MAKE_ARMOR] = "SKILL_MAKE_ARMOR";
+  ESkill_name_by_value[ESkill::SKILL_MAKE_JEWEL] = "SKILL_MAKE_JEWEL";
+  ESkill_name_by_value[ESkill::SKILL_MAKE_WEAR] = "SKILL_MAKE_WEAR";
+  ESkill_name_by_value[ESkill::SKILL_MAKE_POTION] = "SKILL_MAKE_POTION";
+  ESkill_name_by_value[ESkill::SKILL_DIG] = "SKILL_DIG";
+  ESkill_name_by_value[ESkill::SKILL_INSERTGEM] = "SKILL_INSERTGEM";
+  ESkill_name_by_value[ESkill::SKILL_WARCRY] = "SKILL_WARCRY";
+  ESkill_name_by_value[ESkill::SKILL_TURN_UNDEAD] = "SKILL_TURN_UNDEAD";
+  ESkill_name_by_value[ESkill::SKILL_IRON_WIND] = "SKILL_IRON_WIND";
+  ESkill_name_by_value[ESkill::SKILL_STRANGLE] = "SKILL_STRANGLE";
+  ESkill_name_by_value[ESkill::SKILL_AIR_MAGIC] = "SKILL_AIR_MAGIC";
+  ESkill_name_by_value[ESkill::SKILL_FIRE_MAGIC] = "SKILL_FIRE_MAGIC";
+  ESkill_name_by_value[ESkill::SKILL_WATER_MAGIC] = "SKILL_WATER_MAGIC";
+  ESkill_name_by_value[ESkill::SKILL_EARTH_MAGIC] = "SKILL_EARTH_MAGIC";
+  ESkill_name_by_value[ESkill::SKILL_LIGHT_MAGIC] = "SKILL_LIGHT_MAGIC";
+  ESkill_name_by_value[ESkill::SKILL_DARK_MAGIC] = "SKILL_DARK_MAGIC";
+  ESkill_name_by_value[ESkill::SKILL_MIND_MAGIC] = "SKILL_MIND_MAGIC";
+  ESkill_name_by_value[ESkill::SKILL_LIFE_MAGIC] = "SKILL_LIFE_MAGIC";
+  ESkill_name_by_value[ESkill::SKILL_MAKE_AMULET] = "SKILL_MAKE_AMULET";
 
-	for (const auto& i : ESkill_name_by_value)
-	{
-		ESkill_value_by_name[i.second] = i.first;
-	}
+  for (const auto &i : ESkill_name_by_value) {
+    ESkill_value_by_name[i.second] = i.first;
+  }
 }
 
-template <>
-ESkill ITEM_BY_NAME(const std::string& name)
-{
-	if (ESkill_name_by_value.empty())
-	{
-		init_ESkill_ITEM_NAMES();
-	}
-	return ESkill_value_by_name.at(name);
+template<>
+ESkill ITEM_BY_NAME(const std::string &name) {
+  if (ESkill_name_by_value.empty()) {
+    init_ESkill_ITEM_NAMES();
+  }
+  return ESkill_value_by_name.at(name);
 }
 
-template <>
-const std::string& NAME_BY_ITEM<ESkill>(const ESkill item)
-{
-	if (ESkill_name_by_value.empty())
-	{
-		init_ESkill_ITEM_NAMES();
-	}
-	return ESkill_name_by_value.at(item);
+template<>
+const std::string &NAME_BY_ITEM<ESkill>(const ESkill item) {
+  if (ESkill_name_by_value.empty()) {
+    init_ESkill_ITEM_NAMES();
+  }
+  return ESkill_name_by_value.at(item);
 }
 
 std::array<ESkill, MAX_SKILL_NUM - SKILL_FIRST> AVAILABLE_SKILLS =
-{
-	SKILL_PROTECT,
-	SKILL_TOUCH,
-	SKILL_SHIT,
-	SKILL_MIGHTHIT,
-	SKILL_STUPOR,
-	SKILL_POISONED,
-	SKILL_SENSE,
-	SKILL_HORSE,
-	SKILL_HIDETRACK,
-	SKILL_RELIGION,
-	SKILL_MAKEFOOD,
-	SKILL_MULTYPARRY,
-	SKILL_TRANSFORMWEAPON,
-	SKILL_LEADERSHIP,
-	SKILL_PUNCTUAL,
-	SKILL_AWAKE,
-	SKILL_IDENTIFY,
-	SKILL_HEARING,
-	SKILL_CREATE_POTION,
-	SKILL_CREATE_SCROLL,
-	SKILL_CREATE_WAND,
-	SKILL_LOOK_HIDE,
-	SKILL_ARMORED,
-	SKILL_DRUNKOFF,
-	SKILL_AID,
-	SKILL_FIRE,
-	SKILL_CREATEBOW,
-	SKILL_THROW,
-	SKILL_BACKSTAB,
-	SKILL_BASH,
-	SKILL_HIDE,
-	SKILL_KICK,
-	SKILL_PICK_LOCK,
-	SKILL_PUNCH,
-	SKILL_RESCUE,
-	SKILL_SNEAK,
-	SKILL_STEAL,
-	SKILL_TRACK,
-	SKILL_CLUBS,
-	SKILL_AXES,
-	SKILL_LONGS,
-	SKILL_SHORTS,
-	SKILL_NONSTANDART,
-	SKILL_BOTHHANDS,
-	SKILL_PICK,
-	SKILL_SPADES,
-	SKILL_SATTACK,
-	SKILL_DISARM,
-	SKILL_PARRY,
-	SKILL_HEAL,
-	SKILL_MORPH,
-	SKILL_BOWS,
-	SKILL_ADDSHOT,
-	SKILL_CAMOUFLAGE,
-	SKILL_DEVIATE,
-	SKILL_BLOCK,
-	SKILL_LOOKING,
-	SKILL_CHOPOFF,
-	SKILL_REPAIR,
-	SKILL_UPGRADE,
-	SKILL_COURAGE,
-	SKILL_MANADRAIN,
-	SKILL_NOPARRYHIT,
-	SKILL_TOWNPORTAL,
-	SKILL_MAKE_STAFF,
-	SKILL_MAKE_BOW,
-	SKILL_MAKE_WEAPON,
-	SKILL_MAKE_ARMOR,
-	SKILL_MAKE_JEWEL,
-	SKILL_MAKE_WEAR,
-	SKILL_MAKE_POTION,
-	SKILL_DIG,
-	SKILL_INSERTGEM,
-	SKILL_WARCRY,
-	SKILL_TURN_UNDEAD,
-	SKILL_IRON_WIND,
-	SKILL_STRANGLE,
-	SKILL_AIR_MAGIC,
-	SKILL_FIRE_MAGIC,
-	SKILL_WATER_MAGIC,
-	SKILL_EARTH_MAGIC,
-	SKILL_LIGHT_MAGIC,
-	SKILL_DARK_MAGIC,
-	SKILL_MIND_MAGIC,
-	SKILL_LIFE_MAGIC,
-	SKILL_STUN,
-	SKILL_MAKE_AMULET,
-	SKILL_INDEFINITE
-};
+    {
+        SKILL_PROTECT,
+        SKILL_TOUCH,
+        SKILL_SHIT,
+        SKILL_MIGHTHIT,
+        SKILL_STUPOR,
+        SKILL_POISONED,
+        SKILL_SENSE,
+        SKILL_HORSE,
+        SKILL_HIDETRACK,
+        SKILL_RELIGION,
+        SKILL_MAKEFOOD,
+        SKILL_MULTYPARRY,
+        SKILL_TRANSFORMWEAPON,
+        SKILL_LEADERSHIP,
+        SKILL_PUNCTUAL,
+        SKILL_AWAKE,
+        SKILL_IDENTIFY,
+        SKILL_HEARING,
+        SKILL_CREATE_POTION,
+        SKILL_CREATE_SCROLL,
+        SKILL_CREATE_WAND,
+        SKILL_LOOK_HIDE,
+        SKILL_ARMORED,
+        SKILL_DRUNKOFF,
+        SKILL_AID,
+        SKILL_FIRE,
+        SKILL_CREATEBOW,
+        SKILL_THROW,
+        SKILL_BACKSTAB,
+        SKILL_BASH,
+        SKILL_HIDE,
+        SKILL_KICK,
+        SKILL_PICK_LOCK,
+        SKILL_PUNCH,
+        SKILL_RESCUE,
+        SKILL_SNEAK,
+        SKILL_STEAL,
+        SKILL_TRACK,
+        SKILL_CLUBS,
+        SKILL_AXES,
+        SKILL_LONGS,
+        SKILL_SHORTS,
+        SKILL_NONSTANDART,
+        SKILL_BOTHHANDS,
+        SKILL_PICK,
+        SKILL_SPADES,
+        SKILL_SATTACK,
+        SKILL_DISARM,
+        SKILL_PARRY,
+        SKILL_HEAL,
+        SKILL_MORPH,
+        SKILL_BOWS,
+        SKILL_ADDSHOT,
+        SKILL_CAMOUFLAGE,
+        SKILL_DEVIATE,
+        SKILL_BLOCK,
+        SKILL_LOOKING,
+        SKILL_CHOPOFF,
+        SKILL_REPAIR,
+        SKILL_UPGRADE,
+        SKILL_COURAGE,
+        SKILL_MANADRAIN,
+        SKILL_NOPARRYHIT,
+        SKILL_TOWNPORTAL,
+        SKILL_MAKE_STAFF,
+        SKILL_MAKE_BOW,
+        SKILL_MAKE_WEAPON,
+        SKILL_MAKE_ARMOR,
+        SKILL_MAKE_JEWEL,
+        SKILL_MAKE_WEAR,
+        SKILL_MAKE_POTION,
+        SKILL_DIG,
+        SKILL_INSERTGEM,
+        SKILL_WARCRY,
+        SKILL_TURN_UNDEAD,
+        SKILL_IRON_WIND,
+        SKILL_STRANGLE,
+        SKILL_AIR_MAGIC,
+        SKILL_FIRE_MAGIC,
+        SKILL_WATER_MAGIC,
+        SKILL_EARTH_MAGIC,
+        SKILL_LIGHT_MAGIC,
+        SKILL_DARK_MAGIC,
+        SKILL_MIND_MAGIC,
+        SKILL_LIFE_MAGIC,
+        SKILL_STUN,
+        SKILL_MAKE_AMULET,
+        SKILL_INDEFINITE
+    };
 
 ///
 /// \param add = "", строка для добавления после основного сообщения (краткий режим щитов)
 ///
-int skill_message(int dam, CHAR_DATA * ch, CHAR_DATA * vict, int attacktype, std::string add)
-{
-	int i, j, nr;
-	struct message_type *msg;
+int skill_message(int dam, CHAR_DATA *ch, CHAR_DATA *vict, int attacktype, std::string add) {
+  int i, j, nr;
+  struct message_type *msg;
 
-	//log("[SKILL MESSAGE] Message for skill %d",attacktype);
-	for (i = 0; i < MAX_MESSAGES; i++)
-	{
-		if (fight_messages[i].a_type == attacktype)
-		{
-			nr = dice(1, fight_messages[i].number_of_attacks);
-			// log("[SKILL MESSAGE] %d(%d)",fight_messages[i].number_of_attacks,nr);
-			for (j = 1, msg = fight_messages[i].msg; (j < nr) && msg; j++)
-			{
-				msg = msg->next;
-			}
+  //log("[SKILL MESSAGE] Message for skill %d",attacktype);
+  for (i = 0; i < MAX_MESSAGES; i++) {
+    if (fight_messages[i].a_type == attacktype) {
+      nr = dice(1, fight_messages[i].number_of_attacks);
+      // log("[SKILL MESSAGE] %d(%d)",fight_messages[i].number_of_attacks,nr);
+      for (j = 1, msg = fight_messages[i].msg; (j < nr) && msg; j++) {
+        msg = msg->next;
+      }
 
-			const auto weap = init_weap(ch, dam, attacktype);
-			brief_shields brief(ch, vict, weap, add);
-			if (attacktype == SPELL_FIRE_SHIELD
-				|| attacktype == SPELL_MAGICGLASS)
-			{
-				brief.reflect = true;
-			}
+      const auto weap = init_weap(ch, dam, attacktype);
+      brief_shields brief(ch, vict, weap, add);
+      if (attacktype == SPELL_FIRE_SHIELD
+          || attacktype == SPELL_MAGICGLASS) {
+        brief.reflect = true;
+      }
 
-			if (!IS_NPC(vict) && (GET_LEVEL(vict) >= LVL_IMMORT) && !PLR_FLAGGED((ch), PLR_WRITING))
-			{
-				switch (attacktype)
-				{
-				case SKILL_BACKSTAB + TYPE_HIT:
-				case SKILL_THROW + TYPE_HIT:
-				case SKILL_BASH + TYPE_HIT:
-				case SKILL_KICK + TYPE_HIT:
-					send_to_char("&W&q", ch);
-					break;
+      if (!IS_NPC(vict) && (GET_LEVEL(vict) >= LVL_IMMORT) && !PLR_FLAGGED((ch), PLR_WRITING)) {
+        switch (attacktype) {
+          case SKILL_BACKSTAB + TYPE_HIT:
+          case SKILL_THROW + TYPE_HIT:
+          case SKILL_BASH + TYPE_HIT:
+          case SKILL_KICK + TYPE_HIT: send_to_char("&W&q", ch);
+            break;
 
-				default:
-					send_to_char("&y&q", ch);
-					break;
-				}
-				// ch
-				brief.act_to_char(msg->god_msg.attacker_msg);
-				send_to_char("&Q&n", ch);
-				// victim
-				brief.act_to_vict(msg->god_msg.victim_msg);
-				// room
-				brief.act_to_room(msg->god_msg.room_msg);
-			}
-			else if (dam != 0)
-			{
-				if (GET_POS(vict) == POS_DEAD)
-				{
-					// ch
-					send_to_char("&Y&q", ch);
-					brief.act_to_char(msg->die_msg.attacker_msg);
-					send_to_char("&Q&n", ch);
-					// vict
-					send_to_char("&R&q", vict);
-					brief.act_to_vict(msg->die_msg.victim_msg);
-					send_to_char("&Q&n", vict);
-					// room
-					brief.act_to_room(msg->die_msg.room_msg);
-				}
-				else
-				{
-					// ch
-					send_to_char("&Y&q", ch);
-					brief.act_to_char(msg->hit_msg.attacker_msg);
-					send_to_char("&Q&n", ch);
-					// vict
-					send_to_char("&R&q", vict);
-					brief.act_to_vict(msg->hit_msg.victim_msg);
-					send_to_char("&Q&n", vict);
-					// room
-					brief.act_to_room(msg->hit_msg.room_msg);
-				}
-			}
-			else if (ch != vict)  	// Dam == 0
-			{
-				switch (attacktype)
-				{
-				case SKILL_BACKSTAB + TYPE_HIT:
-				case SKILL_THROW + TYPE_HIT:
-				case SKILL_BASH + TYPE_HIT:
-				case SKILL_KICK + TYPE_HIT:
-					send_to_char("&W&q", ch);
-					break;
+          default: send_to_char("&y&q", ch);
+            break;
+        }
+        // ch
+        brief.act_to_char(msg->god_msg.attacker_msg);
+        send_to_char("&Q&n", ch);
+        // victim
+        brief.act_to_vict(msg->god_msg.victim_msg);
+        // room
+        brief.act_to_room(msg->god_msg.room_msg);
+      } else if (dam != 0) {
+        if (GET_POS(vict) == POS_DEAD) {
+          // ch
+          send_to_char("&Y&q", ch);
+          brief.act_to_char(msg->die_msg.attacker_msg);
+          send_to_char("&Q&n", ch);
+          // vict
+          send_to_char("&R&q", vict);
+          brief.act_to_vict(msg->die_msg.victim_msg);
+          send_to_char("&Q&n", vict);
+          // room
+          brief.act_to_room(msg->die_msg.room_msg);
+        } else {
+          // ch
+          send_to_char("&Y&q", ch);
+          brief.act_to_char(msg->hit_msg.attacker_msg);
+          send_to_char("&Q&n", ch);
+          // vict
+          send_to_char("&R&q", vict);
+          brief.act_to_vict(msg->hit_msg.victim_msg);
+          send_to_char("&Q&n", vict);
+          // room
+          brief.act_to_room(msg->hit_msg.room_msg);
+        }
+      } else if (ch != vict)    // Dam == 0
+      {
+        switch (attacktype) {
+          case SKILL_BACKSTAB + TYPE_HIT:
+          case SKILL_THROW + TYPE_HIT:
+          case SKILL_BASH + TYPE_HIT:
+          case SKILL_KICK + TYPE_HIT: send_to_char("&W&q", ch);
+            break;
 
-				default:
-					send_to_char("&y&q", ch);
-					break;
-				}
-				//ch
-				brief.act_to_char(msg->miss_msg.attacker_msg);
-				send_to_char("&Q&n", ch);
-				// vict
-				send_to_char("&r&q", vict);
-				brief.act_to_vict(msg->miss_msg.victim_msg);
-				send_to_char("&Q&n", vict);
-				// room
-				brief.act_to_room(msg->miss_msg.room_msg);
-			}
-			return (1);
-		}
-	}
-	return (0);
+          default: send_to_char("&y&q", ch);
+            break;
+        }
+        //ch
+        brief.act_to_char(msg->miss_msg.attacker_msg);
+        send_to_char("&Q&n", ch);
+        // vict
+        send_to_char("&r&q", vict);
+        brief.act_to_vict(msg->miss_msg.victim_msg);
+        send_to_char("&Q&n", vict);
+        // room
+        brief.act_to_room(msg->miss_msg.room_msg);
+      }
+      return (1);
+    }
+  }
+  return (0);
 }
 
 // *** This function return chance of skill
-int calculate_skill(CHAR_DATA * ch, const ESkill skill_no, CHAR_DATA * vict)
-{
-	//Зачем здесь было SAVING_REFLEX? Оно же просто число
-	int skill_is, percent = 0, victim_sav = 0, victim_modi = 0; // текущее значение умения(прокачанность) / вычисляемый итоговый процент / савис жертвы,
-																	// который влияет на прохождение скила / другие модификаторы, влияющие на прохождение
-	int morale = 0, max_percent = 200, bonus = 0, size = 0, fail_limit = 950;  // удача пациента, максимально возможный процент скила, бонус от дополнительных параметров.
-	bool pass_mod = 0; // в данный момент для доп.выстрела, чтобы оставить его как скилл,
-	// но не применять к нему левых штрафов и плюсов, плюсуется только от инты немного
-
-	if (is_magic_skill(skill_no))
-		max_percent = 1000;
-
-	if (skill_no < SKILL_FIRST
-		|| skill_no > MAX_SKILL_NUM)  	// log("ERROR: ATTEMPT USING UNKNOWN SKILL <%d>", skill_no);
-	{
-		return 0;
-	}
-
-	if ((skill_is = ch->get_skill(skill_no)) <= 0)
-	{
-		return 0;                                         // если скила нет возвращаем 0.
-	}
-
-	if (!IS_NPC(ch) && !ch->affected.empty())
-	{
-		for (const auto& aff : ch->affected)
-		{
-			if (aff->location == APPLY_BONUS_SKILLS) // скушал свиток с эксп умелкой
-			{
-				skill_is += aff->modifier;
-			}
-
-			if (aff->location == APPLY_PLAQUE)
-			{
-				skill_is -= number(ch->get_skill(skill_no) * 0.4, ch->get_skill(skill_no) * 0.05); // при лихорадке умелки ухудшаются на 5-30% рандом
-			}
-		}
-	}
-
-	skill_is += int_app[GET_REAL_INT(ch)].to_skilluse;
-	if (!IS_NPC(ch))
-	{
-		size = (MAX(0, GET_REAL_SIZE(ch) - 50));
-	}
-	else
-	{
-		size = size_app[GET_POS_SIZE(ch)].interpolate / 2;
-	}
-
-	switch (skill_no)
-	{
-	case SKILL_HIDETRACK:          // замести следы
-		{
-		bonus = (can_use_feat(ch, STEALTHY_FEAT) ? 5 : 0);
-		break;
-		}
-
-	case SKILL_BACKSTAB:	//заколоть
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
-		victim_sav = -GET_REAL_SAVING_REFLEX(vict);
-		bonus = dex_bonus(GET_REAL_DEX(ch)) * 2;
-		if (awake_others(ch)
-			|| equip_in_metall(ch))
-		{
-			bonus -= 50;
-		}
-
-		if (vict)
-		{
-			if (!CAN_SEE(vict, ch))
-			{
-				bonus += 25;
-			}
-
-			if (GET_POS(vict) < POS_FIGHTING)
-			{
-				bonus += (20 * (POS_FIGHTING - GET_POS(vict)));
-			}
-			else if (AFF_FLAGGED(vict, EAffectFlag::AFF_AWARNESS))
-			{
-				victim_modi -= 30;
-			}
-			victim_modi += size_app[GET_POS_SIZE(vict)].ac;
-			victim_modi -= dex_bonus(GET_REAL_DEX(vict));
-		}
-		break;
-		}
-
-	case SKILL_BASH:	//сбить
-		{
-		victim_sav = -GET_REAL_SAVING_REFLEX(vict);
-		bonus = size
-			+ dex_bonus(GET_REAL_DEX(ch))
-			+ (GET_EQ(ch, WEAR_SHIELD)
-				? weapon_app[MIN(35, MAX(0, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_SHIELD))))].bashing
-				: 0);
-		if (vict)
-		{
-			if (GET_POS(vict) < POS_FIGHTING && GET_POS(vict) > POS_SLEEPING)
-			{
-				victim_modi -= 20;
-			}
-			if (PRF_FLAGGED(vict, PRF_AWAKE))
-			{
-				victim_modi -= calculate_awake_mod(ch, vict);
-			}
-		}
-		break;
-		}
-
-	case SKILL_HIDE:	//спрятаться
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch))
-			- size_app[GET_POS_SIZE(ch)].ac
-			+ (can_use_feat(ch, STEALTHY_FEAT) ? 5 : 0);
-
-		if (awake_others(ch) || equip_in_metall(ch))
-		{
-			bonus -= 50;
-		}
-
-		if (IS_DARK(ch->in_room))
-		{
-			bonus += 25;
-		}
-
-		if (SECT(ch->in_room) == SECT_INSIDE)
-		{
-			bonus += 20;
-		}
-		else if (SECT(ch->in_room) == SECT_CITY)
-		{
-			bonus -= 15;
-		}
-		else if (SECT(ch->in_room) == SECT_FOREST)
-		{
-			bonus += 20;
-		}
-		else if (SECT(ch->in_room) == SECT_HILLS
-			|| SECT(ch->in_room) == SECT_MOUNTAIN)
-		{
-			bonus += 10;
-		}
-
-		if (vict)
-		{
-			if (AWAKE(vict))
-			{
-				victim_modi -= int_app[GET_REAL_INT(vict)].observation;
-			}
-		}
-		break;
-		}
-
-	case SKILL_KICK:	//пнуть
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_STABILITY) - dex_bonus(GET_REAL_CON(vict));
-		victim_sav = -GET_REAL_SAVING_STABILITY(vict);
-		bonus = dex_bonus(GET_REAL_DEX(ch)) + dex_bonus(GET_REAL_STR(ch));
-		if (vict)
-		{
-			victim_modi += size_app[GET_POS_SIZE(vict)].interpolate;
-			victim_modi -= GET_REAL_CON(vict);
-			if (PRF_FLAGGED(vict, PRF_AWAKE))
-			{
-				victim_modi -= calculate_awake_mod(ch, vict);
-			}
-		}
-		break;
-		}
-
-	case SKILL_PICK_LOCK:	// взлом
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch))
-			+ (can_use_feat(ch, NIMBLE_FINGERS_FEAT) ? 5 : 0);
-		break;
-		}
-
-	case SKILL_PUNCH:	//удар левой рукой
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
-		victim_sav = -GET_REAL_SAVING_REFLEX(vict);
-		break;
-		}
-
-	case SKILL_RESCUE:	//спасти
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch));
-		//		victim_modi = 100;
-		break;
-		}
-
-	case SKILL_SNEAK:	// Подкрасться
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch))
-			+ (can_use_feat(ch, STEALTHY_FEAT) ? 10 : 0);
-
-		if (awake_others(ch) || equip_in_metall(ch))
-			bonus -= 50;
-
-		if (SECT(ch->in_room) == SECT_CITY)
-			bonus -= 10;
-		if (IS_DARK(ch->in_room))
-			bonus += 20;
-
-		if (vict)
-		{
-			if (GET_LEVEL(vict) > 35)
-				bonus -= 50;
-			if (!CAN_SEE(vict, ch))
-				bonus += 25;
-			if (AWAKE(vict))
-			{
-				victim_modi -= int_app[GET_REAL_INT(vict)].observation;
-			}
-		}
-		break;
-		}
-
-	case SKILL_STEAL:	// Украсть
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch))
-			+ (can_use_feat(ch, NIMBLE_FINGERS_FEAT) ? 5 : 0);
-
-		if (awake_others(ch) || equip_in_metall(ch))
-			bonus -= 50;
-		/* работает только для блестящих предметов, так как в темное татям и купцам другое не видно*/
-		if (IS_DARK(ch->in_room))
-			bonus += 20;
-
-		if (vict)
-		{
-			//victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
-			victim_sav = -GET_REAL_SAVING_REFLEX(vict);
-			if (!CAN_SEE(vict, ch))
-				bonus += 25;
-			if (AWAKE(vict))
-			{
-				victim_modi -= int_app[GET_REAL_INT(vict)].observation;
-				if (AFF_FLAGGED(vict, EAffectFlag::AFF_AWARNESS))
-					bonus -= 30;
-			}
-		}
-		break;
-		}
-
-	case SKILL_TRACK:       //выследить
-		{
-		percent = skill_is + int_app[GET_REAL_INT(ch)].observation
-			+ (can_use_feat(ch, TRACKER_FEAT) ? 10 : 0);
-
-		if (SECT(ch->in_room) == SECT_FOREST || SECT(ch->in_room) == SECT_FIELD)
-			percent += 10;
-
-		percent = complex_skill_modifier(ch, SKILL_INDEFINITE, GAPPLY_SKILL_SUCCESS, percent);
-
-		if (SECT(ch->in_room) == SECT_WATER_SWIM ||
-			SECT(ch->in_room) == SECT_WATER_NOSWIM ||
-			SECT(ch->in_room) == SECT_FLYING ||
-			SECT(ch->in_room) == SECT_UNDERWATER ||
-			SECT(ch->in_room) == SECT_SECRET
-			|| ROOM_FLAGGED(ch->in_room, ROOM_NOTRACK)) percent = 0;
-
-
-		if (vict)
-		{
-			victim_modi += GET_REAL_CON(vict) / 2;
-			if (AFF_FLAGGED(vict, EAffectFlag::AFF_NOTRACK)
-				|| ROOM_FLAGGED(ch->in_room, ROOM_NOTRACK))
-			{
-				victim_modi = -100;
-			}
-		}
-		break;
-		}
-
-	case SKILL_SENSE: // найти
-		{
-		bonus = int_app[GET_REAL_INT(ch)].observation
-			+ (can_use_feat(ch, TRACKER_FEAT) ? 20 : 0);
-		break;
-		}
-
-	case SKILL_MULTYPARRY:  // веерная защита
-	case SKILL_PARRY:	//парировать
-		{
-		victim_sav = dex_bonus(GET_REAL_DEX(vict));
-		bonus = dex_bonus(GET_REAL_DEX(ch));
-		if (GET_AF_BATTLE(ch, EAF_AWAKE))
-		{
-			bonus += ch->get_skill(SKILL_AWAKE);
-		}
-
-		if (GET_EQ(ch, WEAR_HOLD)
-			&& GET_OBJ_TYPE(GET_EQ(ch, WEAR_HOLD)) == OBJ_DATA::ITEM_WEAPON)
-		{
-			bonus += weapon_app[MAX(0, MIN(50, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))))].parrying;
-		}
-		victim_modi = 100;
-		break;
-		}
-
-	case SKILL_BLOCK:	//закрыться щитом
-	{		// по 10 бонусом со щита (21-30) и дексы (21-50)
-		int shield_mod = GET_EQ(ch, WEAR_SHIELD) ? MIN(10, MAX(0, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_SHIELD)) - 20)) : 0;
-		int dex_mod = MAX(0, (GET_REAL_DEX(ch) - 20) / 3);
-		bonus = dex_mod + shield_mod;
-		break;
-	}
-
-	case SKILL_TOUCH:	//захватить противника
-		{
-		victim_sav = dex_bonus(GET_REAL_DEX(vict));
-		bonus = dex_bonus(GET_REAL_DEX(ch)) +
-			size_app[GET_POS_SIZE(vict)].interpolate;
-
-		if (vict)
-		{
-			victim_modi -= dex_bonus(GET_REAL_DEX(vict));
-			victim_modi -= size_app[GET_POS_SIZE(vict)].interpolate;
-		}
-		break;
-		}
-
-	case SKILL_PROTECT:	//прикрыть грудью
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch)) + size;
-		victim_modi = 50;
-		break;
-		}
-
-	case SKILL_BOWS:	//луки
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch));
-		break;
-		}
-
-	case SKILL_BOTHHANDS:	//двуручники
-	case SKILL_LONGS:	//длинные лезвия
-	case SKILL_SPADES:	//копья и пики
-	case SKILL_SHORTS:	//короткие лезвия
-	case SKILL_CLUBS:	//палицы и дубины
-	case SKILL_PICK:	//проникающее
-	case SKILL_NONSTANDART:	//разнообразное оружие
-	case SKILL_AXES:	//секиры
-		//victim_sav = GET_SAVE(vict, SAVING_REFLEX);
-		break;
-
-	case SKILL_SATTACK:	//атака второй рукой
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_REFLEX);
-		victim_sav = -GET_REAL_SAVING_REFLEX(vict) + dex_bonus(GET_REAL_DEX(ch)); //equal
-		break;
-		}
-
-	case SKILL_LOOKING:	//приглядеться
-		{
-		bonus = int_app[GET_REAL_INT(ch)].observation;
-		break;
-		}
-
-	case SKILL_HEARING:	//прислушаться
-		{
-		bonus = int_app[GET_REAL_INT(ch)].observation;
-		break;
-		}
-
-	case SKILL_DISARM:
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
-		victim_sav = -GET_REAL_SAVING_REFLEX(vict);
-		bonus = dex_bonus(GET_REAL_DEX(ch)) + dex_bonus(GET_REAL_STR(ch));
-		if (vict)
-		{
-			victim_modi -= dex_bonus(GET_REAL_STR(ch));
-			if (GET_EQ(vict, WEAR_BOTHS))
-				victim_modi -= 10;
-			if (PRF_FLAGGED(vict, PRF_AWAKE))
-				victim_modi -= calculate_awake_mod(ch, vict);
-		}
-		break;
-		}
-
-		//насколько я понимаю не используемое умение
-	case SKILL_HEAL:   // лечить
-		break;
-
-	case SKILL_ADDSHOT:   // дополнительный выстрел
-		{
-		if (equip_in_metall(ch))
-			bonus -= 5;
-		pass_mod = 1;
-		break;
-		}
-
-	case SKILL_NOPARRYHIT:
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch));
-		break;
-		}
-
-	case SKILL_CAMOUFLAGE: // маскировка
-		{
-		bonus = dex_bonus(GET_REAL_DEX(ch)) - size_app[GET_POS_SIZE(ch)].ac
-			+ (can_use_feat(ch, STEALTHY_FEAT) ? 5 : 0);
-
-		if (awake_others(ch))
-			bonus -= 100;
-
-		if (IS_DARK(ch->in_room))
-			bonus += 15;
-
-		if (SECT(ch->in_room) == SECT_CITY)
-			bonus -= 15;
-		else if (SECT(ch->in_room) == SECT_FOREST)
-			bonus += 10;
-		else if (SECT(ch->in_room) == SECT_HILLS
-			|| SECT(ch->in_room) == SECT_MOUNTAIN) bonus += 5;
-		if (equip_in_metall(ch))
-			bonus -= 30;
-
-		if (vict)
-		{
-			if (AWAKE(vict))
-				victim_modi -= int_app[GET_REAL_INT(vict)].observation;
-		}
-		break;
-		}
-
-	case SKILL_DEVIATE:  // уклониться
-		{
-		bonus = -size_app[GET_POS_SIZE(ch)].ac +
-			dex_bonus(GET_REAL_DEX(ch));
-
-		if (equip_in_metall(ch))
-			bonus -= 40;
-
-		if (vict)
-		{
-			victim_modi -= dex_bonus(GET_REAL_DEX(vict));
-		}
-		break;
-		}
-
-	case SKILL_CHOPOFF:  // подножка
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
-		victim_sav = -GET_REAL_SAVING_REFLEX(vict);
-		bonus = dex_bonus(GET_REAL_DEX(ch)) + ((dex_bonus(GET_REAL_DEX(ch)) * 5) / 10)  + size_app[GET_POS_SIZE(ch)].ac; // тест х3 признан вредительским
-		if (equip_in_metall(ch))
-			bonus -= 10;
-		if (vict)
-		{
-			if (!CAN_SEE(vict, ch))
-				bonus += 10;
-			if (GET_POS(vict) < POS_SITTING)
-				bonus -= 50;
-			if (AWAKE(vict) || AFF_FLAGGED(vict, EAffectFlag::AFF_AWARNESS) || MOB_FLAGGED(vict, MOB_AWAKE))
-				victim_modi -= 20;
-			if (PRF_FLAGGED(vict, PRF_AWAKE))
-				victim_modi -= calculate_awake_mod(ch, vict);
-			// в пинке режем дамаг
-			//			if (GET_AF_BATTLE(vict, EAF_AWAKE))
-			//				victim_modi -= calculate_awake_mod(ch, vict);
-			//			victim_modi -= int_app[GET_REAL_INT(vict)].observation;
-		}
-		break;
-		}
-
-	case SKILL_REPAIR: // починка
-		break;
-	case SKILL_UPGRADE:  //заточить
-	case SKILL_WARCRY:
-		break;
-	case SKILL_COURAGE:
-		break;
-	case SKILL_SHIT:
-		break;
-	case SKILL_MIGHTHIT: // богатырский молот
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_STABILITY) - dex_bonus(GET_REAL_CON(vict));
-		victim_sav = -GET_REAL_SAVING_STABILITY(vict);
-		//bonus = size + dex_bonus(GET_REAL_STR(ch));
-		bonus = size + dex_bonus(GET_REAL_STR(ch));
-
-		if (IS_NPC(vict))
-			victim_modi -= (size_app[GET_POS_SIZE(vict)].shocking) / 2;
-		else
-			victim_modi -= size_app[GET_POS_SIZE(vict)].shocking;
-		break;
-		}
-
-	case SKILL_STUPOR:  // оглушить
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_STABILITY) - dex_bonus(GET_REAL_CON(vict));
-		victim_sav = -GET_REAL_SAVING_STABILITY(vict);
-		bonus = dex_bonus(GET_REAL_STR(ch));
-		if (GET_EQ(ch, WEAR_WIELD))
-			bonus +=
-			weapon_app[GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))].shocking;
-		else if (GET_EQ(ch, WEAR_BOTHS))
-			bonus +=
-			weapon_app[GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS))].shocking;
-
-		if (vict)
-		{
-			victim_modi -= GET_REAL_CON(vict);
-		}
-		break;
-		}
-
-	case SKILL_POISONED:  // отравление
-		break;
-	case SKILL_LEADERSHIP: //лидерство
-		{
-		bonus = cha_app[GET_REAL_CHA(ch)].leadership;
-		break;
-		}
-
-	case SKILL_PUNCTUAL:  // точный стиль
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_CRITICAL) - dex_bonus(GET_REAL_CON(vict));
-		victim_sav = -GET_REAL_SAVING_CRITICAL(vict);
-		bonus = dex_bonus(GET_REAL_INT(ch));
-		if (GET_EQ(ch, WEAR_WIELD))
-			bonus += MAX(18, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))) - 18
-			+ MAX(25, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))) - 25
-			+ MAX(30, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))) - 30;
-		if (GET_EQ(ch, WEAR_HOLD))
-			bonus += MAX(18, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))) - 18
-			+ MAX(25, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))) - 25
-			+ MAX(30, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))) - 30;
-		if (GET_EQ(ch, WEAR_BOTHS))
-			bonus += MAX(25, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS))) - 25
-			+ MAX(30, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS))) - 30;
-		if (vict)
-		{
-			victim_modi -= int_app[GET_REAL_INT(vict)].observation;
-		}
-		break;
-		}
-
-	case SKILL_AWAKE:  // осторожный стиль
-	{
-		const size_t real_dex = static_cast<size_t>(GET_REAL_DEX(ch));
-		if (real_dex < INT_APP_SIZE)
-		{
-			bonus = int_app[real_dex].observation;
-
-			if (vict)
-			{
-				victim_modi -= int_app[GET_REAL_INT(vict)].observation;
-			}
-		}
-		else
-		{
-			log("SYSERR: Global buffer overflow for SKILL_AWAKE. Requested real_dex is %zd, but maximal allowed is %zd.",
-				real_dex, INT_APP_SIZE);
-		}
-	}
-	break;
-
-	case SKILL_IDENTIFY:
-		{
-		bonus = int_app[GET_REAL_INT(ch)].observation
-			+ (can_use_feat(ch, CONNOISEUR_FEAT) ? 20 : 0);
-		break;
-		}
-
-	case SKILL_CREATE_POTION:
-	case SKILL_CREATE_SCROLL:
-	case SKILL_CREATE_WAND:
-		break;
-
-	case SKILL_LOOK_HIDE:
-		{
-		bonus = cha_app[GET_REAL_CHA(ch)].illusive;
-		if (vict)
-		{
-			if (!CAN_SEE(vict, ch))
-				bonus += 50;
-			else if (AWAKE(vict))
-				victim_modi -= int_app[GET_REAL_INT(ch)].observation;
-		}
-		break;
-		}
-
-	case SKILL_ARMORED:
-		break;
-
-	case SKILL_DRUNKOFF:
-		{
-		bonus = -GET_REAL_CON(ch) / 2
-			+ (can_use_feat(ch, DRUNKARD_FEAT) ? 20 : 0);
-		break;
-		}
-
-	case SKILL_AID:    // лечить
-		{
-		bonus = (can_use_feat(ch, HEALER_FEAT) ? 10 : 0);
-		break;
-		}
-
-	case SKILL_FIRE:
-		{
-		if (get_room_sky(ch->in_room) == SKY_RAINING)
-			bonus -= 50;
-		else if (get_room_sky(ch->in_room) != SKY_LIGHTNING)
-			bonus -= number(10, 25);
-		break;
-		}
-
-	case SKILL_HORSE: // верховая езда
-		{
-		bonus = cha_app[GET_REAL_CHA(ch)].leadership;
-		break;
-		}
-
-	case SKILL_TURN_UNDEAD:  // изгнать нежить
-		{
-		break;
-		}
-
-	case SKILL_MORPH:
-		break;
-	case SKILL_STRANGLE: // удавить
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_REFLEX) -dex_bonus(GET_REAL_DEX(vict));
-		victim_sav = -GET_REAL_SAVING_REFLEX(vict);
-		bonus = dex_bonus(GET_REAL_DEX(ch));
-		//pass_mod = 1;
-		if (GET_MOB_HOLD(vict))
-		{
-			bonus += (skill_is + bonus) / 2;
-		}
-		else
-		{
-			if (!CAN_SEE(ch, vict))
-				bonus += (skill_is + bonus) / 5;
-			//if (vict->get_fighting() || (MOB_FLAGGED(vict, MOB_AWARE) || AFF_FLAGGED(vict, AFF_AWARNESS) || AWAKE(vict) ))
-				//victim_modi -= 40;
-			if (PRF_FLAGGED(vict, PRF_AWAKE))
-				victim_modi -= calculate_awake_mod(ch, vict);
-		}
-		break;
-		}
-
-	case SKILL_STUN: //ошеломить
-		{
-		//victim_sav = GET_SAVE(vict, SAVING_STABILITY) - dex_bonus(GET_REAL_CON(vict)) - GET_LEVEL(vict);
-		victim_sav = -GET_REAL_SAVING_STABILITY(vict);
-
-		if (!IS_NPC(vict))
-			victim_sav *= 2;
-		else
-			victim_sav -= GET_LEVEL(vict);
-
-		bonus = dex_bonus(GET_REAL_STR(ch));
-		if (GET_EQ(ch, WEAR_WIELD))
-			bonus +=
-			weapon_app[GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))].shocking;
-		else if (GET_EQ(ch, WEAR_BOTHS))
-			bonus +=
-			weapon_app[GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS))].shocking;
-
-		if (PRF_FLAGGED(vict, PRF_AWAKE))
-			victim_modi -= calculate_awake_mod(ch, vict);
-
-		// Полель не убираем учет удачи
-		//pass_mod = 1; //Убираем учет удачи
-		break;
-	}
-
-	default:
-		break;
-	}
-
-	//        if(IS_NPC(ch))
-	//        bonus = 0;
-	if (skill_no == SKILL_TRACK)
-	{
-		return percent;
-	}
-	else
-	{
-		percent = skill_is + bonus + victim_sav + victim_modi / 2;   // вычисление процента прохождения скила
-	}
-	if (PRF_FLAGGED(ch, PRF_AWAKE) && (skill_no == SKILL_BASH))
-		percent /= 2;
-
-	// не все умения надо модифицировать из-за внешних факторов и морали
-	bool abs_fail = false;
-	if (!pass_mod)
-	{
-		//		percent = complex_skill_modifier(ch, skill_no, GAPPLY_SKILL_SUCCESS, percent);
-		morale = ch->calc_morale();
-
-		//		if (vict && percent > skill_info[skill_no].max_percent)
-		//			victim_modi += percent - skill_info[skill_no].max_percent;
-
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
-			morale -= 20;	// у глухого мораль на 20 меньше
-		// Обработка способности "боевой дух"
-		if (vict && can_use_feat(vict, SPIRIT_WARRIOR_FEAT))
-			morale -= 10;
-
-		const int prob = number(0, 999);
-
-		int morale_bonus = morale;
-		if (morale < 0) {
-			morale_bonus = morale * 10;
-		}
-		const int bonus_limit = MIN(150, morale * 10);
-		fail_limit = MIN(990, 950 + morale_bonus * 10 / 6);
-		// Если prob попадает в полуинтервал [0, bonus_limit) - бонус в виде макс. процента и
-		// игнора спас-бросков, если в отрезок [fail_limit, 999] - способность фэйлится. Иначе
-		// все решают спас-броски.
-		if (morale >= 50)   // от 50 удачи абсолютный фейл не работает
-			fail_limit = 999;
-		if (prob >= fail_limit)
-		{   // Абсолютный фейл 4.9 процента
-			percent = 0;
-            abs_fail = true;
-		}
-		else if (prob < bonus_limit)
-		{
-			percent = max_percent + bonus;
-		}
-	}
-
-	// иммские флаги и прокла влияют на все
-	if (IS_IMMORTAL(ch))
-		percent = MAX(percent, skill_info[skill_no].max_percent);
-	else if (GET_GOD_FLAG(ch, GF_GODSCURSE))
-		percent = 0;
-	else if (vict && GET_GOD_FLAG(vict, GF_GODSCURSE))
-		percent = MAX(percent, max_percent);
-	else
-		percent = MIN(MAX(0, percent), max_percent);
-
-	ch->send_to_TC(false, true, true, "&CП: %s, Ц:  %s, Скилл: %d. Итог.скилл = %d, fail_limit = %d, Morale = %d, Bonus == %d, Сейвы цели = %d, Моди.цели = %d&n\r\n",
-									   ch?	GET_NAME(ch): "NULL" , vict? GET_NAME(vict) : "NULL", skill_no, percent, fail_limit, morale, bonus, victim_sav, victim_modi/2);
-	return (percent);
+int calculate_skill(CHAR_DATA *ch, const ESkill skill_no, CHAR_DATA *vict) {
+  //Зачем здесь было SAVING_REFLEX? Оно же просто число
+  int skill_is, percent = 0, victim_sav = 0,
+      victim_modi = 0; // текущее значение умения(прокачанность) / вычисляемый итоговый процент / савис жертвы,
+  // который влияет на прохождение скила / другие модификаторы, влияющие на прохождение
+  int morale = 0, max_percent = 200, bonus = 0, size = 0,
+      fail_limit = 950;  // удача пациента, максимально возможный процент скила, бонус от дополнительных параметров.
+  bool pass_mod = 0; // в данный момент для доп.выстрела, чтобы оставить его как скилл,
+  // но не применять к нему левых штрафов и плюсов, плюсуется только от инты немного
+
+  if (is_magic_skill(skill_no))
+    max_percent = 1000;
+
+  if (skill_no < SKILL_FIRST
+      || skill_no > MAX_SKILL_NUM)    // log("ERROR: ATTEMPT USING UNKNOWN SKILL <%d>", skill_no);
+  {
+    return 0;
+  }
+
+  if ((skill_is = ch->get_skill(skill_no)) <= 0) {
+    return 0;                                         // если скила нет возвращаем 0.
+  }
+
+  if (!IS_NPC(ch) && !ch->affected.empty()) {
+    for (const auto &aff : ch->affected) {
+      if (aff->location == APPLY_BONUS_SKILLS) // скушал свиток с эксп умелкой
+      {
+        skill_is += aff->modifier;
+      }
+
+      if (aff->location == APPLY_PLAQUE) {
+        skill_is -= number(ch->get_skill(skill_no) * 0.4,
+                           ch->get_skill(skill_no) * 0.05); // при лихорадке умелки ухудшаются на 5-30% рандом
+      }
+    }
+  }
+
+  skill_is += int_app[GET_REAL_INT(ch)].to_skilluse;
+  if (!IS_NPC(ch)) {
+    size = (MAX(0, GET_REAL_SIZE(ch) - 50));
+  } else {
+    size = size_app[GET_POS_SIZE(ch)].interpolate / 2;
+  }
+
+  switch (skill_no) {
+    case SKILL_HIDETRACK:          // замести следы
+    {
+      bonus = (can_use_feat(ch, STEALTHY_FEAT) ? 5 : 0);
+      break;
+    }
+
+    case SKILL_BACKSTAB:    //заколоть
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
+      victim_sav = -GET_REAL_SAVING_REFLEX(vict);
+      bonus = dex_bonus(GET_REAL_DEX(ch)) * 2;
+      if (awake_others(ch)
+          || equip_in_metall(ch)) {
+        bonus -= 50;
+      }
+
+      if (vict) {
+        if (!CAN_SEE(vict, ch)) {
+          bonus += 25;
+        }
+
+        if (GET_POS(vict) < POS_FIGHTING) {
+          bonus += (20 * (POS_FIGHTING - GET_POS(vict)));
+        } else if (AFF_FLAGGED(vict, EAffectFlag::AFF_AWARNESS)) {
+          victim_modi -= 30;
+        }
+        victim_modi += size_app[GET_POS_SIZE(vict)].ac;
+        victim_modi -= dex_bonus(GET_REAL_DEX(vict));
+      }
+      break;
+    }
+
+    case SKILL_BASH:    //сбить
+    {
+      victim_sav = -GET_REAL_SAVING_REFLEX(vict);
+      bonus = size
+          + dex_bonus(GET_REAL_DEX(ch))
+          + (GET_EQ(ch, WEAR_SHIELD)
+             ? weapon_app[MIN(35, MAX(0, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_SHIELD))))].bashing
+             : 0);
+      if (vict) {
+        if (GET_POS(vict) < POS_FIGHTING && GET_POS(vict) > POS_SLEEPING) {
+          victim_modi -= 20;
+        }
+        if (PRF_FLAGGED(vict, PRF_AWAKE)) {
+          victim_modi -= calculate_awake_mod(ch, vict);
+        }
+      }
+      break;
+    }
+
+    case SKILL_HIDE:    //спрятаться
+    {
+      bonus = dex_bonus(GET_REAL_DEX(ch))
+          - size_app[GET_POS_SIZE(ch)].ac
+          + (can_use_feat(ch, STEALTHY_FEAT) ? 5 : 0);
+
+      if (awake_others(ch) || equip_in_metall(ch)) {
+        bonus -= 50;
+      }
+
+      if (IS_DARK(ch->in_room)) {
+        bonus += 25;
+      }
+
+      if (SECT(ch->in_room) == SECT_INSIDE) {
+        bonus += 20;
+      } else if (SECT(ch->in_room) == SECT_CITY) {
+        bonus -= 15;
+      } else if (SECT(ch->in_room) == SECT_FOREST) {
+        bonus += 20;
+      } else if (SECT(ch->in_room) == SECT_HILLS
+          || SECT(ch->in_room) == SECT_MOUNTAIN) {
+        bonus += 10;
+      }
+
+      if (vict) {
+        if (AWAKE(vict)) {
+          victim_modi -= int_app[GET_REAL_INT(vict)].observation;
+        }
+      }
+      break;
+    }
+
+    case SKILL_KICK:    //пнуть
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_STABILITY) - dex_bonus(GET_REAL_CON(vict));
+      victim_sav = -GET_REAL_SAVING_STABILITY(vict);
+      bonus = dex_bonus(GET_REAL_DEX(ch)) + dex_bonus(GET_REAL_STR(ch));
+      if (vict) {
+        victim_modi += size_app[GET_POS_SIZE(vict)].interpolate;
+        victim_modi -= GET_REAL_CON(vict);
+        if (PRF_FLAGGED(vict, PRF_AWAKE)) {
+          victim_modi -= calculate_awake_mod(ch, vict);
+        }
+      }
+      break;
+    }
+
+    case SKILL_PICK_LOCK:    // взлом
+    {
+      bonus = dex_bonus(GET_REAL_DEX(ch))
+          + (can_use_feat(ch, NIMBLE_FINGERS_FEAT) ? 5 : 0);
+      break;
+    }
+
+    case SKILL_PUNCH:    //удар левой рукой
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
+      victim_sav = -GET_REAL_SAVING_REFLEX(vict);
+      break;
+    }
+
+    case SKILL_RESCUE:    //спасти
+    {
+      bonus = dex_bonus(GET_REAL_DEX(ch));
+      //		victim_modi = 100;
+      break;
+    }
+
+    case SKILL_SNEAK:    // Подкрасться
+    {
+      bonus = dex_bonus(GET_REAL_DEX(ch))
+          + (can_use_feat(ch, STEALTHY_FEAT) ? 10 : 0);
+
+      if (awake_others(ch) || equip_in_metall(ch))
+        bonus -= 50;
+
+      if (SECT(ch->in_room) == SECT_CITY)
+        bonus -= 10;
+      if (IS_DARK(ch->in_room))
+        bonus += 20;
+
+      if (vict) {
+        if (GET_LEVEL(vict) > 35)
+          bonus -= 50;
+        if (!CAN_SEE(vict, ch))
+          bonus += 25;
+        if (AWAKE(vict)) {
+          victim_modi -= int_app[GET_REAL_INT(vict)].observation;
+        }
+      }
+      break;
+    }
+
+    case SKILL_STEAL:    // Украсть
+    {
+      bonus = dex_bonus(GET_REAL_DEX(ch))
+          + (can_use_feat(ch, NIMBLE_FINGERS_FEAT) ? 5 : 0);
+
+      if (awake_others(ch) || equip_in_metall(ch))
+        bonus -= 50;
+      /* работает только для блестящих предметов, так как в темное татям и купцам другое не видно*/
+      if (IS_DARK(ch->in_room))
+        bonus += 20;
+
+      if (vict) {
+        //victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
+        victim_sav = -GET_REAL_SAVING_REFLEX(vict);
+        if (!CAN_SEE(vict, ch))
+          bonus += 25;
+        if (AWAKE(vict)) {
+          victim_modi -= int_app[GET_REAL_INT(vict)].observation;
+          if (AFF_FLAGGED(vict, EAffectFlag::AFF_AWARNESS))
+            bonus -= 30;
+        }
+      }
+      break;
+    }
+
+    case SKILL_TRACK:       //выследить
+    {
+      percent = skill_is + int_app[GET_REAL_INT(ch)].observation
+          + (can_use_feat(ch, TRACKER_FEAT) ? 10 : 0);
+
+      if (SECT(ch->in_room) == SECT_FOREST || SECT(ch->in_room) == SECT_FIELD)
+        percent += 10;
+
+      percent = complex_skill_modifier(ch, SKILL_INDEFINITE, GAPPLY_SKILL_SUCCESS, percent);
+
+      if (SECT(ch->in_room) == SECT_WATER_SWIM ||
+          SECT(ch->in_room) == SECT_WATER_NOSWIM ||
+          SECT(ch->in_room) == SECT_FLYING ||
+          SECT(ch->in_room) == SECT_UNDERWATER ||
+          SECT(ch->in_room) == SECT_SECRET
+          || ROOM_FLAGGED(ch->in_room, ROOM_NOTRACK))
+        percent = 0;
+
+      if (vict) {
+        victim_modi += GET_REAL_CON(vict) / 2;
+        if (AFF_FLAGGED(vict, EAffectFlag::AFF_NOTRACK)
+            || ROOM_FLAGGED(ch->in_room, ROOM_NOTRACK)) {
+          victim_modi = -100;
+        }
+      }
+      break;
+    }
+
+    case SKILL_SENSE: // найти
+    {
+      bonus = int_app[GET_REAL_INT(ch)].observation
+          + (can_use_feat(ch, TRACKER_FEAT) ? 20 : 0);
+      break;
+    }
+
+    case SKILL_MULTYPARRY:  // веерная защита
+    case SKILL_PARRY:    //парировать
+    {
+      victim_sav = dex_bonus(GET_REAL_DEX(vict));
+      bonus = dex_bonus(GET_REAL_DEX(ch));
+      if (GET_AF_BATTLE(ch, EAF_AWAKE)) {
+        bonus += ch->get_skill(SKILL_AWAKE);
+      }
+
+      if (GET_EQ(ch, WEAR_HOLD)
+          && GET_OBJ_TYPE(GET_EQ(ch, WEAR_HOLD)) == OBJ_DATA::ITEM_WEAPON) {
+        bonus += weapon_app[MAX(0, MIN(50, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))))].parrying;
+      }
+      victim_modi = 100;
+      break;
+    }
+
+    case SKILL_BLOCK:    //закрыться щитом
+    {        // по 10 бонусом со щита (21-30) и дексы (21-50)
+      int shield_mod = GET_EQ(ch, WEAR_SHIELD) ? MIN(10, MAX(0, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_SHIELD)) - 20)) : 0;
+      int dex_mod = MAX(0, (GET_REAL_DEX(ch) - 20) / 3);
+      bonus = dex_mod + shield_mod;
+      break;
+    }
+
+    case SKILL_TOUCH:    //захватить противника
+    {
+      victim_sav = dex_bonus(GET_REAL_DEX(vict));
+      bonus = dex_bonus(GET_REAL_DEX(ch)) +
+          size_app[GET_POS_SIZE(vict)].interpolate;
+
+      if (vict) {
+        victim_modi -= dex_bonus(GET_REAL_DEX(vict));
+        victim_modi -= size_app[GET_POS_SIZE(vict)].interpolate;
+      }
+      break;
+    }
+
+    case SKILL_PROTECT:    //прикрыть грудью
+    {
+      bonus = dex_bonus(GET_REAL_DEX(ch)) + size;
+      victim_modi = 50;
+      break;
+    }
+
+    case SKILL_BOWS:    //луки
+    {
+      bonus = dex_bonus(GET_REAL_DEX(ch));
+      break;
+    }
+
+    case SKILL_BOTHHANDS:    //двуручники
+    case SKILL_LONGS:    //длинные лезвия
+    case SKILL_SPADES:    //копья и пики
+    case SKILL_SHORTS:    //короткие лезвия
+    case SKILL_CLUBS:    //палицы и дубины
+    case SKILL_PICK:    //проникающее
+    case SKILL_NONSTANDART:    //разнообразное оружие
+    case SKILL_AXES:    //секиры
+      //victim_sav = GET_SAVE(vict, SAVING_REFLEX);
+      break;
+
+    case SKILL_SATTACK:    //атака второй рукой
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_REFLEX);
+      victim_sav = -GET_REAL_SAVING_REFLEX(vict) + dex_bonus(GET_REAL_DEX(ch)); //equal
+      break;
+    }
+
+    case SKILL_LOOKING:    //приглядеться
+    {
+      bonus = int_app[GET_REAL_INT(ch)].observation;
+      break;
+    }
+
+    case SKILL_HEARING:    //прислушаться
+    {
+      bonus = int_app[GET_REAL_INT(ch)].observation;
+      break;
+    }
+
+    case SKILL_DISARM: {
+      //victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
+      victim_sav = -GET_REAL_SAVING_REFLEX(vict);
+      bonus = dex_bonus(GET_REAL_DEX(ch)) + dex_bonus(GET_REAL_STR(ch));
+      if (vict) {
+        victim_modi -= dex_bonus(GET_REAL_STR(ch));
+        if (GET_EQ(vict, WEAR_BOTHS))
+          victim_modi -= 10;
+        if (PRF_FLAGGED(vict, PRF_AWAKE))
+          victim_modi -= calculate_awake_mod(ch, vict);
+      }
+      break;
+    }
+
+      //насколько я понимаю не используемое умение
+    case SKILL_HEAL:   // лечить
+      break;
+
+    case SKILL_ADDSHOT:   // дополнительный выстрел
+    {
+      if (equip_in_metall(ch))
+        bonus -= 5;
+      pass_mod = 1;
+      break;
+    }
+
+    case SKILL_NOPARRYHIT: {
+      bonus = dex_bonus(GET_REAL_DEX(ch));
+      break;
+    }
+
+    case SKILL_CAMOUFLAGE: // маскировка
+    {
+      bonus = dex_bonus(GET_REAL_DEX(ch)) - size_app[GET_POS_SIZE(ch)].ac
+          + (can_use_feat(ch, STEALTHY_FEAT) ? 5 : 0);
+
+      if (awake_others(ch))
+        bonus -= 100;
+
+      if (IS_DARK(ch->in_room))
+        bonus += 15;
+
+      if (SECT(ch->in_room) == SECT_CITY)
+        bonus -= 15;
+      else if (SECT(ch->in_room) == SECT_FOREST)
+        bonus += 10;
+      else if (SECT(ch->in_room) == SECT_HILLS
+          || SECT(ch->in_room) == SECT_MOUNTAIN)
+        bonus += 5;
+      if (equip_in_metall(ch))
+        bonus -= 30;
+
+      if (vict) {
+        if (AWAKE(vict))
+          victim_modi -= int_app[GET_REAL_INT(vict)].observation;
+      }
+      break;
+    }
+
+    case SKILL_DEVIATE:  // уклониться
+    {
+      bonus = -size_app[GET_POS_SIZE(ch)].ac +
+          dex_bonus(GET_REAL_DEX(ch));
+
+      if (equip_in_metall(ch))
+        bonus -= 40;
+
+      if (vict) {
+        victim_modi -= dex_bonus(GET_REAL_DEX(vict));
+      }
+      break;
+    }
+
+    case SKILL_CHOPOFF:  // подножка
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_REFLEX) - dex_bonus(GET_REAL_DEX(vict));
+      victim_sav = -GET_REAL_SAVING_REFLEX(vict);
+      bonus = dex_bonus(GET_REAL_DEX(ch)) + ((dex_bonus(GET_REAL_DEX(ch)) * 5) / 10)
+          + size_app[GET_POS_SIZE(ch)].ac; // тест х3 признан вредительским
+      if (equip_in_metall(ch))
+        bonus -= 10;
+      if (vict) {
+        if (!CAN_SEE(vict, ch))
+          bonus += 10;
+        if (GET_POS(vict) < POS_SITTING)
+          bonus -= 50;
+        if (AWAKE(vict) || AFF_FLAGGED(vict, EAffectFlag::AFF_AWARNESS) || MOB_FLAGGED(vict, MOB_AWAKE))
+          victim_modi -= 20;
+        if (PRF_FLAGGED(vict, PRF_AWAKE))
+          victim_modi -= calculate_awake_mod(ch, vict);
+        // в пинке режем дамаг
+        //			if (GET_AF_BATTLE(vict, EAF_AWAKE))
+        //				victim_modi -= calculate_awake_mod(ch, vict);
+        //			victim_modi -= int_app[GET_REAL_INT(vict)].observation;
+      }
+      break;
+    }
+
+    case SKILL_REPAIR: // починка
+      break;
+    case SKILL_UPGRADE:  //заточить
+    case SKILL_WARCRY: break;
+    case SKILL_COURAGE: break;
+    case SKILL_SHIT: break;
+    case SKILL_MIGHTHIT: // богатырский молот
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_STABILITY) - dex_bonus(GET_REAL_CON(vict));
+      victim_sav = -GET_REAL_SAVING_STABILITY(vict);
+      //bonus = size + dex_bonus(GET_REAL_STR(ch));
+      bonus = size + dex_bonus(GET_REAL_STR(ch));
+
+      if (IS_NPC(vict))
+        victim_modi -= (size_app[GET_POS_SIZE(vict)].shocking) / 2;
+      else
+        victim_modi -= size_app[GET_POS_SIZE(vict)].shocking;
+      break;
+    }
+
+    case SKILL_STUPOR:  // оглушить
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_STABILITY) - dex_bonus(GET_REAL_CON(vict));
+      victim_sav = -GET_REAL_SAVING_STABILITY(vict);
+      bonus = dex_bonus(GET_REAL_STR(ch));
+      if (GET_EQ(ch, WEAR_WIELD))
+        bonus +=
+            weapon_app[GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))].shocking;
+      else if (GET_EQ(ch, WEAR_BOTHS))
+        bonus +=
+            weapon_app[GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS))].shocking;
+
+      if (vict) {
+        victim_modi -= GET_REAL_CON(vict);
+      }
+      break;
+    }
+
+    case SKILL_POISONED:  // отравление
+      break;
+    case SKILL_LEADERSHIP: //лидерство
+    {
+      bonus = cha_app[GET_REAL_CHA(ch)].leadership;
+      break;
+    }
+
+    case SKILL_PUNCTUAL:  // точный стиль
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_CRITICAL) - dex_bonus(GET_REAL_CON(vict));
+      victim_sav = -GET_REAL_SAVING_CRITICAL(vict);
+      bonus = dex_bonus(GET_REAL_INT(ch));
+      if (GET_EQ(ch, WEAR_WIELD))
+        bonus += MAX(18, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))) - 18
+            + MAX(25, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))) - 25
+            + MAX(30, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))) - 30;
+      if (GET_EQ(ch, WEAR_HOLD))
+        bonus += MAX(18, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))) - 18
+            + MAX(25, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))) - 25
+            + MAX(30, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_HOLD))) - 30;
+      if (GET_EQ(ch, WEAR_BOTHS))
+        bonus += MAX(25, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS))) - 25
+            + MAX(30, GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS))) - 30;
+      if (vict) {
+        victim_modi -= int_app[GET_REAL_INT(vict)].observation;
+      }
+      break;
+    }
+
+    case SKILL_AWAKE:  // осторожный стиль
+    {
+      const size_t real_dex = static_cast<size_t>(GET_REAL_DEX(ch));
+      if (real_dex < INT_APP_SIZE) {
+        bonus = int_app[real_dex].observation;
+
+        if (vict) {
+          victim_modi -= int_app[GET_REAL_INT(vict)].observation;
+        }
+      } else {
+        log("SYSERR: Global buffer overflow for SKILL_AWAKE. Requested real_dex is %zd, but maximal allowed is %zd.",
+            real_dex, INT_APP_SIZE);
+      }
+    }
+      break;
+
+    case SKILL_IDENTIFY: {
+      bonus = int_app[GET_REAL_INT(ch)].observation
+          + (can_use_feat(ch, CONNOISEUR_FEAT) ? 20 : 0);
+      break;
+    }
+
+    case SKILL_CREATE_POTION:
+    case SKILL_CREATE_SCROLL:
+    case SKILL_CREATE_WAND: break;
+
+    case SKILL_LOOK_HIDE: {
+      bonus = cha_app[GET_REAL_CHA(ch)].illusive;
+      if (vict) {
+        if (!CAN_SEE(vict, ch))
+          bonus += 50;
+        else if (AWAKE(vict))
+          victim_modi -= int_app[GET_REAL_INT(ch)].observation;
+      }
+      break;
+    }
+
+    case SKILL_ARMORED: break;
+
+    case SKILL_DRUNKOFF: {
+      bonus = -GET_REAL_CON(ch) / 2
+          + (can_use_feat(ch, DRUNKARD_FEAT) ? 20 : 0);
+      break;
+    }
+
+    case SKILL_AID:    // лечить
+    {
+      bonus = (can_use_feat(ch, HEALER_FEAT) ? 10 : 0);
+      break;
+    }
+
+    case SKILL_FIRE: {
+      if (get_room_sky(ch->in_room) == SKY_RAINING)
+        bonus -= 50;
+      else if (get_room_sky(ch->in_room) != SKY_LIGHTNING)
+        bonus -= number(10, 25);
+      break;
+    }
+
+    case SKILL_HORSE: // верховая езда
+    {
+      bonus = cha_app[GET_REAL_CHA(ch)].leadership;
+      break;
+    }
+
+    case SKILL_TURN_UNDEAD:  // изгнать нежить
+    {
+      break;
+    }
+
+    case SKILL_MORPH: break;
+    case SKILL_STRANGLE: // удавить
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_REFLEX) -dex_bonus(GET_REAL_DEX(vict));
+      victim_sav = -GET_REAL_SAVING_REFLEX(vict);
+      bonus = dex_bonus(GET_REAL_DEX(ch));
+      //pass_mod = 1;
+      if (GET_MOB_HOLD(vict)) {
+        bonus += (skill_is + bonus) / 2;
+      } else {
+        if (!CAN_SEE(ch, vict))
+          bonus += (skill_is + bonus) / 5;
+        //if (vict->get_fighting() || (MOB_FLAGGED(vict, MOB_AWARE) || AFF_FLAGGED(vict, AFF_AWARNESS) || AWAKE(vict) ))
+        //victim_modi -= 40;
+        if (PRF_FLAGGED(vict, PRF_AWAKE))
+          victim_modi -= calculate_awake_mod(ch, vict);
+      }
+      break;
+    }
+
+    case SKILL_STUN: //ошеломить
+    {
+      //victim_sav = GET_SAVE(vict, SAVING_STABILITY) - dex_bonus(GET_REAL_CON(vict)) - GET_LEVEL(vict);
+      victim_sav = -GET_REAL_SAVING_STABILITY(vict);
+
+      if (!IS_NPC(vict))
+        victim_sav *= 2;
+      else
+        victim_sav -= GET_LEVEL(vict);
+
+      bonus = dex_bonus(GET_REAL_STR(ch));
+      if (GET_EQ(ch, WEAR_WIELD))
+        bonus +=
+            weapon_app[GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD))].shocking;
+      else if (GET_EQ(ch, WEAR_BOTHS))
+        bonus +=
+            weapon_app[GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS))].shocking;
+
+      if (PRF_FLAGGED(vict, PRF_AWAKE))
+        victim_modi -= calculate_awake_mod(ch, vict);
+
+      // Полель не убираем учет удачи
+      //pass_mod = 1; //Убираем учет удачи
+      break;
+    }
+
+    default: break;
+  }
+
+  //        if(IS_NPC(ch))
+  //        bonus = 0;
+  if (skill_no == SKILL_TRACK) {
+    return percent;
+  } else {
+    percent = skill_is + bonus + victim_sav + victim_modi / 2;   // вычисление процента прохождения скила
+  }
+  if (PRF_FLAGGED(ch, PRF_AWAKE) && (skill_no == SKILL_BASH)) {
+    percent /= 2;
+  }
+
+  // не все умения надо модифицировать из-за внешних факторов и морали
+  bool abs_fail = false;
+  if (!pass_mod) {
+    //		percent = complex_skill_modifier(ch, skill_no, GAPPLY_SKILL_SUCCESS, percent);
+    morale = ch->calc_morale();
+
+    //		if (vict && percent > skill_info[skill_no].max_percent)
+    //			victim_modi += percent - skill_info[skill_no].max_percent;
+
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_DEAFNESS))
+      morale -= 20;    // у глухого мораль на 20 меньше
+    // Обработка способности "боевой дух"
+    if (vict && can_use_feat(vict, SPIRIT_WARRIOR_FEAT))
+      morale -= 10;
+
+    const int prob = number(0, 999);
+
+    int morale_bonus = morale;
+    if (morale < 0) {
+      morale_bonus = morale * 10;
+    }
+    const int bonus_limit = MIN(150, morale * 10);
+    fail_limit = MIN(990, 950 + morale_bonus * 10 / 6);
+    // Если prob попадает в полуинтервал [0, bonus_limit) - бонус в виде макс. процента и
+    // игнора спас-бросков, если в отрезок [fail_limit, 999] - способность фэйлится. Иначе
+    // все решают спас-броски.
+    if (morale >= 50)   // от 50 удачи абсолютный фейл не работает
+      fail_limit = 999;
+    if (prob >= fail_limit) {   // Абсолютный фейл 4.9 процента
+      percent = 0;
+      abs_fail = true;
+    } else if (prob < bonus_limit) {
+      percent = max_percent + bonus;
+    }
+  }
+
+  // иммские флаги и прокла влияют на все
+  if (IS_IMMORTAL(ch))
+    percent = MAX(percent, skill_info[skill_no].max_percent);
+  else if (GET_GOD_FLAG(ch, GF_GODSCURSE))
+    percent = 0;
+  else if (vict && GET_GOD_FLAG(vict, GF_GODSCURSE))
+    percent = MAX(percent, max_percent);
+  else
+    percent = MIN(MAX(0, percent), max_percent);
+
+  ch->send_to_TC(false,
+                 true,
+                 true,
+                 "&CП: %s, Ц:  %s, Скилл: %d. Итог.скилл = %d, fail_limit = %d, Morale = %d, Bonus == %d, Сейвы цели = %d, Моди.цели = %d&n\r\n",
+                 ch ? GET_NAME(ch) : "NULL",
+                 vict ? GET_NAME(vict) : "NULL",
+                 skill_no,
+                 percent,
+                 fail_limit,
+                 morale,
+                 bonus,
+                 victim_sav,
+                 victim_modi / 2);
+  return (percent);
 }
 
-void improve_skill(CHAR_DATA * ch, const ESkill skill_no, int success, CHAR_DATA * victim)
-{
-	const int trained_skill = ch->get_trained_skill(skill_no);
-	if ((trained_skill <= 0 || trained_skill >= CAP_SKILLS) && !is_magic_skill(skill_no))
-	{
-		// скила может и не быть, если получен только со шмоток
-		return;
-	}
+void improve_skill(CHAR_DATA *ch, const ESkill skill_no, int success, CHAR_DATA *victim) {
+  const int trained_skill = ch->get_trained_skill(skill_no);
+  if ((trained_skill <= 0 || trained_skill >= CAP_SKILLS) && !is_magic_skill(skill_no)) {
+    // скила может и не быть, если получен только со шмоток
+    return;
+  }
 
-	if (IS_NPC(ch))
-	{
-		return;
-	}
-	if (ch->agrobd) //чтоб на согрупниках не качалось
-	{
-		return;
-	}
-	if (victim && victim->get_master())
-	{
-		if (!IS_NPC(victim->get_master()))
-			return;
-	}
-	if (victim &&
-		(MOB_FLAGGED(victim, MOB_MOUNTING)|| MOB_FLAGGED(victim, MOB_NOTRAIN)))
-	{
-		return;
-	}
+  if (IS_NPC(ch)) {
+    return;
+  }
+  if (ch->agrobd) //чтоб на согрупниках не качалось
+  {
+    return;
+  }
+  if (victim && victim->get_master()) {
+    if (!IS_NPC(victim->get_master()))
+      return;
+  }
+  if (victim &&
+      (MOB_FLAGGED(victim, MOB_MOUNTING) || MOB_FLAGGED(victim, MOB_NOTRAIN))) {
+    return;
+  }
 
-	int skill_is, prob, div;
+  int skill_is, prob, div;
 
-	if ((!victim || OK_GAIN_EXP(ch, victim)) && ch->in_room != NOWHERE && !ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL)
-			&& !ROOM_FLAGGED(ch->in_room, ROOM_ARENA) && !ROOM_FLAGGED(ch->in_room, ROOM_HOUSE) && !ROOM_FLAGGED(ch->in_room, ROOM_ATRIUM)
-			&&  (max_upgradable_skill(ch) - trained_skill > 0))
-	{
-		// Success - multy by 2
-		prob = success ? 20000 : 15000;
+  if ((!victim || OK_GAIN_EXP(ch, victim)) && ch->in_room != NOWHERE && !ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL)
+      && !ROOM_FLAGGED(ch->in_room, ROOM_ARENA) && !ROOM_FLAGGED(ch->in_room, ROOM_HOUSE)
+      && !ROOM_FLAGGED(ch->in_room, ROOM_ATRIUM)
+      && (max_upgradable_skill(ch) - trained_skill > 0)) {
+    // Success - multy by 2
+    prob = success ? 20000 : 15000;
 
 
-	// Если чар нуб, то до 50% скиллы качаются гораздо быстрее
-	int INT_PLAYER = (ch->get_trained_skill(skill_no) < 51 && (AFF_FLAGGED(ch, EAffectFlag::AFF_NOOB_REGEN))) ? 50 : GET_REAL_INT(ch);
-	div = int_app[INT_PLAYER].improve;
+    // Если чар нуб, то до 50% скиллы качаются гораздо быстрее
+    int INT_PLAYER = (ch->get_trained_skill(skill_no) < 51 && (AFF_FLAGGED(ch, EAffectFlag::AFF_NOOB_REGEN))) ? 50
+                                                                                                              : GET_REAL_INT(
+            ch);
+    div = int_app[INT_PLAYER].improve;
 
-		if ((int)GET_CLASS(ch) >= 0 && (int)GET_CLASS(ch) < NUM_PLAYER_CLASSES)
-		{
-			div += (skill_info[skill_no].k_improve[(int)GET_CLASS(ch)][(int)GET_KIN(ch)] / 100);
-		}
+    if ((int) GET_CLASS(ch) >= 0 && (int) GET_CLASS(ch) < NUM_PLAYER_CLASSES) {
+      div += (skill_info[skill_no].k_improve[(int) GET_CLASS(ch)][(int) GET_KIN(ch)] / 100);
+    }
 
-		prob /= (MAX(1, div));
-		// вариант бонуса мудрости без штрафов за кол-во умений
-		prob -= 5 * wis_bonus(GET_REAL_WIS(ch), WIS_MAX_SKILLS);
-		prob += number(1, trained_skill * 5);
+    prob /= std::max(1, div);
+    // вариант бонуса мудрости без штрафов за кол-во умений
+    prob -= 5 * wis_bonus(GET_REAL_WIS(ch), WIS_MAX_SKILLS);
+    prob += number(1, trained_skill * 5);
 
-		skill_is = number(1, MAX(1, prob));
+    skill_is = number(1, MAX(1, prob));
 
-		if ((skill_no == SKILL_STEAL) && (!IS_NPC(victim)))
-		{
-			return;
-		}
-		if ((victim && skill_is <= GET_REAL_INT(ch) * GET_LEVEL(victim) / GET_LEVEL(ch))
-			|| (!victim && skill_is <= GET_REAL_INT(ch)))
-		{
-			if (success)
-			{
-				sprintf(buf, "%sВы повысили уровень умения \"%s\".%s\r\n",
-					CCICYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
-			}
-			else
-			{
-				sprintf(buf, "%sПоняв свои ошибки, вы повысили уровень умения \"%s\".%s\r\n",
-					CCICYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
-			}
-			send_to_char(buf, ch);
-			ch->set_morphed_skill(skill_no, (trained_skill + number(1, 2)));
-			if (!IS_IMMORTAL(ch))
-			{
-				ch->set_morphed_skill(skill_no, (MIN(MAX_EXP_PERCENT + GET_REMORT(ch) * 5, ch->get_trained_skill(skill_no))));
-			}
-			// скилл прокачался, помечаю моба (если он есть)
-			if (victim && IS_NPC(victim))
-			{
-				MOB_FLAGS(victim).set(MOB_NOTRAIN);
-			}
-		}
-	}
+    if ((skill_no == SKILL_STEAL) && (!IS_NPC(victim))) {
+      return;
+    }
+    if ((victim && skill_is <= GET_REAL_INT(ch) * GET_LEVEL(victim) / GET_LEVEL(ch))
+        || (!victim && skill_is <= GET_REAL_INT(ch))) {
+      if (success) {
+        sprintf(buf, "%sВы повысили уровень умения \"%s\".%s\r\n",
+                CCICYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
+      } else {
+        sprintf(buf, "%sПоняв свои ошибки, вы повысили уровень умения \"%s\".%s\r\n",
+                CCICYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
+      }
+      send_to_char(buf, ch);
+      ch->set_morphed_skill(skill_no, (trained_skill + number(1, 2)));
+      if (!IS_IMMORTAL(ch)) {
+        ch->set_morphed_skill(skill_no, (MIN(MAX_EXP_PERCENT + GET_REMORT(ch) * 5, ch->get_trained_skill(skill_no))));
+      }
+      // скилл прокачался, помечаю моба (если он есть)
+      if (victim && IS_NPC(victim)) {
+        MOB_FLAGS(victim).set(MOB_NOTRAIN);
+      }
+    }
+  }
 }
 
-int train_skill(CHAR_DATA * ch, const ESkill skill_no, int max_value, CHAR_DATA * vict)
-{
-	int percent = 0;
+void train_skill(CHAR_DATA *ch, const ESkill skill_no, bool success, CHAR_DATA *vict) {
+  if (!IS_NPC(ch)) {
+    if (skill_no != SKILL_SATTACK
+        && ch->get_trained_skill(skill_no) > 0
+        && (!vict
+            || (IS_NPC(vict)
+                && !MOB_FLAGGED(vict, MOB_PROTECT)
+                && !MOB_FLAGGED(vict, MOB_NOTRAIN)
+                && !AFF_FLAGGED(vict, EAffectFlag::AFF_CHARM)
+                && !IS_HORSE(vict)))) {
+      improve_skill(ch, skill_no, success, vict);
+    }
+  } else if (!IS_CHARMICE(ch)) {
+    if (ch->get_skill(skill_no) > 0
+        && GET_REAL_INT(ch) <= number(0, 1000 - 20 * GET_REAL_WIS(ch))
+        && ch->get_skill(skill_no) < skill_info[skill_no].max_percent) {
+      ch->set_skill(skill_no, ch->get_skill(skill_no) + 1);
+    }
+  }
 
-	percent = calculate_skill(ch, skill_no, vict);
-	if (!IS_NPC(ch))
-	{
-		if (skill_no != SKILL_SATTACK
-			&& ch->get_trained_skill(skill_no) > 0
-			&& (!vict
-				|| (IS_NPC(vict)
-					&& !MOB_FLAGGED(vict, MOB_PROTECT)
-					&& !MOB_FLAGGED(vict, MOB_NOTRAIN)
-					&& !AFF_FLAGGED(vict, EAffectFlag::AFF_CHARM)
-					&& !IS_HORSE(vict))))
-		{
-			improve_skill(ch, skill_no, percent >= max_value, vict);
-		}
-	}
-	else if (!IS_CHARMICE(ch))
-	{
-		if (ch->get_skill(skill_no) > 0
-			&& GET_REAL_INT(ch) <= number(0, 1000 - 20 * GET_REAL_WIS(ch))
-			&& ch->get_skill(skill_no) < skill_info[skill_no].max_percent)
-		{
-			ch->set_skill(skill_no, ch->get_skill(skill_no) + 1);
-		}
-	}
-
-	return (percent);
+  return;
 }
 
 /**
 * Расчет влияния осторожки у victim против умений killer.
 * В данный момент учитывается случай 'игрок против игрока', где осторожка считается как скилл/2
 */
-int calculate_awake_mod(CHAR_DATA *killer, CHAR_DATA *victim)
-{
-	int result = 0;
-	if (!killer || !victim)
-	{
-		log("SYSERROR: zero character in calculate_awake_mod.");
-	}
-	else if (IS_NPC(killer) || IS_NPC(victim))
-	{
-		result = victim->get_skill(SKILL_AWAKE);
-	}
-	else
-	{
-		result = victim->get_skill(SKILL_AWAKE) / 2;
-	}
-	return result;
+int calculate_awake_mod(CHAR_DATA *killer, CHAR_DATA *victim) {
+  int result = 0;
+  if (!killer || !victim) {
+    log("SYSERROR: zero character in calculate_awake_mod.");
+  } else if (IS_NPC(killer) || IS_NPC(victim)) {
+    result = victim->get_skill(SKILL_AWAKE);
+  } else {
+    result = victim->get_skill(SKILL_AWAKE) / 2;
+  }
+  return result;
 }
 
-int find_weapon_focus_by_skill(ESkill skill)
-{
-	switch (skill)
-	{
-	case SKILL_PUNCH:
-		return PUNCH_FOCUS_FEAT;
-	break;
-	case SKILL_CLUBS:
-		return CLUB_FOCUS_FEAT;
-	break;
-	case SKILL_AXES:
-		return AXES_FOCUS_FEAT;
-	break;
-	case SKILL_LONGS:
-		return LONGS_FOCUS_FEAT;
-	break;
-	case SKILL_SHORTS:
-		return SHORTS_FOCUS_FEAT;
-	break;
-	case SKILL_NONSTANDART:
-		return NONSTANDART_FOCUS_FEAT;
-	break;
-	case SKILL_BOTHHANDS:
-		return BOTHHANDS_FOCUS_FEAT;
-	break;
-	case SKILL_PICK:
-		return PICK_FOCUS_FEAT;
-	break;
-	case SKILL_SPADES:
-		return SPADES_FOCUS_FEAT;
-	break;
-	case SKILL_BOWS:
-		return BOWS_FOCUS_FEAT;
-	break;
-	default:
-		return INCORRECT_FEAT;
-	}
+int find_weapon_focus_by_skill(ESkill skill) {
+  switch (skill) {
+    case SKILL_PUNCH: return PUNCH_FOCUS_FEAT;
+      break;
+    case SKILL_CLUBS: return CLUB_FOCUS_FEAT;
+      break;
+    case SKILL_AXES: return AXES_FOCUS_FEAT;
+      break;
+    case SKILL_LONGS: return LONGS_FOCUS_FEAT;
+      break;
+    case SKILL_SHORTS: return SHORTS_FOCUS_FEAT;
+      break;
+    case SKILL_NONSTANDART: return NONSTANDART_FOCUS_FEAT;
+      break;
+    case SKILL_BOTHHANDS: return BOTHHANDS_FOCUS_FEAT;
+      break;
+    case SKILL_PICK: return PICK_FOCUS_FEAT;
+      break;
+    case SKILL_SPADES: return SPADES_FOCUS_FEAT;
+      break;
+    case SKILL_BOWS: return BOWS_FOCUS_FEAT;
+      break;
+    default: return INCORRECT_FEAT;
+  }
 }
 
-int find_weapon_master_by_skill(ESkill skill)
-{
-	switch (skill)
-	{
-	case SKILL_PUNCH:
-		return PUNCH_MASTER_FEAT;
-	break;
-	case SKILL_CLUBS:
-		return CLUBS_MASTER_FEAT;
-	break;
-	case SKILL_AXES:
-		return AXES_MASTER_FEAT;
-	break;
-	case SKILL_LONGS:
-		return LONGS_MASTER_FEAT;
-	break;
-	case SKILL_SHORTS:
-		return SHORTS_MASTER_FEAT;
-	break;
-	case SKILL_NONSTANDART:
-		return NONSTANDART_MASTER_FEAT;
-	break;
-	case SKILL_BOTHHANDS:
-		return BOTHHANDS_MASTER_FEAT;
-	break;
-	case SKILL_PICK:
-		return PICK_MASTER_FEAT;
-	break;
-	case SKILL_SPADES:
-		return SPADES_MASTER_FEAT;
-	break;
-	case SKILL_BOWS:
-		return BOWS_MASTER_FEAT;
-	break;
-	default:
-		return INCORRECT_FEAT;
-	}
+int find_weapon_master_by_skill(ESkill skill) {
+  switch (skill) {
+    case SKILL_PUNCH: return PUNCH_MASTER_FEAT;
+      break;
+    case SKILL_CLUBS: return CLUBS_MASTER_FEAT;
+      break;
+    case SKILL_AXES: return AXES_MASTER_FEAT;
+      break;
+    case SKILL_LONGS: return LONGS_MASTER_FEAT;
+      break;
+    case SKILL_SHORTS: return SHORTS_MASTER_FEAT;
+      break;
+    case SKILL_NONSTANDART: return NONSTANDART_MASTER_FEAT;
+      break;
+    case SKILL_BOTHHANDS: return BOTHHANDS_MASTER_FEAT;
+      break;
+    case SKILL_PICK: return PICK_MASTER_FEAT;
+      break;
+    case SKILL_SPADES: return SPADES_MASTER_FEAT;
+      break;
+    case SKILL_BOWS: return BOWS_MASTER_FEAT;
+      break;
+    default: return INCORRECT_FEAT;
+  }
 }
 
 //Определим мин уровень для изучения скилла из книги
 //req_lvl - требуемый уровень из книги
-int min_skill_level_with_req(CHAR_DATA *ch, int skill, int req_lvl)
-{
-	int min_lvl = MAX(req_lvl, skill_info[skill].min_level[ch->get_class()][ch->get_kin()])
-		- MAX(0, ch->get_remort() / skill_info[skill].level_decrement[ch->get_class()][ch->get_kin()]);
+int min_skill_level_with_req(CHAR_DATA *ch, int skill, int req_lvl) {
+  int min_lvl = MAX(req_lvl, skill_info[skill].min_level[ch->get_class()][ch->get_kin()])
+      - MAX(0, ch->get_remort() / skill_info[skill].level_decrement[ch->get_class()][ch->get_kin()]);
 
-	return MAX(1, min_lvl);
+  return MAX(1, min_lvl);
 };
 
 /*
  * функция определяет, может ли персонаж илучить скилл
  * впоследствии ее нужно будет перенести в класс "инфа о классе персонажа"
  */
-int min_skill_level(CHAR_DATA *ch, int skill)
-{
-	int min_lvl = skill_info[skill].min_level[ch->get_class()][ch->get_kin()]
-		- MAX(0, ch->get_remort() / skill_info[skill].level_decrement[ch->get_class()][ch->get_kin()]);
+int min_skill_level(CHAR_DATA *ch, int skill) {
+  int min_lvl = skill_info[skill].min_level[ch->get_class()][ch->get_kin()]
+      - MAX(0, ch->get_remort() / skill_info[skill].level_decrement[ch->get_class()][ch->get_kin()]);
 
-	return MAX(1, min_lvl);
+  return MAX(1, min_lvl);
 };
 
-bool can_get_skill_with_req(CHAR_DATA *ch, int skill, int req_lvl)
-{
-	if (ch->get_remort() < skill_info[skill].min_remort[ch->get_class()][ch->get_kin()]
-		|| (skill_info[skill].classknow[ch->get_class()][ch->get_kin()] != KNOW_SKILL))
-	{
-		return FALSE;
-	}
-	if (ch->get_level() < min_skill_level_with_req(ch, skill, req_lvl))
-	{
-		return FALSE;
-	}
+bool can_get_skill_with_req(CHAR_DATA *ch, int skill, int req_lvl) {
+  if (ch->get_remort() < skill_info[skill].min_remort[ch->get_class()][ch->get_kin()]
+      || (skill_info[skill].classknow[ch->get_class()][ch->get_kin()] != KNOW_SKILL)) {
+    return FALSE;
+  }
+  if (ch->get_level() < min_skill_level_with_req(ch, skill, req_lvl)) {
+    return FALSE;
+  }
 
-	return TRUE;
+  return TRUE;
 }
 
-bool can_get_skill(CHAR_DATA *ch, int skill)
-{
-	if (ch->get_remort() < skill_info[skill].min_remort[ch->get_class()][ch->get_kin()]
-		|| (skill_info[skill].classknow[ch->get_class()][ch->get_kin()] != KNOW_SKILL))
-	{
-		return FALSE;
-	}
-	if (ch->get_level() < min_skill_level(ch, skill))
-	{
-		return FALSE;
-	}
+bool can_get_skill(CHAR_DATA *ch, int skill) {
+  if (ch->get_remort() < skill_info[skill].min_remort[ch->get_class()][ch->get_kin()]
+      || (skill_info[skill].classknow[ch->get_class()][ch->get_kin()] != KNOW_SKILL)) {
+    return FALSE;
+  }
+  if (ch->get_level() < min_skill_level(ch, skill)) {
+    return FALSE;
+  }
 
-	return TRUE;
+  return TRUE;
 }
 
 //  Реализация класса Skill

--- a/src/skills.cpp
+++ b/src/skills.cpp
@@ -1225,19 +1225,14 @@ int CalcCurrentSkill(CHAR_DATA *ch, const ESkill skill, CHAR_DATA *vict) {
   else
     total_percent = MIN(MAX(0, total_percent), max_percent);
 
-  ch->send_to_TC(false,
-                 true,
-                 true,
-                 "&CП: %s, Ц:  %s, Скилл: %d. Итог.скилл = %d, fail_limit = %d, Morale = %d, Bonus == %d, Сейвы цели = %d, Моди.цели = %d&n\r\n",
-                 ch ? GET_NAME(ch) : "NULL",
+  ch->send_to_TC(false, true, true,
+                 "&CTarget: %s, BaseSkill: %d, Bonus: %d, TargetSave = %d, TargetMod: %d, TotalSkill: %d&n\r\n",
                  vict ? GET_NAME(vict) : "NULL",
-                 skill,
-                 total_percent,
-                 fail_limit,
-                 luck,
+                 base_percent,
                  bonus,
                  victim_sav,
-                 victim_modi / 2);
+                 victim_modi / 2,
+                 total_percent);
   return (total_percent);
 }
 
@@ -1427,6 +1422,14 @@ int CalcSkillHardCap(const CHAR_DATA *ch, const ESkill skill) {
 
 int CalcSkillMinCap(const CHAR_DATA *ch, const ESkill skill) {
   return std::min(CalcSkillSoftCap(ch), skill_info[skill].cap);
+}
+
+// \TODO Не забыть убрать после ребаланса умений
+void SendSkillBalanceMsg (CHAR_DATA* ch, const char* skill_name, int percent, int prob, bool success) {
+  std::stringstream buffer;
+  buffer << "&C" << "Skill: " << skill_name
+         << " Percent: " << percent << " Prob: " << prob << " Success: " << success << "&n" << std::endl;
+  ch->send_to_TC(false, true, true, buffer.str().c_str());
 }
 
 //  Реализация класса Skill

--- a/src/skills.h
+++ b/src/skills.h
@@ -160,6 +160,8 @@ int CalcSkillSoftCap(const CHAR_DATA *ch);
 int CalcSkillHardCap(const CHAR_DATA *ch, const ESkill skill);
 int CalcSkillMinCap(const CHAR_DATA *ch, const ESkill skill);
 
+void SendSkillBalanceMsg (CHAR_DATA* ch, const char* skill_name, int percent, int prob, bool success);
+
 // ГОРНОЕ ДЕЛО
 
 #define DIG_DFLT_HOLE_MAX_DEEP        10

--- a/src/skills.h
+++ b/src/skills.h
@@ -20,140 +20,139 @@
 
 #include <map>
 
-class CHAR_DATA;	// forward declaration to avoid inclusion of char.hpp and any dependencies of that header.
+class CHAR_DATA;    // forward declaration to avoid inclusion of char.hpp and any dependencies of that header.
 
-enum ExtraAttackEnumType
-{
-	EXTRA_ATTACK_UNUSED,
-	EXTRA_ATTACK_THROW,
-	EXTRA_ATTACK_BASH,
-	EXTRA_ATTACK_KICK,
-	EXTRA_ATTACK_CHOPOFF,
-	EXTRA_ATTACK_DISARM,
-	EXTRA_ATTACK_CUT_SHORTS,
-	EXTRA_ATTACK_CUT_PICK
+enum ExtraAttackEnumType {
+  EXTRA_ATTACK_UNUSED,
+  EXTRA_ATTACK_THROW,
+  EXTRA_ATTACK_BASH,
+  EXTRA_ATTACK_KICK,
+  EXTRA_ATTACK_CHOPOFF,
+  EXTRA_ATTACK_DISARM,
+  EXTRA_ATTACK_CUT_SHORTS,
+  EXTRA_ATTACK_CUT_PICK
 };
 
 // PLAYER SKILLS - Numbered from 1 to MAX_SKILL_NUM //
-enum ESkill: int
-{
-	SKILL_UNDEF = -1,
-	SKILL_INVALID = 0,
-	SKILL_GLOBAL_COOLDOWN = 0,	// Internal - ID for global ability cooldown //
-	SKILL_FIRST = 1,
-	SKILL_PROTECT = SKILL_FIRST,	// *** Protect groupers    //
-	SKILL_TOUCH = 2,	// *** Touch attacker       //
-	SKILL_SHIT = 3,
-	SKILL_MIGHTHIT = 4,
-	SKILL_STUPOR = 5,
-	SKILL_POISONED = 6,
-	SKILL_SENSE = 7,
-	SKILL_HORSE = 8,
-	SKILL_HIDETRACK = 9,
-	SKILL_RELIGION = 10,
-	SKILL_MAKEFOOD = 11,
-	SKILL_MULTYPARRY = 12,
-	SKILL_TRANSFORMWEAPON = 13,
-	SKILL_LEADERSHIP = 20,
-	SKILL_PUNCTUAL = 21,
-	SKILL_AWAKE = 22,
-	SKILL_IDENTIFY = 23,
-	SKILL_HEARING = 24,
-	SKILL_CREATE_POTION = 25,
-	SKILL_CREATE_SCROLL = 26,
-	SKILL_CREATE_WAND = 27,
-	SKILL_LOOK_HIDE = 28,
-	SKILL_ARMORED = 29,
-	SKILL_DRUNKOFF = 30,
-	SKILL_AID = 31,
-	SKILL_FIRE = 32,
-	SKILL_CREATEBOW = 33,
-	SKILL_THROW = 130,
-	SKILL_BACKSTAB = 131,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_BASH = 132,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_HIDE = 133,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_KICK = 134,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_PICK_LOCK = 135,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_PUNCH = 136,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_RESCUE = 137,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_SNEAK = 138,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_STEAL = 139,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_TRACK = 140,	// Reserved Skill[] DO NOT CHANGE //
-	SKILL_CLUBS = 141,	// *** Weapon is club, etc    //
-	SKILL_AXES = 142,	// *** Weapon is axe, etc     //
-	SKILL_LONGS = 143,	// *** Weapon is long blades  //
-	SKILL_SHORTS = 144,	// *** Weapon is short blades //
-	SKILL_NONSTANDART = 145,	// *** Weapon is non-standart //
-	SKILL_BOTHHANDS = 146,	// *** Weapon in both hands   //
-	SKILL_PICK = 147,	// *** Weapon is pick         //
-	SKILL_SPADES = 148,	// *** Weapon is spades       //
-	SKILL_SATTACK = 149,
-	SKILL_DISARM = 150,
-	SKILL_PARRY = 151,
-	SKILL_HEAL = 152,
-	SKILL_MORPH = 153,
-	SKILL_BOWS = 154,
-	SKILL_ADDSHOT = 155,
-	SKILL_CAMOUFLAGE = 156,
-	SKILL_DEVIATE = 157,
-	SKILL_BLOCK = 158,
-	SKILL_LOOKING = 159,
-	SKILL_CHOPOFF = 160,
-	SKILL_REPAIR = 161,
-	SKILL_UPGRADE = 164,
-	SKILL_COURAGE = 165,
-	SKILL_MANADRAIN = 166,
-	SKILL_NOPARRYHIT = 167,
-	SKILL_TOWNPORTAL = 168,
-	SKILL_MAKE_STAFF = 169,  //смастерить предмет
-	SKILL_MAKE_BOW = 170,
-	SKILL_MAKE_WEAPON = 171,
-	SKILL_MAKE_ARMOR = 172,
-	SKILL_MAKE_JEWEL = 173,
-	SKILL_MAKE_WEAR = 174,
-	SKILL_MAKE_POTION = 175,
-	SKILL_DIG = 176,
-	SKILL_INSERTGEM = 177,
-	SKILL_WARCRY = 178,
-	SKILL_TURN_UNDEAD = 179,
-	SKILL_IRON_WIND = 180,
-	SKILL_STRANGLE = 181,
-	SKILL_AIR_MAGIC = 182,
-	SKILL_FIRE_MAGIC = 183,
-	SKILL_WATER_MAGIC = 184,
-	SKILL_EARTH_MAGIC = 185,
-	SKILL_LIGHT_MAGIC = 186,
-	SKILL_DARK_MAGIC = 187,
-	SKILL_MIND_MAGIC = 188,
-	SKILL_LIFE_MAGIC = 189,
-	SKILL_STUN = 190,
-	SKILL_MAKE_AMULET = 191,
-	SKILL_INDEFINITE = 192,	// Reserved! Нужен, чтобы указывать "произвольный" скилл в некоторых случаях //
+enum ESkill : int {
+  SKILL_UNDEF = -1,
+  SKILL_INVALID = 0,
+  SKILL_GLOBAL_COOLDOWN = 0,    // Internal - ID for global ability cooldown //
+  SKILL_FIRST = 1,
+  SKILL_PROTECT = SKILL_FIRST,    // *** Protect groupers    //
+  SKILL_TOUCH = 2,    // *** Touch attacker       //
+  SKILL_SHIT = 3,
+  SKILL_MIGHTHIT = 4,
+  SKILL_STUPOR = 5,
+  SKILL_POISONED = 6,
+  SKILL_SENSE = 7,
+  SKILL_HORSE = 8,
+  SKILL_HIDETRACK = 9,
+  SKILL_RELIGION = 10,
+  SKILL_MAKEFOOD = 11,
+  SKILL_MULTYPARRY = 12,
+  SKILL_TRANSFORMWEAPON = 13,
+  SKILL_LEADERSHIP = 20,
+  SKILL_PUNCTUAL = 21,
+  SKILL_AWAKE = 22,
+  SKILL_IDENTIFY = 23,
+  SKILL_HEARING = 24,
+  SKILL_CREATE_POTION = 25,
+  SKILL_CREATE_SCROLL = 26,
+  SKILL_CREATE_WAND = 27,
+  SKILL_LOOK_HIDE = 28,
+  SKILL_ARMORED = 29,
+  SKILL_DRUNKOFF = 30,
+  SKILL_AID = 31,
+  SKILL_FIRE = 32,
+  SKILL_CREATEBOW = 33,
+  SKILL_THROW = 130,
+  SKILL_BACKSTAB = 131,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_BASH = 132,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_HIDE = 133,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_KICK = 134,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_PICK_LOCK = 135,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_PUNCH = 136,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_RESCUE = 137,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_SNEAK = 138,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_STEAL = 139,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_TRACK = 140,    // Reserved Skill[] DO NOT CHANGE //
+  SKILL_CLUBS = 141,    // *** Weapon is club, etc    //
+  SKILL_AXES = 142,    // *** Weapon is axe, etc     //
+  SKILL_LONGS = 143,    // *** Weapon is long blades  //
+  SKILL_SHORTS = 144,    // *** Weapon is short blades //
+  SKILL_NONSTANDART = 145,    // *** Weapon is non-standart //
+  SKILL_BOTHHANDS = 146,    // *** Weapon in both hands   //
+  SKILL_PICK = 147,    // *** Weapon is pick         //
+  SKILL_SPADES = 148,    // *** Weapon is spades       //
+  SKILL_SATTACK = 149,
+  SKILL_DISARM = 150,
+  SKILL_PARRY = 151,
+  SKILL_HEAL = 152,
+  SKILL_MORPH = 153,
+  SKILL_BOWS = 154,
+  SKILL_ADDSHOT = 155,
+  SKILL_CAMOUFLAGE = 156,
+  SKILL_DEVIATE = 157,
+  SKILL_BLOCK = 158,
+  SKILL_LOOKING = 159,
+  SKILL_CHOPOFF = 160,
+  SKILL_REPAIR = 161,
+  SKILL_UPGRADE = 164,
+  SKILL_COURAGE = 165,
+  SKILL_MANADRAIN = 166,
+  SKILL_NOPARRYHIT = 167,
+  SKILL_TOWNPORTAL = 168,
+  SKILL_MAKE_STAFF = 169,  //смастерить предмет
+  SKILL_MAKE_BOW = 170,
+  SKILL_MAKE_WEAPON = 171,
+  SKILL_MAKE_ARMOR = 172,
+  SKILL_MAKE_JEWEL = 173,
+  SKILL_MAKE_WEAR = 174,
+  SKILL_MAKE_POTION = 175,
+  SKILL_DIG = 176,
+  SKILL_INSERTGEM = 177,
+  SKILL_WARCRY = 178,
+  SKILL_TURN_UNDEAD = 179,
+  SKILL_IRON_WIND = 180,
+  SKILL_STRANGLE = 181,
+  SKILL_AIR_MAGIC = 182,
+  SKILL_FIRE_MAGIC = 183,
+  SKILL_WATER_MAGIC = 184,
+  SKILL_EARTH_MAGIC = 185,
+  SKILL_LIGHT_MAGIC = 186,
+  SKILL_DARK_MAGIC = 187,
+  SKILL_MIND_MAGIC = 188,
+  SKILL_LIFE_MAGIC = 189,
+  SKILL_STUN = 190,
+  SKILL_MAKE_AMULET = 191,
+  SKILL_INDEFINITE = 192,    // Reserved! Нужен, чтобы указывать "произвольный" скилл в некоторых случаях //
 
-	// не забываем указывать максимальный номер скилла
-	MAX_SKILL_NUM = SKILL_INDEFINITE
+  // не забываем указывать максимальный номер скилла
+  MAX_SKILL_NUM = SKILL_INDEFINITE
 };
 
 #define KNOW_SKILL  1
 
-inline bool is_magic_skill(int skill)
-{
-	if (skill >= SKILL_AIR_MAGIC && skill <= SKILL_LIFE_MAGIC)
-		return true;
-	else
-		return false;
+inline bool is_magic_skill(int skill) {
+  if (skill >= SKILL_AIR_MAGIC && skill <= SKILL_LIFE_MAGIC)
+    return true;
+  else
+    return false;
 }
-template <> ESkill ITEM_BY_NAME<ESkill>(const std::string& name);
-template <> const std::string& NAME_BY_ITEM<ESkill>(const ESkill item);
+template<>
+ESkill ITEM_BY_NAME<ESkill>(const std::string &name);
+template<>
+const std::string &NAME_BY_ITEM<ESkill>(const ESkill item);
 
 extern std::array<ESkill, MAX_SKILL_NUM - SKILL_PROTECT> AVAILABLE_SKILLS;
 
-int skill_message(int dam, CHAR_DATA * ch, CHAR_DATA * vict, int attacktype, std::string add = "");
+int skill_message(int dam, CHAR_DATA *ch, CHAR_DATA *vict, int attacktype, std::string add = "");
 
-int calculate_skill(CHAR_DATA * ch, const ESkill skill_no, CHAR_DATA * vict);
-void improve_skill(CHAR_DATA * ch, const ESkill skill_no, int success, CHAR_DATA * victim);
+int calculate_skill(CHAR_DATA *ch, const ESkill skill_no, CHAR_DATA *vict);
+void improve_skill(CHAR_DATA *ch, const ESkill skill_no, int success, CHAR_DATA *victim);
+void train_skill(CHAR_DATA *ch, const ESkill skill_no, bool success, CHAR_DATA *vict);
 
-int train_skill(CHAR_DATA * ch, const ESkill skill_no, int max_value, CHAR_DATA * vict);
 int min_skill_level(CHAR_DATA *ch, int skill);
 int min_skill_level_with_req(CHAR_DATA *ch, int skill, int req_lvl);
 bool can_get_skill(CHAR_DATA *ch, int skill);
@@ -166,84 +165,82 @@ const short baseSkillLevel = 80;//базовый уровень умения, е
 
 // ГОРНОЕ ДЕЛО
 
-#define DIG_DFLT_HOLE_MAX_DEEP		10
-#define DIG_DFLT_INSTR_CRASH_CHANCE	2
-#define DIG_DFLT_TREASURE_CHANCE	30000
-#define DIG_DFLT_PANDORA_CHANCE		80000
-#define DIG_DFLT_MOB_CHANCE		300
-#define DIG_DFLT_TRASH_CHANCE		100
-#define DIG_DFLT_LAG			4
-#define DIG_DFLT_PROB_DIVIDE		3
-#define DIG_DFLT_GLASS_CHANCE		3
-#define DIG_DFLT_NEED_MOVES		15
+#define DIG_DFLT_HOLE_MAX_DEEP        10
+#define DIG_DFLT_INSTR_CRASH_CHANCE    2
+#define DIG_DFLT_TREASURE_CHANCE    30000
+#define DIG_DFLT_PANDORA_CHANCE        80000
+#define DIG_DFLT_MOB_CHANCE        300
+#define DIG_DFLT_TRASH_CHANCE        100
+#define DIG_DFLT_LAG            4
+#define DIG_DFLT_PROB_DIVIDE        3
+#define DIG_DFLT_GLASS_CHANCE        3
+#define DIG_DFLT_NEED_MOVES        15
 
-#define DIG_DFLT_STONE1_SKILL		15
-#define DIG_DFLT_STONE2_SKILL		25
-#define	DIG_DFLT_STONE3_SKILL		35
-#define DIG_DFLT_STONE4_SKILL		50
-#define DIG_DFLT_STONE5_SKILL		70
-#define	DIG_DFLT_STONE6_SKILL		80
-#define	DIG_DFLT_STONE7_SKILL		90
-#define	DIG_DFLT_STONE8_SKILL		95
-#define	DIG_DFLT_STONE9_SKILL		99
+#define DIG_DFLT_STONE1_SKILL        15
+#define DIG_DFLT_STONE2_SKILL        25
+#define    DIG_DFLT_STONE3_SKILL        35
+#define DIG_DFLT_STONE4_SKILL        50
+#define DIG_DFLT_STONE5_SKILL        70
+#define    DIG_DFLT_STONE6_SKILL        80
+#define    DIG_DFLT_STONE7_SKILL        90
+#define    DIG_DFLT_STONE8_SKILL        95
+#define    DIG_DFLT_STONE9_SKILL        99
 
-#define DIG_DFLT_STONE1_VNUM		900
-#define DIG_DFLT_TRASH_VNUM_START	920
-#define DIG_DFLT_TRASH_VNUM_END		922
-#define DIG_DFLT_MOB_VNUM_START		100
-#define DIG_DFLT_MOB_VNUM_END		103
-#define DIG_DFLT_PANDORA_VNUM		919
+#define DIG_DFLT_STONE1_VNUM        900
+#define DIG_DFLT_TRASH_VNUM_START    920
+#define DIG_DFLT_TRASH_VNUM_END        922
+#define DIG_DFLT_MOB_VNUM_START        100
+#define DIG_DFLT_MOB_VNUM_END        103
+#define DIG_DFLT_PANDORA_VNUM        919
 // предмет с названием 'стекло' для продажи в магазине
 const int DIG_GLASS_VNUM = 1919;
 
-struct skillvariables_dig
-{
-	int hole_max_deep;
-	int instr_crash_chance;
-	int treasure_chance;
-	int pandora_chance;
-	int mob_chance;
-	int trash_chance;
-	int lag;
-	int prob_divide;
-	int glass_chance;
-	int need_moves;
+struct skillvariables_dig {
+  int hole_max_deep;
+  int instr_crash_chance;
+  int treasure_chance;
+  int pandora_chance;
+  int mob_chance;
+  int trash_chance;
+  int lag;
+  int prob_divide;
+  int glass_chance;
+  int need_moves;
 
-	int stone1_skill;
-	int stone2_skill;
-	int stone3_skill;
-	int stone4_skill;
-	int stone5_skill;
-	int stone6_skill;
-	int stone7_skill;
-	int stone8_skill;
-	int stone9_skill;
+  int stone1_skill;
+  int stone2_skill;
+  int stone3_skill;
+  int stone4_skill;
+  int stone5_skill;
+  int stone6_skill;
+  int stone7_skill;
+  int stone8_skill;
+  int stone9_skill;
 
-	int stone1_vnum;
-	int trash_vnum_start;
-	int trash_vnum_end;
-	int mob_vnum_start;
-	int mob_vnum_end;
-	int pandora_vnum;
+  int stone1_vnum;
+  int trash_vnum_start;
+  int trash_vnum_end;
+  int mob_vnum_start;
+  int mob_vnum_end;
+  int pandora_vnum;
 };
 
 // ЮВЕЛИР
 
-#define INSGEM_DFLT_LAG			4
-#define INSGEM_DFLT_MINUS_FOR_AFFECT	5
-#define INSGEM_DFLT_PROB_DIVIDE		1
-#define INSGEM_DFLT_DIKEY_PERCENT	10
-#define INSGEM_DFLT_TIMER_PLUS_PERCENT	10
-#define INSGEM_DFLT_TIMER_MINUS_PERCENT	10
+#define INSGEM_DFLT_LAG            4
+#define INSGEM_DFLT_MINUS_FOR_AFFECT    5
+#define INSGEM_DFLT_PROB_DIVIDE        1
+#define INSGEM_DFLT_DIKEY_PERCENT    10
+#define INSGEM_DFLT_TIMER_PLUS_PERCENT    10
+#define INSGEM_DFLT_TIMER_MINUS_PERCENT    10
 
-struct skillvariables_insgem
-{
-	int lag;
-	int minus_for_affect;
-	int prob_divide;
-	int dikey_percent;
-	int timer_plus_percent;
-	int timer_minus_percent;
+struct skillvariables_insgem {
+  int lag;
+  int minus_for_affect;
+  int prob_divide;
+  int dikey_percent;
+  int timer_plus_percent;
+  int timer_minus_percent;
 };
 
 int calculate_awake_mod(CHAR_DATA *killer, CHAR_DATA *victim);
@@ -268,26 +265,25 @@ class Skill;
 typedef std::shared_ptr<Skill> SkillPtr;
 typedef std::map<std::string, SkillPtr> SkillListType;
 
-class Skill
-{
-public:
-    Skill();
+class Skill {
+ public:
+  Skill();
 
-    static int GetNumByID(const std::string& ID);   // Получение номера скилла по ИД
-    static void Load(const pugi::xml_node& XMLSkillList);  // Парсинг конфига скиллов
-    static SkillListType SkillList;                 // Глобальный скилллист
+  static int GetNumByID(const std::string &ID);   // Получение номера скилла по ИД
+  static void Load(const pugi::xml_node &XMLSkillList);  // Парсинг конфига скиллов
+  static SkillListType SkillList;                 // Глобальный скилллист
 
-    // Доступ к полям
-    std::string Name() {return this->_Name;}
-    int Number() {return this->_Number;}
-    int MaxPercent() {return this->_MaxPercent;}
+  // Доступ к полям
+  std::string Name() { return this->_Name; }
+  int Number() { return this->_Number; }
+  int MaxPercent() { return this->_MaxPercent; }
 
-private:
-    std::string _Name;  // Имя скилла на русском
-    int _Number;        // Номер скилла
-    int _MaxPercent;    // Максимальная процент
+ private:
+  std::string _Name;  // Имя скилла на русском
+  int _Number;        // Номер скилла
+  int _MaxPercent;    // Максимальная процент
 
-    static void ParseSkill(pugi::xml_node SkillNode);   // Парсинг описания одного скилла
+  static void ParseSkill(pugi::xml_node SkillNode);   // Парсинг описания одного скилла
 };
 
 #endif

--- a/src/skills.h
+++ b/src/skills.h
@@ -20,6 +20,9 @@
 
 #include <map>
 
+extern const byte  kSkillCapOnZeroRemort;
+extern const byte  kSkillCapBonusPerRemort;
+
 class CHAR_DATA;    // forward declaration to avoid inclusion of char.hpp and any dependencies of that header.
 
 enum ExtraAttackEnumType {
@@ -134,12 +137,6 @@ enum ESkill : int {
 
 #define KNOW_SKILL  1
 
-inline bool is_magic_skill(int skill) {
-  if (skill >= SKILL_AIR_MAGIC && skill <= SKILL_LIFE_MAGIC)
-    return true;
-  else
-    return false;
-}
 template<>
 ESkill ITEM_BY_NAME<ESkill>(const std::string &name);
 template<>
@@ -147,21 +144,21 @@ const std::string &NAME_BY_ITEM<ESkill>(const ESkill item);
 
 extern std::array<ESkill, MAX_SKILL_NUM - SKILL_PROTECT> AVAILABLE_SKILLS;
 
-int skill_message(int dam, CHAR_DATA *ch, CHAR_DATA *vict, int attacktype, std::string add = "");
+int SendSkillMessages(int dam, CHAR_DATA *ch, CHAR_DATA *vict, int attacktype, std::string add = "");
 
-int calculate_skill(CHAR_DATA *ch, const ESkill skill_no, CHAR_DATA *vict);
-void improve_skill(CHAR_DATA *ch, const ESkill skill_no, int success, CHAR_DATA *victim);
-void train_skill(CHAR_DATA *ch, const ESkill skill_no, bool success, CHAR_DATA *vict);
+int CalcCurrentSkill(CHAR_DATA *ch, const ESkill skill, CHAR_DATA *vict);
+void ImproveSkill(CHAR_DATA *ch, const ESkill skill, int success, CHAR_DATA *victim);
+void TrainSkill(CHAR_DATA *ch, const ESkill skill, bool success, CHAR_DATA *vict);
 
 int min_skill_level(CHAR_DATA *ch, int skill);
 int min_skill_level_with_req(CHAR_DATA *ch, int skill, int req_lvl);
-bool can_get_skill(CHAR_DATA *ch, int skill);
+bool IsAbleToGetSkill(CHAR_DATA *ch, int skill);
 bool can_get_skill_with_req(CHAR_DATA *ch, int skill, int req_lvl);
-int find_weapon_focus_by_skill(ESkill skill);
-int find_weapon_master_by_skill(ESkill skill);
-
-const short bonusSkillPointsPerRemort = 5;
-const short baseSkillLevel = 80;//базовый уровень умения, если не задано явно
+int FindWeaponMasterBySkill(ESkill skill);
+int CalcSkillRemortCap(const CHAR_DATA* ch);
+int CalcSkillSoftCap(const CHAR_DATA *ch);
+int CalcSkillHardCap(const CHAR_DATA *ch, const ESkill skill);
+int CalcSkillMinCap(const CHAR_DATA *ch, const ESkill skill);
 
 // ГОРНОЕ ДЕЛО
 
@@ -243,7 +240,7 @@ struct skillvariables_insgem {
   int timer_minus_percent;
 };
 
-int calculate_awake_mod(CHAR_DATA *killer, CHAR_DATA *victim);
+int CalcAwakeMod(CHAR_DATA *killer, CHAR_DATA *victim);
 
 /*
     В перспективе описанный далее класс должен будет содержать

--- a/src/skills.info.cpp
+++ b/src/skills.info.cpp
@@ -63,7 +63,7 @@ void InitSkills(void) {
   }
 
   InitSingleSkill(SKILL_GLOBAL_COOLDOWN, "!глобальная задержка", "ОЗ", 1, 1);
-  InitSingleSkill(SKILL_BACKSTAB, "заколоть", "Зк", 180, 200);
+  InitSingleSkill(SKILL_BACKSTAB, "заколоть", "Зк", 180, 1000);
   InitSingleSkill(SKILL_BASH, "сбить", "Сб", 200, 200);
   InitSingleSkill(SKILL_HIDE, "спрятаться", "Сп", 100, 200);
   InitSingleSkill(SKILL_KICK, "пнуть", "Пн", 100, 200);

--- a/src/skills.info.cpp
+++ b/src/skills.info.cpp
@@ -1,144 +1,148 @@
 #include "skills.info.h"
 
-const char *unused_skillname = "!UNUSED!";
-const char *unidentified_skillname = "!UNIDENTIFIED!";
+const char *kUnusedSkillName = "!UNUSED!";
+const char *kUnidentifiedSkillName = "!UNIDENTIFIED!";
+const byte kDefaultMinPosition = 0;
+const int kDefaultFailPercent = 200;
+const unsigned short kDefaultCap = 200;
 
-struct skillInfo_t skill_info[MAX_SKILL_NUM + 1];
+struct SkillInfoType skill_info[MAX_SKILL_NUM + 1];
 
 const char *skill_name(int num);
-void unused_skill(int skill);
-void initSkill(int skill, const char *name, const char *shortName, int max_percent);
-void initSkills(void);
+void InitSingleSkill(int skill, const char *name, const char *short_name, int fail_percent, unsigned short cap);
+void InitSkills(void);
 
 const char *skill_name(int num) {
-	if (num > 0 && num <= MAX_SKILL_NUM) {
-		return (skill_info[num].name);
-	} else {
-		if (num == -1) {
-			return unused_skillname;
-		} else {
-			return unidentified_skillname;
-		}
-	}
+  if (num > 0 && num <= MAX_SKILL_NUM) {
+    return (skill_info[num].name);
+  } else {
+    if (num == -1) {
+      return kUnusedSkillName;
+    } else {
+      return kUnidentifiedSkillName;
+    }
+  }
 }
 
-void initUnusedSkill(int skill) {
-	int i, j;
+void InitUnusedSkill(int skill) {
+  int i, j;
 
-	for (i = 0; i < NUM_PLAYER_CLASSES; i++) {
-		for (j = 0; j < NUM_KIN; j++) {
-			skill_info[skill].min_remort[i][j] = MAX_REMORT;
-			skill_info[skill].min_level[i][j] = 0;
-			skill_info[skill].k_improve[i][j] = 0 ;
-		}
-	}
-	skill_info[skill].min_position = 0;
-	skill_info[skill].max_percent = 200;
-	skill_info[skill].name = unused_skillname;
+  for (i = 0; i < NUM_PLAYER_CLASSES; i++) {
+    for (j = 0; j < NUM_KIN; j++) {
+      skill_info[skill].min_remort[i][j] = MAX_REMORT;
+      skill_info[skill].min_level[i][j] = 0;
+      skill_info[skill].k_improve[i][j] = 0;
+    }
+  }
+  skill_info[skill].min_position = kDefaultMinPosition;
+  skill_info[skill].fail_percent = kDefaultFailPercent;
+  skill_info[skill].cap = kDefaultCap;
+  skill_info[skill].name = kUnusedSkillName;
 }
 
-void initSkill(int skill, const char *name, const char *shortName, int max_percent) {
-	int i, j;
-	for (i = 0; i < NUM_PLAYER_CLASSES; i++) {
-		for (j = 0; j < NUM_KIN; j++) {
-			skill_info[skill].min_remort[i][j] = MAX_REMORT;
-			skill_info[skill].min_level[i][j] = 0 ;
-			skill_info[skill].k_improve[i][j] = 0;
-		}
-	}
-	skill_info[skill].min_position = 0;
-	skill_info[skill].name = name;
-	skill_info[skill].shortName = shortName;
-	skill_info[skill].max_percent = max_percent;
+void InitSingleSkill(int skill, const char *name, const char *short_name, int fail_percent, unsigned short cap) {
+  int i, j;
+  for (i = 0; i < NUM_PLAYER_CLASSES; i++) {
+    for (j = 0; j < NUM_KIN; j++) {
+      skill_info[skill].min_remort[i][j] = MAX_REMORT;
+      skill_info[skill].min_level[i][j] = 0;
+      skill_info[skill].k_improve[i][j] = 0;
+    }
+  }
+  skill_info[skill].min_position = 0;
+  skill_info[skill].name = name;
+  skill_info[skill].shortName = short_name;
+  skill_info[skill].fail_percent = fail_percent;
+  skill_info[skill].cap = cap;
 }
 
-void initSkills(void) {
+void InitSkills(void) {
 
-	for (int i = 0; i <= MAX_SKILL_NUM; i++) {
-		initUnusedSkill(i);
-	}
+  for (int i = 0; i <= MAX_SKILL_NUM; i++) {
+    InitUnusedSkill(i);
+  }
 
-	initSkill(SKILL_GLOBAL_COOLDOWN, "!глобальная задержка", "ОЗ",  1);
-	initSkill(SKILL_BACKSTAB, "заколоть", "Зк", 180);
-	initSkill(SKILL_BASH, "сбить", "Сб", 200);
-	initSkill(SKILL_HIDE, "спрятаться", "Сп", 100);
-	initSkill(SKILL_KICK, "пнуть", "Пн", 100);
-	initSkill(SKILL_PICK_LOCK, "взломать", "Вз", 120);
-	initSkill(SKILL_PUNCH, "кулачный бой", "Кб", 100);
-	initSkill(SKILL_RESCUE, "спасти", "Спс", 130);
-	initSkill(SKILL_SNEAK, "подкрасться", "Пд", 100);
-	initSkill(SKILL_STEAL, "украсть", "Ук", 100);
-	initSkill(SKILL_TRACK, "выследить", "Выс", 100);
-	initSkill(SKILL_PARRY, "парировать", "Пр", 120);
-	initSkill(SKILL_BLOCK, "блокировать щитом", "Бщ", 200);
-	initSkill(SKILL_TOUCH, "перехватить атаку", "Пр", 100);
-	initSkill(SKILL_PROTECT, "прикрыть", "Пр", 120);
-	initSkill(SKILL_BOTHHANDS, "двуручники", "Дв", 160);
-	initSkill(SKILL_LONGS, "длинные лезвия", "Дл", 160);
-	initSkill(SKILL_SPADES, "копья и рогатины", "Кр", 160);
-	initSkill(SKILL_SHORTS, "короткие лезвия", "Кл", 160);
-	initSkill(SKILL_BOWS, "луки", "Лк", 160);
-	initSkill(SKILL_CLUBS, "палицы и дубины", "Пд", 160);
-	initSkill(SKILL_PICK, "проникающее оружие", "Прн", 160);
-	initSkill(SKILL_NONSTANDART, "иное оружие", "Ин", 160);
-	initSkill(SKILL_AXES, "секиры", "Ск", 160);
-	initSkill(SKILL_SATTACK, "атака левой рукой", "Ал", 100);
-	initSkill(SKILL_LOOKING, "приглядеться", "Прг", 100);
-	initSkill(SKILL_HEARING, "прислушаться", "Прс", 100);
-	initSkill(SKILL_DISARM, "обезоружить", "Об", 100);
-	initSkill(SKILL_HEAL, "!heal!", "Hl", 100);
-	initSkill(SKILL_MORPH, "оборотничество", "Об", 150);
-	initSkill(SKILL_ADDSHOT, "дополнительный выстрел", "Доп", 200);
-	initSkill(SKILL_CAMOUFLAGE, "маскировка", "Мск", 100);
-	initSkill(SKILL_DEVIATE, "уклониться", "Укл", 100);
-	initSkill(SKILL_CHOPOFF, "подножка", "Пд", 200);
-	initSkill(SKILL_REPAIR, "ремонт", "Рм", 180);
-	initSkill(SKILL_COURAGE, "ярость", "Яр", 100);
-	initSkill(SKILL_IDENTIFY, "опознание", "Оп", 100);
-	initSkill(SKILL_LOOK_HIDE, "подсмотреть", "Пдм", 100);
-	initSkill(SKILL_UPGRADE, "заточить", "Зат", 100);
-	initSkill(SKILL_ARMORED, "укрепить", "Укр", 100);
-	initSkill(SKILL_DRUNKOFF, "опохмелиться", "Опх", 100);
-	initSkill(SKILL_AID, "лечить", "Лч", 100);
-	initSkill(SKILL_FIRE, "разжечь костер", "Рк", 160);
-	initSkill(SKILL_SHIT, "удар левой рукой", "Улр", 100);
-	initSkill(SKILL_MIGHTHIT, "богатырский молот", "Бм", 200);
-	initSkill(SKILL_STUPOR, "оглушить", "Ог", 200);
-	initSkill(SKILL_POISONED, "отравить", "Отр", 200);
-	initSkill(SKILL_LEADERSHIP, "лидерство", "Лд", 100);
-	initSkill(SKILL_PUNCTUAL, "точный стиль", "Тс", 110);
-	initSkill(SKILL_AWAKE, "осторожный стиль", "Ос", 100);
-	initSkill(SKILL_SENSE, "найти", "Нйт", 160);
-	initSkill(SKILL_HORSE, "сражение верхом", "Срв", 100);
-	initSkill(SKILL_HIDETRACK, "замести следы", "Зс", 120);
-	initSkill(SKILL_RELIGION, "!молитва или жертва!", "Error", 1);
-	initSkill(SKILL_MAKEFOOD, "освежевать", "Осв", 120);
-	initSkill(SKILL_MULTYPARRY, "веерная защита", "Вз", 140);
-	initSkill(SKILL_TRANSFORMWEAPON, "перековать", "Прк", 140);
-	initSkill(SKILL_THROW, "метнуть", "Мт", 150);
-	initSkill(SKILL_MAKE_BOW, "смастерить лук", "Сл", 140);
-	initSkill(SKILL_MAKE_WEAPON, "выковать оружие", "Вкр", 140);
-	initSkill(SKILL_MAKE_ARMOR, "выковать доспех", "Вкд", 140);
-	initSkill(SKILL_MAKE_WEAR, "сшить одежду", "Сш", 140);
-	initSkill(SKILL_MAKE_JEWEL, "смастерить диковинку", "Сд", 140);
-	initSkill(SKILL_MANADRAIN, "сглазить", "Сг", 100);
-	initSkill(SKILL_NOPARRYHIT, "скрытый удар", "Сд", 100);
-	initSkill(SKILL_TOWNPORTAL, "врата", "Вр", 100);
-	initSkill(SKILL_DIG, "горное дело", "Гд", 100);
-	initSkill(SKILL_INSERTGEM, "ювелир", "Юв", 100);
-	initSkill(SKILL_WARCRY, "боевой клич", "Бк", 100);
-	initSkill(SKILL_TURN_UNDEAD, "изгнать нежить", "Из", 100);
-	initSkill(SKILL_IRON_WIND, "железный ветер", "Жв", 150);
-	initSkill(SKILL_STRANGLE, "удавить", "Уд", 200);
-	initSkill(SKILL_AIR_MAGIC, "магия воздуха", "Ма", 200);
-	initSkill(SKILL_FIRE_MAGIC, "магия огня", "Мо", 1000);
-	initSkill(SKILL_WATER_MAGIC, "магия воды", "Мвд", 1000);
-	initSkill(SKILL_EARTH_MAGIC, "магия земли", "Мз", 1000);
-	initSkill(SKILL_LIGHT_MAGIC, "магия света", "Мс", 1000);
-	initSkill(SKILL_DARK_MAGIC, "магия тьмы", "Мт", 1000);
-	initSkill(SKILL_MIND_MAGIC, "магия разума", "Мр", 1000);
-	initSkill(SKILL_LIFE_MAGIC, "магия жизни", "Мж", 1000);
-	initSkill(SKILL_STUN, "ошеломить", "Ош", 200);
-	initSkill(SKILL_MAKE_AMULET, "смастерить оберег", "Со", 200);
-	initSkill(SKILL_INDEFINITE, "!неопределен", "Error", 1);
+  InitSingleSkill(SKILL_GLOBAL_COOLDOWN, "!глобальная задержка", "ОЗ", 1, 1);
+  InitSingleSkill(SKILL_BACKSTAB, "заколоть", "Зк", 180, 200);
+  InitSingleSkill(SKILL_BASH, "сбить", "Сб", 200, 200);
+  InitSingleSkill(SKILL_HIDE, "спрятаться", "Сп", 100, 200);
+  InitSingleSkill(SKILL_KICK, "пнуть", "Пн", 100, 200);
+  InitSingleSkill(SKILL_PICK_LOCK, "взломать", "Вз", 120, 200);
+  InitSingleSkill(SKILL_PUNCH, "кулачный бой", "Кб", 100, 1000);
+  InitSingleSkill(SKILL_RESCUE, "спасти", "Спс", 130, 1000);
+  InitSingleSkill(SKILL_SNEAK, "подкрасться", "Пд", 100, 200);
+  InitSingleSkill(SKILL_STEAL, "украсть", "Ук", 100, 200);
+  InitSingleSkill(SKILL_TRACK, "выследить", "Выс", 100, 1000);
+  InitSingleSkill(SKILL_PARRY, "парировать", "Пр", 120, 1000);
+  InitSingleSkill(SKILL_BLOCK, "блокировать щитом", "Бщ", 200, 200);
+  InitSingleSkill(SKILL_TOUCH, "перехватить атаку", "Пр", 100, 200);
+  InitSingleSkill(SKILL_PROTECT, "прикрыть", "Пр", 120, 200);
+  InitSingleSkill(SKILL_BOTHHANDS, "двуручники", "Дв", 160, 1000);
+  InitSingleSkill(SKILL_LONGS, "длинные лезвия", "Дл", 160, 1000);
+  InitSingleSkill(SKILL_SPADES, "копья и рогатины", "Кр", 160, 1000);
+  InitSingleSkill(SKILL_SHORTS, "короткие лезвия", "Кл", 160, 1000);
+  InitSingleSkill(SKILL_BOWS, "луки", "Лк", 160, 1000);
+  InitSingleSkill(SKILL_CLUBS, "палицы и дубины", "Пд", 160, 1000);
+  InitSingleSkill(SKILL_PICK, "проникающее оружие", "Прн", 160, 1000);
+  InitSingleSkill(SKILL_NONSTANDART, "иное оружие", "Ин", 160, 1000);
+  InitSingleSkill(SKILL_AXES, "секиры", "Ск", 160, 1000);
+  InitSingleSkill(SKILL_SATTACK, "атака левой рукой", "Ал", 100, 200);
+  InitSingleSkill(SKILL_LOOKING, "приглядеться", "Прг", 100, 200);
+  InitSingleSkill(SKILL_HEARING, "прислушаться", "Прс", 100, 200);
+  InitSingleSkill(SKILL_DISARM, "обезоружить", "Об", 100, 200);
+  InitSingleSkill(SKILL_HEAL, "!heal!", "Hl", 100, 200);
+  InitSingleSkill(SKILL_MORPH, "оборотничество", "Об", 150, 200);
+  InitSingleSkill(SKILL_ADDSHOT, "дополнительный выстрел", "Доп", 200, 200);
+  InitSingleSkill(SKILL_CAMOUFLAGE, "маскировка", "Мск", 100, 200);
+  InitSingleSkill(SKILL_DEVIATE, "уклониться", "Укл", 100, 200);
+  InitSingleSkill(SKILL_CHOPOFF, "подножка", "Пд", 200, 200);
+  InitSingleSkill(SKILL_REPAIR, "ремонт", "Рм", 180, 200);
+  InitSingleSkill(SKILL_COURAGE, "ярость", "Яр", 100, 1000);
+  InitSingleSkill(SKILL_IDENTIFY, "опознание", "Оп", 100, 1000);
+  InitSingleSkill(SKILL_LOOK_HIDE, "подсмотреть", "Пдм", 100, 200);
+  InitSingleSkill(SKILL_UPGRADE, "заточить", "Зат", 100, 200);
+  InitSingleSkill(SKILL_ARMORED, "укрепить", "Укр", 100, 200);
+  InitSingleSkill(SKILL_DRUNKOFF, "опохмелиться", "Опх", 100, 200);
+  InitSingleSkill(SKILL_AID, "лечить", "Лч", 100, 200);
+  InitSingleSkill(SKILL_FIRE, "разжечь костер", "Рк", 160, 1000);
+  InitSingleSkill(SKILL_SHIT, "удар левой рукой", "Улр", 100, 200);
+  InitSingleSkill(SKILL_MIGHTHIT, "богатырский молот", "Бм", 200, 200);
+  InitSingleSkill(SKILL_STUPOR, "оглушить", "Ог", 200, 200);
+  InitSingleSkill(SKILL_POISONED, "отравить", "Отр", 200, 200);
+  InitSingleSkill(SKILL_LEADERSHIP, "лидерство", "Лд", 100, 200);
+  InitSingleSkill(SKILL_PUNCTUAL, "точный стиль", "Тс", 110, 200);
+  InitSingleSkill(SKILL_AWAKE, "осторожный стиль", "Ос", 100, 200);
+  InitSingleSkill(SKILL_SENSE, "найти", "Нйт", 160, 200);
+  InitSingleSkill(SKILL_HORSE, "сражение верхом", "Срв", 100, 200);
+  InitSingleSkill(SKILL_HIDETRACK, "замести следы", "Зс", 120, 200);
+  InitSingleSkill(SKILL_RELIGION, "!молитва или жертва!", "Error", 1, 1);
+  InitSingleSkill(SKILL_MAKEFOOD, "освежевать", "Осв", 120, 200);
+  InitSingleSkill(SKILL_MULTYPARRY, "веерная защита", "Вз", 140, 200);
+  InitSingleSkill(SKILL_TRANSFORMWEAPON, "перековать", "Прк", 140, 200);
+  InitSingleSkill(SKILL_THROW, "метнуть", "Мт", 150, 1000);
+  InitSingleSkill(SKILL_MAKE_BOW, "смастерить лук", "Сл", 140, 200);
+  InitSingleSkill(SKILL_MAKE_WEAPON, "выковать оружие", "Вкр", 140, 200);
+  InitSingleSkill(SKILL_MAKE_ARMOR, "выковать доспех", "Вкд", 140, 200);
+  InitSingleSkill(SKILL_MAKE_WEAR, "сшить одежду", "Сш", 140, 200);
+  InitSingleSkill(SKILL_MAKE_JEWEL, "смастерить диковинку", "Сд", 140, 200);
+  InitSingleSkill(SKILL_MANADRAIN, "сглазить", "Сг", 100, 200);
+  InitSingleSkill(SKILL_NOPARRYHIT, "скрытый удар", "Сд", 100, 200);
+  InitSingleSkill(SKILL_TOWNPORTAL, "врата", "Вр", 100, 200);
+  InitSingleSkill(SKILL_DIG, "горное дело", "Гд", 100, 200);
+  InitSingleSkill(SKILL_INSERTGEM, "ювелир", "Юв", 100, 200);
+  InitSingleSkill(SKILL_WARCRY, "боевой клич", "Бк", 100, 200);
+  InitSingleSkill(SKILL_TURN_UNDEAD, "изгнать нежить", "Из", 100, 1000);
+  InitSingleSkill(SKILL_IRON_WIND, "железный ветер", "Жв", 150, 1000);
+  InitSingleSkill(SKILL_STRANGLE, "удавить", "Уд", 200, 200);
+  InitSingleSkill(SKILL_AIR_MAGIC, "магия воздуха", "Ма", 200, 1000);
+  InitSingleSkill(SKILL_FIRE_MAGIC, "магия огня", "Мо", 1000, 1000);
+  InitSingleSkill(SKILL_WATER_MAGIC, "магия воды", "Мвд", 1000, 1000);
+  InitSingleSkill(SKILL_EARTH_MAGIC, "магия земли", "Мз", 1000, 1000);
+  InitSingleSkill(SKILL_LIGHT_MAGIC, "магия света", "Мс", 1000, 1000);
+  InitSingleSkill(SKILL_DARK_MAGIC, "магия тьмы", "Мт", 1000, 1000);
+  InitSingleSkill(SKILL_MIND_MAGIC, "магия разума", "Мр", 1000, 1000);
+  InitSingleSkill(SKILL_LIFE_MAGIC, "магия жизни", "Мж", 1000, 1000);
+  InitSingleSkill(SKILL_STUN, "ошеломить", "Ош", 200, 200);
+  InitSingleSkill(SKILL_MAKE_AMULET, "смастерить оберег", "Со", 200, 200);
+  InitSingleSkill(SKILL_INDEFINITE, "!неопределен", "Error", 1, 1);
 }

--- a/src/skills.info.h
+++ b/src/skills.info.h
@@ -4,19 +4,20 @@
 #include "skills.h"
 #include "classes/constants.hpp"
 
-struct skillInfo_t {
-	byte min_position;
-	int min_remort[NUM_PLAYER_CLASSES][NUM_KIN];
-	int min_level[NUM_PLAYER_CLASSES][NUM_KIN];
-	int level_decrement[NUM_PLAYER_CLASSES][NUM_KIN];
-	long int k_improve[NUM_PLAYER_CLASSES][NUM_KIN];
-	int classknow[NUM_PLAYER_CLASSES][NUM_KIN];
-	int max_percent;
-	const char *name;
-	const char *shortName;
+struct SkillInfoType {
+  byte min_position;
+  int min_remort[NUM_PLAYER_CLASSES][NUM_KIN];
+  int min_level[NUM_PLAYER_CLASSES][NUM_KIN];
+  int level_decrement[NUM_PLAYER_CLASSES][NUM_KIN];
+  long int k_improve[NUM_PLAYER_CLASSES][NUM_KIN];
+  int classknow[NUM_PLAYER_CLASSES][NUM_KIN];
+  int fail_percent;
+  int cap;
+  const char *name;
+  const char *shortName;
 };
 
-extern struct skillInfo_t skill_info[];
+extern struct SkillInfoType skill_info[];
 
 const char *skill_name(int num);
 

--- a/src/skills/backstab.cpp
+++ b/src/skills/backstab.cpp
@@ -10,117 +10,119 @@
 #include "protect.h"
 #include "skills.info.h"
 
-using  namespace FightSystem;
+using namespace FightSystem;
 
 // делегат обработки команды заколоть
 void do_backstab(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-    if (ch->get_skill(SKILL_BACKSTAB) < 1) {
-        send_to_char("Вы не знаете как.\r\n", ch);
-        return;
-    }
-    if (ch->haveCooldown(SKILL_BACKSTAB)) {
-        send_to_char("Вам нужно набраться сил.\r\n", ch);
-        return;
-    };
+  if (ch->get_skill(SKILL_BACKSTAB) < 1) {
+    send_to_char("Вы не знаете как.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_BACKSTAB)) {
+    send_to_char("Вам нужно набраться сил.\r\n", ch);
+    return;
+  };
 
-    if (ch->ahorse()) {
-        send_to_char("Верхом это сделать затруднительно.\r\n", ch);
-        return;
-    }
+  if (ch->ahorse()) {
+    send_to_char("Верхом это сделать затруднительно.\r\n", ch);
+    return;
+  }
 
-    if (GET_POS(ch) < POS_FIGHTING) {
-        send_to_char("Вам стоит встать на ноги.\r\n", ch);
-        return;
-    }
+  if (GET_POS(ch) < POS_FIGHTING) {
+    send_to_char("Вам стоит встать на ноги.\r\n", ch);
+    return;
+  }
 
-    one_argument(argument, arg);
-    CHAR_DATA* vict = get_char_vis(ch, arg, FIND_CHAR_ROOM);
-    if (!vict) {
-        send_to_char("Кого вы так сильно ненавидите, что хотите заколоть?\r\n", ch);
-        return;
-    }
+  one_argument(argument, arg);
+  CHAR_DATA *vict = get_char_vis(ch, arg, FIND_CHAR_ROOM);
+  if (!vict) {
+    send_to_char("Кого вы так сильно ненавидите, что хотите заколоть?\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Вы, определенно, садомазохист!\r\n", ch);
-        return;
-    }
+  if (vict == ch) {
+    send_to_char("Вы, определенно, садомазохист!\r\n", ch);
+    return;
+  }
 
-    if (!GET_EQ(ch, WEAR_WIELD) && (!IS_NPC(ch) || IS_CHARMICE(ch))) {
-        send_to_char("Требуется держать оружие в правой руке.\r\n", ch);
-        return;
-    }
+  if (!GET_EQ(ch, WEAR_WIELD) && (!IS_NPC(ch) || IS_CHARMICE(ch))) {
+    send_to_char("Требуется держать оружие в правой руке.\r\n", ch);
+    return;
+  }
 
-    if ((!IS_NPC(ch) || IS_CHARMICE(ch)) && GET_OBJ_VAL(GET_EQ(ch, WEAR_WIELD), 3) != type_pierce) {
-        send_to_char("ЗаКОЛоть можно только КОЛющим оружием!\r\n", ch);
-        return;
-    }
+  if ((!IS_NPC(ch) || IS_CHARMICE(ch)) && GET_OBJ_VAL(GET_EQ(ch, WEAR_WIELD), 3) != type_pierce) {
+    send_to_char("ЗаКОЛоть можно только КОЛющим оружием!\r\n", ch);
+    return;
+  }
 
-    if (AFF_FLAGGED(ch, EAffectFlag::AFF_STOPRIGHT) || dontCanAct(ch)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
-    }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_STOPRIGHT) || dontCanAct(ch)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
 
-    if (vict->get_fighting() && !can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
-        send_to_char("Ваша цель слишком быстро движется - вы можете пораниться!\r\n", ch);
-        return;
-    }
+  if (vict->get_fighting() && !can_use_feat(ch, THIEVES_STRIKE_FEAT)) {
+    send_to_char("Ваша цель слишком быстро движется - вы можете пораниться!\r\n", ch);
+    return;
+  }
 
-    if (!may_kill_here(ch, vict, argument))
-        return;
-    if (!check_pkill(ch, vict, arg))
-        return;
-    go_backstab(ch, vict);
+  if (!may_kill_here(ch, vict, argument))
+    return;
+  if (!check_pkill(ch, vict, arg))
+    return;
+  go_backstab(ch, vict);
 }
 
 // *********************** BACKSTAB VICTIM
 // Проверка на стаб в бою происходит до вызова этой функции
-void go_backstab(CHAR_DATA * ch, CHAR_DATA * vict) {
-    int percent, prob;
+void go_backstab(CHAR_DATA *ch, CHAR_DATA *vict) {
+  int percent, prob;
 
-    if (ch->isHorsePrevents())
-        return;
+  if (ch->isHorsePrevents())
+    return;
 
-    vict = try_protect(vict, ch);
+  vict = try_protect(vict, ch);
 
-    if (!pk_agro_action(ch, vict))
-        return;
+  if (!pk_agro_action(ch, vict))
+    return;
 
-    if ((MOB_FLAGGED(vict, MOB_AWARE) && AWAKE(vict)) && !IS_GOD(ch)) {
-        act("Вы заметили, что $N попытал$u вас заколоть!", FALSE, vict, 0, ch, TO_CHAR);
-        act("$n заметил$g вашу попытку заколоть $s!", FALSE, vict, 0, ch, TO_VICT);
-        act("$n заметил$g попытку $N1 заколоть $s!", FALSE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-        set_hit(vict, ch);
-        return;
-    }
+  if ((MOB_FLAGGED(vict, MOB_AWARE) && AWAKE(vict)) && !IS_GOD(ch)) {
+    act("Вы заметили, что $N попытал$u вас заколоть!", FALSE, vict, 0, ch, TO_CHAR);
+    act("$n заметил$g вашу попытку заколоть $s!", FALSE, vict, 0, ch, TO_VICT);
+    act("$n заметил$g попытку $N1 заколоть $s!", FALSE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+    set_hit(vict, ch);
+    return;
+  }
 
-    percent = number(1, skill_info[SKILL_BACKSTAB].max_percent - GET_REMORT(ch) * 2);
-    prob = train_skill(ch, SKILL_BACKSTAB, skill_info[SKILL_BACKSTAB].max_percent, vict);
+  percent = number(1, skill_info[SKILL_BACKSTAB].max_percent - GET_REMORT(ch) * 2);
+  prob = calculate_skill(ch, SKILL_BACKSTAB, vict);
 
-    if (can_use_feat(ch, SHADOW_STRIKE_FEAT)) {
-        prob = prob + prob * 20 / 100;
-    };
+  if (can_use_feat(ch, SHADOW_STRIKE_FEAT)) {
+    prob = prob + prob * 20 / 100;
+  };
 
-    if (vict->get_fighting())
-        prob = prob * (GET_REAL_DEX(ch) + 50) / 100;
+  if (vict->get_fighting())
+    prob = prob * (GET_REAL_DEX(ch) + 50) / 100;
 
-    if (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE))
-        prob += 5;
-    if (AFF_FLAGGED(ch, EAffectFlag::AFF_NOOB_REGEN))
-        prob += 5;
-    if (GET_MOB_HOLD(vict))
-        prob = prob * 5 / 4;
-    if (GET_GOD_FLAG(vict, GF_GODSCURSE))
-        prob = percent;
-    if (GET_GOD_FLAG(vict, GF_GODSLIKE) || GET_GOD_FLAG(ch, GF_GODSCURSE))
-        prob = 0;
-    if (percent > prob) {
-        Damage dmg(SkillDmg(SKILL_BACKSTAB), ZERO_DMG, PHYS_DMG);
-        dmg.process(ch, vict);
-    } else {
-        hit(ch, vict, SKILL_BACKSTAB, FightSystem::MAIN_HAND);
-    }
-    setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 1);
-    setSkillCooldownInFight(ch, SKILL_BACKSTAB, 2);
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_HIDE))
+    prob += 5;
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_NOOB_REGEN))
+    prob += 5;
+  if (GET_MOB_HOLD(vict))
+    prob = prob * 5 / 4;
+  if (GET_GOD_FLAG(vict, GF_GODSCURSE))
+    prob = percent;
+  if (GET_GOD_FLAG(vict, GF_GODSLIKE) || GET_GOD_FLAG(ch, GF_GODSCURSE))
+    prob = 0;
+  bool success = percent > prob;
+  train_skill(ch, SKILL_BACKSTAB, success, vict);
+  if (!success) {
+    Damage dmg(SkillDmg(SKILL_BACKSTAB), ZERO_DMG, PHYS_DMG);
+    dmg.process(ch, vict);
+  } else {
+    hit(ch, vict, SKILL_BACKSTAB, FightSystem::MAIN_HAND);
+  }
+  setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 1);
+  setSkillCooldownInFight(ch, SKILL_BACKSTAB, 2);
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/skills/backstab.cpp
+++ b/src/skills/backstab.cpp
@@ -6,7 +6,6 @@
 #include "fightsystem/fight_hit.hpp"
 #include "fightsystem/start.fight.h"
 #include "handler.h"
-#include "spells.h"
 #include "protect.h"
 #include "skills.info.h"
 
@@ -86,14 +85,14 @@ void go_backstab(CHAR_DATA *ch, CHAR_DATA *vict) {
     return;
 
   if ((MOB_FLAGGED(vict, MOB_AWARE) && AWAKE(vict)) && !IS_GOD(ch)) {
-    act("Вы заметили, что $N попытал$u вас заколоть!", FALSE, vict, 0, ch, TO_CHAR);
-    act("$n заметил$g вашу попытку заколоть $s!", FALSE, vict, 0, ch, TO_VICT);
-    act("$n заметил$g попытку $N1 заколоть $s!", FALSE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+    act("Вы заметили, что $N попытал$u вас заколоть!", FALSE, vict, nullptr, ch, TO_CHAR);
+    act("$n заметил$g вашу попытку заколоть $s!", FALSE, vict, nullptr, ch, TO_VICT);
+    act("$n заметил$g попытку $N1 заколоть $s!", FALSE, vict, nullptr, ch, TO_NOTVICT | TO_ARENA_LISTEN);
     set_hit(vict, ch);
     return;
   }
 
-  percent = number(1, skill_info[SKILL_BACKSTAB].fail_percent - GET_REMORT(ch) * 2);
+  percent = number(1, skill_info[SKILL_BACKSTAB].fail_percent);
   prob = CalcCurrentSkill(ch, SKILL_BACKSTAB, vict);
 
   if (can_use_feat(ch, SHADOW_STRIKE_FEAT)) {
@@ -113,8 +112,10 @@ void go_backstab(CHAR_DATA *ch, CHAR_DATA *vict) {
     prob = percent;
   if (GET_GOD_FLAG(vict, GF_GODSLIKE) || GET_GOD_FLAG(ch, GF_GODSCURSE))
     prob = 0;
-  bool success = percent > prob;
+  bool success = percent <= prob;
   TrainSkill(ch, SKILL_BACKSTAB, success, vict);
+
+  SendSkillBalanceMsg(ch, skill_info[SKILL_BACKSTAB].name, percent, prob, success);
   if (!success) {
     Damage dmg(SkillDmg(SKILL_BACKSTAB), ZERO_DMG, PHYS_DMG);
     dmg.process(ch, vict);

--- a/src/skills/backstab.cpp
+++ b/src/skills/backstab.cpp
@@ -93,8 +93,8 @@ void go_backstab(CHAR_DATA *ch, CHAR_DATA *vict) {
     return;
   }
 
-  percent = number(1, skill_info[SKILL_BACKSTAB].max_percent - GET_REMORT(ch) * 2);
-  prob = calculate_skill(ch, SKILL_BACKSTAB, vict);
+  percent = number(1, skill_info[SKILL_BACKSTAB].fail_percent - GET_REMORT(ch) * 2);
+  prob = CalcCurrentSkill(ch, SKILL_BACKSTAB, vict);
 
   if (can_use_feat(ch, SHADOW_STRIKE_FEAT)) {
     prob = prob + prob * 20 / 100;
@@ -114,7 +114,7 @@ void go_backstab(CHAR_DATA *ch, CHAR_DATA *vict) {
   if (GET_GOD_FLAG(vict, GF_GODSLIKE) || GET_GOD_FLAG(ch, GF_GODSCURSE))
     prob = 0;
   bool success = percent > prob;
-  train_skill(ch, SKILL_BACKSTAB, success, vict);
+  TrainSkill(ch, SKILL_BACKSTAB, success, vict);
   if (!success) {
     Damage dmg(SkillDmg(SKILL_BACKSTAB), ZERO_DMG, PHYS_DMG);
     dmg.process(ch, vict);

--- a/src/skills/bash.cpp
+++ b/src/skills/bash.cpp
@@ -7,166 +7,169 @@
 #include "protect.h"
 #include "skills.info.h"
 
-using  namespace FightSystem;
+using namespace FightSystem;
 
 // ************************* BASH PROCEDURES
-void go_bash(CHAR_DATA * ch, CHAR_DATA * vict) {
-    if (dontCanAct(ch) || AFF_FLAGGED(ch, EAffectFlag::AFF_STOPLEFT)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
+void go_bash(CHAR_DATA *ch, CHAR_DATA *vict) {
+  if (dontCanAct(ch) || AFF_FLAGGED(ch, EAffectFlag::AFF_STOPLEFT)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
+
+  if (!(IS_NPC(ch) || GET_EQ(ch, WEAR_SHIELD) || IS_IMMORTAL(ch) || GET_MOB_HOLD(vict)
+      || GET_GOD_FLAG(vict, GF_GODSCURSE))) {
+    send_to_char("Вы не можете сделать этого без щита.\r\n", ch);
+    return;
+  };
+
+  if (PRF_FLAGS(ch).get(PRF_IRON_WIND)) {
+    send_to_char("Вы не можете применять этот прием в таком состоянии!\r\n", ch);
+    return;
+  }
+
+  if (ch->isHorsePrevents())
+    return;
+
+  if (ch == vict) {
+    send_to_char("Ваш сокрушающий удар поверг вас наземь... Вы почувствовали себя глупо.\r\n", ch);
+    return;
+  }
+
+  if (GET_POS(ch) < POS_FIGHTING) {
+    send_to_char("Вам стоит встать на ноги.\r\n", ch);
+    return;
+  }
+
+  vict = try_protect(vict, ch);
+
+  int percent = number(1, skill_info[SKILL_BASH].max_percent);
+  int prob = calculate_skill(ch, SKILL_BASH, vict);
+
+  if (GET_MOB_HOLD(vict) || GET_GOD_FLAG(vict, GF_GODSCURSE)) {
+    prob = percent;
+  }
+  if (MOB_FLAGGED(vict, MOB_NOBASH) || GET_GOD_FLAG(ch, GF_GODSCURSE)) {
+    prob = 0;
+  }
+  bool success = percent <= prob;
+  train_skill(ch, SKILL_BASH, success, vict);
+  if (!success) {
+    Damage dmg(SkillDmg(SKILL_BASH), ZERO_DMG, PHYS_DMG);
+    dmg.process(ch, vict);
+    GET_POS(ch) = POS_SITTING;
+    prob = 3;
+  } else {
+    //не дадим башить мобов в лаге которые спят, оглушены и прочее
+    if (GET_POS(vict) <= POS_STUNNED && GET_WAIT(vict) > 0) {
+      send_to_char("Ваша жертва и так слишком слаба, надо быть милосерднее.\r\n", ch);
+      //set_wait(ch, 1, FALSE);
+      ch->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, PULSE_VIOLENCE);
+      return;
     }
 
-    if (!(IS_NPC(ch)  || GET_EQ(ch, WEAR_SHIELD) || IS_IMMORTAL(ch) || GET_MOB_HOLD(vict) || GET_GOD_FLAG(vict, GF_GODSCURSE))) {
-        send_to_char("Вы не можете сделать этого без щита.\r\n", ch);
-        return;
-    };
-
-    if (PRF_FLAGS(ch).get(PRF_IRON_WIND)) {
-        send_to_char("Вы не можете применять этот прием в таком состоянии!\r\n", ch);
-        return;
-    }
-
-    if (ch->isHorsePrevents())
-        return;
-
-    if (ch == vict) {
-        send_to_char("Ваш сокрушающий удар поверг вас наземь... Вы почувствовали себя глупо.\r\n", ch);
-        return;
-    }
-
-    if (GET_POS(ch) < POS_FIGHTING) {
-        send_to_char("Вам стоит встать на ноги.\r\n", ch);
-        return;
-    }
-
-    vict = try_protect(vict, ch);
-
-    int percent = number(1, skill_info[SKILL_BASH].max_percent);
-    int prob = train_skill(ch, SKILL_BASH, skill_info[SKILL_BASH].max_percent, vict);
-
-    if (GET_MOB_HOLD(vict) || GET_GOD_FLAG(vict, GF_GODSCURSE)) {
-        prob = percent;
-    }
-    if (MOB_FLAGGED(vict, MOB_NOBASH) || GET_GOD_FLAG(ch, GF_GODSCURSE)) {
-        prob = 0;
-    }
-
-    if (percent > prob) {
-        Damage dmg(SkillDmg(SKILL_BASH), ZERO_DMG, PHYS_DMG);
-        dmg.process(ch, vict);
-        GET_POS(ch) = POS_SITTING;
-        prob = 3;
-    } else {
-        //не дадим башить мобов в лаге которые спят, оглушены и прочее
-        if (GET_POS(vict) <= POS_STUNNED && GET_WAIT(vict) > 0) {
-            send_to_char("Ваша жертва и так слишком слаба, надо быть милосерднее.\r\n", ch);
-            //set_wait(ch, 1, FALSE);
-            ch->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, PULSE_VIOLENCE);
-            return;
-        }
-
-        int dam = str_bonus(GET_REAL_STR(ch), STR_TO_DAM) + GET_REAL_DR(ch) +
-                  MAX(0, ch->get_skill(SKILL_BASH) / 10 - 5) + GET_LEVEL(ch) / 5;
+    int dam = str_bonus(GET_REAL_STR(ch), STR_TO_DAM) + GET_REAL_DR(ch) +
+        MAX(0, ch->get_skill(SKILL_BASH) / 10 - 5) + GET_LEVEL(ch) / 5;
 
 //делаем блокирование баша
-        if ((GET_AF_BATTLE(vict, EAF_BLOCK)
-             || (can_use_feat(vict, DEFENDER_FEAT)
-                 && GET_EQ(vict, WEAR_SHIELD)
-                 && PRF_FLAGGED(vict, PRF_AWAKE)
-                 && vict->get_skill(SKILL_AWAKE)
-                 && vict->get_skill(SKILL_BLOCK)
-                 && GET_POS(vict) > POS_SITTING))
-            && !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPFIGHT)
-            && !AFF_FLAGGED(vict, EAffectFlag::AFF_MAGICSTOPFIGHT)
-            && !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPLEFT)
-            && GET_WAIT(vict) <= 0
-            && GET_MOB_HOLD(vict) == 0) {
-            if (!(GET_EQ(vict, WEAR_SHIELD) || IS_NPC(vict) || IS_IMMORTAL(vict) || GET_GOD_FLAG(vict, GF_GODSLIKE)))
-                send_to_char("У вас нечем отразить атаку противника.\r\n", vict);
-            else
-            {
-                int range, prob2;
-                range = number(1, skill_info[SKILL_BLOCK].max_percent);
-                prob2 = train_skill(vict, SKILL_BLOCK, skill_info[SKILL_BLOCK].max_percent, ch);
-                if (prob2 < range) {
-                    act("Вы не смогли блокировать попытку $N1 сбить вас.",
-                        FALSE, vict, 0, ch, TO_CHAR);
-                    act("$N не смог$Q блокировать вашу попытку сбить $S.",
-                        FALSE, ch, 0, vict, TO_CHAR);
-                    act("$n не смог$q блокировать попытку $N1 сбить $s.",
-                        TRUE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-                } else {
-                    act("Вы блокировали попытку $N1 сбить вас с ног.",
-                        FALSE, vict, 0, ch, TO_CHAR);
-                    act("Вы хотели сбить $N1, но он$G блокировал$G Вашу попытку.",
-                        FALSE, ch, 0, vict, TO_CHAR);
-                    act("$n блокировал$g попытку $N1 сбить $s.",
-                        TRUE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-                    alt_equip(vict, WEAR_SHIELD, 30, 10);
-                    if (!ch->get_fighting()) {
-                        set_fighting(ch, vict);
-                        set_wait(ch, 1, TRUE);
-                        //setSkillCooldownInFight(ch, SKILL_BASH, 1);
-                    }
-                    return;
-                }
-            }
+    if ((GET_AF_BATTLE(vict, EAF_BLOCK)
+        || (can_use_feat(vict, DEFENDER_FEAT)
+            && GET_EQ(vict, WEAR_SHIELD)
+            && PRF_FLAGGED(vict, PRF_AWAKE)
+            && vict->get_skill(SKILL_AWAKE)
+            && vict->get_skill(SKILL_BLOCK)
+            && GET_POS(vict) > POS_SITTING))
+        && !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPFIGHT)
+        && !AFF_FLAGGED(vict, EAffectFlag::AFF_MAGICSTOPFIGHT)
+        && !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPLEFT)
+        && GET_WAIT(vict) <= 0
+        && GET_MOB_HOLD(vict) == 0) {
+      if (!(GET_EQ(vict, WEAR_SHIELD) || IS_NPC(vict) || IS_IMMORTAL(vict) || GET_GOD_FLAG(vict, GF_GODSLIKE)))
+        send_to_char("У вас нечем отразить атаку противника.\r\n", vict);
+      else {
+        int range, prob2;
+        range = number(1, skill_info[SKILL_BLOCK].max_percent);
+        prob2 = calculate_skill(vict, SKILL_BLOCK, ch);
+        bool success2 = prob2 >= range;
+        train_skill(vict, SKILL_BLOCK, success2, ch);
+        if (!success2) {
+          act("Вы не смогли блокировать попытку $N1 сбить вас.",
+              FALSE, vict, 0, ch, TO_CHAR);
+          act("$N не смог$Q блокировать вашу попытку сбить $S.",
+              FALSE, ch, 0, vict, TO_CHAR);
+          act("$n не смог$q блокировать попытку $N1 сбить $s.",
+              TRUE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+        } else {
+          act("Вы блокировали попытку $N1 сбить вас с ног.",
+              FALSE, vict, 0, ch, TO_CHAR);
+          act("Вы хотели сбить $N1, но он$G блокировал$G Вашу попытку.",
+              FALSE, ch, 0, vict, TO_CHAR);
+          act("$n блокировал$g попытку $N1 сбить $s.",
+              TRUE, vict, 0, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+          alt_equip(vict, WEAR_SHIELD, 30, 10);
+          if (!ch->get_fighting()) {
+            set_fighting(ch, vict);
+            set_wait(ch, 1, TRUE);
+            //setSkillCooldownInFight(ch, SKILL_BASH, 1);
+          }
+          return;
         }
-
-        prob = 0; // если башем убил - лага не будет
-        Damage dmg(SkillDmg(SKILL_BASH), dam, PHYS_DMG);
-        dmg.flags.set(NO_FLEE_DMG);
-        dam = dmg.process(ch, vict);
-
-        if (dam > 0 || (dam == 0 && AFF_FLAGGED(vict, EAffectFlag::AFF_SHIELD))) {
-            prob = 2;
-            if (!vict->drop_from_horse()) {
-                GET_POS(vict) = POS_SITTING;
-                set_wait(vict, 3, FALSE);
-            }
-        }
+      }
     }
-    set_wait(ch, prob, TRUE);
+
+    prob = 0; // если башем убил - лага не будет
+    Damage dmg(SkillDmg(SKILL_BASH), dam, PHYS_DMG);
+    dmg.flags.set(NO_FLEE_DMG);
+    dam = dmg.process(ch, vict);
+
+    if (dam > 0 || (dam == 0 && AFF_FLAGGED(vict, EAffectFlag::AFF_SHIELD))) {
+      prob = 2;
+      if (!vict->drop_from_horse()) {
+        GET_POS(vict) = POS_SITTING;
+        set_wait(vict, 3, FALSE);
+      }
+    }
+  }
+  set_wait(ch, prob, TRUE);
 }
 
 void do_bash(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-    if ((IS_NPC(ch) && (!AFF_FLAGGED(ch, EAffectFlag::AFF_HELPER))) || !ch->get_skill(SKILL_BASH)) {
-        send_to_char("Вы не знаете как.\r\n", ch);
-        return;
-    }
-    if (ch->haveCooldown(SKILL_BASH)) {
-        send_to_char("Вам нужно набраться сил.\r\n", ch);
-        return;
-    };
+  if ((IS_NPC(ch) && (!AFF_FLAGGED(ch, EAffectFlag::AFF_HELPER))) || !ch->get_skill(SKILL_BASH)) {
+    send_to_char("Вы не знаете как.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_BASH)) {
+    send_to_char("Вам нужно набраться сил.\r\n", ch);
+    return;
+  };
 
-    if (ch->ahorse()) {
-        send_to_char("Верхом это сделать затруднительно.\r\n", ch);
-        return;
-    }
+  if (ch->ahorse()) {
+    send_to_char("Верхом это сделать затруднительно.\r\n", ch);
+    return;
+  }
 
-    CHAR_DATA* vict = findVictim(ch, argument);
-    if (!vict) {
-        send_to_char("Кого же вы так сильно желаете сбить?\r\n", ch);
-        return;
-    }
+  CHAR_DATA *vict = findVictim(ch, argument);
+  if (!vict) {
+    send_to_char("Кого же вы так сильно желаете сбить?\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Ваш сокрушающий удар поверг вас наземь... Вы почувствовали себя глупо.\r\n", ch);
-        return;
-    }
+  if (vict == ch) {
+    send_to_char("Ваш сокрушающий удар поверг вас наземь... Вы почувствовали себя глупо.\r\n", ch);
+    return;
+  }
 
-    if (!may_kill_here(ch, vict, argument))
-        return;
-    if (!check_pkill(ch, vict, arg))
-        return;
+  if (!may_kill_here(ch, vict, argument))
+    return;
+  if (!check_pkill(ch, vict, arg))
+    return;
 
-    if (IS_IMPL(ch) || !ch->get_fighting()) {
-        go_bash(ch, vict);
-    } else if (isHaveNoExtraAttack(ch)) {
-        if (!IS_NPC(ch))
-            act("Хорошо. Вы попытаетесь сбить $N3.", FALSE, ch, 0, vict, TO_CHAR);
-        ch->set_extra_attack(EXTRA_ATTACK_BASH, vict);
-    }
+  if (IS_IMPL(ch) || !ch->get_fighting()) {
+    go_bash(ch, vict);
+  } else if (isHaveNoExtraAttack(ch)) {
+    if (!IS_NPC(ch))
+      act("Хорошо. Вы попытаетесь сбить $N3.", FALSE, ch, 0, vict, TO_CHAR);
+    ch->set_extra_attack(EXTRA_ATTACK_BASH, vict);
+  }
 }
 
 

--- a/src/skills/bash.cpp
+++ b/src/skills/bash.cpp
@@ -53,6 +53,8 @@ void go_bash(CHAR_DATA *ch, CHAR_DATA *vict) {
   }
   bool success = percent <= prob;
   TrainSkill(ch, SKILL_BASH, success, vict);
+
+  SendSkillBalanceMsg(ch, skill_info[SKILL_BASH].name, percent, prob, success);
   if (!success) {
     Damage dmg(SkillDmg(SKILL_BASH), ZERO_DMG, PHYS_DMG);
     dmg.process(ch, vict);

--- a/src/skills/bash.cpp
+++ b/src/skills/bash.cpp
@@ -42,8 +42,8 @@ void go_bash(CHAR_DATA *ch, CHAR_DATA *vict) {
 
   vict = try_protect(vict, ch);
 
-  int percent = number(1, skill_info[SKILL_BASH].max_percent);
-  int prob = calculate_skill(ch, SKILL_BASH, vict);
+  int percent = number(1, skill_info[SKILL_BASH].fail_percent);
+  int prob = CalcCurrentSkill(ch, SKILL_BASH, vict);
 
   if (GET_MOB_HOLD(vict) || GET_GOD_FLAG(vict, GF_GODSCURSE)) {
     prob = percent;
@@ -52,7 +52,7 @@ void go_bash(CHAR_DATA *ch, CHAR_DATA *vict) {
     prob = 0;
   }
   bool success = percent <= prob;
-  train_skill(ch, SKILL_BASH, success, vict);
+  TrainSkill(ch, SKILL_BASH, success, vict);
   if (!success) {
     Damage dmg(SkillDmg(SKILL_BASH), ZERO_DMG, PHYS_DMG);
     dmg.process(ch, vict);
@@ -87,10 +87,10 @@ void go_bash(CHAR_DATA *ch, CHAR_DATA *vict) {
         send_to_char("У вас нечем отразить атаку противника.\r\n", vict);
       else {
         int range, prob2;
-        range = number(1, skill_info[SKILL_BLOCK].max_percent);
-        prob2 = calculate_skill(vict, SKILL_BLOCK, ch);
+        range = number(1, skill_info[SKILL_BLOCK].fail_percent);
+        prob2 = CalcCurrentSkill(vict, SKILL_BLOCK, ch);
         bool success2 = prob2 >= range;
-        train_skill(vict, SKILL_BLOCK, success2, ch);
+        TrainSkill(vict, SKILL_BLOCK, success2, ch);
         if (!success2) {
           act("Вы не смогли блокировать попытку $N1 сбить вас.",
               FALSE, vict, 0, ch, TO_CHAR);

--- a/src/skills/chopoff.cpp
+++ b/src/skills/chopoff.cpp
@@ -57,9 +57,10 @@ void go_chopoff(CHAR_DATA *ch, CHAR_DATA *vict) {
       vict->ahorse() || GET_POS(vict) < POS_FIGHTING || MOB_FLAGGED(vict, MOB_NOTRIP) || IS_IMMORTAL(vict))
     prob = 0;
 
-  bool skillFail = percent > prob;
-  TrainSkill(ch, SKILL_CHOPOFF, !skillFail, vict);
-  if (skillFail) {
+  bool success = percent <= prob;
+  TrainSkill(ch, SKILL_CHOPOFF, success, vict);
+  SendSkillBalanceMsg(ch, skill_info[SKILL_CHOPOFF].name, percent, prob, success);
+  if (!success) {
     sprintf(buf, "%sВы попытались подсечь $N3, но упали сами...%s", CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
     act(buf, FALSE, ch, 0, vict, TO_CHAR);
     act("$n попытал$u подсечь вас, но упал$g сам$g.", FALSE, ch, 0, vict, TO_VICT);
@@ -111,7 +112,7 @@ void go_chopoff(CHAR_DATA *ch, CHAR_DATA *vict) {
     set_hit(vict, ch);
   }
 
-  if (skillFail) {
+  if (!success) {
     set_wait(ch, prob, FALSE);
   } else {
     setSkillCooldownInFight(ch, SKILL_CHOPOFF, prob);

--- a/src/skills/chopoff.cpp
+++ b/src/skills/chopoff.cpp
@@ -40,8 +40,8 @@ void go_chopoff(CHAR_DATA *ch, CHAR_DATA *vict) {
   if (!pk_agro_action(ch, vict))
     return;
 
-  int percent = number(1, skill_info[SKILL_CHOPOFF].max_percent);
-  int prob = calculate_skill(ch, SKILL_CHOPOFF, vict);
+  int percent = number(1, skill_info[SKILL_CHOPOFF].fail_percent);
+  int prob = CalcCurrentSkill(ch, SKILL_CHOPOFF, vict);
 
   if (check_spell_on_player(ch, SPELL_WEB)) {
     prob /= 3;
@@ -58,7 +58,7 @@ void go_chopoff(CHAR_DATA *ch, CHAR_DATA *vict) {
     prob = 0;
 
   bool skillFail = percent > prob;
-  train_skill(ch, SKILL_CHOPOFF, !skillFail, vict);
+  TrainSkill(ch, SKILL_CHOPOFF, !skillFail, vict);
   if (skillFail) {
     sprintf(buf, "%sВы попытались подсечь $N3, но упали сами...%s", CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
     act(buf, FALSE, ch, 0, vict, TO_CHAR);

--- a/src/skills/chopoff.cpp
+++ b/src/skills/chopoff.cpp
@@ -10,143 +10,151 @@
 #include "screen.h"
 #include "skills.info.h"
 
-using  namespace FightSystem;
+using namespace FightSystem;
 
 // ************************* CHOPOFF PROCEDURES
-void go_chopoff(CHAR_DATA * ch, CHAR_DATA * vict) {
-    if (dontCanAct(ch)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
+void go_chopoff(CHAR_DATA *ch, CHAR_DATA *vict) {
+  if (dontCanAct(ch)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
+
+  if (PRF_FLAGS(ch).get(PRF_IRON_WIND)) {
+    send_to_char("Вы не можете применять этот прием в таком состоянии!\r\n", ch);
+    return;
+  }
+
+  if (ch->isHorsePrevents())
+    return;
+
+  if ((GET_POS(vict) < POS_FIGHTING)) {
+    if (number(1, 100) < ch->get_skill(SKILL_CHOPOFF)) {
+      send_to_char("Вы приготовились провести подсечку, но вовремя остановились.\r\n", ch);
+      //set_wait(ch, 1, FALSE);
+      //setSkillCooldown(ch, SKILL_CHOPOFF, 1);
+      ch->setSkillCooldown(SKILL_CHOPOFF, PULSE_VIOLENCE / 6);
+      return;
+    }
+  }
+
+  if (!pk_agro_action(ch, vict))
+    return;
+
+  int percent = number(1, skill_info[SKILL_CHOPOFF].max_percent);
+  int prob = calculate_skill(ch, SKILL_CHOPOFF, vict);
+
+  if (check_spell_on_player(ch, SPELL_WEB)) {
+    prob /= 3;
+  }
+  if (GET_GOD_FLAG(ch, GF_GODSLIKE)
+      || GET_MOB_HOLD(vict)
+      || GET_GOD_FLAG(vict, GF_GODSCURSE)) {
+    prob = percent;
+  }
+
+  if (GET_GOD_FLAG(ch, GF_GODSCURSE) ||
+      GET_GOD_FLAG(vict, GF_GODSLIKE) ||
+      vict->ahorse() || GET_POS(vict) < POS_FIGHTING || MOB_FLAGGED(vict, MOB_NOTRIP) || IS_IMMORTAL(vict))
+    prob = 0;
+
+  bool skillFail = percent > prob;
+  train_skill(ch, SKILL_CHOPOFF, !skillFail, vict);
+  if (skillFail) {
+    sprintf(buf, "%sВы попытались подсечь $N3, но упали сами...%s", CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
+    act(buf, FALSE, ch, 0, vict, TO_CHAR);
+    act("$n попытал$u подсечь вас, но упал$g сам$g.", FALSE, ch, 0, vict, TO_VICT);
+    act("$n попытал$u подсечь $N3, но упал$g сам$g.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+    GET_POS(ch) = POS_SITTING;
+    prob = 3;
+    if (can_use_feat(ch, EVASION_FEAT)) {
+      AFFECT_DATA<EApplyLocation> af;
+      af.type = SPELL_EXPEDIENT;
+      af.location = EApplyLocation::APPLY_PR;
+      af.modifier = 50;
+      af.duration = pc_duration(ch, 3, 0, 0, 0, 0);
+      af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+      affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+      af.location = EApplyLocation::APPLY_AR;
+      affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+      af.location = EApplyLocation::APPLY_MR;
+      affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
+      send_to_char(ch,
+                   "%sВы покатились по земле, пытаясь избежать атак %s.%s\r\n",
+                   CCIGRN(ch, C_NRM),
+                   GET_PAD(vict, 1),
+                   CCNRM(ch, C_NRM));
+      act("$n покатил$u по земле, пытаясь избежать ваших атак.", FALSE, ch, 0, vict, TO_VICT);
+      act("$n покатил$u по земле, пытаясь избежать атак $N1.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+    }
+  } else {
+    send_to_char(ch,
+                 "%sВы провели подсечку, ловко усадив %s на землю.%s\r\n",
+                 CCIBLU(ch, C_NRM),
+                 GET_PAD(vict, 3),
+                 CCNRM(ch, C_NRM));
+    act("$n ловко подсек$q вас, усадив на попу.", FALSE, ch, 0, vict, TO_VICT);
+    act("$n ловко подсек$q $N3, уронив $S на землю.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+    set_wait(vict, 3, FALSE);
+
+    if (ch->isInSameRoom(vict)) {
+      GET_POS(vict) = POS_SITTING;
     }
 
-    if (PRF_FLAGS(ch).get(PRF_IRON_WIND)) {
-        send_to_char("Вы не можете применять этот прием в таком состоянии!\r\n", ch);
-        return;
+    if (IS_HORSE(vict) && vict->get_master()->ahorse()) {
+      vict->drop_from_horse();
     }
+    prob = 1;
+  }
 
-    if (ch->isHorsePrevents())
-        return;
+  appear(ch);
+  if (IS_NPC(vict) && CAN_SEE(vict, ch) && vict->have_mind() && vict->get_wait() <= 0) {
+    set_hit(vict, ch);
+  }
 
-    if ((GET_POS(vict) < POS_FIGHTING)) {
-        if (number(1, 100) < ch->get_skill(SKILL_CHOPOFF)) {
-            send_to_char("Вы приготовились провести подсечку, но вовремя остановились.\r\n", ch);
-            //set_wait(ch, 1, FALSE);
-            //setSkillCooldown(ch, SKILL_CHOPOFF, 1);
-            ch->setSkillCooldown(SKILL_CHOPOFF, PULSE_VIOLENCE/6);
-            return;
-        }
-    }
-
-    if (!pk_agro_action(ch, vict))
-        return;
-
-    int percent = number(1, skill_info[SKILL_CHOPOFF].max_percent);
-    int prob = train_skill(ch, SKILL_CHOPOFF, skill_info[SKILL_CHOPOFF].max_percent, vict);
-
-    if (check_spell_on_player(ch, SPELL_WEB)) {
-        prob /= 3;
-    }
-    if (GET_GOD_FLAG(ch, GF_GODSLIKE)
-        || GET_MOB_HOLD(vict)
-        || GET_GOD_FLAG(vict, GF_GODSCURSE)) {
-        prob = percent;
-    }
-
-    if (GET_GOD_FLAG(ch, GF_GODSCURSE) ||
-        GET_GOD_FLAG(vict, GF_GODSLIKE) ||
-        vict->ahorse() || GET_POS(vict) < POS_FIGHTING || MOB_FLAGGED(vict, MOB_NOTRIP) || IS_IMMORTAL(vict))
-        prob = 0;
-
-    bool skillFail = percent > prob;
-
-    if (skillFail) {
-        sprintf(buf, "%sВы попытались подсечь $N3, но упали сами...%s", CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
-        act(buf,FALSE,ch,0,vict,TO_CHAR);
-        act("$n попытал$u подсечь вас, но упал$g сам$g.", FALSE, ch, 0, vict, TO_VICT);
-        act("$n попытал$u подсечь $N3, но упал$g сам$g.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-        GET_POS(ch) = POS_SITTING;
-        prob = 3;
-        if (can_use_feat(ch, EVASION_FEAT)) {
-            AFFECT_DATA<EApplyLocation> af;
-            af.type = SPELL_EXPEDIENT;
-            af.location = EApplyLocation::APPLY_PR;
-            af.modifier = 50;
-            af.duration = pc_duration(ch, 3, 0, 0, 0, 0);
-            af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-            affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-            af.location = EApplyLocation::APPLY_AR;
-            affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-            af.location = EApplyLocation::APPLY_MR;
-            affect_join(ch, af, FALSE, FALSE, FALSE, FALSE);
-            send_to_char(ch, "%sВы покатились по земле, пытаясь избежать атак %s.%s\r\n", CCIGRN(ch, C_NRM), GET_PAD(vict, 1), CCNRM(ch, C_NRM));
-            act("$n покатил$u по земле, пытаясь избежать ваших атак.", FALSE, ch, 0, vict, TO_VICT);
-            act("$n покатил$u по земле, пытаясь избежать атак $N1.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-        }
-    } else {
-        send_to_char(ch, "%sВы провели подсечку, ловко усадив %s на землю.%s\r\n", CCIBLU(ch, C_NRM), GET_PAD(vict, 3), CCNRM(ch, C_NRM));
-        act("$n ловко подсек$q вас, усадив на попу.", FALSE, ch, 0, vict, TO_VICT);
-        act("$n ловко подсек$q $N3, уронив $S на землю.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-        set_wait(vict, 3, FALSE);
-
-        if (ch->isInSameRoom(vict)) {
-            GET_POS(vict) = POS_SITTING;
-        }
-
-        if (IS_HORSE(vict) && vict->get_master()->ahorse()) {
-            vict->drop_from_horse();
-        }
-        prob = 1;
-    }
-
-    appear(ch);
-    if (IS_NPC(vict) && CAN_SEE(vict, ch) && vict->have_mind() && vict->get_wait() <= 0) {
-        set_hit(vict, ch);
-    }
-
-    if (skillFail) {
-        set_wait(ch, prob, FALSE);
-    } else  {
-        setSkillCooldownInFight(ch, SKILL_CHOPOFF, prob);
-        setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 1);
-    }
+  if (skillFail) {
+    set_wait(ch, prob, FALSE);
+  } else {
+    setSkillCooldownInFight(ch, SKILL_CHOPOFF, prob);
+    setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 1);
+  }
 }
 
 void do_chopoff(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-    if (ch->get_skill(SKILL_CHOPOFF) < 1) {
-        send_to_char("Вы не знаете как.\r\n", ch);
-        return;
-    }
-    if (ch->haveCooldown(SKILL_CHOPOFF)) {
-        send_to_char("Вам нужно набраться сил.\r\n", ch);
-        return;
-    };
+  if (ch->get_skill(SKILL_CHOPOFF) < 1) {
+    send_to_char("Вы не знаете как.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_CHOPOFF)) {
+    send_to_char("Вам нужно набраться сил.\r\n", ch);
+    return;
+  };
 
-    if (ch->ahorse()) {
-        send_to_char("Верхом это сделать затруднительно.\r\n", ch);
-        return;
-    }
+  if (ch->ahorse()) {
+    send_to_char("Верхом это сделать затруднительно.\r\n", ch);
+    return;
+  }
 
-    CHAR_DATA* vict = findVictim(ch, argument);
-    if (!vict) {
-        send_to_char("Кого вы собираетесь подсечь?\r\n", ch);
-        return;
-    }
+  CHAR_DATA *vict = findVictim(ch, argument);
+  if (!vict) {
+    send_to_char("Кого вы собираетесь подсечь?\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Вы можете воспользоваться командой <сесть>.\r\n", ch);
-        return;
-    }
+  if (vict == ch) {
+    send_to_char("Вы можете воспользоваться командой <сесть>.\r\n", ch);
+    return;
+  }
 
-    if (!may_kill_here(ch, vict, argument))
-        return;
-    if (!check_pkill(ch, vict, arg))
-        return;
+  if (!may_kill_here(ch, vict, argument))
+    return;
+  if (!check_pkill(ch, vict, arg))
+    return;
 
-    if (IS_IMPL(ch) || !ch->get_fighting())
-        go_chopoff(ch, vict);
-    else if (isHaveNoExtraAttack(ch)) {
-        if (!IS_NPC(ch))
-            act("Хорошо. Вы попытаетесь подсечь $N3.", FALSE, ch, 0, vict, TO_CHAR);
-        ch->set_extra_attack(EXTRA_ATTACK_CHOPOFF, vict);
-    }
+  if (IS_IMPL(ch) || !ch->get_fighting())
+    go_chopoff(ch, vict);
+  else if (isHaveNoExtraAttack(ch)) {
+    if (!IS_NPC(ch))
+      act("Хорошо. Вы попытаетесь подсечь $N3.", FALSE, ch, 0, vict, TO_CHAR);
+    ch->set_extra_attack(EXTRA_ATTACK_CHOPOFF, vict);
+  }
 }

--- a/src/skills/disarm.cpp
+++ b/src/skills/disarm.cpp
@@ -37,8 +37,8 @@ void go_disarm(CHAR_DATA *ch, CHAR_DATA *vict) {
     return;
   if (!pk_agro_action(ch, vict))
     return;
-  int percent = number(1, skill_info[SKILL_DISARM].max_percent);
-  int prob = calculate_skill(ch, SKILL_DISARM, vict);
+  int percent = number(1, skill_info[SKILL_DISARM].fail_percent);
+  int prob = CalcCurrentSkill(ch, SKILL_DISARM, vict);
   if (IS_IMMORTAL(ch) || GET_GOD_FLAG(vict, GF_GODSCURSE) || GET_GOD_FLAG(ch, GF_GODSLIKE))
     prob = percent;
   if (IS_IMMORTAL(vict) || GET_GOD_FLAG(ch, GF_GODSCURSE) || GET_GOD_FLAG(vict, GF_GODSLIKE)
@@ -46,7 +46,7 @@ void go_disarm(CHAR_DATA *ch, CHAR_DATA *vict) {
     prob = 0;
 
   bool success = percent <= prob;
-  train_skill(ch, SKILL_DISARM, success, vict);
+  TrainSkill(ch, SKILL_DISARM, success, vict);
   if (!success || GET_EQ(vict, pos)->get_extra_flag(EExtraFlag::ITEM_NODISARM)) {
     send_to_char(ch, "%sВы не сумели обезоружить %s...%s\r\n", CCWHT(ch, C_NRM), GET_PAD(vict, 3), CCNRM(ch, C_NRM));
     prob = 3;

--- a/src/skills/disarm.cpp
+++ b/src/skills/disarm.cpp
@@ -10,117 +10,115 @@
 #include "screen.h"
 #include "skills.info.h"
 
-using  namespace FightSystem;
+using namespace FightSystem;
 
 // ************* DISARM PROCEDURES
-void go_disarm(CHAR_DATA * ch, CHAR_DATA * vict) {
-    OBJ_DATA *wielded = GET_EQ(vict, WEAR_WIELD) ? GET_EQ(vict, WEAR_WIELD) :
-                        GET_EQ(vict, WEAR_BOTHS), *helded = GET_EQ(vict, WEAR_HOLD);
+void go_disarm(CHAR_DATA *ch, CHAR_DATA *vict) {
+  OBJ_DATA *wielded = GET_EQ(vict, WEAR_WIELD) ? GET_EQ(vict, WEAR_WIELD) :
+                      GET_EQ(vict, WEAR_BOTHS), *helded = GET_EQ(vict, WEAR_HOLD);
 
-    if (dontCanAct(ch)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
-    }
+  if (dontCanAct(ch)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
 
-    if (!((wielded && GET_OBJ_TYPE(wielded) != OBJ_DATA::ITEM_LIGHT)
-          || (helded && GET_OBJ_TYPE(helded) != OBJ_DATA::ITEM_LIGHT))) {
-        return;
-    }
-    int pos = 0;
-    if (number(1, 100) > 30) {
-        pos = wielded ? (GET_EQ(vict, WEAR_BOTHS) ? WEAR_BOTHS : WEAR_WIELD) : WEAR_HOLD;
+  if (!((wielded && GET_OBJ_TYPE(wielded) != OBJ_DATA::ITEM_LIGHT)
+      || (helded && GET_OBJ_TYPE(helded) != OBJ_DATA::ITEM_LIGHT))) {
+    return;
+  }
+  int pos = 0;
+  if (number(1, 100) > 30) {
+    pos = wielded ? (GET_EQ(vict, WEAR_BOTHS) ? WEAR_BOTHS : WEAR_WIELD) : WEAR_HOLD;
+  } else {
+    pos = helded ? WEAR_HOLD : (GET_EQ(vict, WEAR_BOTHS) ? WEAR_BOTHS : WEAR_WIELD);
+  }
+
+  if (!pos || !GET_EQ(vict, pos))
+    return;
+  if (!pk_agro_action(ch, vict))
+    return;
+  int percent = number(1, skill_info[SKILL_DISARM].max_percent);
+  int prob = calculate_skill(ch, SKILL_DISARM, vict);
+  if (IS_IMMORTAL(ch) || GET_GOD_FLAG(vict, GF_GODSCURSE) || GET_GOD_FLAG(ch, GF_GODSLIKE))
+    prob = percent;
+  if (IS_IMMORTAL(vict) || GET_GOD_FLAG(ch, GF_GODSCURSE) || GET_GOD_FLAG(vict, GF_GODSLIKE)
+      || can_use_feat(vict, STRONGCLUTCH_FEAT))
+    prob = 0;
+
+  bool success = percent <= prob;
+  train_skill(ch, SKILL_DISARM, success, vict);
+  if (!success || GET_EQ(vict, pos)->get_extra_flag(EExtraFlag::ITEM_NODISARM)) {
+    send_to_char(ch, "%sВы не сумели обезоружить %s...%s\r\n", CCWHT(ch, C_NRM), GET_PAD(vict, 3), CCNRM(ch, C_NRM));
+    prob = 3;
+  } else {
+    wielded = GET_EQ(vict, pos);
+    send_to_char(ch, "%sВы ловко выбили %s из рук %s!%s\r\n",
+                 CCIBLU(ch, C_NRM), wielded->get_PName(3).c_str(), GET_PAD(vict, 1), CCNRM(ch, C_NRM));
+    send_to_char(vict, "Ловкий удар %s выбил %s%s из ваших рук.\r\n",
+                 GET_PAD(ch, 1), wielded->get_PName(3).c_str(), char_get_custom_label(wielded, vict).c_str());
+    act("$n ловко выбил$g $o3 из рук $N1.", TRUE, ch, wielded, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+    unequip_char(vict, pos);
+    setSkillCooldown(ch, SKILL_GLOBAL_COOLDOWN, IS_NPC(vict) ? 1 : 2);
+    prob = 2;
+
+    if (ROOM_FLAGGED(IN_ROOM(vict), ROOM_ARENA) || (!IS_MOB(vict)) || vict->has_master()) {
+      obj_to_char(wielded, vict);
     } else {
-        pos = helded ? WEAR_HOLD : (GET_EQ(vict, WEAR_BOTHS) ? WEAR_BOTHS : WEAR_WIELD);
-    }
+      obj_to_room(wielded, IN_ROOM(vict));
+      obj_decay(wielded);
+    };
+  }
 
-    if (!pos || !GET_EQ(vict, pos))
-        return;
-    if (!pk_agro_action(ch, vict))
-        return;
-    int percent = number(1, skill_info[SKILL_DISARM].max_percent);
-    int prob = train_skill(ch, SKILL_DISARM, skill_info[SKILL_DISARM].max_percent, vict);
-    if (IS_IMMORTAL(ch) || GET_GOD_FLAG(vict, GF_GODSCURSE) || GET_GOD_FLAG(ch, GF_GODSLIKE))
-        prob = percent;
-    if (IS_IMMORTAL(vict) || GET_GOD_FLAG(ch, GF_GODSCURSE) || GET_GOD_FLAG(vict, GF_GODSLIKE) || can_use_feat(vict, STRONGCLUTCH_FEAT))
-        prob = 0;
-
-
-    if (percent > prob || GET_EQ(vict, pos)->get_extra_flag(EExtraFlag::ITEM_NODISARM)) {
-        send_to_char(ch, "%sВы не сумели обезоружить %s...%s\r\n", CCWHT(ch, C_NRM), GET_PAD(vict, 3), CCNRM(ch, C_NRM));
-        prob = 3;
-    } else {
-        wielded = GET_EQ(vict, pos);
-        send_to_char(ch, "%sВы ловко выбили %s из рук %s!%s\r\n",
-                     CCIBLU(ch, C_NRM), wielded->get_PName(3).c_str(), GET_PAD(vict, 1), CCNRM(ch, C_NRM));
-        send_to_char(vict, "Ловкий удар %s выбил %s%s из ваших рук.\r\n",
-                     GET_PAD(ch, 1), wielded->get_PName(3).c_str(), char_get_custom_label(wielded, vict).c_str());
-        act("$n ловко выбил$g $o3 из рук $N1.", TRUE, ch, wielded, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-        unequip_char(vict, pos);
-        //if (GET_WAIT(vict) <= 0) {
-        //set_wait(vict, IS_NPC(vict) ? 1 : 2, FALSE);
-        setSkillCooldown(ch, SKILL_GLOBAL_COOLDOWN, IS_NPC(vict) ? 1 : 2);
-        //}
-        prob = 2;
-
-        if (ROOM_FLAGGED(IN_ROOM(vict), ROOM_ARENA) || (!IS_MOB(vict)) || vict->has_master()) {
-            obj_to_char(wielded, vict);
-        } else {
-            obj_to_room(wielded, IN_ROOM(vict));
-            obj_decay(wielded);
-        };
-    }
-
-    appear(ch);
-    if (IS_NPC(vict) && CAN_SEE(vict, ch) && vict->have_mind() && GET_WAIT(ch) <= 0) {
-        set_hit(vict, ch);
-    }
-    //set_wait(ch, prob, FALSE);
-    setSkillCooldown(ch, SKILL_DISARM, prob);
-    setSkillCooldown(ch, SKILL_GLOBAL_COOLDOWN, 1);
+  appear(ch);
+  if (IS_NPC(vict) && CAN_SEE(vict, ch) && vict->have_mind() && GET_WAIT(ch) <= 0) {
+    set_hit(vict, ch);
+  }
+  setSkillCooldown(ch, SKILL_DISARM, prob);
+  setSkillCooldown(ch, SKILL_GLOBAL_COOLDOWN, 1);
 }
 
 void do_disarm(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-    if (IS_NPC(ch) || !ch->get_skill(SKILL_DISARM)) {
-        send_to_char("Вы не знаете как.\r\n", ch);
-        return;
-    }
-    if (ch->haveCooldown(SKILL_DISARM)) {
-        send_to_char("Вам нужно набраться сил.\r\n", ch);
-        return;
-    };
+  if (IS_NPC(ch) || !ch->get_skill(SKILL_DISARM)) {
+    send_to_char("Вы не знаете как.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_DISARM)) {
+    send_to_char("Вам нужно набраться сил.\r\n", ch);
+    return;
+  };
 
-    CHAR_DATA* vict = findVictim(ch, argument);
-    if (!vict) {
-        send_to_char("Кого обезоруживаем?\r\n", ch);
-        return;
-    }
+  CHAR_DATA *vict = findVictim(ch, argument);
+  if (!vict) {
+    send_to_char("Кого обезоруживаем?\r\n", ch);
+    return;
+  }
 
-    if (ch == vict) {
-        send_to_char("Попробуйте набрать \"снять <название.оружия>\".\r\n", ch);
-        return;
-    }
+  if (ch == vict) {
+    send_to_char("Попробуйте набрать \"снять <название.оружия>\".\r\n", ch);
+    return;
+  }
 
-    if (!may_kill_here(ch, vict, argument))
-        return;
-    if (!check_pkill(ch, vict, arg))
-        return;
+  if (!may_kill_here(ch, vict, argument))
+    return;
+  if (!check_pkill(ch, vict, arg))
+    return;
 
-    if (!((GET_EQ(vict, WEAR_WIELD)
-           && GET_OBJ_TYPE(GET_EQ(vict, WEAR_WIELD)) != OBJ_DATA::ITEM_LIGHT)
-          || (GET_EQ(vict, WEAR_HOLD)
-              && GET_OBJ_TYPE(GET_EQ(vict, WEAR_HOLD)) != OBJ_DATA::ITEM_LIGHT)
-          || (GET_EQ(vict, WEAR_BOTHS)
-              && GET_OBJ_TYPE(GET_EQ(vict, WEAR_BOTHS)) != OBJ_DATA::ITEM_LIGHT))) {
-        send_to_char("Вы не можете обезоружить безоружное создание.\r\n", ch);
-        return;
-    }
+  if (!((GET_EQ(vict, WEAR_WIELD)
+      && GET_OBJ_TYPE(GET_EQ(vict, WEAR_WIELD)) != OBJ_DATA::ITEM_LIGHT)
+      || (GET_EQ(vict, WEAR_HOLD)
+          && GET_OBJ_TYPE(GET_EQ(vict, WEAR_HOLD)) != OBJ_DATA::ITEM_LIGHT)
+      || (GET_EQ(vict, WEAR_BOTHS)
+          && GET_OBJ_TYPE(GET_EQ(vict, WEAR_BOTHS)) != OBJ_DATA::ITEM_LIGHT))) {
+    send_to_char("Вы не можете обезоружить безоружное создание.\r\n", ch);
+    return;
+  }
 
-    if (IS_IMPL(ch) || !ch->get_fighting()) {
-        go_disarm(ch, vict);
-    } else if (isHaveNoExtraAttack(ch)) {
-        act("Хорошо. Вы попытаетесь разоружить $N3.", FALSE, ch, 0, vict, TO_CHAR);
-        ch->set_extra_attack(EXTRA_ATTACK_DISARM, vict);
-    }
+  if (IS_IMPL(ch) || !ch->get_fighting()) {
+    go_disarm(ch, vict);
+  } else if (isHaveNoExtraAttack(ch)) {
+    act("Хорошо. Вы попытаетесь разоружить $N3.", FALSE, ch, 0, vict, TO_CHAR);
+    ch->set_extra_attack(EXTRA_ATTACK_DISARM, vict);
+  }
 }
 
 

--- a/src/skills/disarm.cpp
+++ b/src/skills/disarm.cpp
@@ -47,6 +47,7 @@ void go_disarm(CHAR_DATA *ch, CHAR_DATA *vict) {
 
   bool success = percent <= prob;
   TrainSkill(ch, SKILL_DISARM, success, vict);
+  SendSkillBalanceMsg(ch, skill_info[SKILL_DISARM].name, percent, prob, success);
   if (!success || GET_EQ(vict, pos)->get_extra_flag(EExtraFlag::ITEM_NODISARM)) {
     send_to_char(ch, "%sВы не сумели обезоружить %s...%s\r\n", CCWHT(ch, C_NRM), GET_PAD(vict, 3), CCNRM(ch, C_NRM));
     prob = 3;

--- a/src/skills/expendientcut.cpp
+++ b/src/skills/expendientcut.cpp
@@ -9,6 +9,7 @@
 #include "fightsystem/fight_constants.hpp"
 #include "fightsystem/pk.h"
 #include "skills/protect.h"
+#include "skills.h"
 #include "handler.h"
 
 #include <math.h>
@@ -16,300 +17,288 @@
 using namespace FightSystem;
 
 ESkill ExpedientWeaponSkill(CHAR_DATA *ch) {
-    ESkill skill = SKILL_PUNCH;
+  ESkill skill = SKILL_PUNCH;
 
-    if (GET_EQ(ch, WEAR_WIELD) && (GET_OBJ_TYPE(GET_EQ(ch, WEAR_WIELD)) == CObjectPrototype::ITEM_WEAPON)) {
-        skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_WIELD));
-    } else if (GET_EQ(ch, WEAR_BOTHS) && (GET_OBJ_TYPE(GET_EQ(ch, WEAR_BOTHS)) == CObjectPrototype::ITEM_WEAPON)) {
-        skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS));
-    } else if (GET_EQ(ch, WEAR_HOLD) && (GET_OBJ_TYPE(GET_EQ(ch, WEAR_HOLD)) == CObjectPrototype::ITEM_WEAPON)) {
-        skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_HOLD));
-    };
+  if (GET_EQ(ch, WEAR_WIELD) && (GET_OBJ_TYPE(GET_EQ(ch, WEAR_WIELD)) == CObjectPrototype::ITEM_WEAPON)) {
+    skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_WIELD));
+  } else if (GET_EQ(ch, WEAR_BOTHS) && (GET_OBJ_TYPE(GET_EQ(ch, WEAR_BOTHS)) == CObjectPrototype::ITEM_WEAPON)) {
+    skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS));
+  } else if (GET_EQ(ch, WEAR_HOLD) && (GET_OBJ_TYPE(GET_EQ(ch, WEAR_HOLD)) == CObjectPrototype::ITEM_WEAPON)) {
+    skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_HOLD));
+  };
 
-    return skill;
+  return skill;
 }
 int GetExpedientKeyParameter(CHAR_DATA *ch, ESkill skill) {
-    switch (skill) {
-        case SKILL_PUNCH:
-        case SKILL_CLUBS:
-        case SKILL_AXES:
-        case SKILL_BOTHHANDS:
-        case SKILL_SPADES:
-            return ch->get_str();
-            break;
-        case SKILL_LONGS:
-        case SKILL_SHORTS:
-        case SKILL_NONSTANDART:
-        case SKILL_BOWS:
-        case SKILL_PICK:
-            return ch->get_dex();
-            break;
-        default:
-            return ch->get_str();
-    }
+  switch (skill) {
+    case SKILL_PUNCH:
+    case SKILL_CLUBS:
+    case SKILL_AXES:
+    case SKILL_BOTHHANDS:
+    case SKILL_SPADES:return ch->get_str();
+      break;
+    case SKILL_LONGS:
+    case SKILL_SHORTS:
+    case SKILL_NONSTANDART:
+    case SKILL_BOWS:
+    case SKILL_PICK:return ch->get_dex();
+      break;
+    default:return ch->get_str();
+  }
 }
 int ParameterBonus(int parameter) {
-    return ((parameter-20)/4);
+  return ((parameter - 20) / 4);
 }
 int ExpedientRating(CHAR_DATA *ch, ESkill skill) {
-    return (ch->get_skill(skill)/2.00+ParameterBonus(GetExpedientKeyParameter(ch, skill)));
+  return floor(ch->get_skill(skill) / 2.00 + ParameterBonus(GetExpedientKeyParameter(ch, skill)));
 }
 int ExpedientCap(CHAR_DATA *ch, ESkill skill) {
-    if (!IS_NPC(ch)) {
-        return floor(1.33*(MAX_EXP_RMRT_PERCENT(ch)/2.00+ParameterBonus(GetExpedientKeyParameter(ch, skill))));
-    } else {
-        return floor(1.33*((MAX_EXP_PERCENT+5*MAX(0,GET_LEVEL(ch)-30)/2.00+ParameterBonus(GetExpedientKeyParameter(ch, skill)))));
-    }
+  if (!IS_NPC(ch)) {
+    return floor(1.33 * (CalcSkillRemortCap(ch) / 2.00 + ParameterBonus(GetExpedientKeyParameter(ch, skill))));
+  } else {
+    return floor(1.33 * ((kSkillCapOnZeroRemort + 5 * MAX(0, GET_LEVEL(ch) - 30) / 2.00
+        + ParameterBonus(GetExpedientKeyParameter(ch, skill)))));
+  }
 }
 int DegreeOfSuccess(int roll, int rating) {
-    return ((rating-roll)/5);
+  return ((rating - roll) / 5);
 }
 
 bool CheckExpedientSuccess(CHAR_DATA *ch, CHAR_DATA *victim) {
-    ESkill DoerSkill = ExpedientWeaponSkill(ch);
-    int DoerRating = ExpedientRating(ch, DoerSkill);
-    int DoerCap = ExpedientCap(ch, DoerSkill);
-    int DoerRoll = dice(1, DoerCap);
-    int DoerSuccess = DegreeOfSuccess(DoerRoll, DoerRating);
+  ESkill DoerSkill = ExpedientWeaponSkill(ch);
+  int DoerRating = ExpedientRating(ch, DoerSkill);
+  int DoerCap = ExpedientCap(ch, DoerSkill);
+  int DoerRoll = dice(1, DoerCap);
+  int DoerSuccess = DegreeOfSuccess(DoerRoll, DoerRating);
 
-    ESkill VictimSkill = ExpedientWeaponSkill(victim);
-    int VictimRating = ExpedientRating(victim, VictimSkill);
-    int VictimCap = ExpedientCap(victim, VictimSkill);
-    int VictimRoll = dice(1, VictimCap);
-    int VictimSuccess = DegreeOfSuccess(VictimRoll, VictimRating);
+  ESkill VictimSkill = ExpedientWeaponSkill(victim);
+  int VictimRating = ExpedientRating(victim, VictimSkill);
+  int VictimCap = ExpedientCap(victim, VictimSkill);
+  int VictimRoll = dice(1, VictimCap);
+  int VictimSuccess = DegreeOfSuccess(VictimRoll, VictimRating);
 
-    if ((DoerRoll <= DoerRating) && (VictimRoll > VictimRating))
-        return true;
-    if ((DoerRoll > DoerRating) && (VictimRoll <= VictimRating))
-        return false;
-    if ((DoerRoll > DoerRating) && (VictimRoll > VictimRating))
-        return CheckExpedientSuccess(ch, victim);
-
-    if (DoerSuccess > VictimSuccess)
-        return true;
-    if (DoerSuccess < VictimSuccess)
-        return false;
-
-    if (ParameterBonus(GetExpedientKeyParameter(ch, DoerSkill)) > ParameterBonus(GetExpedientKeyParameter(victim, VictimSkill)))
-        return true;
-    if (ParameterBonus(GetExpedientKeyParameter(ch, DoerSkill)) < ParameterBonus(GetExpedientKeyParameter(victim, VictimSkill)))
-        return false;
-
-    if (DoerRoll < VictimRoll)
-        return true;
-    if (DoerRoll > VictimRoll)
-        return true;
-
+  if ((DoerRoll <= DoerRating) && (VictimRoll > VictimRating))
+    return true;
+  if ((DoerRoll > DoerRating) && (VictimRoll <= VictimRating))
+    return false;
+  if ((DoerRoll > DoerRating) && (VictimRoll > VictimRating))
     return CheckExpedientSuccess(ch, victim);
-}
 
+  if (DoerSuccess > VictimSuccess)
+    return true;
+  if (DoerSuccess < VictimSuccess)
+    return false;
+
+  if (ParameterBonus(GetExpedientKeyParameter(ch, DoerSkill))
+      > ParameterBonus(GetExpedientKeyParameter(victim, VictimSkill)))
+    return true;
+  if (ParameterBonus(GetExpedientKeyParameter(ch, DoerSkill))
+      < ParameterBonus(GetExpedientKeyParameter(victim, VictimSkill)))
+    return false;
+
+  if (DoerRoll < VictimRoll)
+    return true;
+  if (DoerRoll > VictimRoll)
+    return true;
+
+  return CheckExpedientSuccess(ch, victim);
+}
 
 void ApplyNoFleeAffect(CHAR_DATA *ch, int duration) {
-    //Это жутко криво, но почемук-то при простановке сразу 2 флагов битвектора начинаются глюки, хотя все должно быть нормально
-    //По-видимому, где-то просто не учтено, что ненулевых битов может быть более 1
-    AFFECT_DATA<EApplyLocation> Noflee;
-    Noflee.type = SPELL_BATTLE;
-    Noflee.bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
-    Noflee.location = EApplyLocation::APPLY_NONE;
-    Noflee.modifier = 0;
-    Noflee.duration = pc_duration(ch, duration, 0, 0, 0, 0);;
-    Noflee.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-    affect_join(ch, Noflee, TRUE, FALSE, TRUE, FALSE);
+  //Это жутко криво, но почемук-то при простановке сразу 2 флагов битвектора начинаются глюки, хотя все должно быть нормально
+  //По-видимому, где-то просто не учтено, что ненулевых битов может быть более 1
+  AFFECT_DATA<EApplyLocation> Noflee;
+  Noflee.type = SPELL_BATTLE;
+  Noflee.bitvector = to_underlying(EAffectFlag::AFF_NOFLEE);
+  Noflee.location = EApplyLocation::APPLY_NONE;
+  Noflee.modifier = 0;
+  Noflee.duration = pc_duration(ch, duration, 0, 0, 0, 0);;
+  Noflee.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+  affect_join(ch, Noflee, TRUE, FALSE, TRUE, FALSE);
 
-    AFFECT_DATA<EApplyLocation> Battle;
-    Battle.type = SPELL_BATTLE;
-    Battle.bitvector = to_underlying(EAffectFlag::AFF_EXPEDIENT);
-    Battle.location = EApplyLocation::APPLY_NONE;
-    Battle.modifier = 0;
-    Battle.duration = pc_duration(ch, duration, 0, 0, 0, 0);;
-    Battle.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-    affect_join(ch, Battle, TRUE, FALSE, TRUE, FALSE);
+  AFFECT_DATA<EApplyLocation> Battle;
+  Battle.type = SPELL_BATTLE;
+  Battle.bitvector = to_underlying(EAffectFlag::AFF_EXPEDIENT);
+  Battle.location = EApplyLocation::APPLY_NONE;
+  Battle.modifier = 0;
+  Battle.duration = pc_duration(ch, duration, 0, 0, 0, 0);;
+  Battle.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+  affect_join(ch, Battle, TRUE, FALSE, TRUE, FALSE);
 
-    send_to_char("Вы выпали из ритма боя.\r\n", ch);
+  send_to_char("Вы выпали из ритма боя.\r\n", ch);
 }
 
+void go_cut_shorts(CHAR_DATA *ch, CHAR_DATA *vict) {
 
-void go_cut_shorts(CHAR_DATA * ch, CHAR_DATA * vict) {
+  if (dontCanAct(ch)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
 
-    if (dontCanAct(ch)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
-    }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_EXPEDIENT)) {
+    send_to_char("Вы еще не восстановил равновесие после предыдущего приема.\r\n", ch);
+    return;
+  }
 
-    if (AFF_FLAGGED(ch, EAffectFlag::AFF_EXPEDIENT)) {
-        send_to_char("Вы еще не восстановил равновесие после предыдущего приема.\r\n", ch);
-        return;
-    }
+  vict = try_protect(vict, ch);
 
-    vict = try_protect(vict, ch);
+  if (!CheckExpedientSuccess(ch, vict)) {
+    act("Ваши свистящие удары пропали втуне, не задев $N3.", FALSE, ch, 0, vict, TO_CHAR);
+    Damage dmg(SkillDmg(SKILL_SHORTS), ZERO_DMG, PHYS_DMG);
+    dmg.process(ch, vict);
+    ApplyNoFleeAffect(ch, 2);
+    return;
+  }
 
-    if (!CheckExpedientSuccess(ch, vict)) {
-        act("Ваши свистящие удары пропали втуне, не задев $N3.", FALSE, ch, 0, vict, TO_CHAR);
-        Damage dmg(SkillDmg(SKILL_SHORTS), ZERO_DMG, PHYS_DMG);
-        dmg.process(ch, vict);
-        ApplyNoFleeAffect(ch, 2);
-        return;
-    }
+  act("$n сделал$g неуловимое движение и на мгновение исчез$q из вида.", FALSE, ch, 0, vict, TO_VICT);
+  act("$n сделал$g неуловимое движение, сместившись за спину $N1.",
+      TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+  hit(ch, vict, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
+  hit(ch, vict, ESkill::SKILL_UNDEF, FightSystem::OFFHAND);
 
-    act("$n сделал$g неуловимое движение и на мгновение исчез$q из вида.", FALSE, ch, 0, vict, TO_VICT);
-    act("$n сделал$g неуловимое движение, сместившись за спину $N1.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-    hit(ch, vict, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
-    hit(ch, vict, ESkill::SKILL_UNDEF, FightSystem::OFFHAND);
+  AFFECT_DATA<EApplyLocation> AffectImmunPhysic;
+  AffectImmunPhysic.type = SPELL_EXPEDIENT;
+  AffectImmunPhysic.location = EApplyLocation::APPLY_PR;
+  AffectImmunPhysic.modifier = 100;
+  AffectImmunPhysic.duration = pc_duration(ch, 3, 0, 0, 0, 0);
+  AffectImmunPhysic.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+  affect_join(ch, AffectImmunPhysic, FALSE, FALSE, FALSE, FALSE);
+  AFFECT_DATA<EApplyLocation> AffectImmunMagic;
+  AffectImmunMagic.type = SPELL_EXPEDIENT;
+  AffectImmunMagic.location = EApplyLocation::APPLY_MR;
+  AffectImmunMagic.modifier = 100;
+  AffectImmunMagic.duration = pc_duration(ch, 3, 0, 0, 0, 0);
+  AffectImmunMagic.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+  affect_join(ch, AffectImmunMagic, FALSE, FALSE, FALSE, FALSE);
 
-    AFFECT_DATA<EApplyLocation> AffectImmunPhysic;
-    AffectImmunPhysic.type = SPELL_EXPEDIENT;
-    AffectImmunPhysic.location = EApplyLocation::APPLY_PR;
-    AffectImmunPhysic.modifier = 100;
-    AffectImmunPhysic.duration = pc_duration(ch, 3, 0, 0, 0, 0);
-    AffectImmunPhysic.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-    affect_join(ch, AffectImmunPhysic, FALSE, FALSE, FALSE, FALSE);
-    AFFECT_DATA<EApplyLocation> AffectImmunMagic;
-    AffectImmunMagic.type = SPELL_EXPEDIENT;
-    AffectImmunMagic.location = EApplyLocation::APPLY_MR;
-    AffectImmunMagic.modifier = 100;
-    AffectImmunMagic.duration = pc_duration(ch, 3, 0, 0, 0, 0);
-    AffectImmunMagic.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-    affect_join(ch, AffectImmunMagic, FALSE, FALSE, FALSE, FALSE);
-
-    ApplyNoFleeAffect(ch, 3);
+  ApplyNoFleeAffect(ch, 3);
 }
 
 void SetExtraAttackCutShorts(CHAR_DATA *ch, CHAR_DATA *victim) {
-    if (!isHaveNoExtraAttack(ch)) {
-        return;
-    }
+  if (!isHaveNoExtraAttack(ch)) {
+    return;
+  }
 
-    if (!pk_agro_action(ch, victim)) {
-        return;
-    }
+  if (!pk_agro_action(ch, victim)) {
+    return;
+  }
 
-
-    if (!ch->get_fighting()) {
-        act("Ваше оружие свистнуло, когда вы бросились на $N3, применив \"порез\".", FALSE, ch, 0, victim, TO_CHAR);
-        set_fighting(ch, victim);
-        ch->set_extra_attack(EXTRA_ATTACK_CUT_SHORTS, victim);
-    } else {
-        act("Хорошо. Вы попытаетесь порезать $N3.", FALSE, ch, 0, victim, TO_CHAR);
-        ch->set_extra_attack(EXTRA_ATTACK_CUT_SHORTS, victim);
-    }
+  if (!ch->get_fighting()) {
+    act("Ваше оружие свистнуло, когда вы бросились на $N3, применив \"порез\".", FALSE, ch, 0, victim, TO_CHAR);
+    set_fighting(ch, victim);
+    ch->set_extra_attack(EXTRA_ATTACK_CUT_SHORTS, victim);
+  } else {
+    act("Хорошо. Вы попытаетесь порезать $N3.", FALSE, ch, 0, victim, TO_CHAR);
+    ch->set_extra_attack(EXTRA_ATTACK_CUT_SHORTS, victim);
+  }
 }
 
 void SetExtraAttackCutPick(CHAR_DATA *ch, CHAR_DATA *victim) {
-    if (!isHaveNoExtraAttack(ch)) {
-        return;
-    }
-    if (!pk_agro_action(ch, victim)) {
-        return;
-    }
+  if (!isHaveNoExtraAttack(ch)) {
+    return;
+  }
+  if (!pk_agro_action(ch, victim)) {
+    return;
+  }
 
-    if (!ch->get_fighting()) {
-        act("Вы перехватили оружие обратным хватом и проскользнули за спину $N1.", FALSE, ch, 0, victim, TO_CHAR);
-        set_fighting(ch, victim);
-        ch->set_extra_attack(EXTRA_ATTACK_CUT_PICK, victim);
-    } else {
-        act("Хорошо. Вы попытаетесь порезать $N3.", FALSE, ch, 0, victim, TO_CHAR);
-        ch->set_extra_attack(EXTRA_ATTACK_CUT_PICK, victim);
-    }
+  if (!ch->get_fighting()) {
+    act("Вы перехватили оружие обратным хватом и проскользнули за спину $N1.", FALSE, ch, 0, victim, TO_CHAR);
+    set_fighting(ch, victim);
+    ch->set_extra_attack(EXTRA_ATTACK_CUT_PICK, victim);
+  } else {
+    act("Хорошо. Вы попытаетесь порезать $N3.", FALSE, ch, 0, victim, TO_CHAR);
+    ch->set_extra_attack(EXTRA_ATTACK_CUT_PICK, victim);
+  }
 }
 
-
-
-
-
-
-
-
-
 ESkill GetExpedientCutSkill(CHAR_DATA *ch) {
-    ESkill skill = SKILL_INVALID;
+  ESkill skill = SKILL_INVALID;
 
-    if (GET_EQ(ch, WEAR_WIELD) && GET_EQ(ch, WEAR_HOLD)) {
-        skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_WIELD));
-        if (skill != GET_OBJ_SKILL(GET_EQ(ch, WEAR_HOLD))) {
-            send_to_char("Для этого приема в обеих руках нужно держать оружие одого типа!\r\n", ch);
-            return SKILL_INVALID;
-        }
-    } else if (GET_EQ(ch, WEAR_BOTHS)) {
-        skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS));
-    } else {
-        send_to_char("Для этого приема вам надо использовать одинаковое оружие в обеих руках либо двуручное.\r\n", ch);
-        return SKILL_INVALID;
+  if (GET_EQ(ch, WEAR_WIELD) && GET_EQ(ch, WEAR_HOLD)) {
+    skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_WIELD));
+    if (skill != GET_OBJ_SKILL(GET_EQ(ch, WEAR_HOLD))) {
+      send_to_char("Для этого приема в обеих руках нужно держать оружие одого типа!\r\n", ch);
+      return SKILL_INVALID;
     }
+  } else if (GET_EQ(ch, WEAR_BOTHS)) {
+    skill = static_cast<ESkill>GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS));
+  } else {
+    send_to_char("Для этого приема вам надо использовать одинаковое оружие в обеих руках либо двуручное.\r\n", ch);
+    return SKILL_INVALID;
+  }
 
-    if (!can_use_feat(ch, find_weapon_master_by_skill(skill)) && !IS_IMPL(ch)) {
-        send_to_char("Вы недостаточно искусны в обращении с этим видом оружия.\r\n", ch);
-        return SKILL_INVALID;
-    }
+  if (!can_use_feat(ch, FindWeaponMasterBySkill(skill)) && !IS_IMPL(ch)) {
+    send_to_char("Вы недостаточно искусны в обращении с этим видом оружия.\r\n", ch);
+    return SKILL_INVALID;
+  }
 
-    return skill;
+  return skill;
 }
 
 void do_expedient_cut(CHAR_DATA *ch, char *argument, int/* cmd*/, int /*subcmd*/) {
 
-    ESkill skill;
+  ESkill skill;
 
-    if (IS_NPC(ch) || (!can_use_feat(ch, EXPEDIENT_CUT_FEAT) && !IS_IMPL(ch))) {
-        send_to_char("Вы не владеете таким приемом.\r\n", ch);
-        return;
-    }
+  if (IS_NPC(ch) || (!can_use_feat(ch, EXPEDIENT_CUT_FEAT) && !IS_IMPL(ch))) {
+    send_to_char("Вы не владеете таким приемом.\r\n", ch);
+    return;
+  }
 
-    if (ch->ahorse()) {
-        send_to_char("Верхом это сделать затруднительно.\r\n", ch);
-        return;
-    }
+  if (ch->ahorse()) {
+    send_to_char("Верхом это сделать затруднительно.\r\n", ch);
+    return;
+  }
 
-    if (GET_POS(ch) < POS_FIGHTING) {
-        send_to_char("Вам стоит встать на ноги.\r\n", ch);
-        return;
-    }
+  if (GET_POS(ch) < POS_FIGHTING) {
+    send_to_char("Вам стоит встать на ноги.\r\n", ch);
+    return;
+  }
 
-    if (!isHaveNoExtraAttack(ch)) {
-        return;
-    }
+  if (!isHaveNoExtraAttack(ch)) {
+    return;
+  }
 
-    if (AFF_FLAGGED(ch, EAffectFlag::AFF_STOPRIGHT) || AFF_FLAGGED(ch, EAffectFlag::AFF_STOPFIGHT)
-        || AFF_FLAGGED(ch, EAffectFlag::AFF_MAGICSTOPFIGHT)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
-    }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_STOPRIGHT) || AFF_FLAGGED(ch, EAffectFlag::AFF_STOPFIGHT)
+      || AFF_FLAGGED(ch, EAffectFlag::AFF_MAGICSTOPFIGHT)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
 
-    CHAR_DATA* vict = findVictim(ch, argument);
-    if (!vict) {
-        send_to_char("Кого вы хотите порезать?\r\n", ch);
-        return;
-    }
+  CHAR_DATA *vict = findVictim(ch, argument);
+  if (!vict) {
+    send_to_char("Кого вы хотите порезать?\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Вы таки да? Ой-вей, но тут таки Древняя Русь, а не Палестина!\r\n", ch);
-        return;
-    }
-    if (ch->get_fighting() && vict->get_fighting() != ch) {
-        act("$N не сражается с вами, не трогайте $S.", FALSE, ch, 0, vict, TO_CHAR);
-        return;
-    }
+  if (vict == ch) {
+    send_to_char("Вы таки да? Ой-вей, но тут таки Древняя Русь, а не Палестина!\r\n", ch);
+    return;
+  }
+  if (ch->get_fighting() && vict->get_fighting() != ch) {
+    act("$N не сражается с вами, не трогайте $S.", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
 
-    if (!may_kill_here(ch, vict, argument))
-        return;
-    if (!check_pkill(ch, vict, arg))
-        return;
+  if (!may_kill_here(ch, vict, argument))
+    return;
+  if (!check_pkill(ch, vict, arg))
+    return;
 
-    skill = GetExpedientCutSkill(ch);
-    if (skill == SKILL_INVALID)
-        return;
+  skill = GetExpedientCutSkill(ch);
+  if (skill == SKILL_INVALID)
+    return;
 
-    switch (skill) {
-        case SKILL_SHORTS:
-            SetExtraAttackCutShorts(ch, vict);
-            break;
-        case SKILL_SPADES:
-            SetExtraAttackCutShorts(ch, vict);
-            break;
-        case SKILL_LONGS:
-        case SKILL_BOTHHANDS:
-            send_to_char("Порез мечом (а тем более двуручником или копьем) - это сурьезно. Но пока невозможно.\r\n", ch);
-            break;
-        default:
-            send_to_char("Ваше оружие не позволяет провести такой прием.\r\n", ch);
-    }
+  switch (skill) {
+    case SKILL_SHORTS:SetExtraAttackCutShorts(ch, vict);
+      break;
+    case SKILL_SPADES:SetExtraAttackCutShorts(ch, vict);
+      break;
+    case SKILL_LONGS:
+    case SKILL_BOTHHANDS:
+      send_to_char("Порез мечом (а тем более двуручником или копьем) - это сурьезно. Но пока невозможно.\r\n",
+                   ch);
+      break;
+    default:send_to_char("Ваше оружие не позволяет провести такой прием.\r\n", ch);
+  }
 
 }

--- a/src/skills/kick.cpp
+++ b/src/skills/kick.cpp
@@ -8,177 +8,175 @@
 #include "protect.h"
 #include "skills.info.h"
 
-using  namespace FightSystem;
+using namespace FightSystem;
 
 // ******************  KICK PROCEDURES
-void go_kick(CHAR_DATA * ch, CHAR_DATA * vict) {
-    const char *to_char = NULL, *to_vict = NULL, *to_room = NULL;
+void go_kick(CHAR_DATA *ch, CHAR_DATA *vict) {
+  const char *to_char = NULL, *to_vict = NULL, *to_room = NULL;
 
-    if (dontCanAct(ch)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
+  if (dontCanAct(ch)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_KICK)) {
+    send_to_char("Вы уже все ноги себе отбили, отдохните слегка.\r\n", ch);
+    return;
+  };
+
+  vict = try_protect(vict, ch);
+
+  int percent = ((10 - (compute_armor_class(vict) / 10)) * 2) + number(1, skill_info[SKILL_KICK].max_percent);
+  int prob = calculate_skill(ch, SKILL_KICK, vict);
+  if (GET_GOD_FLAG(vict, GF_GODSCURSE) || GET_MOB_HOLD(vict)) {
+    prob = percent;
+  }
+  if (GET_GOD_FLAG(ch, GF_GODSCURSE) || (!ch->ahorse() && vict->ahorse())) {
+    prob = 0;
+  }
+
+  if (check_spell_on_player(ch, SPELL_WEB)) {
+    prob /= 3;
+  }
+
+  bool success = percent <= prob;
+  train_skill(ch, SKILL_KICK, success, vict);
+  if (!success) {
+    Damage dmg(SkillDmg(SKILL_KICK), ZERO_DMG, PHYS_DMG);
+    dmg.process(ch, vict);
+    prob = 2;
+  } else {
+    int dam = str_bonus(GET_REAL_STR(ch), STR_TO_DAM) + GET_REAL_DR(ch) + GET_LEVEL(ch) / 6;
+    if (!IS_NPC(ch) || (IS_NPC(ch) && GET_EQ(ch, WEAR_FEET))) {
+      int modi = MAX(0, (ch->get_skill(SKILL_KICK) + 4) / 5);
+      dam += number(0, modi * 2);
+      modi = 5 * (10 + (GET_EQ(ch, WEAR_FEET) ? GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_FEET)) : 0));
+      dam = modi * dam / 100;
     }
-    if (ch->haveCooldown(SKILL_KICK)) {
-        send_to_char("Вы уже все ноги себе отбили, отдохните слегка.\r\n", ch);
-        return;
-    };
-
-    vict = try_protect(vict, ch);
-
-    int percent = ((10 - (compute_armor_class(vict) / 10)) * 2) + number(1, skill_info[SKILL_KICK].max_percent);
-    int prob = train_skill(ch, SKILL_KICK, skill_info[SKILL_KICK].max_percent, vict);
-    if (GET_GOD_FLAG(vict, GF_GODSCURSE) || GET_MOB_HOLD(vict)) {
-        prob = percent;
-    }
-    if (GET_GOD_FLAG(ch, GF_GODSCURSE) || (!ch->ahorse() && vict->ahorse())) {
-        prob = 0;
-    }
-
-    if (check_spell_on_player(ch, SPELL_WEB)) {
-        prob /= 3;
-    }
-
-    if (percent > prob) {
-        Damage dmg(SkillDmg(SKILL_KICK), ZERO_DMG, PHYS_DMG);
-        dmg.process(ch, vict);
-        prob = 2;
-    } else {
-        int dam = str_bonus(GET_REAL_STR(ch), STR_TO_DAM) + GET_REAL_DR(ch) + GET_LEVEL(ch) / 6;
-        if (!IS_NPC(ch) || (IS_NPC(ch) && GET_EQ(ch, WEAR_FEET))) {
-            int modi = MAX(0, (ch->get_skill(SKILL_KICK) + 4) / 5);
-            dam += number(0, modi * 2);
-            modi = 5 * (10 + (GET_EQ(ch, WEAR_FEET) ? GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_FEET)) : 0));
-            dam = modi * dam / 100;
-        }
-        if (ch->ahorse() && (ch->get_skill(SKILL_HORSE) >= 150) && (ch->get_skill(SKILL_KICK) >= 150)) {
-            AFFECT_DATA<EApplyLocation> af;
-            af.location = APPLY_NONE;
+    if (ch->ahorse() && (ch->get_skill(SKILL_HORSE) >= 150) && (ch->get_skill(SKILL_KICK) >= 150)) {
+      AFFECT_DATA<EApplyLocation> af;
+      af.location = APPLY_NONE;
+      af.type = SPELL_BATTLE;
+      af.modifier = 0;
+      af.battleflag = 0;
+      float modi = ((ch->get_skill(SKILL_KICK) + GET_REAL_STR(ch) * 5)
+          + (GET_EQ(ch, WEAR_FEET) ? GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_FEET)) : 0) * 3) / float(GET_SIZE(vict));
+      if (number(1, 1000) < modi * 10) {
+        switch (number(0, (ch->get_skill(SKILL_KICK) - 150) / 10)) {
+          case 0:
+          case 1:
+            if (!AFF_FLAGGED(vict, EAffectFlag::AFF_STOPRIGHT)) {
+              to_char = "Каблук вашего сапога надолго запомнится $N2, если конечно он выживет.";
+              to_vict = "Мощный удар ноги $n1 изуродовал вам правую руку.";
+              to_room = "След сапога $n1 надолго запомнится $N2, если конечно он выживет.";
+              af.type = SPELL_BATTLE;
+              af.bitvector = to_underlying(EAffectFlag::AFF_STOPRIGHT);
+              af.duration = pc_duration(vict, 3 + GET_REMORT(ch) / 4, 0, 0, 0, 0);
+              af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+            } else if (!AFF_FLAGGED(vict, EAffectFlag::AFF_STOPLEFT)) {
+              to_char = "Каблук вашего сапога надолго запомнится $N2, если конечно он выживет.";
+              to_vict = "Мощный удар ноги $n1 изуродовал вам левую руку.";
+              to_room = "След сапога $n1 надолго запомнится $N2, если конечно он выживет.";
+              af.bitvector = to_underlying(EAffectFlag::AFF_STOPLEFT);
+              af.duration = pc_duration(vict, 3 + GET_REMORT(ch) / 4, 0, 0, 0, 0);
+              af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+            } else {
+              to_char = "Каблук вашего сапога надолго запомнится $N2, $M теперь даже бить вас нечем.";
+              to_vict = "Мощный удар ноги $n1 вывел вас из строя.";
+              to_room = "Каблук сапога $n1 надолго запомнится $N2, $M теперь даже биться нечем.";
+              af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+              af.duration = pc_duration(vict, 3 + GET_REMORT(ch) / 4, 0, 0, 0, 0);
+              af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+            }
+            dam *= 2;
+            break;
+          case 2:
+          case 3:to_char = "Сильно пнув в челюсть, вы заставили $N3 замолчать.";
+            to_vict = "Мощный удар ноги $n1 попал вам точно в челюсть, заставив вас замолчать.";
+            to_room = "Сильно пнув ногой в челюсть $N3, $n заставил$q $S замолчать.";
             af.type = SPELL_BATTLE;
-            af.modifier = 0;
-            af.battleflag = 0;
-            float modi = ((ch->get_skill(SKILL_KICK) + GET_REAL_STR(ch) * 5)
-                          + (GET_EQ(ch, WEAR_FEET) ? GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_FEET)) : 0) * 3) / float(GET_SIZE(vict));
-            if (number(1, 1000) < modi * 10) {
-                switch (number(0, (ch->get_skill(SKILL_KICK) - 150) / 10)) {
-                    case 0:
-                    case 1:
-                        if (!AFF_FLAGGED(vict, EAffectFlag::AFF_STOPRIGHT)) {
-                            to_char = "Каблук вашего сапога надолго запомнится $N2, если конечно он выживет.";
-                            to_vict = "Мощный удар ноги $n1 изуродовал вам правую руку.";
-                            to_room = "След сапога $n1 надолго запомнится $N2, если конечно он выживет.";
-                            af.type = SPELL_BATTLE;
-                            af.bitvector = to_underlying(EAffectFlag::AFF_STOPRIGHT);
-                            af.duration = pc_duration(vict, 3 + GET_REMORT(ch) / 4, 0, 0, 0, 0);
-                            af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-                        } else if (!AFF_FLAGGED(vict, EAffectFlag::AFF_STOPLEFT)) {
-                            to_char = "Каблук вашего сапога надолго запомнится $N2, если конечно он выживет.";
-                            to_vict = "Мощный удар ноги $n1 изуродовал вам левую руку.";
-                            to_room = "След сапога $n1 надолго запомнится $N2, если конечно он выживет.";
-                            af.bitvector = to_underlying(EAffectFlag::AFF_STOPLEFT);
-                            af.duration = pc_duration(vict, 3 + GET_REMORT(ch) / 4, 0, 0, 0, 0);
-                            af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-                        } else {
-                            to_char = "Каблук вашего сапога надолго запомнится $N2, $M теперь даже бить вас нечем.";
-                            to_vict = "Мощный удар ноги $n1 вывел вас из строя.";
-                            to_room = "Каблук сапога $n1 надолго запомнится $N2, $M теперь даже биться нечем.";
-                            af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-                            af.duration = pc_duration(vict, 3 + GET_REMORT(ch) / 4, 0, 0, 0, 0);
-                            af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-                        }
-                        dam *= 2;
-                        break;
-                    case 2:
-                    case 3:
-                        to_char = "Сильно пнув в челюсть, вы заставили $N3 замолчать.";
-                        to_vict = "Мощный удар ноги $n1 попал вам точно в челюсть, заставив вас замолчать.";
-                        to_room = "Сильно пнув ногой в челюсть $N3, $n заставил$q $S замолчать.";
-                        af.type = SPELL_BATTLE;
-                        af.bitvector = to_underlying(EAffectFlag::AFF_SILENCE);
-                        af.duration = pc_duration(vict, 3 + GET_REMORT(ch) / 5, 0, 0, 0, 0);
-                        af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-                        dam *= 2;
-                        break;
-                    case 4:
-                    case 5:
-                        WAIT_STATE(vict, number(2, 5) * PULSE_VIOLENCE);
-                        if (GET_POS(vict) > POS_SITTING) {
-                            GET_POS(vict) = POS_SITTING;
-                        }
-                        to_char = "Ваш мощный пинок выбил пару зубов $N2, усадив $S на землю!";
-                        to_vict = "Мощный удар ноги $n1 попал точно в голову, свалив вас с ног.";
-                        to_room = "Мощный пинок $n1 выбил пару зубов $N2, усадив $S на землю!";
-                        dam *= 2;
-                        break;
-                    default:
-                        break;
-                }
-            } else if (number(1, 1000) < (ch->get_skill(SKILL_HORSE) / 2)) {
-                dam *= 2;
-                if (!IS_NPC(ch))
-                    send_to_char("Вы привстали на стременах.\r\n", ch);
+            af.bitvector = to_underlying(EAffectFlag::AFF_SILENCE);
+            af.duration = pc_duration(vict, 3 + GET_REMORT(ch) / 5, 0, 0, 0, 0);
+            af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+            dam *= 2;
+            break;
+          case 4:
+          case 5:WAIT_STATE(vict, number(2, 5) * PULSE_VIOLENCE);
+            if (GET_POS(vict) > POS_SITTING) {
+              GET_POS(vict) = POS_SITTING;
             }
-
-            if (to_char) {
-                if (!IS_NPC(ch)) {
-                    sprintf(buf, "&G&q%s&Q&n", to_char);
-                    act(buf, FALSE, ch, 0, vict, TO_CHAR);
-                    sprintf(buf, "%s", to_room);
-                    act(buf, TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-                }
-            }
-            if (to_vict) {
-                if (!IS_NPC(vict)) {
-                    sprintf(buf, "&R&q%s&Q&n", to_vict);
-                    act(buf, FALSE, ch, 0, vict, TO_VICT);
-                }
-            }
-            affect_join(vict, af, TRUE, FALSE, TRUE, FALSE);
+            to_char = "Ваш мощный пинок выбил пару зубов $N2, усадив $S на землю!";
+            to_vict = "Мощный удар ноги $n1 попал точно в голову, свалив вас с ног.";
+            to_room = "Мощный пинок $n1 выбил пару зубов $N2, усадив $S на землю!";
+            dam *= 2;
+            break;
+          default:break;
         }
+      } else if (number(1, 1000) < (ch->get_skill(SKILL_HORSE) / 2)) {
+        dam *= 2;
+        if (!IS_NPC(ch))
+          send_to_char("Вы привстали на стременах.\r\n", ch);
+      }
 
-        if (GET_AF_BATTLE(vict, EAF_AWAKE)) {
-            dam >>= (2 - (ch->ahorse()? 1 : 0));
+      if (to_char) {
+        if (!IS_NPC(ch)) {
+          sprintf(buf, "&G&q%s&Q&n", to_char);
+          act(buf, FALSE, ch, 0, vict, TO_CHAR);
+          sprintf(buf, "%s", to_room);
+          act(buf, TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
         }
-        Damage dmg(SkillDmg(SKILL_KICK), dam, PHYS_DMG);
-        dmg.process(ch, vict);
-        prob = 2;
+      }
+      if (to_vict) {
+        if (!IS_NPC(vict)) {
+          sprintf(buf, "&R&q%s&Q&n", to_vict);
+          act(buf, FALSE, ch, 0, vict, TO_VICT);
+        }
+      }
+      affect_join(vict, af, TRUE, FALSE, TRUE, FALSE);
     }
-    //set_wait(ch, prob, TRUE);
-    setSkillCooldownInFight(ch, SKILL_KICK, prob);
-    setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 1);
+
+    if (GET_AF_BATTLE(vict, EAF_AWAKE)) {
+      dam >>= (2 - (ch->ahorse() ? 1 : 0));
+    }
+    Damage dmg(SkillDmg(SKILL_KICK), dam, PHYS_DMG);
+    dmg.process(ch, vict);
+    prob = 2;
+  }
+  setSkillCooldownInFight(ch, SKILL_KICK, prob);
+  setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 1);
 }
 
 void do_kick(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-    if (IS_NPC(ch) || !ch->get_skill(SKILL_KICK)) {
-        send_to_char("Вы не знаете как.\r\n", ch);
-        return;
-    }
-    if (ch->haveCooldown(SKILL_KICK)) {
-        send_to_char("Вам нужно набраться сил.\r\n", ch);
-        return;
-    };
+  if (IS_NPC(ch) || !ch->get_skill(SKILL_KICK)) {
+    send_to_char("Вы не знаете как.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_KICK)) {
+    send_to_char("Вам нужно набраться сил.\r\n", ch);
+    return;
+  };
 
-    CHAR_DATA* vict = findVictim(ch, argument);
-    if (!vict) {
-        send_to_char("Кто это так сильно путается под вашими ногами?\r\n", ch);
-        return;
-    }
+  CHAR_DATA *vict = findVictim(ch, argument);
+  if (!vict) {
+    send_to_char("Кто это так сильно путается под вашими ногами?\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Вы БОЛЬНО пнули себя! Поздравляю, вы сошли с ума...\r\n", ch);
-        return;
-    }
+  if (vict == ch) {
+    send_to_char("Вы БОЛЬНО пнули себя! Поздравляю, вы сошли с ума...\r\n", ch);
+    return;
+  }
 
-    if (!may_kill_here(ch, vict, argument))
-        return;
-    if (!check_pkill(ch, vict, arg))
-        return;
+  if (!may_kill_here(ch, vict, argument))
+    return;
+  if (!check_pkill(ch, vict, arg))
+    return;
 
-    if (IS_IMPL(ch) || !ch->get_fighting()) {
-        go_kick(ch, vict);
-    } else if (isHaveNoExtraAttack(ch)) {
-        act("Хорошо. Вы попытаетесь пнуть $N3.", FALSE, ch, 0, vict, TO_CHAR);
-        ch->set_extra_attack(EXTRA_ATTACK_KICK, vict);
-    }
+  if (IS_IMPL(ch) || !ch->get_fighting()) {
+    go_kick(ch, vict);
+  } else if (isHaveNoExtraAttack(ch)) {
+    act("Хорошо. Вы попытаетесь пнуть $N3.", FALSE, ch, 0, vict, TO_CHAR);
+    ch->set_extra_attack(EXTRA_ATTACK_KICK, vict);
+  }
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/skills/kick.cpp
+++ b/src/skills/kick.cpp
@@ -40,6 +40,7 @@ void go_kick(CHAR_DATA *ch, CHAR_DATA *vict) {
 
   bool success = percent <= prob;
   TrainSkill(ch, SKILL_KICK, success, vict);
+  SendSkillBalanceMsg(ch, skill_info[SKILL_KICK].name, percent, prob, success);
   if (!success) {
     Damage dmg(SkillDmg(SKILL_KICK), ZERO_DMG, PHYS_DMG);
     dmg.process(ch, vict);

--- a/src/skills/kick.cpp
+++ b/src/skills/kick.cpp
@@ -25,8 +25,8 @@ void go_kick(CHAR_DATA *ch, CHAR_DATA *vict) {
 
   vict = try_protect(vict, ch);
 
-  int percent = ((10 - (compute_armor_class(vict) / 10)) * 2) + number(1, skill_info[SKILL_KICK].max_percent);
-  int prob = calculate_skill(ch, SKILL_KICK, vict);
+  int percent = ((10 - (compute_armor_class(vict) / 10)) * 2) + number(1, skill_info[SKILL_KICK].fail_percent);
+  int prob = CalcCurrentSkill(ch, SKILL_KICK, vict);
   if (GET_GOD_FLAG(vict, GF_GODSCURSE) || GET_MOB_HOLD(vict)) {
     prob = percent;
   }
@@ -39,7 +39,7 @@ void go_kick(CHAR_DATA *ch, CHAR_DATA *vict) {
   }
 
   bool success = percent <= prob;
-  train_skill(ch, SKILL_KICK, success, vict);
+  TrainSkill(ch, SKILL_KICK, success, vict);
   if (!success) {
     Damage dmg(SkillDmg(SKILL_KICK), ZERO_DMG, PHYS_DMG);
     dmg.process(ch, vict);

--- a/src/skills/manadrain.cpp
+++ b/src/skills/manadrain.cpp
@@ -55,9 +55,9 @@ void do_manadrain(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
     skill = ch->get_skill(SKILL_MANADRAIN);
 
-    percent = number(1, skill_info[SKILL_MANADRAIN].max_percent);
+    percent = number(1, skill_info[SKILL_MANADRAIN].fail_percent);
     prob = MAX(20, 90 - 5 * MAX(0, GET_LEVEL(vict) - GET_LEVEL(ch)));
-    improve_skill(ch, SKILL_MANADRAIN, percent > prob, vict);
+  ImproveSkill(ch, SKILL_MANADRAIN, percent > prob, vict);
 
     Damage manadrainDamage(SkillDmg(SKILL_MANADRAIN), ZERO_DMG, MAGE_DMG);
     manadrainDamage.magic_type = STYPE_DARK;

--- a/src/skills/protect.cpp
+++ b/src/skills/protect.cpp
@@ -126,13 +126,13 @@ CHAR_DATA* try_protect(CHAR_DATA* victim, CHAR_DATA* ch) {
             }
 
             protect = true;
-            percent = number(1, skill_info[SKILL_PROTECT].max_percent);
-            prob = calculate_skill(vict, SKILL_PROTECT, victim);
+            percent = number(1, skill_info[SKILL_PROTECT].fail_percent);
+            prob = CalcCurrentSkill(vict, SKILL_PROTECT, victim);
             prob = prob * 8 / 10;
             if (vict->haveCooldown(SKILL_PROTECT)) {
                 prob /= 2;
             };
-            improve_skill(vict, SKILL_PROTECT, prob >= percent, ch);
+          ImproveSkill(vict, SKILL_PROTECT, prob >= percent, ch);
 
             if (GET_GOD_FLAG(vict, GF_GODSCURSE))
                 prob = 0;

--- a/src/skills/protect.cpp
+++ b/src/skills/protect.cpp
@@ -9,163 +9,170 @@
 #include "skills.info.h"
 
 // ************** PROTECT PROCEDURES
-void go_protect(CHAR_DATA * ch, CHAR_DATA * vict) {
-    if (dontCanAct(ch)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
-    }
+void go_protect(CHAR_DATA *ch, CHAR_DATA *vict) {
+  if (dontCanAct(ch)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
 
-    ch->set_protecting(vict);
-    act("Вы попытаетесь прикрыть $N3 от нападения.", FALSE, ch, 0, vict, TO_CHAR);
-    SET_AF_BATTLE(ch, EAF_PROTECT);
+  ch->set_protecting(vict);
+  act("Вы попытаетесь прикрыть $N3 от нападения.", FALSE, ch, 0, vict, TO_CHAR);
+  SET_AF_BATTLE(ch, EAF_PROTECT);
 }
 
 void do_protect(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-    one_argument(argument, arg);
-    if (!*arg) {
-        if (ch->get_protecting()) {
-            CLR_AF_BATTLE(ch, EAF_PROTECT);
-            ch->set_protecting(0);
-            send_to_char("Вы перестали прикрывать своего товарища.\r\n", ch);
-        } else {
-            send_to_char("Вы никого не прикрываете.\r\n", ch);
-        }
-        return;
+  one_argument(argument, arg);
+  if (!*arg) {
+    if (ch->get_protecting()) {
+      CLR_AF_BATTLE(ch, EAF_PROTECT);
+      ch->set_protecting(0);
+      send_to_char("Вы перестали прикрывать своего товарища.\r\n", ch);
+    } else {
+      send_to_char("Вы никого не прикрываете.\r\n", ch);
     }
+    return;
+  }
 
-    if (IS_NPC(ch) || !ch->get_skill(SKILL_PROTECT)) {
-        send_to_char("Вы не знаете как.\r\n", ch);
-        return;
+  if (IS_NPC(ch) || !ch->get_skill(SKILL_PROTECT)) {
+    send_to_char("Вы не знаете как.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_PROTECT)) {
+    send_to_char("Вам нужно набраться сил.\r\n", ch);
+    return;
+  };
+
+  CHAR_DATA *vict = get_char_vis(ch, arg, FIND_CHAR_ROOM);
+  if (!vict) {
+    send_to_char("И кто так сильно мил вашему сердцу?\r\n", ch);
+    return;
+  };
+
+  if (vict == ch) {
+    send_to_char("Попробуйте парировать удары или защищаться щитом.\r\n", ch);
+    return;
+  }
+
+  if (ch->get_fighting() == vict) {
+    send_to_char("Вы явно пацифист, или мазохист.\r\n", ch);
+    return;
+  }
+
+  CHAR_DATA *tch = nullptr;
+  for (const auto i : world[ch->in_room]->people) {
+    if (i->get_fighting() == vict) {
+      tch = i;
+      break;
     }
-    if (ch->haveCooldown(SKILL_PROTECT)) {
-        send_to_char("Вам нужно набраться сил.\r\n", ch);
-        return;
-    };
+  }
 
-    CHAR_DATA *vict = get_char_vis(ch, arg, FIND_CHAR_ROOM);
-    if (!vict) {
-        send_to_char("И кто так сильно мил вашему сердцу?\r\n", ch);
-        return;
-    };
+  if (IS_NPC(vict) && tch
+      && (!IS_NPC(tch)
+          || (AFF_FLAGGED(tch, EAffectFlag::AFF_CHARM)
+              && tch->has_master()
+              && !IS_NPC(tch->get_master())))
+      && (!IS_NPC(ch)
+          || (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+              && ch->has_master()
+              && !IS_NPC(ch->get_master())))) {
+    send_to_char("Вы пытаетесь прикрыть чужого противника.\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Попробуйте парировать удары или защищаться щитом.\r\n", ch);
-        return;
+  for (const auto tch : world[ch->in_room]->people) {
+    if (tch->get_fighting() == vict && !may_kill_here(ch, tch, argument)) {
+      return;
     }
+  }
 
-    if (ch->get_fighting() == vict) {
-        send_to_char("Вы явно пацифист, или мазохист.\r\n", ch);
-        return;
-    }
-
-    CHAR_DATA *tch = nullptr;
-    for (const auto i : world[ch->in_room]->people) {
-        if (i->get_fighting() == vict) 	{
-            tch = i;
-            break;
-        }
-    }
-
-    if (IS_NPC(vict) && tch
-        && (!IS_NPC(tch)
-            || (AFF_FLAGGED(tch, EAffectFlag::AFF_CHARM)
-                && tch->has_master()
-                && !IS_NPC(tch->get_master())))
-        && (!IS_NPC(ch)
-            || (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-                && ch->has_master()
-                && !IS_NPC(ch->get_master())))) {
-        send_to_char("Вы пытаетесь прикрыть чужого противника.\r\n", ch);
-        return;
-    }
-
-    for (const auto tch : world[ch->in_room]->people) {
-        if (tch->get_fighting() == vict && !may_kill_here(ch, tch, argument)) {
-            return;
-        }
-    }
-
-    go_protect(ch, vict);
+  go_protect(ch, vict);
 }
 
-CHAR_DATA* try_protect(CHAR_DATA* victim, CHAR_DATA* ch) {
-    int percent = 0;
-    int prob = 0;
-    bool protect = false;
+CHAR_DATA *try_protect(CHAR_DATA *victim, CHAR_DATA *ch) {
+  int percent = 0;
+  int prob = 0;
+  bool protect = false;
 
-    if (ch->get_fighting() == victim)
-        return victim;
-
-    for (const auto vict : world[IN_ROOM(victim)]->people) {
-        if (vict->get_protecting() == victim
-            && !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPFIGHT)
-            && !AFF_FLAGGED(vict, EAffectFlag::AFF_MAGICSTOPFIGHT)
-            && !AFF_FLAGGED(vict, EAffectFlag::AFF_BLIND)
-            && !GET_MOB_HOLD(vict)
-            && GET_POS(vict) >= POS_FIGHTING) {
-            if (vict == ch) {
-                act("Вы попытались напасть на того, кого прикрывали, и замерли в глубокой задумчивости.", FALSE, vict, 0, victim, TO_CHAR);
-                act("$N пытается напасть на вас! Лучше бы вам отойти.", FALSE, victim, 0, vict, TO_CHAR);
-                vict->set_protecting(0);
-                vict->BattleAffects.unset(EAF_PROTECT);
-                WAIT_STATE(vict, PULSE_VIOLENCE);
-                AFFECT_DATA<EApplyLocation> af;
-                af.type = SPELL_BATTLE;
-                af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
-                af.location = EApplyLocation::APPLY_NONE;
-                af.modifier = 0;
-                af.duration = pc_duration(vict, 1, 0, 0, 0, 0);
-                af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
-                affect_join(vict, af, TRUE, FALSE, TRUE, FALSE);
-                return victim;
-            }
-
-            if (protect) {
-                send_to_char(vict, "Чьи-то широкие плечи помешали вам прикрыть %s.\r\n", GET_PAD(vict->get_protecting(), 3));
-                continue;
-            }
-
-            protect = true;
-            percent = number(1, skill_info[SKILL_PROTECT].fail_percent);
-            prob = CalcCurrentSkill(vict, SKILL_PROTECT, victim);
-            prob = prob * 8 / 10;
-            if (vict->haveCooldown(SKILL_PROTECT)) {
-                prob /= 2;
-            };
-          ImproveSkill(vict, SKILL_PROTECT, prob >= percent, ch);
-
-            if (GET_GOD_FLAG(vict, GF_GODSCURSE))
-                prob = 0;
-
-            if ((vict->get_fighting() != ch) && (ch != victim)) {
-                // агрим жертву после чего можно будет проверить возможно ли его здесь прикрыть(костыли конечно)
-                if (!pk_agro_action(ch, victim))
-                    return victim;
-                if (!may_kill_here(vict, ch, NoArgument))
-                    continue;
-                // Вписываемся в противника прикрываемого ...
-                stop_fighting(vict, FALSE);
-                set_fighting(vict, ch);
-            }
-
-            if (prob < percent) {
-                act("Вы не смогли прикрыть $N3.", FALSE, vict, 0, victim, TO_CHAR);
-                act("$N не смог$Q прикрыть вас.", FALSE, victim, 0, vict, TO_CHAR);
-                act("$n не смог$q прикрыть $N3.", TRUE, vict, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-                //set_wait(vict, 3, TRUE);
-                setSkillCooldownInFight(vict, SKILL_GLOBAL_COOLDOWN, 3);
-            } else {
-                if (!pk_agro_action(vict, ch))
-                    return victim; // по аналогии с реском прикрывая кого-то можно пофлагаться
-                act("Вы героически прикрыли $N3, приняв удар на себя.", FALSE, vict, 0, victim, TO_CHAR);
-                act("$N героически прикрыл$G вас, приняв удар на себя.", FALSE, victim, 0, vict, TO_CHAR);
-                act("$n героически прикрыл$g $N3, приняв удар на себя.", TRUE, vict, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
-                //set_wait(vict, 1, TRUE);
-                setSkillCooldownInFight(vict, SKILL_GLOBAL_COOLDOWN, 1);
-                setSkillCooldownInFight(vict, SKILL_PROTECT, 1);
-                return vict;
-            }
-        }
-    }
+  if (ch->get_fighting() == victim)
     return victim;
+
+  for (const auto vict : world[IN_ROOM(victim)]->people) {
+    if (vict->get_protecting() == victim
+        && !AFF_FLAGGED(vict, EAffectFlag::AFF_STOPFIGHT)
+        && !AFF_FLAGGED(vict, EAffectFlag::AFF_MAGICSTOPFIGHT)
+        && !AFF_FLAGGED(vict, EAffectFlag::AFF_BLIND)
+        && !GET_MOB_HOLD(vict)
+        && GET_POS(vict) >= POS_FIGHTING) {
+      if (vict == ch) {
+        act("Вы попытались напасть на того, кого прикрывали, и замерли в глубокой задумчивости.",
+            FALSE,
+            vict,
+            0,
+            victim,
+            TO_CHAR);
+        act("$N пытается напасть на вас! Лучше бы вам отойти.", FALSE, victim, 0, vict, TO_CHAR);
+        vict->set_protecting(0);
+        vict->BattleAffects.unset(EAF_PROTECT);
+        WAIT_STATE(vict, PULSE_VIOLENCE);
+        AFFECT_DATA<EApplyLocation> af;
+        af.type = SPELL_BATTLE;
+        af.bitvector = to_underlying(EAffectFlag::AFF_STOPFIGHT);
+        af.location = EApplyLocation::APPLY_NONE;
+        af.modifier = 0;
+        af.duration = pc_duration(vict, 1, 0, 0, 0, 0);
+        af.battleflag = AF_BATTLEDEC | AF_PULSEDEC;
+        affect_join(vict, af, TRUE, FALSE, TRUE, FALSE);
+        return victim;
+      }
+
+      if (protect) {
+        send_to_char(vict, "Чьи-то широкие плечи помешали вам прикрыть %s.\r\n", GET_PAD(vict->get_protecting(), 3));
+        continue;
+      }
+
+      protect = true;
+      percent = number(1, skill_info[SKILL_PROTECT].fail_percent);
+      prob = CalcCurrentSkill(vict, SKILL_PROTECT, victim);
+      prob = prob * 8 / 10;
+      if (vict->haveCooldown(SKILL_PROTECT)) {
+        prob /= 2;
+      };
+      if (GET_GOD_FLAG(vict, GF_GODSCURSE)) {
+        prob = 0;
+      }
+      bool success = prob >= percent;
+      ImproveSkill(vict, SKILL_PROTECT, success, ch);
+      SendSkillBalanceMsg(ch, skill_info[SKILL_PROTECT].name, percent, prob, success);
+
+      if ((vict->get_fighting() != ch) && (ch != victim)) {
+        // агрим жертву после чего можно будет проверить возможно ли его здесь прикрыть(костыли конечно)
+        if (!pk_agro_action(ch, victim))
+          return victim;
+        if (!may_kill_here(vict, ch, NoArgument))
+          continue;
+        // Вписываемся в противника прикрываемого ...
+        stop_fighting(vict, FALSE);
+        set_fighting(vict, ch);
+      }
+
+      if (!success) {
+        act("Вы не смогли прикрыть $N3.", FALSE, vict, 0, victim, TO_CHAR);
+        act("$N не смог$Q прикрыть вас.", FALSE, victim, 0, vict, TO_CHAR);
+        act("$n не смог$q прикрыть $N3.", TRUE, vict, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+        //set_wait(vict, 3, TRUE);
+        setSkillCooldownInFight(vict, SKILL_GLOBAL_COOLDOWN, 3);
+      } else {
+        if (!pk_agro_action(vict, ch))
+          return victim; // по аналогии с реском прикрывая кого-то можно пофлагаться
+        act("Вы героически прикрыли $N3, приняв удар на себя.", FALSE, vict, 0, victim, TO_CHAR);
+        act("$N героически прикрыл$G вас, приняв удар на себя.", FALSE, victim, 0, vict, TO_CHAR);
+        act("$n героически прикрыл$g $N3, приняв удар на себя.", TRUE, vict, 0, victim, TO_NOTVICT | TO_ARENA_LISTEN);
+        //set_wait(vict, 1, TRUE);
+        setSkillCooldownInFight(vict, SKILL_GLOBAL_COOLDOWN, 1);
+        setSkillCooldownInFight(vict, SKILL_PROTECT, 1);
+        return vict;
+      }
+    }
+  }
+  return victim;
 }

--- a/src/skills/resque.cpp
+++ b/src/skills/resque.cpp
@@ -35,16 +35,16 @@ void go_rescue(CHAR_DATA * ch, CHAR_DATA * vict, CHAR_DATA * tmp_ch) {
         return;
     }
 
-    int percent = number(1, skill_info[SKILL_RESCUE].max_percent);
-    int prob = calculate_skill(ch, SKILL_RESCUE, tmp_ch);
-    improve_skill(ch, SKILL_RESCUE, prob >= percent, tmp_ch);
+    int percent = number(1, skill_info[SKILL_RESCUE].fail_percent);
+    int prob = CalcCurrentSkill(ch, SKILL_RESCUE, tmp_ch);
+  ImproveSkill(ch, SKILL_RESCUE, prob >= percent, tmp_ch);
 
     if (GET_GOD_FLAG(ch, GF_GODSLIKE))
         prob = percent;
     if (GET_GOD_FLAG(ch, GF_GODSCURSE))
         prob = 0;
 
-    if (percent != skill_info[SKILL_RESCUE].max_percent && percent > prob) {
+    if (percent != skill_info[SKILL_RESCUE].fail_percent && percent > prob) {
         act("Вы безуспешно пытались спасти $N3.", FALSE, ch, 0, vict, TO_CHAR);
         //set_wait(ch, 1, FALSE);
         ch->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, PULSE_VIOLENCE);

--- a/src/skills/resque.cpp
+++ b/src/skills/resque.cpp
@@ -8,145 +8,146 @@
 #include "spells.h"
 #include "skills.info.h"
 
-using  namespace FightSystem;
+using namespace FightSystem;
 
 // ******************* RESCUE PROCEDURES
-void fighting_rescue(CHAR_DATA * ch,CHAR_DATA * vict, CHAR_DATA * tmp_ch)
-{
-    if (vict->get_fighting() == tmp_ch)
-        stop_fighting(vict, FALSE);
-    if (ch->get_fighting())
-        ch->set_fighting(tmp_ch);
-    else
-        set_fighting(ch, tmp_ch);
-    if (tmp_ch->get_fighting())
-        tmp_ch->set_fighting(ch);
-    else
-        set_fighting(tmp_ch, ch);
+void fighting_rescue(CHAR_DATA *ch, CHAR_DATA *vict, CHAR_DATA *tmp_ch) {
+  if (vict->get_fighting() == tmp_ch)
+    stop_fighting(vict, FALSE);
+  if (ch->get_fighting())
+    ch->set_fighting(tmp_ch);
+  else
+    set_fighting(ch, tmp_ch);
+  if (tmp_ch->get_fighting())
+    tmp_ch->set_fighting(ch);
+  else
+    set_fighting(tmp_ch, ch);
 }
 
-void go_rescue(CHAR_DATA * ch, CHAR_DATA * vict, CHAR_DATA * tmp_ch) {
-    if (dontCanAct(ch)) {
-        send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
-        return;
-    }
-    if (ch->ahorse()) {
-        send_to_char(ch, "Ну раскорячили вы ноги по сторонам, но спасти %s как?\r\n", GET_PAD(vict,1));
-        return;
-    }
+void go_rescue(CHAR_DATA *ch, CHAR_DATA *vict, CHAR_DATA *tmp_ch) {
+  if (dontCanAct(ch)) {
+    send_to_char("Вы временно не в состоянии сражаться.\r\n", ch);
+    return;
+  }
+  if (ch->ahorse()) {
+    send_to_char(ch, "Ну раскорячили вы ноги по сторонам, но спасти %s как?\r\n", GET_PAD(vict, 1));
+    return;
+  }
 
-    int percent = number(1, skill_info[SKILL_RESCUE].fail_percent);
-    int prob = CalcCurrentSkill(ch, SKILL_RESCUE, tmp_ch);
+  int percent = number(1, skill_info[SKILL_RESCUE].fail_percent);
+  int prob = CalcCurrentSkill(ch, SKILL_RESCUE, tmp_ch);
   ImproveSkill(ch, SKILL_RESCUE, prob >= percent, tmp_ch);
 
-    if (GET_GOD_FLAG(ch, GF_GODSLIKE))
-        prob = percent;
-    if (GET_GOD_FLAG(ch, GF_GODSCURSE))
-        prob = 0;
+  if (GET_GOD_FLAG(ch, GF_GODSLIKE))
+    prob = percent;
+  if (GET_GOD_FLAG(ch, GF_GODSCURSE))
+    prob = 0;
 
-    if (percent != skill_info[SKILL_RESCUE].fail_percent && percent > prob) {
-        act("Вы безуспешно пытались спасти $N3.", FALSE, ch, 0, vict, TO_CHAR);
-        //set_wait(ch, 1, FALSE);
-        ch->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, PULSE_VIOLENCE);
-        return;
-    }
-
-    if (!pk_agro_action(ch, tmp_ch))
-        return;
-
-    act("Хвала Богам, вы героически спасли $N3!", FALSE, ch, 0, vict, TO_CHAR);
-    act("Вы были спасены $N4. Вы чувствуете себя Иудой!", FALSE, vict, 0, ch, TO_CHAR);
-    act("$n героически спас$q $N3!", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-
-    int hostilesCounter = 0;
-    if (can_use_feat(ch, LIVE_SHIELD_FEAT)) {
-        for (const auto i : world[ch->in_room]->people) {
-            if (i->get_fighting() == vict) {
-                fighting_rescue(ch, vict, i);
-                ++hostilesCounter;
-            }
-        }
-        hostilesCounter /= 2;
-    } else {
-        fighting_rescue(ch, vict, tmp_ch);
-    }
+  bool success = percent <= prob;
+  SendSkillBalanceMsg(ch, skill_info[SKILL_RESCUE].name, percent, prob, success);
+  if (!success) {
+    act("Вы безуспешно пытались спасти $N3.", FALSE, ch, 0, vict, TO_CHAR);
     //set_wait(ch, 1, FALSE);
-    setSkillCooldown(ch, SKILL_GLOBAL_COOLDOWN, 1);
-    setSkillCooldown(ch, SKILL_RESCUE, 1 + hostilesCounter);
-    set_wait(vict, 2, FALSE);
+    ch->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, PULSE_VIOLENCE);
+    return;
+  }
+
+  if (!pk_agro_action(ch, tmp_ch))
+    return;
+
+  act("Хвала Богам, вы героически спасли $N3!", FALSE, ch, 0, vict, TO_CHAR);
+  act("Вы были спасены $N4. Вы чувствуете себя Иудой!", FALSE, vict, 0, ch, TO_CHAR);
+  act("$n героически спас$q $N3!", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+
+  int hostilesCounter = 0;
+  if (can_use_feat(ch, LIVE_SHIELD_FEAT)) {
+    for (const auto i : world[ch->in_room]->people) {
+      if (i->get_fighting() == vict) {
+        fighting_rescue(ch, vict, i);
+        ++hostilesCounter;
+      }
+    }
+    hostilesCounter /= 2;
+  } else {
+    fighting_rescue(ch, vict, tmp_ch);
+  }
+  //set_wait(ch, 1, FALSE);
+  setSkillCooldown(ch, SKILL_GLOBAL_COOLDOWN, 1);
+  setSkillCooldown(ch, SKILL_RESCUE, 1 + hostilesCounter);
+  set_wait(vict, 2, FALSE);
 }
 
 void do_rescue(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-    if (!ch->get_skill(SKILL_RESCUE)) {
-        send_to_char("Но вы не знаете как.\r\n", ch);
-        return;
-    }
-    if (ch->haveCooldown(SKILL_RESCUE)) {
-        send_to_char("Вам нужно набраться сил.\r\n", ch);
-        return;
-    };
+  if (!ch->get_skill(SKILL_RESCUE)) {
+    send_to_char("Но вы не знаете как.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_RESCUE)) {
+    send_to_char("Вам нужно набраться сил.\r\n", ch);
+    return;
+  };
 
-    CHAR_DATA* vict = findVictim(ch, argument);
-    if (!vict) {
-        send_to_char("Кто это так сильно путается под вашими ногами?\r\n", ch);
-        return;
-    }
+  CHAR_DATA *vict = findVictim(ch, argument);
+  if (!vict) {
+    send_to_char("Кто это так сильно путается под вашими ногами?\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Ваше спасение вы можете доверить только Богам.\r\n", ch);
-        return;
-    }
-    if (ch->get_fighting() == vict) {
-        send_to_char("Вы пытаетесь спасти атакующего вас?\r\n" "Это не о вас ли писали Марк и Лука?\r\n", ch);
-        return;
-    }
+  if (vict == ch) {
+    send_to_char("Ваше спасение вы можете доверить только Богам.\r\n", ch);
+    return;
+  }
+  if (ch->get_fighting() == vict) {
+    send_to_char("Вы пытаетесь спасти атакующего вас?\r\n" "Это не о вас ли писали Марк и Лука?\r\n", ch);
+    return;
+  }
 
-    CHAR_DATA* enemy = nullptr;
-    for (const auto i : world[ch->in_room]->people) {
-        if (i->get_fighting() == vict) {
-            enemy = i;
-            break;
-        }
+  CHAR_DATA *enemy = nullptr;
+  for (const auto i : world[ch->in_room]->people) {
+    if (i->get_fighting() == vict) {
+      enemy = i;
+      break;
     }
+  }
 
-    if (!enemy) {
-        act("Но никто не сражается с $N4!", FALSE, ch, 0, vict, TO_CHAR);
-        return;
+  if (!enemy) {
+    act("Но никто не сражается с $N4!", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
+
+  if (IS_NPC(vict)
+      && enemy
+      && (!IS_NPC(enemy)
+          || (AFF_FLAGGED(enemy, EAffectFlag::AFF_CHARM)
+              && enemy->has_master()
+              && !IS_NPC(enemy->get_master())))
+      && (!IS_NPC(ch)
+          || (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+              && ch->has_master()
+              && !IS_NPC(ch->get_master())))) {
+    send_to_char("Вы пытаетесь спасти чужого противника.\r\n", ch);
+    return;
+  }
+
+  // Двойники и прочие очарки не в группе с тем, кого собираются спасать:
+  // Если тот, кто собирается спасать - "чармис" и у него существует хозяин
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) && ch->has_master()) {
+    // Если спасаем "чармиса", то проверять надо на нахождение в одной
+    // группе хозянина спасющего и спасаемого.
+    if (AFF_FLAGGED(vict, EAffectFlag::AFF_CHARM)
+        && vict->has_master()
+        && !same_group(vict->get_master(), ch->get_master())) {
+      act("Спасали бы вы лучше другов своих.", FALSE, ch, 0, vict, TO_CHAR);
+      act("Вы не можете спасти весь мир.", FALSE, ch->get_master(), 0, vict, TO_CHAR);
+      return;
     }
+  }
 
-    if (IS_NPC(vict)
-        && enemy
-        && (!IS_NPC(enemy)
-            || (AFF_FLAGGED(enemy, EAffectFlag::AFF_CHARM)
-                && enemy->has_master()
-                && !IS_NPC(enemy->get_master())))
-        && (!IS_NPC(ch)
-            || (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-                && ch->has_master()
-                && !IS_NPC(ch->get_master())))) {
-        send_to_char("Вы пытаетесь спасти чужого противника.\r\n", ch);
-        return;
-    }
+  if (!may_kill_here(ch, enemy, argument)) {
+    return;
+  }
 
-    // Двойники и прочие очарки не в группе с тем, кого собираются спасать:
-    // Если тот, кто собирается спасать - "чармис" и у него существует хозяин
-    if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM) && ch->has_master()) {
-        // Если спасаем "чармиса", то проверять надо на нахождение в одной
-        // группе хозянина спасющего и спасаемого.
-        if (AFF_FLAGGED(vict, EAffectFlag::AFF_CHARM)
-            && vict->has_master()
-            && !same_group(vict->get_master(), ch->get_master())) {
-            act("Спасали бы вы лучше другов своих.", FALSE, ch, 0, vict, TO_CHAR);
-            act("Вы не можете спасти весь мир.", FALSE, ch->get_master(), 0, vict, TO_CHAR);
-            return;
-        }
-    }
-
-    if (!may_kill_here(ch, enemy, argument)) {
-        return;
-    }
-
-    go_rescue(ch, vict, enemy);
+  go_rescue(ch, vict, enemy);
 }
 
 

--- a/src/skills/strangle.cpp
+++ b/src/skills/strangle.cpp
@@ -11,120 +11,122 @@
 #include "protect.h"
 #include "skills.info.h"
 
-using  namespace FightSystem;
+using namespace FightSystem;
 
-void go_strangle(CHAR_DATA * ch, CHAR_DATA * vict) {
-    if (AFF_FLAGGED(ch, EAffectFlag::AFF_STOPRIGHT) || dontCanAct(ch)) {
-        send_to_char("Сейчас у вас не получится выполнить этот прием.\r\n", ch);
-        return;
+void go_strangle(CHAR_DATA *ch, CHAR_DATA *vict) {
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_STOPRIGHT) || dontCanAct(ch)) {
+    send_to_char("Сейчас у вас не получится выполнить этот прием.\r\n", ch);
+    return;
+  }
+
+  if (ch->get_fighting()) {
+    send_to_char("Вы не можете делать это в бою!\r\n", ch);
+    return;
+  }
+
+  if (GET_POS(ch) < POS_FIGHTING) {
+    send_to_char("Вам стоит встать на ноги.\r\n", ch);
+    return;
+  }
+
+  vict = try_protect(vict, ch);
+  if (!pk_agro_action(ch, vict)) {
+    return;
+  }
+
+  act("Вы попытались накинуть удавку на шею $N2.\r\n", FALSE, ch, nullptr, vict, TO_CHAR);
+
+  int prob = calculate_skill(ch, SKILL_STRANGLE, vict);
+  int delay = 6 - MIN(4, (ch->get_skill(SKILL_STRANGLE) + 30) / 50);
+  int percent = number(1, skill_info[SKILL_STRANGLE].max_percent);
+
+  bool success = percent <= prob;
+  train_skill(ch, SKILL_STRANGLE, success, vict);
+  if (!success) {
+    Damage dmg(SkillDmg(SKILL_STRANGLE), ZERO_DMG, PHYS_DMG);
+    dmg.flags.set(IGNORE_ARMOR);
+    dmg.process(ch, vict);
+    //set_wait(ch, 3, TRUE);
+    setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 3);
+  } else {
+    AFFECT_DATA<EApplyLocation> af;
+    af.type = SPELL_STRANGLE;
+    af.duration = IS_NPC(vict) ? 8 : 15;
+    af.modifier = 0;
+    af.location = APPLY_NONE;
+    af.battleflag = AF_SAME_TIME;
+    af.bitvector = to_underlying(EAffectFlag::AFF_STRANGLED);
+    affect_to_char(vict, af);
+
+    int dam = (GET_MAX_HIT(vict) * GaussIntNumber((300 + 5 * ch->get_skill(SKILL_STRANGLE)) / 70, 7.0, 1, 30)) / 100;
+    dam = (IS_NPC(vict) ? MIN(dam, 6 * GET_MAX_HIT(ch)) : MIN(dam, 2 * GET_MAX_HIT(ch)));
+    Damage dmg(SkillDmg(SKILL_STRANGLE), dam, PHYS_DMG);
+    dmg.flags.set(IGNORE_ARMOR);
+    dmg.process(ch, vict);
+    if (GET_POS(vict) > POS_DEAD) {
+      set_wait(vict, 2, TRUE);
+      //vict->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, 2);
+      if (vict->ahorse()) {
+        act("Рванув на себя, $N стащил$G Вас на землю.", FALSE, vict, nullptr, ch, TO_CHAR);
+        act("Рванув на себя, Вы стащили $n3 на землю.", FALSE, vict, nullptr, ch, TO_VICT);
+        act("Рванув на себя, $N стащил$G $n3 на землю.", FALSE, vict, nullptr, ch, TO_NOTVICT | TO_ARENA_LISTEN);
+        vict->drop_from_horse();
+      }
+      if (ch->get_skill(SKILL_CHOPOFF) && ch->isInSameRoom(vict)) {
+        go_chopoff(ch, vict);
+      }
+      setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 2);
     }
+  }
 
-    if (ch->get_fighting()) {
-        send_to_char("Вы не можете делать это в бою!\r\n", ch);
-        return;
-    }
-
-    if (GET_POS(ch) < POS_FIGHTING) {
-        send_to_char("Вам стоит встать на ноги.\r\n", ch);
-        return;
-    }
-
-    vict = try_protect(vict, ch);
-    if (!pk_agro_action(ch, vict))
-        return;
-
-    act("Вы попытались накинуть удавку на шею $N2.\r\n", FALSE, ch, nullptr, vict, TO_CHAR);
-
-    int prob = train_skill(ch, SKILL_STRANGLE, skill_info[SKILL_STRANGLE].max_percent, vict);
-    int delay = 6 - MIN(4, (ch->get_skill(SKILL_STRANGLE) + 30) / 50);
-    int percent = number(1, skill_info[SKILL_STRANGLE].max_percent);
-
-    if (percent > prob) {
-        Damage dmg(SkillDmg(SKILL_STRANGLE), ZERO_DMG, PHYS_DMG);
-        dmg.flags.set(IGNORE_ARMOR);
-        dmg.process(ch, vict);
-        //set_wait(ch, 3, TRUE);
-        setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 3);
-    } else {
-        AFFECT_DATA<EApplyLocation> af;
-        af.type = SPELL_STRANGLE;
-        af.duration = IS_NPC(vict) ? 8 : 15;
-        af.modifier = 0;
-        af.location = APPLY_NONE;
-        af.battleflag = AF_SAME_TIME;
-        af.bitvector = to_underlying(EAffectFlag::AFF_STRANGLED);
-        affect_to_char(vict, af);
-
-        int dam = (GET_MAX_HIT(vict)*GaussIntNumber((300 + 5 * ch->get_skill(SKILL_STRANGLE)) / 70, 7.0, 1, 30)) / 100;
-        dam = (IS_NPC(vict) ? MIN(dam, 6*GET_MAX_HIT(ch)) : MIN(dam, 2*GET_MAX_HIT(ch)));
-        Damage dmg(SkillDmg(SKILL_STRANGLE), dam, PHYS_DMG);
-        dmg.flags.set(IGNORE_ARMOR);
-        dmg.process(ch, vict);
-        if (GET_POS(vict) > POS_DEAD) {
-            set_wait(vict, 2, TRUE);
-            //vict->setSkillCooldown(SKILL_GLOBAL_COOLDOWN, 2);
-            if (vict->ahorse()) {
-                act("Рванув на себя, $N стащил$G Вас на землю.", FALSE, vict, nullptr, ch, TO_CHAR);
-                act("Рванув на себя, Вы стащили $n3 на землю.", FALSE, vict, nullptr, ch, TO_VICT);
-                act("Рванув на себя, $N стащил$G $n3 на землю.", FALSE, vict, nullptr, ch, TO_NOTVICT | TO_ARENA_LISTEN);
-                vict->drop_from_horse();
-            }
-            if (ch->get_skill(SKILL_CHOPOFF) && ch->isInSameRoom(vict)) {
-                go_chopoff(ch, vict);
-            }
-            //set_wait(ch, 2, TRUE);
-            setSkillCooldownInFight(ch, SKILL_GLOBAL_COOLDOWN, 2);
-        }
-    }
-
-    timed_type timed;
-    timed.skill = SKILL_STRANGLE;
-    timed.time = delay;
-    timed_to_char(ch, &timed);
+  timed_type timed;
+  timed.skill = SKILL_STRANGLE;
+  timed.time = delay;
+  timed_to_char(ch, &timed);
 }
 
 void do_strangle(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-    if (!ch->get_skill(SKILL_STRANGLE)) {
-        send_to_char("Вы не умеете этого.\r\n", ch);
-        return;
-    }
+  if (!ch->get_skill(SKILL_STRANGLE)) {
+    send_to_char("Вы не умеете этого.\r\n", ch);
+    return;
+  }
 
-    if (timed_by_skill(ch, SKILL_STRANGLE) || ch->haveCooldown(SKILL_STRANGLE)) {
-        send_to_char("Так часто душить нельзя - человеки кончатся.\r\n", ch);
-        return;
-    }
+  if (timed_by_skill(ch, SKILL_STRANGLE) || ch->haveCooldown(SKILL_STRANGLE)) {
+    send_to_char("Так часто душить нельзя - человеки кончатся.\r\n", ch);
+    return;
+  }
 
-    CHAR_DATA* vict = findVictim(ch, argument);
-    if (!vict) {
-        send_to_char("Кого вы жаждете удавить?\r\n", ch);
-        return;
-    }
+  CHAR_DATA *vict = findVictim(ch, argument);
+  if (!vict) {
+    send_to_char("Кого вы жаждете удавить?\r\n", ch);
+    return;
+  }
 
-    if (AFF_FLAGGED(vict, EAffectFlag::AFF_STRANGLED)) {
-        send_to_char("Ваша жертва хватается руками за горло - не подобраться!\r\n", ch);
-        return;
-    }
+  if (AFF_FLAGGED(vict, EAffectFlag::AFF_STRANGLED)) {
+    send_to_char("Ваша жертва хватается руками за горло - не подобраться!\r\n", ch);
+    return;
+  }
 
-    if (IS_UNDEAD(vict)
-        || GET_RACE(vict) == NPC_RACE_FISH
-        || GET_RACE(vict) == NPC_RACE_PLANT
-        || GET_RACE(vict) == NPC_RACE_THING) {
-        send_to_char("Вы бы еще верстовой столб удавить попробовали...\r\n", ch);
-        return;
-    }
+  if (IS_UNDEAD(vict)
+      || GET_RACE(vict) == NPC_RACE_FISH
+      || GET_RACE(vict) == NPC_RACE_PLANT
+      || GET_RACE(vict) == NPC_RACE_THING) {
+    send_to_char("Вы бы еще верстовой столб удавить попробовали...\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Воспользуйтесь услугами княжеского палача. Постоянным клиентам - скидки!\r\n", ch);
-        return;
-    }
+  if (vict == ch) {
+    send_to_char("Воспользуйтесь услугами княжеского палача. Постоянным клиентам - скидки!\r\n", ch);
+    return;
+  }
 
-    if (!may_kill_here(ch, vict, argument)) {
-        return;
-    }
-    if (!check_pkill(ch, vict, arg)) {
-        return;
-    }
-    go_strangle(ch, vict);
+  if (!may_kill_here(ch, vict, argument)) {
+    return;
+  }
+  if (!check_pkill(ch, vict, arg)) {
+    return;
+  }
+  go_strangle(ch, vict);
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/skills/strangle.cpp
+++ b/src/skills/strangle.cpp
@@ -42,6 +42,7 @@ void go_strangle(CHAR_DATA *ch, CHAR_DATA *vict) {
 
   bool success = percent <= prob;
   TrainSkill(ch, SKILL_STRANGLE, success, vict);
+  SendSkillBalanceMsg(ch, skill_info[SKILL_STRANGLE].name, percent, prob, success);
   if (!success) {
     Damage dmg(SkillDmg(SKILL_STRANGLE), ZERO_DMG, PHYS_DMG);
     dmg.flags.set(IGNORE_ARMOR);

--- a/src/skills/strangle.cpp
+++ b/src/skills/strangle.cpp
@@ -36,12 +36,12 @@ void go_strangle(CHAR_DATA *ch, CHAR_DATA *vict) {
 
   act("Вы попытались накинуть удавку на шею $N2.\r\n", FALSE, ch, nullptr, vict, TO_CHAR);
 
-  int prob = calculate_skill(ch, SKILL_STRANGLE, vict);
+  int prob = CalcCurrentSkill(ch, SKILL_STRANGLE, vict);
   int delay = 6 - MIN(4, (ch->get_skill(SKILL_STRANGLE) + 30) / 50);
-  int percent = number(1, skill_info[SKILL_STRANGLE].max_percent);
+  int percent = number(1, skill_info[SKILL_STRANGLE].fail_percent);
 
   bool success = percent <= prob;
-  train_skill(ch, SKILL_STRANGLE, success, vict);
+  TrainSkill(ch, SKILL_STRANGLE, success, vict);
   if (!success) {
     Damage dmg(SkillDmg(SKILL_STRANGLE), ZERO_DMG, PHYS_DMG);
     dmg.flags.set(IGNORE_ARMOR);

--- a/src/skills/stun.cpp
+++ b/src/skills/stun.cpp
@@ -59,7 +59,7 @@ void do_stun(CHAR_DATA* ch, char* argument, int, int) {
 void go_stun(CHAR_DATA * ch, CHAR_DATA * vict) {
     timed_type timed;
     if (GET_SKILL(ch, SKILL_STUN) < 150) {
-        improve_skill(ch, SKILL_STUN, TRUE, vict);
+      ImproveSkill(ch, SKILL_STUN, TRUE, vict);
         timed.skill = SKILL_STUN;
         timed.time = 7;
         timed_to_char(ch, &timed);
@@ -77,12 +77,12 @@ void go_stun(CHAR_DATA * ch, CHAR_DATA * vict) {
     //float num = MIN(95, (pow(GET_SKILL(ch, SKILL_STUN), 2) + pow(weap_weight, 2) + pow(GET_REAL_STR(ch), 2)) /
     //(pow(GET_REAL_DEX(vict), 2) + (GET_REAL_CON(vict) - GET_SAVE(vict, SAVING_STABILITY)) * 30.0));
 
-    int percent = number(1, skill_info[SKILL_STUN].max_percent);
-    int prob = calculate_skill(ch, SKILL_STUN, vict);
+    int percent = number(1, skill_info[SKILL_STUN].fail_percent);
+    int prob = CalcCurrentSkill(ch, SKILL_STUN, vict);
 
     if (percent > prob)
     {
-        improve_skill(ch, SKILL_STUN, FALSE, vict);
+      ImproveSkill(ch, SKILL_STUN, FALSE, vict);
         act("У вас не получилось ошеломить $N3, надо больше тренироваться!", FALSE, ch, 0, vict, TO_CHAR);
         act("$N3 попытал$U ошеломить вас, но не получилось.", FALSE, vict, 0, ch, TO_CHAR);
         act("$n попытал$u ошеломить $N3, но плохому танцору и тапки мешают.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
@@ -90,7 +90,7 @@ void go_stun(CHAR_DATA * ch, CHAR_DATA * vict) {
 //			dmg.process(ch, vict);
         set_hit(ch, vict);
     } else {
-        improve_skill(ch, SKILL_STUN, TRUE, vict);
+      ImproveSkill(ch, SKILL_STUN, TRUE, vict);
         if (GET_EQ(ch, WEAR_BOTHS) && GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS)) == SKILL_BOWS) {
             act("Точным выстрелом вы ошеломили $N3!", FALSE, ch, 0, vict, TO_CHAR);
             act("Точный выстрел $N1 повалил вас с ног и лишил сознания.", FALSE, vict, 0, ch, TO_CHAR);

--- a/src/skills/stun.cpp
+++ b/src/skills/stun.cpp
@@ -8,105 +8,106 @@
 #include "spells.h"
 #include "skills.info.h"
 
-using  namespace FightSystem;
+using namespace FightSystem;
 
+void do_stun(CHAR_DATA *ch, char *argument, int, int) {
+  if (ch->get_skill(SKILL_STUN) < 1) {
+    send_to_char("Вы не знаете как.\r\n", ch);
+    return;
+  }
+  if (ch->haveCooldown(SKILL_STUN)) {
+    send_to_char("Вам нужно набраться сил.\r\n", ch);
+    return;
+  };
 
-void do_stun(CHAR_DATA* ch, char* argument, int, int) {
-    if (ch->get_skill(SKILL_STUN) < 1) {
-        send_to_char("Вы не знаете как.\r\n", ch);
-        return;
-    }
-    if (ch->haveCooldown(SKILL_STUN)) {
-        send_to_char("Вам нужно набраться сил.\r\n", ch);
-        return;
-    };
+  if (!ch->ahorse()) {
+    send_to_char("Вы привстали на стременах и поняли: 'лошадь украли!!!'\r\n", ch);
+    return;
+  }
+  if ((GET_SKILL(ch, SKILL_HORSE) < 151) && (!IS_NPC(ch))) {
+    send_to_char("Вы слишком неуверенно управляете лошадью, чтоб на ней пытаться ошеломить противника.\r\n", ch);
+    return;
+  }
+  if (timed_by_skill(ch, SKILL_STUN) && (!IS_NPC(ch))) {
+    send_to_char("Ваш грозный вид не испугает даже мышь, попробуйте ошеломить попозже.\r\n", ch);
+    return;
+  }
+  if (!IS_NPC(ch) && !(GET_EQ(ch, WEAR_WIELD) || GET_EQ(ch, WEAR_BOTHS))) {
+    send_to_char("Вы должны держать оружие в основной руке.\r\n", ch);
+    return;
+  }
+  CHAR_DATA *vict = findVictim(ch, argument);
+  if (!vict) {
+    send_to_char("Кто это так сильно путается у вас под руками?\r\n", ch);
+    return;
+  }
 
-    if (!ch->ahorse()) {
-        send_to_char("Вы привстали на стременах и поняли: 'лошадь украли!!!'\r\n", ch);
-        return;
-    }
-    if ((GET_SKILL(ch, SKILL_HORSE) < 151) && (!IS_NPC(ch))) {
-        send_to_char("Вы слишком неуверенно управляете лошадью, чтоб на ней пытаться ошеломить противника.\r\n", ch);
-        return;
-    }
-    if (timed_by_skill(ch, SKILL_STUN) && (!IS_NPC(ch))) {
-        send_to_char("Ваш грозный вид не испугает даже мышь, попробуйте ошеломить попозже.\r\n", ch);
-        return;
-    }
-    if (!IS_NPC(ch) && !(GET_EQ(ch, WEAR_WIELD) || GET_EQ(ch, WEAR_BOTHS))) {
-        send_to_char("Вы должны держать оружие в основной руке.\r\n", ch);
-        return;
-    }
-    CHAR_DATA* vict = findVictim(ch, argument);
-    if (!vict) {
-        send_to_char("Кто это так сильно путается у вас под руками?\r\n", ch);
-        return;
-    }
+  if (vict == ch) {
+    send_to_char("Вы БОЛЬНО стукнули себя по голове! 'А еще я туда ем', - подумали вы...\r\n", ch);
+    return;
+  }
 
-    if (vict == ch) {
-        send_to_char("Вы БОЛЬНО стукнули себя по голове! 'А еще я туда ем', - подумали вы...\r\n", ch);
-        return;
-    }
+  if (!may_kill_here(ch, vict, argument))
+    return;
+  if (!check_pkill(ch, vict, arg))
+    return;
 
-    if (!may_kill_here(ch, vict, argument))
-        return;
-    if (!check_pkill(ch, vict, arg))
-        return;
-
-    go_stun(ch, vict);
+  go_stun(ch, vict);
 }
 
-void go_stun(CHAR_DATA * ch, CHAR_DATA * vict) {
-    timed_type timed;
-    if (GET_SKILL(ch, SKILL_STUN) < 150) {
-      ImproveSkill(ch, SKILL_STUN, TRUE, vict);
-        timed.skill = SKILL_STUN;
-        timed.time = 7;
-        timed_to_char(ch, &timed);
-        act("У вас не получилось ошеломить $N3, надо больше тренироваться!", FALSE, ch, 0, vict, TO_CHAR);
-        act("$N3 попытал$U ошеломить вас, но не получилось.", FALSE, vict, 0, ch, TO_CHAR);
-        act("$n попытал$u ошеломить $N3, но плохому танцору и тапки мешают.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-        set_hit(ch, vict);
-        return;
-    }
-
+void go_stun(CHAR_DATA *ch, CHAR_DATA *vict) {
+  timed_type timed;
+  if (GET_SKILL(ch, SKILL_STUN) < 150) {
+    ImproveSkill(ch, SKILL_STUN, TRUE, vict);
     timed.skill = SKILL_STUN;
-    timed.time = std::clamp(7 - (GET_SKILL(ch, SKILL_STUN) - 150)/10, 2, 7);
+    timed.time = 7;
     timed_to_char(ch, &timed);
-    //weap_weight = GET_EQ(ch, WEAR_BOTHS)?  GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS)) : GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD));
-    //float num = MIN(95, (pow(GET_SKILL(ch, SKILL_STUN), 2) + pow(weap_weight, 2) + pow(GET_REAL_STR(ch), 2)) /
-    //(pow(GET_REAL_DEX(vict), 2) + (GET_REAL_CON(vict) - GET_SAVE(vict, SAVING_STABILITY)) * 30.0));
+    act("У вас не получилось ошеломить $N3, надо больше тренироваться!", FALSE, ch, 0, vict, TO_CHAR);
+    act("$N3 попытал$U ошеломить вас, но не получилось.", FALSE, vict, 0, ch, TO_CHAR);
+    act("$n попытал$u ошеломить $N3, но плохому танцору и тапки мешают.",
+        TRUE,
+        ch,
+        0,
+        vict,
+        TO_NOTVICT | TO_ARENA_LISTEN);
+    set_hit(ch, vict);
+    return;
+  }
 
-    int percent = number(1, skill_info[SKILL_STUN].fail_percent);
-    int prob = CalcCurrentSkill(ch, SKILL_STUN, vict);
+  timed.skill = SKILL_STUN;
+  timed.time = std::clamp(7 - (GET_SKILL(ch, SKILL_STUN) - 150) / 10, 2, 7);
+  timed_to_char(ch, &timed);
+  //weap_weight = GET_EQ(ch, WEAR_BOTHS)?  GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_BOTHS)) : GET_OBJ_WEIGHT(GET_EQ(ch, WEAR_WIELD));
+  //float num = MIN(95, (pow(GET_SKILL(ch, SKILL_STUN), 2) + pow(weap_weight, 2) + pow(GET_REAL_STR(ch), 2)) /
+  //(pow(GET_REAL_DEX(vict), 2) + (GET_REAL_CON(vict) - GET_SAVE(vict, SAVING_STABILITY)) * 30.0));
 
-    if (percent > prob)
-    {
-      ImproveSkill(ch, SKILL_STUN, FALSE, vict);
-        act("У вас не получилось ошеломить $N3, надо больше тренироваться!", FALSE, ch, 0, vict, TO_CHAR);
-        act("$N3 попытал$U ошеломить вас, но не получилось.", FALSE, vict, 0, ch, TO_CHAR);
-        act("$n попытал$u ошеломить $N3, но плохому танцору и тапки мешают.", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-//			Damage dmg(SkillDmg(SKILL_STUN), 1, PHYS_DMG);
-//			dmg.process(ch, vict);
-        set_hit(ch, vict);
+  int percent = number(1, skill_info[SKILL_STUN].fail_percent);
+  int prob = CalcCurrentSkill(ch, SKILL_STUN, vict);
+  bool success = percent <= prob;
+  TrainSkill(ch, SKILL_STUN, success, vict);
+  SendSkillBalanceMsg(ch, skill_info[SKILL_STUN].name, percent, prob, success);
+  if (!success) {
+    act("У вас не получилось ошеломить $N3, надо больше тренироваться!", FALSE, ch, 0, vict, TO_CHAR);
+    act("$N3 попытал$U ошеломить вас, но не получилось.", FALSE, vict, 0, ch, TO_CHAR);
+    act("$n попытал$u ошеломить $N3, но плохому танцору и тапки мешают.",
+        true, ch,  nullptr, vict, TO_NOTVICT | TO_ARENA_LISTEN);
+    set_hit(ch, vict);
+  } else {
+    if (GET_EQ(ch, WEAR_BOTHS) && GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS)) == SKILL_BOWS) {
+      act("Точным выстрелом вы ошеломили $N3!", FALSE, ch, 0, vict, TO_CHAR);
+      act("Точный выстрел $N1 повалил вас с ног и лишил сознания.", FALSE, vict, 0, ch, TO_CHAR);
+      act("$n точным выстрелом ошеломил$g $N3!", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
     } else {
-      ImproveSkill(ch, SKILL_STUN, TRUE, vict);
-        if (GET_EQ(ch, WEAR_BOTHS) && GET_OBJ_SKILL(GET_EQ(ch, WEAR_BOTHS)) == SKILL_BOWS) {
-            act("Точным выстрелом вы ошеломили $N3!", FALSE, ch, 0, vict, TO_CHAR);
-            act("Точный выстрел $N1 повалил вас с ног и лишил сознания.", FALSE, vict, 0, ch, TO_CHAR);
-            act("$n точным выстрелом ошеломил$g $N3!", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-        }
-        else {
-            act("Мощным ударом вы ошеломили $N3!", FALSE, ch, 0, vict, TO_CHAR);
-            act("Ошеломляющий удар $N1 сбил вас с ног и лишил сознания.", FALSE, vict, 0, ch, TO_CHAR);
-            act("$n мощным ударом ошеломил$g $N3!", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
-        }
-        GET_POS(vict) = POS_INCAP;
-        WAIT_STATE(vict, (2 + GET_REMORT(ch) / 5) * PULSE_VIOLENCE);
-        //WAIT_STATE(ch, (3 * PULSE_VIOLENCE));
-        ch->setSkillCooldown(SKILL_STUN, 3*PULSE_VIOLENCE);
-        set_hit(ch, vict);
+      act("Мощным ударом вы ошеломили $N3!", FALSE, ch, 0, vict, TO_CHAR);
+      act("Ошеломляющий удар $N1 сбил вас с ног и лишил сознания.", FALSE, vict, 0, ch, TO_CHAR);
+      act("$n мощным ударом ошеломил$g $N3!", TRUE, ch, 0, vict, TO_NOTVICT | TO_ARENA_LISTEN);
     }
+    GET_POS(vict) = POS_INCAP;
+    WAIT_STATE(vict, (2 + GET_REMORT(ch) / 5) * PULSE_VIOLENCE);
+    //WAIT_STATE(ch, (3 * PULSE_VIOLENCE));
+    ch->setSkillCooldown(SKILL_STUN, 3 * PULSE_VIOLENCE);
+    set_hit(ch, vict);
+  }
 }
 
 

--- a/src/skills/townportal.cpp
+++ b/src/skills/townportal.cpp
@@ -105,7 +105,7 @@ void spell_townportal(CHAR_DATA *ch, char *arg)
         }
 
         // Открываем пентаграмму в комнату rnum //
-        improve_skill(ch, SKILL_TOWNPORTAL, 1, NULL);
+      ImproveSkill(ch, SKILL_TOWNPORTAL, 1, NULL);
         ROOM_DATA* from_room = world[ch->in_room];
         from_room->portal_room = real_room(port->vnum);
         from_room->portal_time = 1;

--- a/src/skills/track.cpp
+++ b/src/skills/track.cpp
@@ -8,305 +8,258 @@
 #include "handler.h"
 #include "skills.info.h"
 
-
-const char *track_when[] = { "совсем свежие",
-                             "свежие",
-                             "менее полудневной давности",
-                             "примерно полудневной давности",
-                             "почти дневной давности",
-                             "примерно дневной давности",
-                             "совсем старые"
+const char *track_when[] = {"совсем свежие",
+                            "свежие",
+                            "менее полудневной давности",
+                            "примерно полудневной давности",
+                            "почти дневной давности",
+                            "примерно дневной давности",
+                            "совсем старые"
 };
 
-int age_track(CHAR_DATA* /*ch*/, int time, int calc_track)
-{
-    int when = 0;
+int age_track(CHAR_DATA * /*ch*/, int time, int calc_track) {
+  int when = 0;
 
-    if (calc_track >= number(1, 50))
-    {
-        if (time & 0x03)	// 2
-            when = 0;
-        else if (time & 0x1F)	// 5
-            when = 1;
-        else if (time & 0x3FF)	// 10
-            when = 2;
-        else if (time & 0x7FFF)	// 15
-            when = 3;
-        else if (time & 0xFFFFF)	// 20
-            when = 4;
-        else if (time & 0x3FFFFFF)	// 26
-            when = 5;
-        else
-            when = 6;
-    }
+  if (calc_track >= number(1, 50)) {
+    if (time & 0x03)    // 2
+      when = 0;
+    else if (time & 0x1F)    // 5
+      when = 1;
+    else if (time & 0x3FF)    // 10
+      when = 2;
+    else if (time & 0x7FFF)    // 15
+      when = 3;
+    else if (time & 0xFFFFF)    // 20
+      when = 4;
+    else if (time & 0x3FFFFFF)    // 26
+      when = 5;
     else
-        when = number(0, 6);
-    return (when);
+      when = 6;
+  } else
+    when = number(0, 6);
+  return (when);
 }
-
 
 // * Functions and Commands which use the above functions. *
-int go_track(CHAR_DATA * ch, CHAR_DATA * victim, const ESkill skill_no)
-{
-    int percent, dir;
-    int if_sense;
+int go_track(CHAR_DATA *ch, CHAR_DATA *victim, const ESkill skill_no) {
+  int percent, dir;
+  int if_sense;
 
-    if (AFF_FLAGGED(victim, EAffectFlag::AFF_NOTRACK) && (skill_no != SKILL_SENSE))
-    {
-        return BFS_ERROR;
-    }
-    // 101 is a complete failure, no matter what the proficiency.
-    //Временная затычка. Перевести на резисты
-    //Изменил макс скилл со 100 до 200, чтобы не ломать алгоритм, в данном значении вернем старое значение.
-    if_sense = (skill_no == SKILL_SENSE) ? 100 : 0;
-    percent = number(0, skill_info[skill_no].max_percent - if_sense);
-    //current_skillpercent = GET_SKILL(ch, SKILL_SENSE);
-    if ((!IS_NPC(victim)) && (!IS_GOD(ch)) && (!IS_NPC(ch))) //Если цель чар и ищет не бог
-    {
-        percent = MIN(99, number(0, GET_REMORT(victim)) + percent);
-    }
-    if (percent > calculate_skill(ch, skill_no, victim))
-    {
-        int tries = 10;
-        // Find a random direction. :)
-        do
-        {
-            dir = number(0, NUM_OF_DIRS - 1);
-        }
-        while (!CAN_GO(ch, dir) && --tries);
-        return dir;
-    }
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_NOTRACK) && (skill_no != SKILL_SENSE)) {
+    return BFS_ERROR;
+  }
+  // 101 is a complete failure, no matter what the proficiency.
+  //Временная затычка. Перевести на резисты
+  //Изменил макс скилл со 100 до 200, чтобы не ломать алгоритм, в данном значении вернем старое значение.
+  if_sense = (skill_no == SKILL_SENSE) ? 100 : 0;
+  percent = number(0, skill_info[skill_no].fail_percent - if_sense);
+  //current_skillpercent = GET_SKILL(ch, SKILL_SENSE);
+  if ((!IS_NPC(victim)) && (!IS_GOD(ch)) && (!IS_NPC(ch))) //Если цель чар и ищет не бог
+  {
+    percent = MIN(99, number(0, GET_REMORT(victim)) + percent);
+  }
+  if (percent > CalcCurrentSkill(ch, skill_no, victim)) {
+    int tries = 10;
+    // Find a random direction. :)
+    do {
+      dir = number(0, NUM_OF_DIRS - 1);
+    } while (!CAN_GO(ch, dir) && --tries);
+    return dir;
+  }
 
-    // They passed the skill check.
-    return find_first_step(ch->in_room, victim->in_room, ch);
+  // They passed the skill check.
+  return find_first_step(ch->in_room, victim->in_room, ch);
 }
 
+void do_track(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  CHAR_DATA *vict = NULL;
+  struct track_data *track;
+  int found = FALSE, calc_track = 0, track_t, i;
+  char name[MAX_INPUT_LENGTH];
 
-void do_track(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-    CHAR_DATA *vict = NULL;
-    struct track_data *track;
-    int found = FALSE, calc_track = 0, track_t, i;
-    char name[MAX_INPUT_LENGTH];
+  // The character must have the track skill.
+  if (IS_NPC(ch) || !ch->get_skill(SKILL_TRACK)) {
+    send_to_char("Но вы не знаете как.\r\n", ch);
+    return;
+  }
 
-    // The character must have the track skill.
-    if (IS_NPC(ch) || !ch->get_skill(SKILL_TRACK))
-    {
-        send_to_char("Но вы не знаете как.\r\n", ch);
-        return;
-    }
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND)) {
+    send_to_char("Вы слепы как крот.\r\n", ch);
+    return;
+  }
 
-    if (AFF_FLAGGED(ch, EAffectFlag::AFF_BLIND))
-    {
-        send_to_char("Вы слепы как крот.\r\n", ch);
-        return;
-    }
+  if (!check_moves(ch, can_use_feat(ch, TRACKER_FEAT) ? TRACK_MOVES / 2 : TRACK_MOVES))
+    return;
 
-    if (!check_moves(ch, can_use_feat(ch, TRACKER_FEAT) ? TRACK_MOVES / 2 : TRACK_MOVES))
-        return;
+  calc_track = CalcCurrentSkill(ch, SKILL_TRACK, 0);
+  act("Похоже, $n кого-то выслеживает.", FALSE, ch, 0, 0, TO_ROOM);
+  one_argument(argument, arg);
 
-    calc_track = calculate_skill(ch, SKILL_TRACK, 0);
-    act("Похоже, $n кого-то выслеживает.", FALSE, ch, 0, 0, TO_ROOM);
-    one_argument(argument, arg);
-
-    // No argument - show all
-    if (!*arg)
-    {
-        for (track = world[ch->in_room]->track; track; track = track->next)
-        {
-            *name = '\0';
-            if (IS_SET(track->track_info, TRACK_NPC))
-            {
-                strcpy(name, GET_NAME(mob_proto + track->who));
-            }
-            else
-            {
-                for (std::size_t c = 0; c < player_table.size(); c++)
-                {
-                    if (player_table[c].id() == track->who)
-                    {
-                        strcpy(name, player_table[c].name());
-                        break;
-                    }
-                }
-            }
-
-            if (*name && calc_track > number(1, 40))
-            {
-                CAP(name);
-                for (track_t = i = 0; i < NUM_OF_DIRS; i++)
-                {
-                    track_t |= track->time_outgone[i];
-                    track_t |= track->time_income[i];
-                }
-                sprintf(buf, "%s : следы %s.\r\n", name,
-                        track_when[age_track(ch, track_t, calc_track)]);
-                send_to_char(buf, ch);
-                found = TRUE;
-            }
-        }
-        if (!found)
-            send_to_char("Вы не видите ничьих следов.\r\n", ch);
-        return;
-    }
-
-    if ((vict = get_char_vis(ch, arg, FIND_CHAR_ROOM)))
-    {
-        act("Вы же в одной комнате с $N4!", FALSE, ch, 0, vict, TO_CHAR);
-        return;
-    }
-
-    // found victim
-    for (track = world[ch->in_room]->track; track; track = track->next)
-    {
-        *name = '\0';
-        if (IS_SET(track->track_info, TRACK_NPC))
-        {
-            strcpy(name, GET_NAME(mob_proto + track->who));
-        }
-        else
-        {
-            for (std::size_t c = 0; c < player_table.size(); c++)
-            {
-                if (player_table[c].id() == track->who)
-                {
-                    strcpy(name, player_table[c].name());
-                    break;
-                }
-            }
-        }
-
-        if (*name && isname(arg, name))
+  // No argument - show all
+  if (!*arg) {
+    for (track = world[ch->in_room]->track; track; track = track->next) {
+      *name = '\0';
+      if (IS_SET(track->track_info, TRACK_NPC)) {
+        strcpy(name, GET_NAME(mob_proto + track->who));
+      } else {
+        for (std::size_t c = 0; c < player_table.size(); c++) {
+          if (player_table[c].id() == track->who) {
+            strcpy(name, player_table[c].name());
             break;
-        else
-            *name = '\0';
-    }
-
-    if (calc_track < number(1, 40) || !*name || ROOM_FLAGGED(ch->in_room, ROOM_NOTRACK))
-    {
-        send_to_char("Вы не видите похожих следов.\r\n", ch);
-        return;
-    }
-
-    ch->track_dirs = 0;
-    CAP(name);
-    sprintf(buf, "%s:\r\n", name);
-
-    for (int c = 0; c < NUM_OF_DIRS; c++)
-    {
-        if ((track && track->time_income[c]
-             && calc_track >= number(0, skill_info[SKILL_TRACK].max_percent))
-            || (!track && calc_track < number(0, skill_info[SKILL_TRACK].max_percent)))
-        {
-            found = TRUE;
-            sprintf(buf + strlen(buf), "- %s следы ведут %s\r\n",
-                    track_when[age_track
-                            (ch,
-                             track ? track->
-                                     time_income[c] : (1 << number(0, 25)), calc_track)], DirsFrom[Reverse[c]]);
+          }
         }
-        if ((track && track->time_outgone[c]
-             && calc_track >= number(0, skill_info[SKILL_TRACK].max_percent))
-            || (!track && calc_track < number(0, skill_info[SKILL_TRACK].max_percent)))
-        {
-            found = TRUE;
-            SET_BIT(ch->track_dirs, 1 << c);
-            sprintf(buf + strlen(buf), "- %s следы ведут %s\r\n",
-                    track_when[age_track
-                            (ch,
-                             track ? track->
-                                     time_outgone[c] : (1 << number(0, 25)), calc_track)], DirsTo[c]);
-        }
-    }
+      }
 
+      if (*name && calc_track > number(1, 40)) {
+        CAP(name);
+        for (track_t = i = 0; i < NUM_OF_DIRS; i++) {
+          track_t |= track->time_outgone[i];
+          track_t |= track->time_income[i];
+        }
+        sprintf(buf, "%s : следы %s.\r\n", name,
+                track_when[age_track(ch, track_t, calc_track)]);
+        send_to_char(buf, ch);
+        found = TRUE;
+      }
+    }
     if (!found)
-    {
-        sprintf(buf, "След неожиданно оборвался.\r\n");
-    }
-    send_to_char(buf, ch);
-}
+      send_to_char("Вы не видите ничьих следов.\r\n", ch);
+    return;
+  }
 
-void do_hidetrack(CHAR_DATA *ch, char* /*argument*/, int/* cmd*/, int/* subcmd*/)
-{
-    struct track_data *track[NUM_OF_DIRS + 1], *temp;
-    int percent, prob, i, croom, found = FALSE, dir, rdir;
+  if ((vict = get_char_vis(ch, arg, FIND_CHAR_ROOM))) {
+    act("Вы же в одной комнате с $N4!", FALSE, ch, 0, vict, TO_CHAR);
+    return;
+  }
 
-    if (IS_NPC(ch) || !ch->get_skill(SKILL_HIDETRACK))
-    {
-        send_to_char("Но вы не знаете как.\r\n", ch);
-        return;
-    }
-
-    croom = ch->in_room;
-
-    for (dir = 0; dir < NUM_OF_DIRS; dir++)
-    {
-        track[dir] = NULL;
-        rdir = Reverse[dir];
-        if (EXITDATA(croom, dir) &&
-            EXITDATA(EXITDATA(croom, dir)->to_room(), rdir) &&
-            EXITDATA(EXITDATA(croom, dir)->to_room(), rdir)->to_room() == croom)
-        {
-            for (temp = world[EXITDATA(croom, dir)->to_room()]->track; temp; temp = temp->next)
-                if (!IS_SET(temp->track_info, TRACK_NPC)
-                    && GET_IDNUM(ch) == temp->who && !IS_SET(temp->track_info, TRACK_HIDE)
-                    && IS_SET(temp->time_outgone[rdir], 3))
-                {
-                    found = TRUE;
-                    track[dir] = temp;
-                    break;
-                }
+  // found victim
+  for (track = world[ch->in_room]->track; track; track = track->next) {
+    *name = '\0';
+    if (IS_SET(track->track_info, TRACK_NPC)) {
+      strcpy(name, GET_NAME(mob_proto + track->who));
+    } else {
+      for (std::size_t c = 0; c < player_table.size(); c++) {
+        if (player_table[c].id() == track->who) {
+          strcpy(name, player_table[c].name());
+          break;
         }
+      }
     }
 
-    track[NUM_OF_DIRS] = NULL;
-    for (temp = world[ch->in_room]->track; temp; temp = temp->next)
-        if (!IS_SET(temp->track_info, TRACK_NPC) &&
-            GET_IDNUM(ch) == temp->who && !IS_SET(temp->track_info, TRACK_HIDE))
-        {
-            found = TRUE;
-            track[NUM_OF_DIRS] = temp;
-            break;
-        }
-
-    if (!found)
-    {
-        send_to_char("Вы не видите своих следов.\r\n", ch);
-        return;
-    }
-    if (!check_moves(ch, can_use_feat(ch, STEALTHY_FEAT) ? HIDETRACK_MOVES / 2 : HIDETRACK_MOVES))
-        return;
-    percent = number(1, skill_info[SKILL_HIDETRACK].max_percent);
-    prob = calculate_skill(ch, SKILL_HIDETRACK, 0);
-    if (percent > prob)
-    {
-        send_to_char("Вы безуспешно попытались замести свои следы.\r\n", ch);
-        if (!number(0, 25 - timed_by_skill(ch, SKILL_HIDETRACK) ? 0 : 15))
-            improve_skill(ch, SKILL_HIDETRACK, FALSE, 0);
-    }
+    if (*name && isname(arg, name))
+      break;
     else
-    {
-        send_to_char("Вы успешно замели свои следы.\r\n", ch);
-        if (!number(0, 25 - timed_by_skill(ch, SKILL_HIDETRACK) ? 0 : 15))
-            improve_skill(ch, SKILL_HIDETRACK, TRUE, 0);
-        prob -= percent;
-        for (i = 0; i <= NUM_OF_DIRS; i++)
-            if (track[i])
-            {
-                if (i < NUM_OF_DIRS)
-                    track[i]->time_outgone[Reverse[i]] <<= MIN(31, prob);
-                else
-                    for (rdir = 0; rdir < NUM_OF_DIRS; rdir++)
-                    {
-                        track[i]->time_income[rdir] <<= MIN(31, prob);
-                        track[i]->time_outgone[rdir] <<= MIN(31, prob);
-                    }
-                //sprintf(buf,"Заметены следы %d\r\n",i);
-                //send_to_char(buf,ch);
-            }
+      *name = '\0';
+  }
+
+  if (calc_track < number(1, 40) || !*name || ROOM_FLAGGED(ch->in_room, ROOM_NOTRACK)) {
+    send_to_char("Вы не видите похожих следов.\r\n", ch);
+    return;
+  }
+
+  ch->track_dirs = 0;
+  CAP(name);
+  sprintf(buf, "%s:\r\n", name);
+
+  for (int c = 0; c < NUM_OF_DIRS; c++) {
+    if ((track && track->time_income[c]
+        && calc_track >= number(0, skill_info[SKILL_TRACK].fail_percent))
+        || (!track && calc_track < number(0, skill_info[SKILL_TRACK].fail_percent))) {
+      found = TRUE;
+      sprintf(buf + strlen(buf), "- %s следы ведут %s\r\n",
+              track_when[age_track
+                  (ch,
+                   track ? track->
+                       time_income[c] : (1 << number(0, 25)), calc_track)], DirsFrom[Reverse[c]]);
+    }
+    if ((track && track->time_outgone[c]
+        && calc_track >= number(0, skill_info[SKILL_TRACK].fail_percent))
+        || (!track && calc_track < number(0, skill_info[SKILL_TRACK].fail_percent))) {
+      found = TRUE;
+      SET_BIT(ch->track_dirs, 1 << c);
+      sprintf(buf + strlen(buf), "- %s следы ведут %s\r\n",
+              track_when[age_track
+                  (ch,
+                   track ? track->
+                       time_outgone[c] : (1 << number(0, 25)), calc_track)], DirsTo[c]);
+    }
+  }
+
+  if (!found) {
+    sprintf(buf, "След неожиданно оборвался.\r\n");
+  }
+  send_to_char(buf, ch);
+}
+
+void do_hidetrack(CHAR_DATA *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
+  struct track_data *track[NUM_OF_DIRS + 1], *temp;
+  int percent, prob, i, croom, found = FALSE, dir, rdir;
+
+  if (IS_NPC(ch) || !ch->get_skill(SKILL_HIDETRACK)) {
+    send_to_char("Но вы не знаете как.\r\n", ch);
+    return;
+  }
+
+  croom = ch->in_room;
+
+  for (dir = 0; dir < NUM_OF_DIRS; dir++) {
+    track[dir] = NULL;
+    rdir = Reverse[dir];
+    if (EXITDATA(croom, dir) &&
+        EXITDATA(EXITDATA(croom, dir)->to_room(), rdir) &&
+        EXITDATA(EXITDATA(croom, dir)->to_room(), rdir)->to_room() == croom) {
+      for (temp = world[EXITDATA(croom, dir)->to_room()]->track; temp; temp = temp->next)
+        if (!IS_SET(temp->track_info, TRACK_NPC)
+            && GET_IDNUM(ch) == temp->who && !IS_SET(temp->track_info, TRACK_HIDE)
+            && IS_SET(temp->time_outgone[rdir], 3)) {
+          found = TRUE;
+          track[dir] = temp;
+          break;
+        }
+    }
+  }
+
+  track[NUM_OF_DIRS] = NULL;
+  for (temp = world[ch->in_room]->track; temp; temp = temp->next)
+    if (!IS_SET(temp->track_info, TRACK_NPC) &&
+        GET_IDNUM(ch) == temp->who && !IS_SET(temp->track_info, TRACK_HIDE)) {
+      found = TRUE;
+      track[NUM_OF_DIRS] = temp;
+      break;
     }
 
+  if (!found) {
+    send_to_char("Вы не видите своих следов.\r\n", ch);
+    return;
+  }
+  if (!check_moves(ch, can_use_feat(ch, STEALTHY_FEAT) ? HIDETRACK_MOVES / 2 : HIDETRACK_MOVES))
+    return;
+  percent = number(1, skill_info[SKILL_HIDETRACK].fail_percent);
+  prob = CalcCurrentSkill(ch, SKILL_HIDETRACK, 0);
+  if (percent > prob) {
+    send_to_char("Вы безуспешно попытались замести свои следы.\r\n", ch);
+    if (!number(0, 25 - timed_by_skill(ch, SKILL_HIDETRACK) ? 0 : 15))
+      ImproveSkill(ch, SKILL_HIDETRACK, FALSE, 0);
+  } else {
+    send_to_char("Вы успешно замели свои следы.\r\n", ch);
+    if (!number(0, 25 - timed_by_skill(ch, SKILL_HIDETRACK) ? 0 : 15))
+      ImproveSkill(ch, SKILL_HIDETRACK, TRUE, 0);
+    prob -= percent;
     for (i = 0; i <= NUM_OF_DIRS; i++)
-        if (track[i])
-            SET_BIT(track[i]->track_info, TRACK_HIDE);
+      if (track[i]) {
+        if (i < NUM_OF_DIRS)
+          track[i]->time_outgone[Reverse[i]] <<= MIN(31, prob);
+        else
+          for (rdir = 0; rdir < NUM_OF_DIRS; rdir++) {
+            track[i]->time_income[rdir] <<= MIN(31, prob);
+            track[i]->time_outgone[rdir] <<= MIN(31, prob);
+          }
+        //sprintf(buf,"Заметены следы %d\r\n",i);
+        //send_to_char(buf,ch);
+      }
+  }
+
+  for (i = 0; i <= NUM_OF_DIRS; i++)
+    if (track[i])
+      SET_BIT(track[i]->track_info, TRACK_HIDE);
 }

--- a/src/skills/warcry.cpp
+++ b/src/skills/warcry.cpp
@@ -8,144 +8,127 @@
 
 #include <boost/tokenizer.hpp>
 
-void do_warcry(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/)
-{
-	int spellnum, cnt;
+void do_warcry(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
+  int spellnum, cnt;
 
-	if (IS_NPC(ch) && AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM))
-		return;
+  if (IS_NPC(ch) && AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM))
+    return;
 
-	if (!ch->get_skill(SKILL_WARCRY))
-	{
-		send_to_char("Но вы не знаете как.\r\n", ch);
-		return;
-	}
+  if (!ch->get_skill(SKILL_WARCRY)) {
+    send_to_char("Но вы не знаете как.\r\n", ch);
+    return;
+  }
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_SILENCE) || AFF_FLAGGED(ch, EAffectFlag::AFF_STRANGLED))
-	{
-		send_to_char("Вы не смогли вымолвить и слова.\r\n", ch);
-		return;
-	}
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_SILENCE) || AFF_FLAGGED(ch, EAffectFlag::AFF_STRANGLED)) {
+    send_to_char("Вы не смогли вымолвить и слова.\r\n", ch);
+    return;
+  }
 
-	std::string buffer = argument;
-	typedef boost::tokenizer<pred_separator> tokenizer;
-	pred_separator sep;
-	tokenizer tok(buffer, sep);
-	tokenizer::iterator tok_iter = tok.begin();
+  std::string buffer = argument;
+  typedef boost::tokenizer<pred_separator> tokenizer;
+  pred_separator sep;
+  tokenizer tok(buffer, sep);
+  tokenizer::iterator tok_iter = tok.begin();
 
-	if (tok_iter == tok.end())
-	{
-		sprintf(buf, "Вам доступны :\r\n");
-		for (cnt = spellnum = 1; spellnum <= SPELLS_COUNT; spellnum++)
-		{
-			const char *realname = spell_info[spellnum].name
-				&& *spell_info[spellnum].name ? spell_info[spellnum].name : spell_info[spellnum].syn
-				&& *spell_info[spellnum].syn ? spell_info[spellnum].syn : NULL;
+  if (tok_iter == tok.end()) {
+    sprintf(buf, "Вам доступны :\r\n");
+    for (cnt = spellnum = 1; spellnum <= SPELLS_COUNT; spellnum++) {
+      const char *realname = spell_info[spellnum].name
+                                 && *spell_info[spellnum].name ? spell_info[spellnum].name : spell_info[spellnum].syn
+                                                                                                 && *spell_info[spellnum].syn
+                                                                                             ? spell_info[spellnum].syn
+                                                                                             : NULL;
 
-			if (realname
-				&& IS_SET(spell_info[spellnum].routines, MAG_WARCRY)
-				&& ch->get_skill(SKILL_WARCRY) >= spell_info[spellnum].mana_change)
-			{
-				if (!IS_SET(GET_SPELL_TYPE(ch, spellnum), SPELL_KNOW | SPELL_TEMP))
-					continue;
-				sprintf(buf + strlen(buf), "%s%2d%s) %s%s%s\r\n",
-					KGRN, cnt++, KNRM,
-					spell_info[spellnum].violent ? KIRED : KIGRN, realname, KNRM);
-			}
-		}
-		send_to_char(buf, ch);
-		return;
-	}
+      if (realname
+          && IS_SET(spell_info[spellnum].routines, MAG_WARCRY)
+          && ch->get_skill(SKILL_WARCRY) >= spell_info[spellnum].mana_change) {
+        if (!IS_SET(GET_SPELL_TYPE(ch, spellnum), SPELL_KNOW | SPELL_TEMP))
+          continue;
+        sprintf(buf + strlen(buf), "%s%2d%s) %s%s%s\r\n",
+                KGRN, cnt++, KNRM,
+                spell_info[spellnum].violent ? KIRED : KIGRN, realname, KNRM);
+      }
+    }
+    send_to_char(buf, ch);
+    return;
+  }
 
-	std::string wc_name = *(tok_iter++);
+  std::string wc_name = *(tok_iter++);
 
-	if (CompareParam(wc_name, "of"))
-	{
-		if (tok_iter == tok.end())
-		{
-			send_to_char("Какой клич вы хотите использовать?\r\n", ch);
-			return;
-		}
-		else
-			wc_name = "warcry of " + *(tok_iter++);
-	}
-	else
-		wc_name = "клич " + wc_name;
+  if (CompareParam(wc_name, "of")) {
+    if (tok_iter == tok.end()) {
+      send_to_char("Какой клич вы хотите использовать?\r\n", ch);
+      return;
+    } else
+      wc_name = "warcry of " + *(tok_iter++);
+  } else
+    wc_name = "клич " + wc_name;
 
-	spellnum = fix_name_and_find_spell_num(wc_name);
+  spellnum = fix_name_and_find_spell_num(wc_name);
 
-	// Unknown warcry
-	if (spellnum < 1 || spellnum > MAX_SPELLS
-		|| (ch->get_skill(SKILL_WARCRY) < spell_info[spellnum].mana_change)
-		|| !IS_SET(GET_SPELL_TYPE(ch, spellnum), SPELL_KNOW | SPELL_TEMP))
-	{
-		send_to_char("И откуда вы набрались таких выражений?\r\n", ch);
-		return;
-	}
+  // Unknown warcry
+  if (spellnum < 1 || spellnum > MAX_SPELLS
+      || (ch->get_skill(SKILL_WARCRY) < spell_info[spellnum].mana_change)
+      || !IS_SET(GET_SPELL_TYPE(ch, spellnum), SPELL_KNOW | SPELL_TEMP)) {
+    send_to_char("И откуда вы набрались таких выражений?\r\n", ch);
+    return;
+  }
 
-	CHAR_DATA *tch;
-	OBJ_DATA *tobj;
-	ROOM_DATA *troom;
-	//афтар сотворил клона функции, а остальное не перевёл :(
+  CHAR_DATA *tch;
+  OBJ_DATA *tobj;
+  ROOM_DATA *troom;
+  //афтар сотворил клона функции, а остальное не перевёл :(
 
-	int target = find_cast_target(spellnum, tok_iter == tok.end() ? "" : (*tok_iter).c_str(), ch, &tch, &tobj, &troom);
+  int target = find_cast_target(spellnum, tok_iter == tok.end() ? "" : (*tok_iter).c_str(), ch, &tch, &tobj, &troom);
 
-	if (!target)
-	{
-		send_to_char("Тяжеловато найти цель!\r\n", ch);
-		return;
-	}
+  if (!target) {
+    send_to_char("Тяжеловато найти цель!\r\n", ch);
+    return;
+  }
 
-	if (tch == ch && spell_info[spellnum].violent)
-	{
-		send_to_char("Не накликайте беды!\r\n", ch);
-		return;
-	}
+  if (tch == ch && spell_info[spellnum].violent) {
+    send_to_char("Не накликайте беды!\r\n", ch);
+    return;
+  }
 
-	if (tch && IS_MOB(tch) && IS_MOB(ch) && !SAME_ALIGN(ch, tch) && !spell_info[spellnum].violent)
-		return;
+  if (tch && IS_MOB(tch) && IS_MOB(ch) && !SAME_ALIGN(ch, tch) && !spell_info[spellnum].violent)
+    return;
 
-	if (tch != ch && !IS_IMMORTAL(ch) && IS_SET(spell_info[spellnum].targets, TAR_SELF_ONLY))
-	{
-		send_to_char("Этот клич предназначен только для вас!\r\n", ch);
-		return;
-	}
+  if (tch != ch && !IS_IMMORTAL(ch) && IS_SET(spell_info[spellnum].targets, TAR_SELF_ONLY)) {
+    send_to_char("Этот клич предназначен только для вас!\r\n", ch);
+    return;
+  }
 
-	if (tch == ch && IS_SET(spell_info[spellnum].targets, TAR_NOT_SELF))
-	{
-		send_to_char("Да вы с ума сошли!\r\n", ch);
-		return;
-	}
+  if (tch == ch && IS_SET(spell_info[spellnum].targets, TAR_NOT_SELF)) {
+    send_to_char("Да вы с ума сошли!\r\n", ch);
+    return;
+  }
 
-	struct timed_type timed;
-	timed.skill = SKILL_WARCRY;
-	timed.time = timed_by_skill(ch, SKILL_WARCRY) + HOURS_PER_WARCRY;
+  struct timed_type timed;
+  timed.skill = SKILL_WARCRY;
+  timed.time = timed_by_skill(ch, SKILL_WARCRY) + HOURS_PER_WARCRY;
 
-	if (timed.time > HOURS_PER_DAY)
-	{
-		send_to_char("Вы охрипли и не можете кричать.\r\n", ch);
-		return;
-	}
+  if (timed.time > HOURS_PER_DAY) {
+    send_to_char("Вы охрипли и не можете кричать.\r\n", ch);
+    return;
+  }
 
-	if (GET_MOVE(ch) < spell_info[spellnum].mana_max)
-	{
-		send_to_char("У вас не хватит сил для этого.\r\n", ch);
-		return;
-	}
+  if (GET_MOVE(ch) < spell_info[spellnum].mana_max) {
+    send_to_char("У вас не хватит сил для этого.\r\n", ch);
+    return;
+  }
 
-	say_spell(ch, spellnum, tch, tobj);
+  say_spell(ch, spellnum, tch, tobj);
 
-	if (call_magic(ch, tch, tobj, troom, spellnum, GET_LEVEL(ch)) >= 0)
-	{
-		if (!WAITLESS(ch))
-		{
-			if (!CHECK_WAIT(ch))
-				WAIT_STATE(ch, PULSE_VIOLENCE);
-			timed_to_char(ch, &timed);
-			GET_MOVE(ch) -= spell_info[spellnum].mana_max;
-		}
-		train_skill(ch, SKILL_WARCRY, skill_info[SKILL_WARCRY].max_percent, tch);
-	}
+  if (call_magic(ch, tch, tobj, troom, spellnum, GET_LEVEL(ch)) >= 0) {
+    if (!WAITLESS(ch)) {
+      if (!CHECK_WAIT(ch))
+        WAIT_STATE(ch, PULSE_VIOLENCE);
+      timed_to_char(ch, &timed);
+      GET_MOVE(ch) -= spell_info[spellnum].mana_max;
+    }
+    train_skill(ch, SKILL_WARCRY, true, tch);
+  }
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/skills/warcry.cpp
+++ b/src/skills/warcry.cpp
@@ -127,7 +127,7 @@ void do_warcry(CHAR_DATA *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
       timed_to_char(ch, &timed);
       GET_MOVE(ch) -= spell_info[spellnum].mana_max;
     }
-    train_skill(ch, SKILL_WARCRY, true, tch);
+    TrainSkill(ch, SKILL_WARCRY, true, tch);
   }
 }
 

--- a/src/spec_procs.cpp
+++ b/src/spec_procs.cpp
@@ -59,98 +59,98 @@ extern TIME_INFO_DATA time_info;
 extern struct spell_create_type spell_create[];
 extern int guild_info[][3];
 
-typedef int special_f(CHAR_DATA*, void*, int, char*);
+typedef int special_f(CHAR_DATA *, void *, int, char *);
 
 // extern functions
 void do_drop(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 void do_say(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
-int find_first_step(room_rnum src, room_rnum target, CHAR_DATA * ch);
+int find_first_step(room_rnum src, room_rnum target, CHAR_DATA *ch);
 void ASSIGNMASTER(mob_vnum mob, special_f, int learn_info);
 
 // local functions
-char *how_good(CHAR_DATA * ch, int percent);
+char *how_good(int skill_level, int skill_cap);
 int feat_slot_lvl(int remort, int slot_for_remort, int slot);
-void list_feats(CHAR_DATA * ch, CHAR_DATA * vict, bool all_feats);
-void list_skills(CHAR_DATA * ch, CHAR_DATA * vict, const char* filter = NULL);
-void list_spells(CHAR_DATA * ch, CHAR_DATA * vict, int all_spells);
-int guild_mono(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int guild_poly(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int guild(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int dump(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int mayor(CHAR_DATA *ch, void *me, int cmd, char* argument);
+void list_feats(CHAR_DATA *ch, CHAR_DATA *vict, bool all_feats);
+void list_skills(CHAR_DATA *ch, CHAR_DATA *vict, const char *filter = NULL);
+void list_spells(CHAR_DATA *ch, CHAR_DATA *vict, int all_spells);
+int guild_mono(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int guild_poly(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int guild(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int dump(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int mayor(CHAR_DATA *ch, void *me, int cmd, char *argument);
 //int thief(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int magic_user(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int guild_guard(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int fido(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int janitor(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int cityguard(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int pet_shops(CHAR_DATA *ch, void *me, int cmd, char* argument);
-int bank(CHAR_DATA *ch, void *me, int cmd, char* argument);
+int magic_user(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int guild_guard(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int fido(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int janitor(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int cityguard(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int pet_shops(CHAR_DATA *ch, void *me, int cmd, char *argument);
+int bank(CHAR_DATA *ch, void *me, int cmd, char *argument);
 
 // ********************************************************************
 // *  Special procedures for mobiles                                  *
 // ********************************************************************
 
-char *how_good(CHAR_DATA * ch, int percent)
-{
-	static char out_str[128];
+char *how_good(int skill_level, int skill_cap) {
+  static char out_str[128];
+  int skill_percent = skill_level*100/skill_cap;
 
-	if (percent < 0)
-		strcpy(out_str, " !Ошибка! ");
-	else if (percent == 0)
-		sprintf(out_str, " %s(не изучено)%s", CCINRM(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 10)
-		sprintf(out_str, " %s(ужасно)%s", CCINRM(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 20)
-		sprintf(out_str, " %s(очень плохо)%s", CCRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 30)
-		sprintf(out_str, " %s(плохо)%s", CCRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 40)
-		sprintf(out_str, " %s(слабо)%s", CCRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 50)
-		sprintf(out_str, " %s(ниже среднего)%s", CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 60)
-		sprintf(out_str, " %s(средне)%s", CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 70)
-		sprintf(out_str, " %s(выше среднего)%s", CCIRED(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 80)
-		sprintf(out_str, " %s(хорошо)%s", CCYEL(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 90)
-		sprintf(out_str, " %s(очень хорошо)%s", CCYEL(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 100)
-		sprintf(out_str, " %s(отлично)%s", CCIYEL(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 110)
-		sprintf(out_str, " %s(превосходно)%s", CCIYEL(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 120)
-		sprintf(out_str, " %s(великолепно)%s", CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 130)
-		sprintf(out_str, " %s(мастерски)%s", CCIBLU(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 140)
-		sprintf(out_str, " %s(идеально)%s", CCGRN(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 150)
-		sprintf(out_str, " %s(совершенно)%s", CCIGRN(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 160)
-		sprintf(out_str, " %s(бесподобно)%s", CCMAG(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 170)
-		sprintf(out_str, " %s(возвышенно)%s", CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 180)
-		sprintf(out_str, " %s(заоблачно)%s", CCICYN(ch, C_NRM), CCNRM(ch, C_NRM));
-	else if (percent <= 190)
-		sprintf(out_str, " %s(божественно)%s", CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
-	else
-		sprintf(out_str, " %s(недостижимо)%s", CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
-	sprintf(out_str + strlen(out_str), " %d%% ", percent);
-	return out_str;
+  if (skill_level < 0)
+    strcpy(out_str, " !Ошибка! ");
+  else if (skill_level == 0)
+    sprintf(out_str, " %s(не изучено)", KIDRK);
+  else if (skill_percent <= 10)
+    sprintf(out_str, " %s(ужасно)", KIDRK);
+  else if (skill_percent <= 20)
+    sprintf(out_str, " %s(очень плохо)", KRED);
+  else if (skill_percent <= 30)
+    sprintf(out_str, " %s(плохо)", KRED);
+  else if (skill_percent <= 40)
+    sprintf(out_str, " %s(слабо)", KIRED);
+  else if (skill_percent <= 50)
+    sprintf(out_str, " %s(ниже среднего)", KIRED);
+  else if (skill_percent <= 55)
+    sprintf(out_str, " %s(средне)", KYEL);
+  else if (skill_percent <= 60)
+    sprintf(out_str, " %s(выше среднего)", KYEL);
+  else if (skill_percent <= 70)
+    sprintf(out_str, " %s(хорошо)", KYEL);
+  else if (skill_percent <= 75)
+    sprintf(out_str, " %s(очень хорошо)", KIYEL);
+  else if (skill_percent <= 80)
+    sprintf(out_str, " %s(отлично)", KIYEL);
+  else if (skill_percent <= 90)
+    sprintf(out_str, " %s(превосходно)", KGRN);
+  else if (skill_percent <= 95)
+    sprintf(out_str, " %s(великолепно)", KGRN);
+  else if (skill_percent <= 100)
+    sprintf(out_str, " %s(мастерски)", KIGRN);
+  else if (skill_percent <= 110)
+    sprintf(out_str, " %s(идеально)", KIGRN);
+  else if (skill_percent <= 120)
+    sprintf(out_str, " %s(совершенно)", KMAG);
+  else if (skill_percent <= 130)
+    sprintf(out_str, " %s(бесподобно)", KMAG);
+  else if (skill_percent <= 140)
+    sprintf(out_str, " %s(возвышенно)", KCYN);
+  else if (skill_percent <= 150)
+    sprintf(out_str, " %s(заоблачно)", KICYN);
+  else if (skill_percent <= 160)
+    sprintf(out_str, " %s(божественно)", KWHT);
+  else
+    sprintf(out_str, " %s(недостижимо)", KWHT);
+  sprintf(out_str + strlen(out_str), " %d", skill_level);
+  return out_str;
 }
 
-const char *prac_types[] = { "spell",
-							 "skill"
-						   };
+const char *prac_types[] = {"spell",
+                            "skill"
+};
 
-#define LEARNED_LEVEL	0	// % known which is considered "learned" //
-#define MAX_PER_PRAC	1	// max percent gain in skill per practice //
-#define MIN_PER_PRAC	2	// min percent gain in skill per practice //
-#define PRAC_TYPE	3	// should it say 'spell' or 'skill'?     //
+#define LEARNED_LEVEL    0    // % known which is considered "learned" //
+#define MAX_PER_PRAC    1    // max percent gain in skill per practice //
+#define MIN_PER_PRAC    2    // min percent gain in skill per practice //
+#define PRAC_TYPE    3    // should it say 'spell' or 'skill'?     //
 
 // actual prac_params are in class.cpp //
 extern int prac_params[4][NUM_PLAYER_CLASSES];
@@ -160,23 +160,20 @@ extern int prac_params[4][NUM_PLAYER_CLASSES];
 #define MAXGAIN(ch) (prac_params[MAX_PER_PRAC][(int)GET_CLASS(ch)])
 #define SPLSKL(ch) (prac_types[prac_params[PRAC_TYPE][(int)GET_CLASS(ch)]])
 
-int feat_slot_lvl(int remort, int slot_for_remort, int slot)
-{
-	int result = 0;
-	for (result = 1; result < LVL_IMMORT; result++)
-	{
-		if (result*(5 + remort / slot_for_remort) / 28 == slot)
-		{
-			break;
-		}
-	}
-	/*
+int feat_slot_lvl(int remort, int slot_for_remort, int slot) {
+  int result = 0;
+  for (result = 1; result < LVL_IMMORT; result++) {
+    if (result * (5 + remort / slot_for_remort) / 28 == slot) {
+      break;
+    }
+  }
+  /*
 	ВНИМАНИЕ: формула содрана с NUM_LEV_FEAT (utils.h)!
 	((int) 1+GET_LEVEL(ch)*(5+GET_REMORT(ch)/feat_slot_for_remort[(int) GET_CLASS(ch)])/28)
 	сделано это потому, что "обратная" формула, использованная ранее в list_feats,
 	выдавала неверные результаты ввиду нюансов округления
 	*/
-	return result;
+  return result;
 }
 
 /*
@@ -190,360 +187,311 @@ int feat_slot_lvl(int remort, int slot_for_remort, int slot)
 Примечание: удаление реализовано с целью сделать возможнным изменение слота в процессе игры.
 Лишние способности у персонажей удалятся автоматически при использовании команды "способности".
 */
-void list_feats(CHAR_DATA * ch, CHAR_DATA * vict, bool all_feats)
-{
-	int i = 0, j = 0, sortpos, slot, max_slot=0;
-	char msg[MAX_STRING_LENGTH];
-	bool sfound;
+void list_feats(CHAR_DATA *ch, CHAR_DATA *vict, bool all_feats) {
+  int i = 0, j = 0, sortpos, slot, max_slot = 0;
+  char msg[MAX_STRING_LENGTH];
+  bool sfound;
 
-	//Найдем максимальный слот, который вобще может потребоваться данному персонажу на текущем морте
-	max_slot =  MAX_ACC_FEAT(ch);
-	char  **names = new char*[max_slot];
-	for (int k = 0; k< max_slot; k++)
-		names[k]=new char[MAX_STRING_LENGTH];
+  //Найдем максимальный слот, который вобще может потребоваться данному персонажу на текущем морте
+  max_slot = MAX_ACC_FEAT(ch);
+  char **names = new char *[max_slot];
+  for (int k = 0; k < max_slot; k++)
+    names[k] = new char[MAX_STRING_LENGTH];
 
-	if (all_feats)
-	{
-		sprintf(names[0], "\r\nКруг 1  (1  уровень):\r\n");
-	}
-	else
-		*names[0] = '\0';
-	for (i = 1; i < max_slot; i++)
-		if (all_feats)
-		{
-			//j = i*28/(5+GET_REMORT(ch)/feat_slot_for_remort[(int) GET_CLASS(ch)]); // старая формула, работавшая криво!
-			j = feat_slot_lvl(GET_REMORT(ch), feat_slot_for_remort[(int) GET_CLASS(ch)], i); // на каком уровне будет слот i?
-			sprintf(names[i], "\r\nКруг %-2d (%-2d уровень):\r\n", i + 1, j);
-		}
-		else
-			*names[i] = '\0';
+  if (all_feats) {
+    sprintf(names[0], "\r\nКруг 1  (1  уровень):\r\n");
+  } else
+    *names[0] = '\0';
+  for (i = 1; i < max_slot; i++)
+    if (all_feats) {
+      //j = i*28/(5+GET_REMORT(ch)/feat_slot_for_remort[(int) GET_CLASS(ch)]); // старая формула, работавшая криво!
+      j = feat_slot_lvl(GET_REMORT(ch), feat_slot_for_remort[(int) GET_CLASS(ch)], i); // на каком уровне будет слот i?
+      sprintf(names[i], "\r\nКруг %-2d (%-2d уровень):\r\n", i + 1, j);
+    } else
+      *names[i] = '\0';
 
-	sprintf(buf2, "\r\nВрожденные способности :\r\n");
-	j = 0;
-	if (all_feats)
-	{
-		if (clr(vict, C_NRM)) // реж цвет >= обычный
-			send_to_char(" Список способностей, доступных с текущим числом перевоплощений.\r\n"
-						" &gЗеленым цветом и пометкой [И] выделены уже изученные способности.\r\n&n"
-						" Пометкой [Д] выделены доступные для изучения способности.\r\n"
-						" &rКрасным цветом и пометкой [Н] выделены способности, недоступные вам в настоящий момент.&n\r\n\r\n", vict);
-		else
-			send_to_char(" Список способностей, доступных с текущим числом перевоплощений.\r\n"
-						" Пометкой [И] выделены уже изученные способности.\r\n"
-						" Пометкой [Д] выделены доступные для изучения способности.\r\n"
-						" Пометкой [Н] выделены способности, недоступные вам в настоящий момент.\r\n\r\n", vict);
-		for (sortpos = 1; sortpos < MAX_FEATS; sortpos++)
-		{
-			if (!feat_info[sortpos].classknow[(int) GET_CLASS(ch)][(int) GET_KIN(ch)] && !PlayerRace::FeatureCheck((int)GET_KIN(ch),(int)GET_RACE(ch),sortpos))
-				continue;
-			if (clr(vict, C_NRM))
-				sprintf(buf, "        %s%s %-30s%s\r\n",
-					HAVE_FEAT(ch, sortpos) ? KGRN :
-					can_get_feat(ch, sortpos) ? KNRM : KRED,
-					HAVE_FEAT(ch, sortpos) ? "[И]" :
-					can_get_feat(ch, sortpos) ? "[Д]" : "[Н]",
-					feat_info[sortpos].name, KNRM);
-			else
-				sprintf(buf, "    %s %-30s\r\n",
-					HAVE_FEAT(ch, sortpos) ? "[И]" :
-					can_get_feat(ch, sortpos) ? "[Д]" : "[Н]",
-					feat_info[sortpos].name);
+  sprintf(buf2, "\r\nВрожденные способности :\r\n");
+  j = 0;
+  if (all_feats) {
+    if (clr(vict, C_NRM)) // реж цвет >= обычный
+      send_to_char(" Список способностей, доступных с текущим числом перевоплощений.\r\n"
+                   " &gЗеленым цветом и пометкой [И] выделены уже изученные способности.\r\n&n"
+                   " Пометкой [Д] выделены доступные для изучения способности.\r\n"
+                   " &rКрасным цветом и пометкой [Н] выделены способности, недоступные вам в настоящий момент.&n\r\n\r\n",
+                   vict);
+    else
+      send_to_char(" Список способностей, доступных с текущим числом перевоплощений.\r\n"
+                   " Пометкой [И] выделены уже изученные способности.\r\n"
+                   " Пометкой [Д] выделены доступные для изучения способности.\r\n"
+                   " Пометкой [Н] выделены способности, недоступные вам в настоящий момент.\r\n\r\n", vict);
+    for (sortpos = 1; sortpos < MAX_FEATS; sortpos++) {
+      if (!feat_info[sortpos].classknow[(int) GET_CLASS(ch)][(int) GET_KIN(ch)]
+          && !PlayerRace::FeatureCheck((int) GET_KIN(ch), (int) GET_RACE(ch), sortpos))
+        continue;
+      if (clr(vict, C_NRM))
+        sprintf(buf, "        %s%s %-30s%s\r\n",
+                HAVE_FEAT(ch, sortpos) ? KGRN :
+                can_get_feat(ch, sortpos) ? KNRM : KRED,
+                HAVE_FEAT(ch, sortpos) ? "[И]" :
+                can_get_feat(ch, sortpos) ? "[Д]" : "[Н]",
+                feat_info[sortpos].name, KNRM);
+      else
+        sprintf(buf, "    %s %-30s\r\n",
+                HAVE_FEAT(ch, sortpos) ? "[И]" :
+                can_get_feat(ch, sortpos) ? "[Д]" : "[Н]",
+                feat_info[sortpos].name);
 
-			if (feat_info[sortpos].inbornFeatureOfClass[(int) GET_CLASS(ch)][(int) GET_KIN(ch)] || PlayerRace::FeatureCheck((int)GET_KIN(ch),(int)GET_RACE(ch),sortpos))
-			{
-				strcat(buf2, buf);
-				j++;
-			}
-			else if (FEAT_SLOT(ch, sortpos) < max_slot)
-			{
-				const auto slot = FEAT_SLOT(ch, sortpos);
-				strcat(names[slot], buf);
-			}
-		}
-		sprintf(buf1, "--------------------------------------");
-		for (i = 0; i < max_slot; i++)
-		{
-			if (strlen(buf1) >= MAX_STRING_LENGTH - 60)
-			{
-				strcat(buf1, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-				break;
-			}
-			sprintf(buf1 + strlen(buf1), "%s", names[i]);
-		}
+      if (feat_info[sortpos].inbornFeatureOfClass[(int) GET_CLASS(ch)][(int) GET_KIN(ch)]
+          || PlayerRace::FeatureCheck((int) GET_KIN(ch), (int) GET_RACE(ch), sortpos)) {
+        strcat(buf2, buf);
+        j++;
+      } else if (FEAT_SLOT(ch, sortpos) < max_slot) {
+        const auto slot = FEAT_SLOT(ch, sortpos);
+        strcat(names[slot], buf);
+      }
+    }
+    sprintf(buf1, "--------------------------------------");
+    for (i = 0; i < max_slot; i++) {
+      if (strlen(buf1) >= MAX_STRING_LENGTH - 60) {
+        strcat(buf1, "***ПЕРЕПОЛНЕНИЕ***\r\n");
+        break;
+      }
+      sprintf(buf1 + strlen(buf1), "%s", names[i]);
+    }
 
-		send_to_char(buf1, vict);
+    send_to_char(buf1, vict);
 //		page_string(ch->desc, buf, 1);
-		if (j)
-			send_to_char(buf2, vict);
+    if (j)
+      send_to_char(buf2, vict);
 
-		for (int k = 0; k < max_slot; k++)
-			delete[] names[k];
+    for (int k = 0; k < max_slot; k++)
+      delete[] names[k];
 
-		delete[] names;
+    delete[] names;
 
-		return;
-	}
+    return;
+  }
 
 // ======================================================
 
-	sprintf(buf1, "Вы обладаете следующими способностями :\r\n");
+  sprintf(buf1, "Вы обладаете следующими способностями :\r\n");
 
-	for (sortpos = 1; sortpos < MAX_FEATS; sortpos++)
-	{
-		if (strlen(buf2) >= MAX_STRING_LENGTH - 60)
-		{
-			strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-			break;
-		}
-		if (HAVE_FEAT(ch, sortpos))
-		{
-			if (!feat_info[sortpos].name || *feat_info[sortpos].name == '!')
-				continue;
+  for (sortpos = 1; sortpos < MAX_FEATS; sortpos++) {
+    if (strlen(buf2) >= MAX_STRING_LENGTH - 60) {
+      strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
+      break;
+    }
+    if (HAVE_FEAT(ch, sortpos)) {
+      if (!feat_info[sortpos].name || *feat_info[sortpos].name == '!')
+        continue;
 
-			switch (sortpos)
-			{
-			case BERSERK_FEAT:
-			case LIGHT_WALK_FEAT:
-			case SPELL_CAPABLE_FEAT:
-			case RELOCATE_FEAT:
-			case SHADOW_THROW_FEAT:
-				if (timed_by_feat(ch, sortpos))
-					sprintf(buf, "[%3d] ", timed_by_feat(ch, sortpos));
-				else
-					sprintf(buf, "[-!-] ");
-				break;
-			case POWER_ATTACK_FEAT:
-			case GREAT_POWER_ATTACK_FEAT:
-			case AIMING_ATTACK_FEAT:
-			case GREAT_AIMING_ATTACK_FEAT:
-			case SKIRMISHER_FEAT:
-			case DOUBLE_THROW_FEAT:
-			case TRIPLE_THROW_FEAT:
-				if (PRF_FLAGGED(ch, getPRFWithFeatureNumber(sortpos)))
-					sprintf(buf, "[-%s*%s-] ", CCIGRN(vict, C_NRM), CCNRM(vict, C_NRM));
-				else
-					sprintf(buf, "[-:-] ");
-				break;
-			default:
-				sprintf(buf, "      ");
-			}
-			if (can_use_feat(ch, sortpos))
-				sprintf(buf + strlen(buf), "%s%s%s\r\n",
-					CCIYEL(vict, C_NRM), feat_info[sortpos].name, CCNRM(vict, C_NRM));
-			else if (clr(vict, C_NRM))
-				sprintf(buf + strlen(buf), "%s\r\n", feat_info[sortpos].name);
-			else
-				sprintf(buf, "[-Н-] %s\r\n", feat_info[sortpos].name);
-			if (feat_info[sortpos].inbornFeatureOfClass[(int) GET_CLASS(ch)][(int) GET_KIN(ch)] || PlayerRace::FeatureCheck((int)GET_KIN(ch),(int)GET_RACE(ch),sortpos))
-			{
-				sprintf(buf2 + strlen(buf2), "    ");
-				strcat(buf2, buf);
-				j++;
-			}
-			else
-			{
-				slot = FEAT_SLOT(ch, sortpos);
-				sfound = FALSE;
-				while (slot < max_slot)
-				{
-					if (*names[slot] == '\0')
-					{
-						sprintf(names[slot], " %s%-2d%s) ",
-								CCGRN(vict, C_NRM), slot + 1, CCNRM(vict, C_NRM));
-						strcat(names[slot],  buf);
-						sfound = TRUE;
-						break;
-					}
-					else
-						slot++;
-				}
-				if (!sfound)
-				{
-					// Если способность не врожденная и под нее нет слота - удаляем нафик
-					//	чтобы можно было менять слоты на лету и чтобы не читерили :)
-					sprintf(msg, "WARNING: Unset out of slots feature '%s' for character '%s'!",
-							feat_info[sortpos].name, GET_NAME(ch));
-					mudlog(msg, BRF, LVL_IMPL, SYSLOG, TRUE);
-					UNSET_FEAT(ch, sortpos);
-				}
-			}
-		}
-	}
+      switch (sortpos) {
+        case BERSERK_FEAT:
+        case LIGHT_WALK_FEAT:
+        case SPELL_CAPABLE_FEAT:
+        case RELOCATE_FEAT:
+        case SHADOW_THROW_FEAT:
+          if (timed_by_feat(ch, sortpos))
+            sprintf(buf, "[%3d] ", timed_by_feat(ch, sortpos));
+          else
+            sprintf(buf, "[-!-] ");
+          break;
+        case POWER_ATTACK_FEAT:
+        case GREAT_POWER_ATTACK_FEAT:
+        case AIMING_ATTACK_FEAT:
+        case GREAT_AIMING_ATTACK_FEAT:
+        case SKIRMISHER_FEAT:
+        case DOUBLE_THROW_FEAT:
+        case TRIPLE_THROW_FEAT:
+          if (PRF_FLAGGED(ch, getPRFWithFeatureNumber(sortpos)))
+            sprintf(buf, "[-%s*%s-] ", CCIGRN(vict, C_NRM), CCNRM(vict, C_NRM));
+          else
+            sprintf(buf, "[-:-] ");
+          break;
+        default: sprintf(buf, "      ");
+      }
+      if (can_use_feat(ch, sortpos))
+        sprintf(buf + strlen(buf), "%s%s%s\r\n",
+                CCIYEL(vict, C_NRM), feat_info[sortpos].name, CCNRM(vict, C_NRM));
+      else if (clr(vict, C_NRM))
+        sprintf(buf + strlen(buf), "%s\r\n", feat_info[sortpos].name);
+      else
+        sprintf(buf, "[-Н-] %s\r\n", feat_info[sortpos].name);
+      if (feat_info[sortpos].inbornFeatureOfClass[(int) GET_CLASS(ch)][(int) GET_KIN(ch)]
+          || PlayerRace::FeatureCheck((int) GET_KIN(ch), (int) GET_RACE(ch), sortpos)) {
+        sprintf(buf2 + strlen(buf2), "    ");
+        strcat(buf2, buf);
+        j++;
+      } else {
+        slot = FEAT_SLOT(ch, sortpos);
+        sfound = FALSE;
+        while (slot < max_slot) {
+          if (*names[slot] == '\0') {
+            sprintf(names[slot], " %s%-2d%s) ",
+                    CCGRN(vict, C_NRM), slot + 1, CCNRM(vict, C_NRM));
+            strcat(names[slot], buf);
+            sfound = TRUE;
+            break;
+          } else
+            slot++;
+        }
+        if (!sfound) {
+          // Если способность не врожденная и под нее нет слота - удаляем нафик
+          //	чтобы можно было менять слоты на лету и чтобы не читерили :)
+          sprintf(msg, "WARNING: Unset out of slots feature '%s' for character '%s'!",
+                  feat_info[sortpos].name, GET_NAME(ch));
+          mudlog(msg, BRF, LVL_IMPL, SYSLOG, TRUE);
+          UNSET_FEAT(ch, sortpos);
+        }
+      }
+    }
+  }
 
-	for (i = 0; i < max_slot; i++)
-	{
-		if (*names[i] == '\0')
-			sprintf(names[i], " %s%-2d%s)       %s[пусто]%s\r\n",
-					CCGRN(vict, C_NRM), i + 1, CCNRM(vict, C_NRM), CCIWHT(vict, C_NRM), CCNRM(vict, C_NRM));
-		if (i >= NUM_LEV_FEAT(ch))
-			break;
-		sprintf(buf1 + strlen(buf1), "%s", names[i]);
-	}
-	send_to_char(buf1, vict);
+  for (i = 0; i < max_slot; i++) {
+    if (*names[i] == '\0')
+      sprintf(names[i], " %s%-2d%s)       %s[пусто]%s\r\n",
+              CCGRN(vict, C_NRM), i + 1, CCNRM(vict, C_NRM), CCIWHT(vict, C_NRM), CCNRM(vict, C_NRM));
+    if (i >= NUM_LEV_FEAT(ch))
+      break;
+    sprintf(buf1 + strlen(buf1), "%s", names[i]);
+  }
+  send_to_char(buf1, vict);
 
-	if (j)
-		send_to_char(buf2, vict);
+  if (j)
+    send_to_char(buf2, vict);
 
-	for (int k = 0; k < max_slot; k++)
-		delete[] names[k];
+  for (int k = 0; k < max_slot; k++)
+    delete[] names[k];
 
-	delete[] names;
+  delete[] names;
 }
 
-void list_skills(CHAR_DATA * ch, CHAR_DATA * vict, const char* filter/* = NULL*/)
-{
-	int i = 0, bonus = 0;
+void list_skills(CHAR_DATA *ch, CHAR_DATA *vict, const char *filter/* = NULL*/) {
+  int i = 0, bonus = 0;
 
+  sprintf(buf, "Вы владеете следующими умениями:\r\n");
+  strcpy(buf2, buf);
+  if (!IS_NPC(ch)
+      && !ch->affected.empty()) {
+    for (const auto &aff : ch->affected) {
+      if (aff->location == APPLY_BONUS_SKILLS) // скушал свиток с скилл бонусом
+      {
+        bonus = aff->modifier; // сколько крут стал
+      }
+    }
+  }
 
-	sprintf(buf, "Вы владеете следующими умениями (можно повысить до %d%%) :\r\n", max_upgradable_skill(ch));
-	strcpy(buf2, buf);
-	if (!IS_NPC(ch)
-		&& !ch->affected.empty())
-	{
-		for (const auto& aff : ch->affected)
-		{
-			if (aff->location == APPLY_BONUS_SKILLS) // скушал свиток с скилл бонусом
-			{
-				bonus = aff->modifier; // сколько крут стал
-			}
-		}
-	}
+  typedef std::list<std::string> skills_t;
+  skills_t skills;
 
-	typedef std::list<std::string> skills_t;
-	skills_t skills;
+  for (const auto sortpos : AVAILABLE_SKILLS) {
+    if (ch->get_skill(sortpos)) {
+      // filter out skills without name or name beginning with '!' character
+      if (!skill_info[sortpos].name
+          || *skill_info[sortpos].name == '!') {
+        continue;
+      }
 
-	for (const auto sortpos : AVAILABLE_SKILLS)
-	{
-		if (ch->get_skill(sortpos))
-		{
-			// filter out skills without name or name beginning with '!' character
-			if (!skill_info[sortpos].name
-				|| *skill_info[sortpos].name == '!')
-			{
-				continue;
-			}
+      // filter out skill that does not correspond to filter condition
+      if (filter
+          && NULL == strstr(skill_info[sortpos].name, filter)) {
+        continue;
+      }
 
-			// filter out skill that does not correspond to filter condition
-			if (filter
-				&& NULL == strstr(skill_info[sortpos].name, filter))
-			{
-				continue;
-			}
+      switch (sortpos) {
+        case SKILL_WARCRY: sprintf(buf, "[-%d-] ", (HOURS_PER_DAY - timed_by_skill(ch, sortpos)) / HOURS_PER_WARCRY);
+          break;
+        case SKILL_TURN_UNDEAD:
+          if (can_use_feat(ch, EXORCIST_FEAT)) {
+            sprintf(buf, "[-%d-] ", (HOURS_PER_DAY - timed_by_skill(ch, sortpos)) / (HOURS_PER_TURN_UNDEAD - 2));
+          } else {
+            sprintf(buf, "[-%d-] ", (HOURS_PER_DAY - timed_by_skill(ch, sortpos)) / HOURS_PER_TURN_UNDEAD);
+          }
+          break;
+        case SKILL_AID:
+        case SKILL_DRUNKOFF:
+        case SKILL_IDENTIFY:
+        case SKILL_CAMOUFLAGE:
+        case SKILL_COURAGE:
+        case SKILL_MANADRAIN:
+        case SKILL_TOWNPORTAL:
+        case SKILL_STRANGLE:
+        case SKILL_STUN:
+        case SKILL_REPAIR:
+          if (timed_by_skill(ch, sortpos))
+            sprintf(buf, "[%3d] ", timed_by_skill(ch, sortpos));
+          else
+            sprintf(buf, "[-!-] ");
+          break;
+        default: sprintf(buf, "      ");
+      }
 
-			switch (sortpos)
-			{
-			case SKILL_WARCRY:
-				sprintf(buf, "[-%d-] ", (HOURS_PER_DAY - timed_by_skill(ch, sortpos)) / HOURS_PER_WARCRY);
-				break;
-			case SKILL_TURN_UNDEAD:
-				if (can_use_feat(ch, EXORCIST_FEAT)) {
-					sprintf(buf, "[-%d-] ", (HOURS_PER_DAY - timed_by_skill(ch, sortpos)) / (HOURS_PER_TURN_UNDEAD - 2));
-				} else {
-					sprintf(buf, "[-%d-] ", (HOURS_PER_DAY - timed_by_skill(ch, sortpos)) / HOURS_PER_TURN_UNDEAD);
-				}
-				break;
-			case SKILL_AID:
-			case SKILL_DRUNKOFF:
-			case SKILL_IDENTIFY:
-			case SKILL_CAMOUFLAGE:
-			case SKILL_COURAGE:
-			case SKILL_MANADRAIN:
-			case SKILL_TOWNPORTAL:
-			case SKILL_STRANGLE:
-			case SKILL_STUN:
-			case SKILL_REPAIR:
-				if (timed_by_skill(ch, sortpos))
-					sprintf(buf, "[%3d] ", timed_by_skill(ch, sortpos));
-				else
-					sprintf(buf, "[-!-] ");
-				break;
-			default:
-				sprintf(buf, "      ");
-			}
+      sprintf(buf + strlen(buf), "%-23s %s (%d)%s \r\n",
+              skill_info[sortpos].name,
+              how_good(ch->get_skill(sortpos) + bonus, CalcSkillHardCap(ch, sortpos)),
+              CalcSkillMinCap(ch, sortpos),
+              CCNRM(ch, C_NRM));
 
-			sprintf(buf + strlen(buf), "%-23s %s\r\n",
-				skill_info[sortpos].name,
-				how_good(ch, ch->get_skill(sortpos) + bonus));
+      skills.push_back(buf);
 
-			skills.push_back(buf);
+      i++;
+    }
+  }
 
-			i++;
-		}
-	}
+  if (!i) {
+    if (NULL == filter) {
+      sprintf(buf2 + strlen(buf2), "Нет умений.\r\n");
+    } else {
+      sprintf(buf2 + strlen(buf2), "Нет умений, удовлетворяющих фильтру.\r\n");
+    }
+  } else {
+    // output set of skills
+    size_t buf2_length = strlen(buf2);
+    for (skills_t::const_iterator i = skills.begin(); i != skills.end(); ++i) {
+      // why 60?
+      if (buf2_length + i->length() >= MAX_STRING_LENGTH - 60) {
+        strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
+        break;
+      }
 
-	if (!i)
-	{
-		if (NULL == filter)
-		{
-			sprintf(buf2 + strlen(buf2), "Нет умений.\r\n");
-		}
-		else
-		{
-			sprintf(buf2 + strlen(buf2), "Нет умений, удовлетворяющих фильтру.\r\n");
-		}
-	}
-	else
-	{
-		// output set of skills
-		size_t buf2_length = strlen(buf2);
-		for (skills_t::const_iterator i = skills.begin(); i != skills.end(); ++i)
-		{
-			if (buf2_length + i->length() >= MAX_STRING_LENGTH - 60)		// why 60?
-			{
-				strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-				break;
-			}
-
-			strncat(buf2 + buf2_length, i->c_str(), i->length());
-			buf2_length += i->length();
-		}
-	}
-	send_to_char(buf2, vict);
+      strncat(buf2 + buf2_length, i->c_str(), i->length());
+      buf2_length += i->length();
+    }
+  }
+  send_to_char(buf2, vict);
 
 }
-const char *spells_color(int spellnum )
-{
-		switch (spell_info[spellnum].spell_class)
-		{
-		case STYPE_AIR:
-			return "&W";
-			break;
+const char *spells_color(int spellnum) {
+  switch (spell_info[spellnum].spell_class) {
+    case STYPE_AIR: return "&W";
+      break;
 
-		case STYPE_FIRE:
-			return "&R";
-			break;
+    case STYPE_FIRE: return "&R";
+      break;
 
-	        case STYPE_WATER:
-			return "&C";
-			break;
+    case STYPE_WATER: return "&C";
+      break;
 
-	        case STYPE_EARTH:
-			return "&y";
-			break;
+    case STYPE_EARTH: return "&y";
+      break;
 
-	        case STYPE_LIGHT:
-			return "&Y";
-			break;
+    case STYPE_LIGHT: return "&Y";
+      break;
 
-	        case STYPE_DARK:
-			return "&K";
-			break;
+    case STYPE_DARK: return "&K";
+      break;
 
-	        case STYPE_MIND:
-			return "&M";
-			break;
+    case STYPE_MIND: return "&M";
+      break;
 
-	        case STYPE_LIFE:
-			return "&G";
-			break;
+    case STYPE_LIFE: return "&G";
+      break;
 
-	        case STYPE_NEUTRAL:
-	        	return "&n";
-			break;
-	        default:
-	        	return "&n";
-			break;
-	        }
+    case STYPE_NEUTRAL: return "&n";
+      break;
+    default: return "&n";
+      break;
+  }
 }
 
 
@@ -552,163 +500,143 @@ const char *spells_color(int spellnum )
    на своем уровне, но на которые у них нет необходимых предметов
    при параметре TRUE */
 #include "classes/spell.slots.hpp"
-void list_spells(CHAR_DATA * ch, CHAR_DATA * vict, int all_spells)
-{
-	using PlayerClass::slot_for_char;
+void list_spells(CHAR_DATA *ch, CHAR_DATA *vict, int all_spells) {
+  using PlayerClass::slot_for_char;
 
-	char names[MAX_SLOT][MAX_STRING_LENGTH];
-	std::string time_str;
-	int slots[MAX_SLOT], i, max_slot = 0, slot_num, is_full, gcount = 0, can_cast = 1;
+  char names[MAX_SLOT][MAX_STRING_LENGTH];
+  std::string time_str;
+  int slots[MAX_SLOT], i, max_slot = 0, slot_num, is_full, gcount = 0, can_cast = 1;
 
-	is_full = 0;
-	max_slot = 0;
-	for (i = 0; i < MAX_SLOT; i++)
-	{
-		*names[i] = '\0';
-		slots[i] = 0;
-	}
-	for (i = 1; i <= MAX_SPELLS; i++)
-	{
-		if (!GET_SPELL_TYPE(ch, i) && !all_spells)
-			continue;
+  is_full = 0;
+  max_slot = 0;
+  for (i = 0; i < MAX_SLOT; i++) {
+    *names[i] = '\0';
+    slots[i] = 0;
+  }
+  for (i = 1; i <= MAX_SPELLS; i++) {
+    if (!GET_SPELL_TYPE(ch, i) && !all_spells)
+      continue;
 
-		if ((MIN_CAST_LEV(spell_info[i], ch) > GET_LEVEL(ch)
-				|| MIN_CAST_REM(spell_info[i], ch) > GET_REMORT(ch)
-				|| slot_for_char(ch, spell_info[i].slot_forc[(int) GET_CLASS(ch)][(int) GET_KIN(ch)]) <= 0)
-				&& all_spells && !GET_SPELL_TYPE(ch, i))
-			continue;
+    if ((MIN_CAST_LEV(spell_info[i], ch) > GET_LEVEL(ch)
+        || MIN_CAST_REM(spell_info[i], ch) > GET_REMORT(ch)
+        || slot_for_char(ch, spell_info[i].slot_forc[(int) GET_CLASS(ch)][(int) GET_KIN(ch)]) <= 0)
+        && all_spells && !GET_SPELL_TYPE(ch, i))
+      continue;
 
-		if (!spell_info[i].name || *spell_info[i].name == '!')
-			continue;
+    if (!spell_info[i].name || *spell_info[i].name == '!')
+      continue;
 
-		if ((GET_SPELL_TYPE(ch, i) & 0xFF) == SPELL_RUNES && !check_recipe_items(ch, i, SPELL_RUNES, FALSE) )
-		{
-			if (all_spells)
-			{
-				can_cast = 0;
-			}
-			else
-			{
-				continue;
-			}
-		}
-		else
-		{
-			can_cast = 1;
-		}
+    if ((GET_SPELL_TYPE(ch, i) & 0xFF) == SPELL_RUNES && !check_recipe_items(ch, i, SPELL_RUNES, FALSE)) {
+      if (all_spells) {
+        can_cast = 0;
+      } else {
+        continue;
+      }
+    } else {
+      can_cast = 1;
+    }
 
-		if (MIN_CAST_REM(spell_info[i], ch) > GET_REMORT(ch))
-			slot_num = MAX_SLOT - 1;
-		else
-			slot_num = spell_info[i].slot_forc[(int) GET_CLASS(ch)][(int) GET_KIN(ch)] - 1;
-		max_slot = MAX(slot_num + 1, max_slot);
-		if (IS_MANA_CASTER(ch))
-		{
-			if (GET_MANA_COST(ch, i) > GET_MAX_MANA(ch))
-				continue;
-			if (can_cast)
-			{
-				slots[slot_num] += sprintf(names[slot_num] + slots[slot_num],
-										   "%s|<...%4d.> %s%-38s&n|",
-										   slots[slot_num] % 114 <
-										   10 ? "\r\n" : "  ",
-										   GET_MANA_COST(ch, i), spells_color(i), spell_info[i].name);
-			}
-			else
-			{
-				slots[slot_num] += sprintf(names[slot_num] + slots[slot_num],
-										   "%s|+--------+ %s%-38s&n|",
-										   slots[slot_num] % 114 <
-										   10 ? "\r\n" : "  ", spells_color(i), spell_info[i].name);
-			}
-		}
-		else
-		{
-			time_str.clear();
-			if (IS_SET(GET_SPELL_TYPE(ch, i), SPELL_TEMP))
-			{
-				time_str.append("[");
-				time_str.append(std::to_string(MAX(1, static_cast<int>(std::ceil(static_cast<double>(Temporary_Spells::spell_left_time(ch, i)) / SECS_PER_MUD_HOUR)))));
-				time_str.append("]");
-			}
+    if (MIN_CAST_REM(spell_info[i], ch) > GET_REMORT(ch))
+      slot_num = MAX_SLOT - 1;
+    else
+      slot_num = spell_info[i].slot_forc[(int) GET_CLASS(ch)][(int) GET_KIN(ch)] - 1;
+    max_slot = MAX(slot_num + 1, max_slot);
+    if (IS_MANA_CASTER(ch)) {
+      if (GET_MANA_COST(ch, i) > GET_MAX_MANA(ch))
+        continue;
+      if (can_cast) {
+        slots[slot_num] += sprintf(names[slot_num] + slots[slot_num],
+                                   "%s|<...%4d.> %s%-38s&n|",
+                                   slots[slot_num] % 114 <
+                                       10 ? "\r\n" : "  ",
+                                   GET_MANA_COST(ch, i), spells_color(i), spell_info[i].name);
+      } else {
+        slots[slot_num] += sprintf(names[slot_num] + slots[slot_num],
+                                   "%s|+--------+ %s%-38s&n|",
+                                   slots[slot_num] % 114 <
+                                       10 ? "\r\n" : "  ", spells_color(i), spell_info[i].name);
+      }
+    } else {
+      time_str.clear();
+      if (IS_SET(GET_SPELL_TYPE(ch, i), SPELL_TEMP)) {
+        time_str.append("[");
+        time_str.append(std::to_string(MAX(1,
+                                           static_cast<int>(std::ceil(
+                                               static_cast<double>(Temporary_Spells::spell_left_time(ch, i))
+                                                   / SECS_PER_MUD_HOUR)))));
+        time_str.append("]");
+      }
 
+      slots[slot_num] += sprintf(names[slot_num] + slots[slot_num],
+                                 "%s|<%c%c%c%c%c%c%c%c>%s %-30s %-7s&n|",
 
-			slots[slot_num] += sprintf(names[slot_num] + slots[slot_num],
-				"%s|<%c%c%c%c%c%c%c%c>%s %-30s %-7s&n|",
-
-				slots[slot_num] % 114 < 10 ? "\r\n" : "  ",
-				IS_SET(GET_SPELL_TYPE(ch, i),
-					SPELL_KNOW) ? ((MIN_CAST_LEV(spell_info[i], ch) > GET_LEVEL(ch)) ? 'N' : 'K') : '.',
-				IS_SET(GET_SPELL_TYPE(ch, i),
-					SPELL_TEMP) ? 'T' : '.',
-				IS_SET(GET_SPELL_TYPE(ch, i),
-					SPELL_POTION) ? 'P' : '.',
-				IS_SET(GET_SPELL_TYPE(ch, i),
-					SPELL_WAND) ? 'W' : '.',
-				IS_SET(GET_SPELL_TYPE(ch, i),
-					SPELL_SCROLL) ? 'S' : '.',
-				IS_SET(GET_SPELL_TYPE(ch, i),
-					SPELL_ITEMS) ? 'I' : '.',
-				IS_SET(GET_SPELL_TYPE(ch, i),
-					SPELL_RUNES) ? 'R' : '.',
-				'.',
-				spells_color(i),
-				spell_info[i].name,
-				time_str.c_str());
-		}
-		is_full++;
-	};
-	gcount = sprintf(buf2 + gcount, "  %sВам доступна следующая магия :%s", CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
-	if (is_full)
-	{
-		for (i = 0; i < max_slot; i++)
-		{
-			if (slots[i] != 0)
-			{
-				if (!IS_MANA_CASTER(ch))
-					gcount += sprintf(buf2 + gcount, "\r\nКруг %d", i + 1);
-			}
-			if (slots[i])
-				gcount += sprintf(buf2 + gcount, "%s", names[i]);
-			//else
-			//gcount += sprintf(buf2+gcount,"\n\rПусто.");
-		}
-	}
-	else
-		gcount += sprintf(buf2 + gcount, "\r\nВ настоящее время магия вам недоступна!");
-	gcount += sprintf(buf2 + gcount, "\r\n");
-	//page_string(ch->desc, buf2, 1);
-	send_to_char(buf2, vict);
+                                 slots[slot_num] % 114 < 10 ? "\r\n" : "  ",
+                                 IS_SET(GET_SPELL_TYPE(ch, i),
+                                        SPELL_KNOW) ? ((MIN_CAST_LEV(spell_info[i], ch) > GET_LEVEL(ch)) ? 'N' : 'K')
+                                                    : '.',
+                                 IS_SET(GET_SPELL_TYPE(ch, i),
+                                        SPELL_TEMP) ? 'T' : '.',
+                                 IS_SET(GET_SPELL_TYPE(ch, i),
+                                        SPELL_POTION) ? 'P' : '.',
+                                 IS_SET(GET_SPELL_TYPE(ch, i),
+                                        SPELL_WAND) ? 'W' : '.',
+                                 IS_SET(GET_SPELL_TYPE(ch, i),
+                                        SPELL_SCROLL) ? 'S' : '.',
+                                 IS_SET(GET_SPELL_TYPE(ch, i),
+                                        SPELL_ITEMS) ? 'I' : '.',
+                                 IS_SET(GET_SPELL_TYPE(ch, i),
+                                        SPELL_RUNES) ? 'R' : '.',
+                                 '.',
+                                 spells_color(i),
+                                 spell_info[i].name,
+                                 time_str.c_str());
+    }
+    is_full++;
+  };
+  gcount = sprintf(buf2 + gcount, "  %sВам доступна следующая магия :%s", CCCYN(ch, C_NRM), CCNRM(ch, C_NRM));
+  if (is_full) {
+    for (i = 0; i < max_slot; i++) {
+      if (slots[i] != 0) {
+        if (!IS_MANA_CASTER(ch))
+          gcount += sprintf(buf2 + gcount, "\r\nКруг %d", i + 1);
+      }
+      if (slots[i])
+        gcount += sprintf(buf2 + gcount, "%s", names[i]);
+      //else
+      //gcount += sprintf(buf2+gcount,"\n\rПусто.");
+    }
+  } else
+    gcount += sprintf(buf2 + gcount, "\r\nВ настоящее время магия вам недоступна!");
+  gcount += sprintf(buf2 + gcount, "\r\n");
+  //page_string(ch->desc, buf2, 1);
+  send_to_char(buf2, vict);
 }
 
-struct guild_learn_type
-{
-	int feat_no;
-	ESkill skill_no;
-	int spell_no;
-	int level;
+struct guild_learn_type {
+  int feat_no;
+  ESkill skill_no;
+  int spell_no;
+  int level;
 };
 
-struct guild_mono_type
-{
-	guild_mono_type() : races(0), classes(0), religion(0), alignment(0), learn_info(0) {};
-	int races;		// bitvector //
-	int classes;		// bitvector //
-	int religion;		// bitvector //
-	int alignment;		// bitvector //
-	struct guild_learn_type *learn_info;
+struct guild_mono_type {
+  guild_mono_type() : races(0), classes(0), religion(0), alignment(0), learn_info(0) {};
+  int races;        // bitvector //
+  int classes;        // bitvector //
+  int religion;        // bitvector //
+  int alignment;        // bitvector //
+  struct guild_learn_type *learn_info;
 };
 
-struct guild_poly_type
-{
-	int races;		// bitvector //
-	int classes;		// bitvector //
-	int religion;		// bitvector //
-	int alignment;		// bitvector //
-	int feat_no;
-	ESkill skill_no;
-	int spell_no;
-	int level;
+struct guild_poly_type {
+  int races;        // bitvector //
+  int classes;        // bitvector //
+  int religion;        // bitvector //
+  int alignment;        // bitvector //
+  int feat_no;
+  ESkill skill_no;
+  int spell_no;
+  int level;
 };
 
 int GUILDS_MONO_USED = 0;
@@ -717,2211 +645,1819 @@ int GUILDS_POLY_USED = 0;
 struct guild_mono_type *guild_mono_info = nullptr;
 struct guild_poly_type **guild_poly_info = nullptr;
 
-void init_guilds(void)
-{
-	FILE *magic;
-	char name[MAX_INPUT_LENGTH],
-	line[256], line1[256], line2[256], line3[256], line4[256], line5[256], line6[256], *pos;
-	int i, spellnum, skillnum, featnum, num, type = 0, lines = 0, level, pgcount = 0, mgcount = 0;
-	std::unique_ptr<struct guild_poly_type, decltype(free) *> poly_guild(nullptr, free);
-	struct guild_mono_type mono_guild;
-	std::unique_ptr<struct guild_learn_type, decltype(free) *> mono_guild_learn(nullptr, free);
+void init_guilds(void) {
+  FILE *magic;
+  char name[MAX_INPUT_LENGTH],
+      line[256], line1[256], line2[256], line3[256], line4[256], line5[256], line6[256], *pos;
+  int i, spellnum, skillnum, featnum, num, type = 0, lines = 0, level, pgcount = 0, mgcount = 0;
+  std::unique_ptr<struct guild_poly_type, decltype(free) *> poly_guild(nullptr, free);
+  struct guild_mono_type mono_guild;
+  std::unique_ptr<struct guild_learn_type, decltype(free) *> mono_guild_learn(nullptr, free);
 
-	if (!(magic = fopen(LIB_MISC "guilds.lst", "r")))
-	{
-		log("Cann't open guilds list file...");
-		return;
-	}
-	while (get_line(magic, name))
-	{
-		if (!name[0] || name[0] == ';')
-			continue;
-		log("<%s>", name);
-		if ((lines = sscanf(name, "%s %s %s %s %s %s %s", line, line1, line2, line3, line4, line5, line6)) == 0)
-			continue;
-		// log("%d",lines);
+  if (!(magic = fopen(LIB_MISC "guilds.lst", "r"))) {
+    log("Cann't open guilds list file...");
+    return;
+  }
+  while (get_line(magic, name)) {
+    if (!name[0] || name[0] == ';')
+      continue;
+    log("<%s>", name);
+    if ((lines = sscanf(name, "%s %s %s %s %s %s %s", line, line1, line2, line3, line4, line5, line6)) == 0)
+      continue;
+    // log("%d",lines);
 
-		if (!strn_cmp(line, "monoguild", strlen(line))
-				|| !strn_cmp(line, "одноклассовая", strlen(line)))
-		{
-			type = 1;
-			if (lines < 5)
-			{
-				log("Bad format for monoguild header, #s #s #s #s #s need...");
-				graceful_exit(1);
-			}
-			mono_guild_learn.reset();
-			mono_guild.learn_info = nullptr;
-			mono_guild.races = 0;
-			mono_guild.classes = 0;
-			mono_guild.religion = 0;
-			mono_guild.alignment = 0;
-			mgcount = 0;
-			for (i = 0; *(line1 + i); i++)
-				if (strchr("!1xX", *(line1 + i)))
-					SET_BIT(mono_guild.races, (1 << i));
-			for (i = 0; *(line2 + i); i++)
-				if (strchr("!1xX", *(line2 + i)))
-					SET_BIT(mono_guild.classes, (1 << i));
-			for (i = 0; *(line3 + i); i++)
-				if (strchr("!1xX", *(line3 + i)))
-					SET_BIT(mono_guild.religion, (1 << i));
-			for (i = 0; *(line4 + i); i++)
-				if (strchr("!1xX", *(line4 + i)))
-					SET_BIT(mono_guild.alignment, (1 << i));
-		}
-		else if (!strn_cmp(line, "polyguild", strlen(line))
-				 || !strn_cmp(line, "многоклассовая", strlen(line)))
-		{
-			type = 2;
-			poly_guild.reset();
-			pgcount = 0;
-		}
-		else if (!strn_cmp(line, "master", strlen(line))
-				 || !strn_cmp(line, "учитель", strlen(line)))
-		{
-			if ((num = atoi(line1)) == 0 || real_mobile(num) < 0)
-			{
-				log("WARNING: Can't assign master %s in guilds.lst. Skipped.", line1);
-				continue;
-			}
+    if (!strn_cmp(line, "monoguild", strlen(line))
+        || !strn_cmp(line, "одноклассовая", strlen(line))) {
+      type = 1;
+      if (lines < 5) {
+        log("Bad format for monoguild header, #s #s #s #s #s need...");
+        graceful_exit(1);
+      }
+      mono_guild_learn.reset();
+      mono_guild.learn_info = nullptr;
+      mono_guild.races = 0;
+      mono_guild.classes = 0;
+      mono_guild.religion = 0;
+      mono_guild.alignment = 0;
+      mgcount = 0;
+      for (i = 0; *(line1 + i); i++)
+        if (strchr("!1xX", *(line1 + i)))
+          SET_BIT(mono_guild.races, (1 << i));
+      for (i = 0; *(line2 + i); i++)
+        if (strchr("!1xX", *(line2 + i)))
+          SET_BIT(mono_guild.classes, (1 << i));
+      for (i = 0; *(line3 + i); i++)
+        if (strchr("!1xX", *(line3 + i)))
+          SET_BIT(mono_guild.religion, (1 << i));
+      for (i = 0; *(line4 + i); i++)
+        if (strchr("!1xX", *(line4 + i)))
+          SET_BIT(mono_guild.alignment, (1 << i));
+    } else if (!strn_cmp(line, "polyguild", strlen(line))
+        || !strn_cmp(line, "многоклассовая", strlen(line))) {
+      type = 2;
+      poly_guild.reset();
+      pgcount = 0;
+    } else if (!strn_cmp(line, "master", strlen(line))
+        || !strn_cmp(line, "учитель", strlen(line))) {
+      if ((num = atoi(line1)) == 0 || real_mobile(num) < 0) {
+        log("WARNING: Can't assign master %s in guilds.lst. Skipped.", line1);
+        continue;
+      }
 
-			if (!((type == 1 && mono_guild_learn) || type == 11) &&
-					!((type == 2 && poly_guild) || type == 12))
-			{
-				log("WARNING: Can't define guild info for master %s. Skipped.", line1);
-				continue;
-			}
-			if (type == 1 || type == 11)
-			{
-				if (type == 1)
-				{
-					if (!guild_mono_info)
-					{
-						CREATE(guild_mono_info, GUILDS_MONO_USED + 1);
-					}
-					else
-					{
-						RECREATE(guild_mono_info, GUILDS_MONO_USED + 1);
-					}
-					log("Create mono guild %d", GUILDS_MONO_USED + 1);
-					mono_guild.learn_info = mono_guild_learn.release();
-					RECREATE(mono_guild.learn_info, mgcount + 1);
-					(mono_guild.learn_info + mgcount)->skill_no = SKILL_INVALID;
-					(mono_guild.learn_info + mgcount)->feat_no = -1;
-					(mono_guild.learn_info + mgcount)->spell_no = -1;
-					(mono_guild.learn_info + mgcount)->level = -1;
-					guild_mono_info[GUILDS_MONO_USED] = mono_guild;
-					GUILDS_MONO_USED++;
-					type = 11;
-				}
-				log("Assign mono guild %d to mobile %s", GUILDS_MONO_USED, line1);
-				ASSIGNMASTER(num, guild_mono, GUILDS_MONO_USED);
-			}
-			if (type == 2 || type == 12)
-			{
-				if (type == 2)
-				{
-					if (!guild_poly_info)
-					{
-						CREATE(guild_poly_info, GUILDS_POLY_USED + 1);
-					}
-					else
-					{
-						RECREATE(guild_poly_info, GUILDS_POLY_USED + 1);
-					}
-					log("Create poly guild %d", GUILDS_POLY_USED + 1);
-					auto ptr = poly_guild.release();
-					RECREATE(ptr, pgcount + 1);
-					(ptr + pgcount)->feat_no = -1;
-					(ptr + pgcount)->skill_no = SKILL_INVALID;
-					(ptr + pgcount)->spell_no = -1;
-					(ptr + pgcount)->level = -1;
-					guild_poly_info[GUILDS_POLY_USED] = ptr;
-					GUILDS_POLY_USED++;
-					type = 12;
-				}
-				log("Assign poly guild %d to mobile %s", GUILDS_POLY_USED, line1);
-				ASSIGNMASTER(num, guild_poly, GUILDS_POLY_USED);
-			}
-		}
-		else if (type == 1)
-		{
-			if (lines < 3)
-			{
-				log("You need use 3 arguments for monoguild");
-				graceful_exit(1);
-			}
-			if ((spellnum = atoi(line)) == 0 || spellnum > MAX_SPELLS)
-			{
-				spellnum = fix_name_and_find_spell_num(line);
-			}
-			if ((skillnum = atoi(line1)) == 0 || skillnum > MAX_SKILL_NUM)
-			{
-				skillnum = fix_name_and_find_skill_num(line1);
-			}
+      if (!((type == 1 && mono_guild_learn) || type == 11) &&
+          !((type == 2 && poly_guild) || type == 12)) {
+        log("WARNING: Can't define guild info for master %s. Skipped.", line1);
+        continue;
+      }
+      if (type == 1 || type == 11) {
+        if (type == 1) {
+          if (!guild_mono_info) {
+            CREATE(guild_mono_info, GUILDS_MONO_USED + 1);
+          } else {
+            RECREATE(guild_mono_info, GUILDS_MONO_USED + 1);
+          }
+          log("Create mono guild %d", GUILDS_MONO_USED + 1);
+          mono_guild.learn_info = mono_guild_learn.release();
+          RECREATE(mono_guild.learn_info, mgcount + 1);
+          (mono_guild.learn_info + mgcount)->skill_no = SKILL_INVALID;
+          (mono_guild.learn_info + mgcount)->feat_no = -1;
+          (mono_guild.learn_info + mgcount)->spell_no = -1;
+          (mono_guild.learn_info + mgcount)->level = -1;
+          guild_mono_info[GUILDS_MONO_USED] = mono_guild;
+          GUILDS_MONO_USED++;
+          type = 11;
+        }
+        log("Assign mono guild %d to mobile %s", GUILDS_MONO_USED, line1);
+        ASSIGNMASTER(num, guild_mono, GUILDS_MONO_USED);
+      }
+      if (type == 2 || type == 12) {
+        if (type == 2) {
+          if (!guild_poly_info) {
+            CREATE(guild_poly_info, GUILDS_POLY_USED + 1);
+          } else {
+            RECREATE(guild_poly_info, GUILDS_POLY_USED + 1);
+          }
+          log("Create poly guild %d", GUILDS_POLY_USED + 1);
+          auto ptr = poly_guild.release();
+          RECREATE(ptr, pgcount + 1);
+          (ptr + pgcount)->feat_no = -1;
+          (ptr + pgcount)->skill_no = SKILL_INVALID;
+          (ptr + pgcount)->spell_no = -1;
+          (ptr + pgcount)->level = -1;
+          guild_poly_info[GUILDS_POLY_USED] = ptr;
+          GUILDS_POLY_USED++;
+          type = 12;
+        }
+        log("Assign poly guild %d to mobile %s", GUILDS_POLY_USED, line1);
+        ASSIGNMASTER(num, guild_poly, GUILDS_POLY_USED);
+      }
+    } else if (type == 1) {
+      if (lines < 3) {
+        log("You need use 3 arguments for monoguild");
+        graceful_exit(1);
+      }
+      if ((spellnum = atoi(line)) == 0 || spellnum > MAX_SPELLS) {
+        spellnum = fix_name_and_find_spell_num(line);
+      }
+      if ((skillnum = atoi(line1)) == 0 || skillnum > MAX_SKILL_NUM) {
+        skillnum = fix_name_and_find_skill_num(line1);
+      }
 
-			if ((featnum = atoi(line1)) == 0 || featnum >= MAX_FEATS)
-			{
-				if ((pos = strchr(line1, '.')))
-					* pos = ' ';
-				featnum = find_feat_num(line1);
-			}
+      if ((featnum = atoi(line1)) == 0 || featnum >= MAX_FEATS) {
+        if ((pos = strchr(line1, '.')))
+          *pos = ' ';
+        featnum = find_feat_num(line1);
+      }
 
-			if (skillnum <= 0 && spellnum <= 0 && featnum <= 0)
-			{
-				log("Unknown skill, spell or feat for monoguild");
-				graceful_exit(1);
-			}
-			if ((level = atoi(line2)) == 0 || level >= LVL_IMMORT)
-			{
-				log("Use 1-%d level for guilds", LVL_IMMORT);
-				graceful_exit(1);
-			}
+      if (skillnum <= 0 && spellnum <= 0 && featnum <= 0) {
+        log("Unknown skill, spell or feat for monoguild");
+        graceful_exit(1);
+      }
+      if ((level = atoi(line2)) == 0 || level >= LVL_IMMORT) {
+        log("Use 1-%d level for guilds", LVL_IMMORT);
+        graceful_exit(1);
+      }
 
-			auto ptr = mono_guild_learn.release();
-			if (!ptr)
-			{
-				CREATE(ptr, mgcount + 1);
-			}
-			else
-			{
-				RECREATE(ptr, mgcount + 1);
-			}
-			mono_guild_learn.reset(ptr);
+      auto ptr = mono_guild_learn.release();
+      if (!ptr) {
+        CREATE(ptr, mgcount + 1);
+      } else {
+        RECREATE(ptr, mgcount + 1);
+      }
+      mono_guild_learn.reset(ptr);
 
-			ptr += mgcount;
-			ptr->spell_no = MAX(0, spellnum);
-			ptr->skill_no = static_cast<ESkill>(MAX(0, skillnum));
-			ptr->feat_no = MAX(0, featnum);
-			ptr->level = level;
-			// log("->%d %d %d<-",spellnum,skillnum,level);
-			mgcount++;
-		}
-		else if (type == 2)
-		{
-			if (lines < 7)
-			{
-				log("You need use 7 arguments for polyguild");
-				graceful_exit(1);
-			}
-			auto ptr = poly_guild.release();
-			if (!ptr)
-			{
-				CREATE(ptr, pgcount + 1);
-			}
-			else
-			{
-				RECREATE(ptr, pgcount + 1);
-			}
-			poly_guild.reset(ptr);
+      ptr += mgcount;
+      ptr->spell_no = MAX(0, spellnum);
+      ptr->skill_no = static_cast<ESkill>(MAX(0, skillnum));
+      ptr->feat_no = MAX(0, featnum);
+      ptr->level = level;
+      // log("->%d %d %d<-",spellnum,skillnum,level);
+      mgcount++;
+    } else if (type == 2) {
+      if (lines < 7) {
+        log("You need use 7 arguments for polyguild");
+        graceful_exit(1);
+      }
+      auto ptr = poly_guild.release();
+      if (!ptr) {
+        CREATE(ptr, pgcount + 1);
+      } else {
+        RECREATE(ptr, pgcount + 1);
+      }
+      poly_guild.reset(ptr);
 
-			ptr += pgcount;
-			ptr->races = 0;
-			ptr->classes = 0;
-			ptr->religion = 0;
-			ptr->alignment = 0;
-			for (i = 0; *(line + i); i++)
-				if (strchr("!1xX", *(line + i)))
-					SET_BIT(ptr->races, (1 << i));
-			for (i = 0; *(line1 + i); i++)
-				if (strchr("!1xX", *(line1 + i)))
-					SET_BIT(ptr->classes, (1 << i));
-			for (i = 0; *(line2 + i); i++)
-				if (strchr("!1xX", *(line2 + i)))
-					SET_BIT(ptr->religion, (1 << i));
-			for (i = 0; *(line3 + i); i++)
-				if (strchr("!1xX", *(line3 + i)))
-					SET_BIT(ptr->alignment, (1 << i));
-			if ((spellnum = atoi(line4)) == 0 || spellnum > MAX_SPELLS)
-			{
-				spellnum = fix_name_and_find_spell_num(line4);
-			}
-			if ((skillnum = atoi(line5)) == 0 || skillnum > MAX_SKILL_NUM)
-			{
-				skillnum = fix_name_and_find_skill_num(line5);
-			}
+      ptr += pgcount;
+      ptr->races = 0;
+      ptr->classes = 0;
+      ptr->religion = 0;
+      ptr->alignment = 0;
+      for (i = 0; *(line + i); i++)
+        if (strchr("!1xX", *(line + i)))
+          SET_BIT(ptr->races, (1 << i));
+      for (i = 0; *(line1 + i); i++)
+        if (strchr("!1xX", *(line1 + i)))
+          SET_BIT(ptr->classes, (1 << i));
+      for (i = 0; *(line2 + i); i++)
+        if (strchr("!1xX", *(line2 + i)))
+          SET_BIT(ptr->religion, (1 << i));
+      for (i = 0; *(line3 + i); i++)
+        if (strchr("!1xX", *(line3 + i)))
+          SET_BIT(ptr->alignment, (1 << i));
+      if ((spellnum = atoi(line4)) == 0 || spellnum > MAX_SPELLS) {
+        spellnum = fix_name_and_find_spell_num(line4);
+      }
+      if ((skillnum = atoi(line5)) == 0 || skillnum > MAX_SKILL_NUM) {
+        skillnum = fix_name_and_find_skill_num(line5);
+      }
 
-			if ((featnum = atoi(line5)) == 0 || featnum >= MAX_FEATS)
-			{
-				if ((pos = strchr(line5, '.')))
-					* pos = ' ';
+      if ((featnum = atoi(line5)) == 0 || featnum >= MAX_FEATS) {
+        if ((pos = strchr(line5, '.')))
+          *pos = ' ';
 
-				featnum = find_feat_num(line1);
-				sprintf(buf, "feature number 2: %d", featnum);
-				featnum = find_feat_num(line5);
-			}
-			if (skillnum <= 0 && spellnum <= 0 && featnum <= 0)
-			{
-				log("Unknown skill, spell or feat for polyguild");
-				graceful_exit(1);
-			}
-			if ((level = atoi(line6)) == 0 || level >= LVL_IMMORT)
-			{
-				log("Use 1-%d level for guilds", LVL_IMMORT);
-				graceful_exit(1);
-			}
-			ptr->spell_no = MAX(0, spellnum);
-			ptr->skill_no = static_cast<ESkill>(MAX(0, skillnum));
-			ptr->feat_no = MAX(0, featnum);
-			ptr->level = level;
-			// log("->%d %d %d<-",spellnum,skillnum,level);
-			pgcount++;
-		}
-	}
-	fclose(magic);
-	return;
+        featnum = find_feat_num(line1);
+        sprintf(buf, "feature number 2: %d", featnum);
+        featnum = find_feat_num(line5);
+      }
+      if (skillnum <= 0 && spellnum <= 0 && featnum <= 0) {
+        sprintf(buf2, "Unknown skill, spell or feat for polyguild - \'%s\'", line5);
+        //log("Unknown skill, spell or feat for polyguild");
+        log(buf2);
+        graceful_exit(1);
+      }
+      if ((level = atoi(line6)) == 0 || level >= LVL_IMMORT) {
+        log("Use 1-%d level for guilds", LVL_IMMORT);
+        graceful_exit(1);
+      }
+      ptr->spell_no = MAX(0, spellnum);
+      ptr->skill_no = static_cast<ESkill>(MAX(0, skillnum));
+      ptr->feat_no = MAX(0, featnum);
+      ptr->level = level;
+      // log("->%d %d %d<-",spellnum,skillnum,level);
+      pgcount++;
+    }
+  }
+  fclose(magic);
 }
 
 #define SCMD_LEARN 1
 
-int guild_mono(CHAR_DATA *ch, void *me, int cmd, char* argument)
-{
-	int command = 0, gcount = 0, info_num = 0, found = FALSE, sfound = FALSE, i, bits;
-	CHAR_DATA *victim = (CHAR_DATA *) me;
+int guild_mono(CHAR_DATA *ch, void *me, int cmd, char *argument) {
+  int command = 0, gcount = 0, info_num = 0, found = FALSE, sfound = FALSE, i, bits;
+  CHAR_DATA *victim = (CHAR_DATA *) me;
 
-	if (IS_NPC(ch))
-	{
-		return 0;
-	}
+  if (IS_NPC(ch)) {
+    return 0;
+  }
 
-	if (CMD_IS("учить")
-		|| CMD_IS("practice"))
-	{
-		command = SCMD_LEARN;
-	}
-	else
-	{
-		return 0;
-	}
+  if (CMD_IS("учить")
+      || CMD_IS("practice")) {
+    command = SCMD_LEARN;
+  } else {
+    return 0;
+  }
 
-	info_num = mob_index[victim->get_rnum()].stored;
-	if (info_num <= 0
-		|| info_num > GUILDS_MONO_USED)
-	{
-		act("$N сказал$G : 'Извини, $n, я уже в отставке.'", FALSE, ch, 0, victim, TO_CHAR);
-		return (1);
-	}
+  info_num = mob_index[victim->get_rnum()].stored;
+  if (info_num <= 0
+      || info_num > GUILDS_MONO_USED) {
+    act("$N сказал$G : 'Извини, $n, я уже в отставке.'", FALSE, ch, 0, victim, TO_CHAR);
+    return (1);
+  }
 
-	info_num--;
-	if (!IS_BITS(guild_mono_info[info_num].classes, GET_CLASS(ch))
-		|| !IS_BITS(guild_mono_info[info_num].races, GET_RACE(ch))
-		|| !IS_BITS(guild_mono_info[info_num].religion, GET_RELIGION(ch)))
-	{
-		act("$N сказал$g : '$n, я не учу таких, как ты.'", FALSE, ch, 0, victim, TO_CHAR);
-		return 1;
-	}
+  info_num--;
+  if (!IS_BITS(guild_mono_info[info_num].classes, GET_CLASS(ch))
+      || !IS_BITS(guild_mono_info[info_num].races, GET_RACE(ch))
+      || !IS_BITS(guild_mono_info[info_num].religion, GET_RELIGION(ch))) {
+    act("$N сказал$g : '$n, я не учу таких, как ты.'", FALSE, ch, 0, victim, TO_CHAR);
+    return 1;
+  }
 
-	skip_spaces(&argument);
+  skip_spaces(&argument);
 
-	switch (command)
-	{
-	case SCMD_LEARN:
-		if (!*argument)
-		{
-			gcount += sprintf(buf, "Я могу научить тебя следующему:\r\n");
-			for (i = 0, found = FALSE; (guild_mono_info[info_num].learn_info + i)->spell_no >= 0; i++)
-			{
-				if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
+  switch (command) {
+    case SCMD_LEARN:
+      if (!*argument) {
+        gcount += sprintf(buf, "Я могу научить тебя следующему:\r\n");
+        for (i = 0, found = FALSE; (guild_mono_info[info_num].learn_info + i)->spell_no >= 0; i++) {
+          if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
 
-				const auto skill_no = (guild_mono_info[info_num].learn_info + i)->skill_no;
-				bits = skill_no;
-				if (SKILL_INVALID != skill_no
-					&& (!ch->get_trained_skill(skill_no)
-						|| IS_GRGOD(ch))
-					&& can_get_skill(ch, skill_no))
-				{
-					gcount += sprintf(buf + gcount, "- умение %s\"%s\"%s\r\n",
-						CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
-					found = TRUE;
-				}
+          const auto skill_no = (guild_mono_info[info_num].learn_info + i)->skill_no;
+          bits = skill_no;
+          if (SKILL_INVALID != skill_no
+              && (!ch->get_trained_skill(skill_no)
+                  || IS_GRGOD(ch))
+              && IsAbleToGetSkill(ch, skill_no)) {
+            gcount += sprintf(buf + gcount, "- умение %s\"%s\"%s\r\n",
+                              CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
+            found = TRUE;
+          }
 
-				if (!(bits = -2 * bits)
-					|| bits == SPELL_TEMP)
-				{
-					bits = SPELL_KNOW;
-				}
+          if (!(bits = -2 * bits)
+              || bits == SPELL_TEMP) {
+            bits = SPELL_KNOW;
+          }
 
-				const auto spell_no = (guild_mono_info[info_num].learn_info + i)->spell_no;
-				if (spell_no
-					&& (!((GET_SPELL_TYPE(ch, spell_no) & bits) == bits)
-						|| IS_GRGOD(ch)))
-				{
-					gcount += sprintf(buf + gcount, "- магия %s\"%s\"%s\r\n",
-						CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
-					found = TRUE;
-				}
+          const auto spell_no = (guild_mono_info[info_num].learn_info + i)->spell_no;
+          if (spell_no
+              && (!((GET_SPELL_TYPE(ch, spell_no) & bits) == bits)
+                  || IS_GRGOD(ch))) {
+            gcount += sprintf(buf + gcount, "- магия %s\"%s\"%s\r\n",
+                              CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
+            found = TRUE;
+          }
 
-				const auto feat_no = (guild_mono_info[info_num].learn_info + i)->feat_no;
-				if (feat_no > 0
-					&& !HAVE_FEAT(ch, feat_no)
-					&& can_get_feat(ch, feat_no))
-				{
-					gcount += sprintf(buf + gcount, "- способность %s\"%s\"%s\r\n",
-						CCCYN(ch, C_NRM), feat_name(feat_no), CCNRM(ch, C_NRM));
-					found = TRUE;
-				}
-			}
+          const auto feat_no = (guild_mono_info[info_num].learn_info + i)->feat_no;
+          if (feat_no > 0
+              && !HAVE_FEAT(ch, feat_no)
+              && can_get_feat(ch, feat_no)) {
+            gcount += sprintf(buf + gcount, "- способность %s\"%s\"%s\r\n",
+                              CCCYN(ch, C_NRM), feat_name(feat_no), CCNRM(ch, C_NRM));
+            found = TRUE;
+          }
+        }
 
-			if (!found)
-			{
-				act("$N сказал$G : 'Похоже, твои знания полнее моих.'", FALSE, ch, 0, victim, TO_CHAR);
-				return (1);
-			}
-			else
-			{
-				send_to_char(buf, ch);
-				return (1);
-			}
-		}
+        if (!found) {
+          act("$N сказал$G : 'Похоже, твои знания полнее моих.'", FALSE, ch, 0, victim, TO_CHAR);
+          return (1);
+        } else {
+          send_to_char(buf, ch);
+          return (1);
+        }
+      }
 
-		if (!strn_cmp(argument, "все", strlen(argument)) || !strn_cmp(argument, "all", strlen(argument)))
-		{
-			for (i = 0, found = FALSE, sfound = TRUE;
-			(guild_mono_info[info_num].learn_info + i)->spell_no >= 0; i++)
-			{
-				if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch))
-					continue;
+      if (!strn_cmp(argument, "все", strlen(argument)) || !strn_cmp(argument, "all", strlen(argument))) {
+        for (i = 0, found = FALSE, sfound = TRUE;
+             (guild_mono_info[info_num].learn_info + i)->spell_no >= 0; i++) {
+          if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch))
+            continue;
 
-				const ESkill skill_no = (guild_mono_info[info_num].learn_info + i)->skill_no;
-				bits = skill_no;
-				if (SKILL_INVALID != skill_no
-					&& !ch->get_trained_skill(skill_no))  	// sprintf(buf, "$N научил$G вас умению %s\"%s\"\%s",
-				{
-					//             CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
-					// act(buf,FALSE,ch,0,victim,TO_CHAR);
-					// ch->get_skill(skill_no) = 10;
-					sfound = TRUE;
-				}
+          const ESkill skill_no = (guild_mono_info[info_num].learn_info + i)->skill_no;
+          bits = skill_no;
+          if (SKILL_INVALID != skill_no
+              && !ch->get_trained_skill(skill_no))    // sprintf(buf, "$N научил$G вас умению %s\"%s\"\%s",
+          {
+            //             CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
+            // act(buf,FALSE,ch,0,victim,TO_CHAR);
+            // ch->get_skill(skill_no) = 10;
+            sfound = TRUE;
+          }
 
-				if (!(bits = -2 * bits) || bits == SPELL_TEMP)
-				{
-					bits = SPELL_KNOW;
-				}
+          if (!(bits = -2 * bits) || bits == SPELL_TEMP) {
+            bits = SPELL_KNOW;
+          }
 
-				const int spell_no = (guild_mono_info[info_num].learn_info + i)->spell_no;
-				if (spell_no
-					&& !((GET_SPELL_TYPE(ch, spell_no) & bits) == bits))
-				{
-					gcount += sprintf(buf, "$N научил$G вас магии %s\"%s\"%s",
-						CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
-					act(buf, FALSE, ch, 0, victim, TO_CHAR);
-					if (IS_SET(bits, SPELL_KNOW))
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_KNOW);
-					if (IS_SET(bits, SPELL_ITEMS))
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_ITEMS);
-					if (IS_SET(bits, SPELL_RUNES))
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_RUNES);
-					if (IS_SET(bits, SPELL_POTION))
-					{
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_POTION);
-						ch->set_skill(SKILL_CREATE_POTION, MAX(10, ch->get_trained_skill(SKILL_CREATE_POTION)));
-					}
-					if (IS_SET(bits, SPELL_WAND))
-					{
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_WAND);
-						ch->set_skill(SKILL_CREATE_WAND, MAX(10, ch->get_trained_skill(SKILL_CREATE_WAND)));
-					}
-					if (IS_SET(bits, SPELL_SCROLL))
-					{
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_SCROLL);
-						ch->set_skill(SKILL_CREATE_SCROLL, MAX(10, ch->get_trained_skill(SKILL_CREATE_SCROLL)));
-					}
-					found = TRUE;
-				}
+          const int spell_no = (guild_mono_info[info_num].learn_info + i)->spell_no;
+          if (spell_no
+              && !((GET_SPELL_TYPE(ch, spell_no) & bits) == bits)) {
+            gcount += sprintf(buf, "$N научил$G вас магии %s\"%s\"%s",
+                              CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
+            act(buf, FALSE, ch, 0, victim, TO_CHAR);
+            if (IS_SET(bits, SPELL_KNOW))
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_KNOW);
+            if (IS_SET(bits, SPELL_ITEMS))
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_ITEMS);
+            if (IS_SET(bits, SPELL_RUNES))
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_RUNES);
+            if (IS_SET(bits, SPELL_POTION)) {
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_POTION);
+              ch->set_skill(SKILL_CREATE_POTION, MAX(10, ch->get_trained_skill(SKILL_CREATE_POTION)));
+            }
+            if (IS_SET(bits, SPELL_WAND)) {
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_WAND);
+              ch->set_skill(SKILL_CREATE_WAND, MAX(10, ch->get_trained_skill(SKILL_CREATE_WAND)));
+            }
+            if (IS_SET(bits, SPELL_SCROLL)) {
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_SCROLL);
+              ch->set_skill(SKILL_CREATE_SCROLL, MAX(10, ch->get_trained_skill(SKILL_CREATE_SCROLL)));
+            }
+            found = TRUE;
+          }
 
-				const int feat_no = (guild_mono_info[info_num].learn_info + i)->feat_no;
-				if (feat_no > 0
-					&& feat_no < MAX_FEATS)
-				{
-					if (!HAVE_FEAT(ch, feat_no) && can_get_feat(ch, feat_no))
-					{
-						sfound = TRUE;
-					}
-				}
-			}
+          const int feat_no = (guild_mono_info[info_num].learn_info + i)->feat_no;
+          if (feat_no > 0
+              && feat_no < MAX_FEATS) {
+            if (!HAVE_FEAT(ch, feat_no) && can_get_feat(ch, feat_no)) {
+              sfound = TRUE;
+            }
+          }
+        }
 
-			if (sfound)
-			{
-				act("$N сказал$G : \r\n"
-					"'$n, к сожалению, это может сильно затруднить твое постижение умений.'\r\n"
-					"'Выбери лишь самые необходимые тебе умения.'", FALSE, ch, 0, victim, TO_CHAR);
-			}
+        if (sfound) {
+          act("$N сказал$G : \r\n"
+              "'$n, к сожалению, это может сильно затруднить твое постижение умений.'\r\n"
+              "'Выбери лишь самые необходимые тебе умения.'", FALSE, ch, 0, victim, TO_CHAR);
+        }
 
-			if (!found)
-			{
-				act("$N ничему новому вас не научил$G.", FALSE, ch, 0, victim, TO_CHAR);
-			}
+        if (!found) {
+          act("$N ничему новому вас не научил$G.", FALSE, ch, 0, victim, TO_CHAR);
+        }
 
-			return (1);
-		}
+        return (1);
+      }
 
-		const int feat_no = find_feat_num(argument);
-		if ((feat_no > 0 && feat_no < MAX_FEATS))
-		{
-			for (i = 0, found = FALSE; (guild_mono_info[info_num].learn_info + i)->feat_no >= 0; i++)
-			{
-				if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
+      const int feat_no = find_feat_num(argument);
+      if ((feat_no > 0 && feat_no < MAX_FEATS)) {
+        for (i = 0, found = FALSE; (guild_mono_info[info_num].learn_info + i)->feat_no >= 0; i++) {
+          if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
 
-				if (feat_no == (guild_mono_info[info_num].learn_info + i)->feat_no)
-				{
-					if (HAVE_FEAT(ch, feat_no))
-					{
-						act("$N сказал$g вам : 'Ничем помочь не могу, ты уже владеешь этой способностью.'", FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else if (!can_get_feat(ch, feat_no))
-					{
-						act("$N сказал$G : 'Я не могу тебя этому научить.'", FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else
-					{
-						sprintf(buf, "$N научил$G вас способности %s\"%s\"%s",
-							CCCYN(ch, C_NRM), feat_name(feat_no), CCNRM(ch, C_NRM));
-						act(buf, FALSE, ch, 0, victim, TO_CHAR);
-						SET_FEAT(ch, feat_no);
-					}
-					found = TRUE;
-				}
-			}
+          if (feat_no == (guild_mono_info[info_num].learn_info + i)->feat_no) {
+            if (HAVE_FEAT(ch, feat_no)) {
+              act("$N сказал$g вам : 'Ничем помочь не могу, ты уже владеешь этой способностью.'",
+                  FALSE,
+                  ch,
+                  0,
+                  victim,
+                  TO_CHAR);
+            } else if (!can_get_feat(ch, feat_no)) {
+              act("$N сказал$G : 'Я не могу тебя этому научить.'", FALSE, ch, 0, victim, TO_CHAR);
+            } else {
+              sprintf(buf, "$N научил$G вас способности %s\"%s\"%s",
+                      CCCYN(ch, C_NRM), feat_name(feat_no), CCNRM(ch, C_NRM));
+              act(buf, FALSE, ch, 0, victim, TO_CHAR);
+              SET_FEAT(ch, feat_no);
+            }
+            found = TRUE;
+          }
+        }
 
-			if (!found)
-			{
-				act("$N сказал$G : 'Мне не ведомо такое мастерство.'", FALSE, ch, 0, victim, TO_CHAR);
-			}
+        if (!found) {
+          act("$N сказал$G : 'Мне не ведомо такое мастерство.'", FALSE, ch, 0, victim, TO_CHAR);
+        }
 
-			return (1);
-		}
+        return (1);
+      }
 
-		const ESkill skill_no = fix_name_and_find_skill_num(argument);
-		if ((SKILL_INVALID != skill_no
-			&& skill_no <= MAX_SKILL_NUM))
-		{
-			for (i = 0, found = FALSE; (guild_mono_info[info_num].learn_info + i)->spell_no >= 0; i++)
-			{
-				if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
+      const ESkill skill_no = fix_name_and_find_skill_num(argument);
+      if ((SKILL_INVALID != skill_no
+          && skill_no <= MAX_SKILL_NUM)) {
+        for (i = 0, found = FALSE; (guild_mono_info[info_num].learn_info + i)->spell_no >= 0; i++) {
+          if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
 
-				if (skill_no == (guild_mono_info[info_num].learn_info + i)->skill_no)
-				{
-					if (ch->get_trained_skill(skill_no))
-					{
-						act("$N сказал$g вам : 'Ничем помочь не могу, ты уже владеешь этим умением.'", FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else if (!can_get_skill(ch, skill_no))
-					{
-						act("$N сказал$G : 'Я не могу тебя этому научить.'", FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else
-					{
-						sprintf(buf, "$N научил$G вас умению %s\"%s\"%s",
-							CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
-						act(buf, FALSE, ch, 0, victim, TO_CHAR);
-						ch->set_skill(skill_no, 10);
-					}
-					found = TRUE;
-				}
-			}
+          if (skill_no == (guild_mono_info[info_num].learn_info + i)->skill_no) {
+            if (ch->get_trained_skill(skill_no)) {
+              act("$N сказал$g вам : 'Ничем помочь не могу, ты уже владеешь этим умением.'",
+                  FALSE,
+                  ch,
+                  0,
+                  victim,
+                  TO_CHAR);
+            } else if (!IsAbleToGetSkill(ch, skill_no)) {
+              act("$N сказал$G : 'Я не могу тебя этому научить.'", FALSE, ch, 0, victim, TO_CHAR);
+            } else {
+              sprintf(buf, "$N научил$G вас умению %s\"%s\"%s",
+                      CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
+              act(buf, FALSE, ch, 0, victim, TO_CHAR);
+              ch->set_skill(skill_no, 10);
+            }
+            found = TRUE;
+          }
+        }
 
-			if (!found)
-			{
-				act("$N сказал$G : 'Мне не ведомо такое умение.'", FALSE, ch, 0, victim, TO_CHAR);
-			}
+        if (!found) {
+          act("$N сказал$G : 'Мне не ведомо такое умение.'", FALSE, ch, 0, victim, TO_CHAR);
+        }
 
-			return (1);
-		}
+        return (1);
+      }
 
-		const int spell_no = fix_name_and_find_spell_num(argument);
-		if (spell_no > 0
-			&& spell_no <= MAX_SPELLS)
-		{
-			for (i = 0, found = FALSE; (guild_mono_info[info_num].learn_info + i)->spell_no >= 0; i++)
-			{
-				if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
+      const int spell_no = fix_name_and_find_spell_num(argument);
+      if (spell_no > 0
+          && spell_no <= MAX_SPELLS) {
+        for (i = 0, found = FALSE; (guild_mono_info[info_num].learn_info + i)->spell_no >= 0; i++) {
+          if ((guild_mono_info[info_num].learn_info + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
 
-				if (spell_no == (guild_mono_info[info_num].learn_info + i)->spell_no)
-				{
-					if (!(bits = -2 * (guild_mono_info[info_num].learn_info + i)->skill_no)
-						|| bits == SPELL_TEMP)
-					{
-						bits = SPELL_KNOW;
-					}
+          if (spell_no == (guild_mono_info[info_num].learn_info + i)->spell_no) {
+            if (!(bits = -2 * (guild_mono_info[info_num].learn_info + i)->skill_no)
+                || bits == SPELL_TEMP) {
+              bits = SPELL_KNOW;
+            }
 
-					if ((GET_SPELL_TYPE(ch, spell_no) & bits) == bits)
-					{
-						if (IS_SET(bits, SPELL_KNOW))
-						{
-							sprintf(buf, "$N сказал$G : \r\n"
-								"'$n, чтобы применить это заклинание, тебе необходимо набрать\r\n"
-								"%s колд(овать) '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
-								CCCYN(ch, C_NRM), spell_name(spell_no),
-								CCNRM(ch, C_NRM));
-						}
-						else if (IS_SET(bits, SPELL_ITEMS))
-						{
-							sprintf(buf, "$N сказал$G : \r\n"
-								"'$n, чтобы применить эту магию, тебе необходимо набрать\r\n"
-								"%s смешать '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
-								CCCYN(ch, C_NRM), spell_name(spell_no),
-								CCNRM(ch, C_NRM));
-						}
-						else if (IS_SET(bits, SPELL_RUNES))
-						{
-							sprintf(buf, "$N сказал$G : \r\n"
-								"'$n, чтобы применить эту магию, тебе необходимо набрать\r\n"
-								"%s руны '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
-								CCCYN(ch, C_NRM), spell_name(spell_no),
-								CCNRM(ch, C_NRM));
-						}
-						else
-						{
-							strcpy(buf, "Вы уже умеете это.");
-						}
-						act(buf, FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else
-					{
-						sprintf(buf, "$N научил$G вас магии %s\"%s\"%s",
-							CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
-						act(buf, FALSE, ch, 0, victim, TO_CHAR);
-						if (IS_SET(bits, SPELL_KNOW))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_KNOW);
-						}
-						if (IS_SET(bits, SPELL_ITEMS))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_ITEMS);
-						}
-						if (IS_SET(bits, SPELL_RUNES))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_RUNES);
-						}
-						if (IS_SET(bits, SPELL_POTION))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_POTION);
-							ch->set_skill(SKILL_CREATE_POTION, MAX(10, ch->get_trained_skill(SKILL_CREATE_POTION)));
-						}
-						if (IS_SET(bits, SPELL_WAND))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_WAND);
-							ch->set_skill(SKILL_CREATE_WAND, MAX(10, ch->get_trained_skill(SKILL_CREATE_WAND)));
-						}
-						if (IS_SET(bits, SPELL_SCROLL))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_SCROLL);
-							ch->set_skill(SKILL_CREATE_SCROLL, MAX(10, ch->get_trained_skill(SKILL_CREATE_SCROLL)));
-						}
-					}
-					found = TRUE;
-				}
-			}
+            if ((GET_SPELL_TYPE(ch, spell_no) & bits) == bits) {
+              if (IS_SET(bits, SPELL_KNOW)) {
+                sprintf(buf, "$N сказал$G : \r\n"
+                             "'$n, чтобы применить это заклинание, тебе необходимо набрать\r\n"
+                             "%s колд(овать) '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
+                        CCCYN(ch, C_NRM), spell_name(spell_no),
+                        CCNRM(ch, C_NRM));
+              } else if (IS_SET(bits, SPELL_ITEMS)) {
+                sprintf(buf, "$N сказал$G : \r\n"
+                             "'$n, чтобы применить эту магию, тебе необходимо набрать\r\n"
+                             "%s смешать '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
+                        CCCYN(ch, C_NRM), spell_name(spell_no),
+                        CCNRM(ch, C_NRM));
+              } else if (IS_SET(bits, SPELL_RUNES)) {
+                sprintf(buf, "$N сказал$G : \r\n"
+                             "'$n, чтобы применить эту магию, тебе необходимо набрать\r\n"
+                             "%s руны '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
+                        CCCYN(ch, C_NRM), spell_name(spell_no),
+                        CCNRM(ch, C_NRM));
+              } else {
+                strcpy(buf, "Вы уже умеете это.");
+              }
+              act(buf, FALSE, ch, 0, victim, TO_CHAR);
+            } else {
+              sprintf(buf, "$N научил$G вас магии %s\"%s\"%s",
+                      CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
+              act(buf, FALSE, ch, 0, victim, TO_CHAR);
+              if (IS_SET(bits, SPELL_KNOW)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_KNOW);
+              }
+              if (IS_SET(bits, SPELL_ITEMS)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_ITEMS);
+              }
+              if (IS_SET(bits, SPELL_RUNES)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_RUNES);
+              }
+              if (IS_SET(bits, SPELL_POTION)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_POTION);
+                ch->set_skill(SKILL_CREATE_POTION, MAX(10, ch->get_trained_skill(SKILL_CREATE_POTION)));
+              }
+              if (IS_SET(bits, SPELL_WAND)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_WAND);
+                ch->set_skill(SKILL_CREATE_WAND, MAX(10, ch->get_trained_skill(SKILL_CREATE_WAND)));
+              }
+              if (IS_SET(bits, SPELL_SCROLL)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_SCROLL);
+                ch->set_skill(SKILL_CREATE_SCROLL, MAX(10, ch->get_trained_skill(SKILL_CREATE_SCROLL)));
+              }
+            }
+            found = TRUE;
+          }
+        }
 
-			if (!found)
-			{
-				act("$N сказал$G : 'Я и сам$G не знаю такой магии.'", FALSE, ch, 0, victim, TO_CHAR);
-			}
+        if (!found) {
+          act("$N сказал$G : 'Я и сам$G не знаю такой магии.'", FALSE, ch, 0, victim, TO_CHAR);
+        }
 
-			return (1);
-		}
+        return (1);
+      }
 
-		act("$N сказал$G вам : 'Я никогда и никого этому не учил$G.'", FALSE, ch, 0, victim, TO_CHAR);
-		return (1);
-	}
+      act("$N сказал$G вам : 'Я никогда и никого этому не учил$G.'", FALSE, ch, 0, victim, TO_CHAR);
+      return (1);
+  }
 
-	return (0);
+  return (0);
 }
 
-int guild_poly(CHAR_DATA *ch, void *me, int cmd, char* argument)
-{
-	int command = 0, gcount = 0, info_num = 0, found = FALSE, sfound = FALSE, i, bits;
-	CHAR_DATA *victim = (CHAR_DATA *) me;
+int guild_poly(CHAR_DATA *ch, void *me, int cmd, char *argument) {
+  int command = 0, gcount = 0, info_num = 0, found = FALSE, sfound = FALSE, i, bits;
+  CHAR_DATA *victim = (CHAR_DATA *) me;
 
-	if (IS_NPC(ch))
-	{
-		return 0;
-	}
+  if (IS_NPC(ch)) {
+    return 0;
+  }
 
-	if (CMD_IS("учить") || CMD_IS("practice"))
-	{
-		command = SCMD_LEARN;
-	}
-	else
-	{
-		return 0;
-	}
+  if (CMD_IS("учить") || CMD_IS("practice")) {
+    command = SCMD_LEARN;
+  } else {
+    return 0;
+  }
 
-	if ((info_num = mob_index[victim->get_rnum()].stored) <= 0 || info_num > GUILDS_POLY_USED)
-	{
-		act("$N сказал$G : 'Извини, $n, я уже в отставке.'", FALSE, ch, 0, victim, TO_CHAR);
-		return 1;
-	}
+  if ((info_num = mob_index[victim->get_rnum()].stored) <= 0 || info_num > GUILDS_POLY_USED) {
+    act("$N сказал$G : 'Извини, $n, я уже в отставке.'", FALSE, ch, 0, victim, TO_CHAR);
+    return 1;
+  }
 
-	info_num--;
+  info_num--;
 
-	skip_spaces(&argument);
+  skip_spaces(&argument);
 
-	switch (command)
-	{
-	case SCMD_LEARN:
-		if (!*argument)
-		{
-			gcount += sprintf(buf, "Я могу научить тебя следующему:\r\n");
-			for (i = 0, found = FALSE; (guild_poly_info[info_num] + i)->spell_no >= 0; i++)
-			{
-				if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
+  switch (command) {
+    case SCMD_LEARN:
+      if (!*argument) {
+        gcount += sprintf(buf, "Я могу научить тебя следующему:\r\n");
+        for (i = 0, found = FALSE; (guild_poly_info[info_num] + i)->spell_no >= 0; i++) {
+          if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
 
-				if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch)))
-					continue;
+          if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch)))
+            continue;
 
-				const ESkill skill_no = (guild_poly_info[info_num] + i)->skill_no;
-				bits = skill_no;
-				if (SKILL_INVALID != skill_no
-					&& (!ch->get_trained_skill(skill_no)
-						|| IS_GRGOD(ch))
-					&& can_get_skill(ch, skill_no))
-				{
-					gcount += sprintf(buf + gcount, "- умение %s\"%s\"%s\r\n",
-						CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
-					found = TRUE;
-				}
+          const ESkill skill_no = (guild_poly_info[info_num] + i)->skill_no;
+          bits = skill_no;
+          if (SKILL_INVALID != skill_no
+              && (!ch->get_trained_skill(skill_no)
+                  || IS_GRGOD(ch))
+              && IsAbleToGetSkill(ch, skill_no)) {
+            gcount += sprintf(buf + gcount, "- умение %s\"%s\"%s\r\n",
+                              CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
+            found = TRUE;
+          }
 
-				if (!(bits = -2 * bits)
-					|| bits == SPELL_TEMP)
-				{
-					bits = SPELL_KNOW;
-				}
+          if (!(bits = -2 * bits)
+              || bits == SPELL_TEMP) {
+            bits = SPELL_KNOW;
+          }
 
-				const int spell_no = (guild_poly_info[info_num] + i)->spell_no;
-				if (spell_no
-					&& (!((GET_SPELL_TYPE(ch, spell_no) & bits) == bits)
-						|| IS_GRGOD(ch)))
-				{
-					gcount += sprintf(buf + gcount, "- магия %s\"%s\"%s\r\n",
-						CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
-					found = TRUE;
-				}
+          const int spell_no = (guild_poly_info[info_num] + i)->spell_no;
+          if (spell_no
+              && (!((GET_SPELL_TYPE(ch, spell_no) & bits) == bits)
+                  || IS_GRGOD(ch))) {
+            gcount += sprintf(buf + gcount, "- магия %s\"%s\"%s\r\n",
+                              CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
+            found = TRUE;
+          }
 
-				const int feat_no = (guild_poly_info[info_num] + i)->feat_no;
-				if (feat_no > 0
-					&& feat_no < MAX_FEATS)
-				{
-					if (!HAVE_FEAT(ch, feat_no) && can_get_feat(ch, feat_no))
-					{
-						gcount += sprintf(buf + gcount, "- способность %s\"%s\"%s\r\n",
-							CCCYN(ch, C_NRM), feat_name(feat_no), CCNRM(ch, C_NRM));
-						found = TRUE;
-					}
-				}
-			}
+          const int feat_no = (guild_poly_info[info_num] + i)->feat_no;
+          if (feat_no > 0
+              && feat_no < MAX_FEATS) {
+            if (!HAVE_FEAT(ch, feat_no) && can_get_feat(ch, feat_no)) {
+              gcount += sprintf(buf + gcount, "- способность %s\"%s\"%s\r\n",
+                                CCCYN(ch, C_NRM), feat_name(feat_no), CCNRM(ch, C_NRM));
+              found = TRUE;
+            }
+          }
+        }
 
-			if (!found)
-			{
-				act("$N сказал$G : 'Похоже, я не смогу тебе помочь.'", FALSE, ch, 0, victim, TO_CHAR);
-				return (1);
-			}
-			else
-			{
-				send_to_char(buf, ch);
-				return (1);
-			}
-		}
+        if (!found) {
+          act("$N сказал$G : 'Похоже, я не смогу тебе помочь.'", FALSE, ch, 0, victim, TO_CHAR);
+          return (1);
+        } else {
+          send_to_char(buf, ch);
+          return (1);
+        }
+      }
 
-		if (!strn_cmp(argument, "все", strlen(argument))
-			|| !strn_cmp(argument, "all", strlen(argument)))
-		{
-			for (i = 0, found = FALSE, sfound = FALSE; (guild_poly_info[info_num] + i)->spell_no >= 0; i++)
-			{
-				if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
-				if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch)))
-				{
-					continue;
-				}
+      if (!strn_cmp(argument, "все", strlen(argument))
+          || !strn_cmp(argument, "all", strlen(argument))) {
+        for (i = 0, found = FALSE, sfound = FALSE; (guild_poly_info[info_num] + i)->spell_no >= 0; i++) {
+          if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
+          if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch))) {
+            continue;
+          }
 
-				const ESkill skill_no = (guild_poly_info[info_num] + i)->skill_no;
-				bits = skill_no;
-				if (SKILL_INVALID != skill_no
-					&& !ch->get_trained_skill(skill_no))  	// sprintf(buf, "$N научил$G вас умению %s\"%s\"\%s",
-				{
-					//             CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
-					// act(buf,FALSE,ch,0,victim,TO_CHAR);
-					// ch->get_skill(skill_no) = 10;
-					sfound = TRUE;
-				}
+          const ESkill skill_no = (guild_poly_info[info_num] + i)->skill_no;
+          bits = skill_no;
+          if (SKILL_INVALID != skill_no
+              && !ch->get_trained_skill(skill_no))    // sprintf(buf, "$N научил$G вас умению %s\"%s\"\%s",
+          {
+            //             CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
+            // act(buf,FALSE,ch,0,victim,TO_CHAR);
+            // ch->get_skill(skill_no) = 10;
+            sfound = TRUE;
+          }
 
-				const int feat_no = (guild_poly_info[info_num] + i)->feat_no;
-				if (feat_no > 0
-					&& feat_no < MAX_FEATS)
-				{
-					if (!HAVE_FEAT(ch, feat_no)
-						&& can_get_feat(ch, feat_no))
-					{
-						sfound = TRUE;
-					}
-				}
+          const int feat_no = (guild_poly_info[info_num] + i)->feat_no;
+          if (feat_no > 0
+              && feat_no < MAX_FEATS) {
+            if (!HAVE_FEAT(ch, feat_no)
+                && can_get_feat(ch, feat_no)) {
+              sfound = TRUE;
+            }
+          }
 
-				if (!(bits = -2 * bits) || bits == SPELL_TEMP)
-				{
-					bits = SPELL_KNOW;
-				}
+          if (!(bits = -2 * bits) || bits == SPELL_TEMP) {
+            bits = SPELL_KNOW;
+          }
 
-				const int spell_no = (guild_poly_info[info_num] + i)->spell_no;
-				if (spell_no
-					&& !((GET_SPELL_TYPE(ch, spell_no) & bits) == bits))
-				{
-					gcount += sprintf(buf, "$N научил$G вас магии %s\"%s\"%s",
-						CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
-					act(buf, FALSE, ch, 0, victim, TO_CHAR);
+          const int spell_no = (guild_poly_info[info_num] + i)->spell_no;
+          if (spell_no
+              && !((GET_SPELL_TYPE(ch, spell_no) & bits) == bits)) {
+            gcount += sprintf(buf, "$N научил$G вас магии %s\"%s\"%s",
+                              CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
+            act(buf, FALSE, ch, 0, victim, TO_CHAR);
 
-					if (IS_SET(bits, SPELL_KNOW))
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_KNOW);
-					if (IS_SET(bits, SPELL_ITEMS))
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_ITEMS);
-					if (IS_SET(bits, SPELL_RUNES))
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_RUNES);
-					if (IS_SET(bits, SPELL_POTION))
-					{
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_POTION);
-						ch->set_skill(SKILL_CREATE_POTION, MAX(10, ch->get_trained_skill(SKILL_CREATE_POTION)));
-					}
-					if (IS_SET(bits, SPELL_WAND))
-					{
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_WAND);
-						ch->set_skill(SKILL_CREATE_WAND, MAX(10, ch->get_trained_skill(SKILL_CREATE_WAND)));
-					}
-					if (IS_SET(bits, SPELL_SCROLL))
-					{
-						SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_SCROLL);
-						ch->set_skill(SKILL_CREATE_SCROLL, MAX(10, ch->get_trained_skill(SKILL_CREATE_SCROLL)));
-					}
-					found = TRUE;
-				}
-			}
+            if (IS_SET(bits, SPELL_KNOW))
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_KNOW);
+            if (IS_SET(bits, SPELL_ITEMS))
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_ITEMS);
+            if (IS_SET(bits, SPELL_RUNES))
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_RUNES);
+            if (IS_SET(bits, SPELL_POTION)) {
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_POTION);
+              ch->set_skill(SKILL_CREATE_POTION, MAX(10, ch->get_trained_skill(SKILL_CREATE_POTION)));
+            }
+            if (IS_SET(bits, SPELL_WAND)) {
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_WAND);
+              ch->set_skill(SKILL_CREATE_WAND, MAX(10, ch->get_trained_skill(SKILL_CREATE_WAND)));
+            }
+            if (IS_SET(bits, SPELL_SCROLL)) {
+              SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_SCROLL);
+              ch->set_skill(SKILL_CREATE_SCROLL, MAX(10, ch->get_trained_skill(SKILL_CREATE_SCROLL)));
+            }
+            found = TRUE;
+          }
+        }
 
-			if (sfound)
-			{
-				act("$N сказал$G : \r\n"
-					"'$n, к сожалению, это может сильно затруднить твое постижение умений.'\r\n"
-					"'Выбери лишь самые необходимые тебе умения.'", FALSE, ch, 0, victim, TO_CHAR);
-			}
+        if (sfound) {
+          act("$N сказал$G : \r\n"
+              "'$n, к сожалению, это может сильно затруднить твое постижение умений.'\r\n"
+              "'Выбери лишь самые необходимые тебе умения.'", FALSE, ch, 0, victim, TO_CHAR);
+        }
 
-			if (!found)
-			{
-				act("$N ничему новому вас не научил$G.", FALSE, ch, 0, victim, TO_CHAR);
-			}
+        if (!found) {
+          act("$N ничему новому вас не научил$G.", FALSE, ch, 0, victim, TO_CHAR);
+        }
 
-			return (1);
-		}
+        return (1);
+      }
 
-		const ESkill skill_no = fix_name_and_find_skill_num(argument);
-		if (SKILL_INVALID != skill_no
-			&& skill_no <= MAX_SKILL_NUM)
-		{
-			for (i = 0, found = FALSE; (guild_poly_info[info_num] + i)->spell_no >= 0; i++)
-			{
-				if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
-				if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch)))
-				{
-					continue;
-				}
+      const ESkill skill_no = fix_name_and_find_skill_num(argument);
+      if (SKILL_INVALID != skill_no
+          && skill_no <= MAX_SKILL_NUM) {
+        for (i = 0, found = FALSE; (guild_poly_info[info_num] + i)->spell_no >= 0; i++) {
+          if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
+          if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch))) {
+            continue;
+          }
 
-				if (skill_no == (guild_poly_info[info_num] + i)->skill_no)
-				{
-					if (ch->get_trained_skill(skill_no))
-					{
-						act("$N сказал$G вам : 'Ты уже владеешь этим умением.'", FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else if (!can_get_skill(ch, skill_no))
-					{
-						act("$N сказал$G : 'Я не могу тебя этому научить.'", FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else
-					{
-						sprintf(buf, "$N научил$G вас умению %s\"%s\"%s",
-							CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
-						act(buf, FALSE, ch, 0, victim, TO_CHAR);
-						ch->set_skill(skill_no, 10);
-					}
-					found = TRUE;
-				}
-			}
+          if (skill_no == (guild_poly_info[info_num] + i)->skill_no) {
+            if (ch->get_trained_skill(skill_no)) {
+              act("$N сказал$G вам : 'Ты уже владеешь этим умением.'", FALSE, ch, 0, victim, TO_CHAR);
+            } else if (!IsAbleToGetSkill(ch, skill_no)) {
+              act("$N сказал$G : 'Я не могу тебя этому научить.'", FALSE, ch, 0, victim, TO_CHAR);
+            } else {
+              sprintf(buf, "$N научил$G вас умению %s\"%s\"%s",
+                      CCCYN(ch, C_NRM), skill_name(skill_no), CCNRM(ch, C_NRM));
+              act(buf, FALSE, ch, 0, victim, TO_CHAR);
+              ch->set_skill(skill_no, 10);
+            }
+            found = TRUE;
+          }
+        }
 
-			if (!found)
-			{
-				//				found_skill = FALSE;
-				//				act("$N сказал$G : 'Мне не ведомо такое умение.'", FALSE, ch, 0, victim, TO_CHAR);
-			}
-			else
-			{
-				return (1);
-			}
-		}
+        if (!found) {
+          //				found_skill = FALSE;
+          //				act("$N сказал$G : 'Мне не ведомо такое умение.'", FALSE, ch, 0, victim, TO_CHAR);
+        } else {
+          return (1);
+        }
+      }
 
-		int feat_no = find_feat_num(argument);
-		if (feat_no < 0 || feat_no >= MAX_FEATS)
-		{
-			std::string str(argument);
-			std::replace_if(str.begin(), str.end(), boost::is_any_of("_:"), ' ');
-			feat_no = find_feat_num(str.c_str(), true);
-		}
+      int feat_no = find_feat_num(argument);
+      if (feat_no < 0 || feat_no >= MAX_FEATS) {
+        std::string str(argument);
+        std::replace_if(str.begin(), str.end(), boost::is_any_of("_:"), ' ');
+        feat_no = find_feat_num(str.c_str(), true);
+      }
 
-		if (feat_no > 0 && feat_no < MAX_FEATS)
-		{
-			for (i = 0, found = FALSE; (guild_poly_info[info_num] + i)->feat_no >= 0; i++)
-			{
-				if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
-				if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch)))
-				{
-					continue;
-				}
-				if (feat_no == (guild_poly_info[info_num] + i)->feat_no)
-				{
-					if (HAVE_FEAT(ch, feat_no))
-					{
-						act("$N сказал$G вам : 'Ничем помочь не могу, ты уже владеешь этой способностью.'", FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else if (!can_get_feat(ch, feat_no))
-					{
-						act("$N сказал$G : 'Я не могу тебя этому научить.'", FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else
-					{
-						sprintf(buf, "$N научил$G вас способности %s\"%s\"%s",
-							CCCYN(ch, C_NRM), feat_name(feat_no), CCNRM(ch, C_NRM));
-						act(buf, FALSE, ch, 0, victim, TO_CHAR);
-						SET_FEAT(ch, feat_no);
-					}
-					found = TRUE;
-				}
-			}
+      if (feat_no > 0 && feat_no < MAX_FEATS) {
+        for (i = 0, found = FALSE; (guild_poly_info[info_num] + i)->feat_no >= 0; i++) {
+          if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
+          if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch))) {
+            continue;
+          }
+          if (feat_no == (guild_poly_info[info_num] + i)->feat_no) {
+            if (HAVE_FEAT(ch, feat_no)) {
+              act("$N сказал$G вам : 'Ничем помочь не могу, ты уже владеешь этой способностью.'",
+                  FALSE,
+                  ch,
+                  0,
+                  victim,
+                  TO_CHAR);
+            } else if (!can_get_feat(ch, feat_no)) {
+              act("$N сказал$G : 'Я не могу тебя этому научить.'", FALSE, ch, 0, victim, TO_CHAR);
+            } else {
+              sprintf(buf, "$N научил$G вас способности %s\"%s\"%s",
+                      CCCYN(ch, C_NRM), feat_name(feat_no), CCNRM(ch, C_NRM));
+              act(buf, FALSE, ch, 0, victim, TO_CHAR);
+              SET_FEAT(ch, feat_no);
+            }
+            found = TRUE;
+          }
+        }
 
-			if (!found)
-			{
-				//				found_feat = FALSE;
-				//				act("$N сказал$G : 'Мне не ведомо такое умение.'", FALSE, ch, 0, victim, TO_CHAR);
-			}
-			else
-			{
-				return (1);
-			}
-		}
+        if (!found) {
+          //				found_feat = FALSE;
+          //				act("$N сказал$G : 'Мне не ведомо такое умение.'", FALSE, ch, 0, victim, TO_CHAR);
+        } else {
+          return (1);
+        }
+      }
 
-		const int spell_no = fix_name_and_find_spell_num(argument);
-		if (spell_no > 0 && spell_no <= MAX_SPELLS)
-		{
-			for (i = 0, found = FALSE; (guild_poly_info[info_num] + i)->spell_no >= 0; i++)
-			{
-				if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch))
-				{
-					continue;
-				}
-				if (!(bits = -2 * (guild_poly_info[info_num] + i)->skill_no)
-					|| bits == SPELL_TEMP)
-				{
-					bits = SPELL_KNOW;
-				}
-				if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
-					|| !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch)))
-				{
-					continue;
-				}
+      const int spell_no = fix_name_and_find_spell_num(argument);
+      if (spell_no > 0 && spell_no <= MAX_SPELLS) {
+        for (i = 0, found = FALSE; (guild_poly_info[info_num] + i)->spell_no >= 0; i++) {
+          if ((guild_poly_info[info_num] + i)->level > GET_LEVEL(ch)) {
+            continue;
+          }
+          if (!(bits = -2 * (guild_poly_info[info_num] + i)->skill_no)
+              || bits == SPELL_TEMP) {
+            bits = SPELL_KNOW;
+          }
+          if (!IS_BITS((guild_poly_info[info_num] + i)->classes, GET_CLASS(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->races, GET_RACE(ch))
+              || !IS_BITS((guild_poly_info[info_num] + i)->religion, GET_RELIGION(ch))) {
+            continue;
+          }
 
-				if (spell_no == (guild_poly_info[info_num] + i)->spell_no)
-				{
-					if ((GET_SPELL_TYPE(ch, spell_no) & bits) == bits)
-					{
-						if (IS_SET(bits, SPELL_KNOW))
-						{
-							sprintf(buf, "$N сказал$G : \r\n"
-								"'$n, чтобы применить это заклинание, тебе необходимо набрать\r\n"
-								"%s колд(овать) '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
-								CCCYN(ch, C_NRM), spell_name(skill_no),
-								CCNRM(ch, C_NRM));
-						}
-						else if (IS_SET(bits, SPELL_ITEMS))
-						{
-							sprintf(buf, "$N сказал$G : \r\n"
-								"'$n, чтобы применить эту магию, тебе необходимо набрать\r\n"
-								"%s смешать '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
-								CCCYN(ch, C_NRM), spell_name(skill_no),
-								CCNRM(ch, C_NRM));
-						}
-						else if (IS_SET(bits, SPELL_RUNES))
-						{
-							sprintf(buf, "$N сказал$G : \r\n"
-								"'$n, чтобы применить эту магию, тебе необходимо набрать\r\n"
-								"%s руны '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
-								CCCYN(ch, C_NRM), spell_name(skill_no),
-								CCNRM(ch, C_NRM));
-						}
-						else
-						{
-							strcpy(buf, "Вы уже умеете это.");
-						}
-						act(buf, FALSE, ch, 0, victim, TO_CHAR);
-					}
-					else
-					{
-						sprintf(buf, "$N научил$G вас магии %s\"%s\"%s",
-							CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
-						act(buf, FALSE, ch, 0, victim, TO_CHAR);
-						if (IS_SET(bits, SPELL_KNOW))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_KNOW);
-						}
-						if (IS_SET(bits, SPELL_ITEMS))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_ITEMS);
-						}
-						if (IS_SET(bits, SPELL_RUNES))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_RUNES);
-						}
-						if (IS_SET(bits, SPELL_POTION))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_POTION);
-							ch->set_skill(SKILL_CREATE_POTION, MAX(10, ch->get_trained_skill(SKILL_CREATE_POTION)));
-						}
-						if (IS_SET(bits, SPELL_WAND))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_WAND);
-							ch->set_skill(SKILL_CREATE_WAND, MAX(10, ch->get_trained_skill(SKILL_CREATE_WAND)));
-						}
-						if (IS_SET(bits, SPELL_SCROLL))
-						{
-							SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_SCROLL);
-							ch->set_skill(SKILL_CREATE_SCROLL, MAX(10, ch->get_trained_skill(SKILL_CREATE_SCROLL)));
-						}
-					}
-					found = TRUE;
-				}
-			}
+          if (spell_no == (guild_poly_info[info_num] + i)->spell_no) {
+            if ((GET_SPELL_TYPE(ch, spell_no) & bits) == bits) {
+              if (IS_SET(bits, SPELL_KNOW)) {
+                sprintf(buf, "$N сказал$G : \r\n"
+                             "'$n, чтобы применить это заклинание, тебе необходимо набрать\r\n"
+                             "%s колд(овать) '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
+                        CCCYN(ch, C_NRM), spell_name(skill_no),
+                        CCNRM(ch, C_NRM));
+              } else if (IS_SET(bits, SPELL_ITEMS)) {
+                sprintf(buf, "$N сказал$G : \r\n"
+                             "'$n, чтобы применить эту магию, тебе необходимо набрать\r\n"
+                             "%s смешать '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
+                        CCCYN(ch, C_NRM), spell_name(skill_no),
+                        CCNRM(ch, C_NRM));
+              } else if (IS_SET(bits, SPELL_RUNES)) {
+                sprintf(buf, "$N сказал$G : \r\n"
+                             "'$n, чтобы применить эту магию, тебе необходимо набрать\r\n"
+                             "%s руны '%s' <цель>%s и щелкнуть клавишей <ENTER>'.",
+                        CCCYN(ch, C_NRM), spell_name(skill_no),
+                        CCNRM(ch, C_NRM));
+              } else {
+                strcpy(buf, "Вы уже умеете это.");
+              }
+              act(buf, FALSE, ch, 0, victim, TO_CHAR);
+            } else {
+              sprintf(buf, "$N научил$G вас магии %s\"%s\"%s",
+                      CCCYN(ch, C_NRM), spell_name(spell_no), CCNRM(ch, C_NRM));
+              act(buf, FALSE, ch, 0, victim, TO_CHAR);
+              if (IS_SET(bits, SPELL_KNOW)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_KNOW);
+              }
+              if (IS_SET(bits, SPELL_ITEMS)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_ITEMS);
+              }
+              if (IS_SET(bits, SPELL_RUNES)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_RUNES);
+              }
+              if (IS_SET(bits, SPELL_POTION)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_POTION);
+                ch->set_skill(SKILL_CREATE_POTION, MAX(10, ch->get_trained_skill(SKILL_CREATE_POTION)));
+              }
+              if (IS_SET(bits, SPELL_WAND)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_WAND);
+                ch->set_skill(SKILL_CREATE_WAND, MAX(10, ch->get_trained_skill(SKILL_CREATE_WAND)));
+              }
+              if (IS_SET(bits, SPELL_SCROLL)) {
+                SET_BIT(GET_SPELL_TYPE(ch, spell_no), SPELL_SCROLL);
+                ch->set_skill(SKILL_CREATE_SCROLL, MAX(10, ch->get_trained_skill(SKILL_CREATE_SCROLL)));
+              }
+            }
+            found = TRUE;
+          }
+        }
 
-			if (!found)
-			{
-				//				found_spell = FALSE;
-				//				act("$N сказал$G : 'Я и сам$G не знаю такого заклинания.'", FALSE, ch, 0, victim, TO_CHAR);
-			}
-			else
-			{
-				return (1);
-			}
-		}
+        if (!found) {
+          //				found_spell = FALSE;
+          //				act("$N сказал$G : 'Я и сам$G не знаю такого заклинания.'", FALSE, ch, 0, victim, TO_CHAR);
+        } else {
+          return (1);
+        }
+      }
 
-		act("$N сказал$G вам : 'Я никогда и никого этому не учил$G.'", FALSE, ch, 0, victim, TO_CHAR);
-		return (1);
-	}
+      act("$N сказал$G вам : 'Я никогда и никого этому не учил$G.'", FALSE, ch, 0, victim, TO_CHAR);
+      return (1);
+  }
 
-	return (0);
+  return (0);
 }
 
-int horse_keeper(CHAR_DATA *ch, void *me, int cmd, char* argument)
-{
-	CHAR_DATA *victim = (CHAR_DATA *) me, *horse = NULL;
+int horse_keeper(CHAR_DATA *ch, void *me, int cmd, char *argument) {
+  CHAR_DATA *victim = (CHAR_DATA *) me, *horse = NULL;
 
-	if (IS_NPC(ch))
-		return (0);
+  if (IS_NPC(ch))
+    return (0);
 
-	if (!CMD_IS("лошадь") && !CMD_IS("horse"))
-		return (0);
+  if (!CMD_IS("лошадь") && !CMD_IS("horse"))
+    return (0);
 
-	if (ch->is_morphed())
-	{
-		send_to_char("Лошадка испугается вас в таком виде... \r\n", ch);
-		return (TRUE);
-	}
+  if (ch->is_morphed()) {
+    send_to_char("Лошадка испугается вас в таком виде... \r\n", ch);
+    return (TRUE);
+  }
 
-	skip_spaces(&argument);
+  skip_spaces(&argument);
 
-	if (!*argument)
-	{
-		if (ch->has_horse(false))
-		{
-			act("$N поинтересовал$U : \"$n, зачем тебе второй скакун? У тебя ведь одно седалище.\"",
-				FALSE, ch, 0, victim, TO_CHAR);
-			return (TRUE);
-		}
-		sprintf(buf, "$N сказал$G : \"Я продам тебе скакуна за %d %s.\"",
-				HORSE_COST, desc_count(HORSE_COST, WHAT_MONEYa));
-		act(buf, FALSE, ch, 0, victim, TO_CHAR);
-		return (TRUE);
-	}
+  if (!*argument) {
+    if (ch->has_horse(false)) {
+      act("$N поинтересовал$U : \"$n, зачем тебе второй скакун? У тебя ведь одно седалище.\"",
+          FALSE, ch, 0, victim, TO_CHAR);
+      return (TRUE);
+    }
+    sprintf(buf, "$N сказал$G : \"Я продам тебе скакуна за %d %s.\"",
+            HORSE_COST, desc_count(HORSE_COST, WHAT_MONEYa));
+    act(buf, FALSE, ch, 0, victim, TO_CHAR);
+    return (TRUE);
+  }
 
-	if (!strn_cmp(argument, "купить", strlen(argument)) || !strn_cmp(argument, "buy", strlen(argument)))
-	{
-		if (ch->has_horse(false))
-		{
-			act("$N засмеял$U : \"$n, ты шутишь, у тебя же есть скакун.\"", FALSE, ch, 0, victim, TO_CHAR);
-			return (TRUE);
-		}
-		if (ch->get_gold() < HORSE_COST)
-		{
-			act("\"Ступай отсюда, злыдень, у тебя нет таких денег!\"-заорал$G $N",
-				FALSE, ch, 0, victim, TO_CHAR);
-			return (TRUE);
-		}
-		if (!(horse = read_mobile(HORSE_VNUM, VIRTUAL)))
-		{
-			act("\"Извини, у меня нет для тебя скакуна.\"-смущенно произнес$Q $N",
-				FALSE, ch, 0, victim, TO_CHAR);
-			return (TRUE);
-		}
-		make_horse(horse, ch);
-		char_to_room(horse, ch->in_room);
-		sprintf(buf, "$N оседлал$G %s и отдал$G %s вам.", GET_PAD(horse, 3), HSHR(horse));
-		act(buf, FALSE, ch, 0, victim, TO_CHAR);
-		sprintf(buf, "$N оседлал$G %s и отдал$G %s $n2.", GET_PAD(horse, 3), HSHR(horse));
-		act(buf, FALSE, ch, 0, victim, TO_ROOM);
-		ch->remove_gold(HORSE_COST);
-		PLR_FLAGS(ch).set(PLR_CRASH);
-		return (TRUE);
-	}
+  if (!strn_cmp(argument, "купить", strlen(argument)) || !strn_cmp(argument, "buy", strlen(argument))) {
+    if (ch->has_horse(false)) {
+      act("$N засмеял$U : \"$n, ты шутишь, у тебя же есть скакун.\"", FALSE, ch, 0, victim, TO_CHAR);
+      return (TRUE);
+    }
+    if (ch->get_gold() < HORSE_COST) {
+      act("\"Ступай отсюда, злыдень, у тебя нет таких денег!\"-заорал$G $N",
+          FALSE, ch, 0, victim, TO_CHAR);
+      return (TRUE);
+    }
+    if (!(horse = read_mobile(HORSE_VNUM, VIRTUAL))) {
+      act("\"Извини, у меня нет для тебя скакуна.\"-смущенно произнес$Q $N",
+          FALSE, ch, 0, victim, TO_CHAR);
+      return (TRUE);
+    }
+    make_horse(horse, ch);
+    char_to_room(horse, ch->in_room);
+    sprintf(buf, "$N оседлал$G %s и отдал$G %s вам.", GET_PAD(horse, 3), HSHR(horse));
+    act(buf, FALSE, ch, 0, victim, TO_CHAR);
+    sprintf(buf, "$N оседлал$G %s и отдал$G %s $n2.", GET_PAD(horse, 3), HSHR(horse));
+    act(buf, FALSE, ch, 0, victim, TO_ROOM);
+    ch->remove_gold(HORSE_COST);
+    PLR_FLAGS(ch).set(PLR_CRASH);
+    return (TRUE);
+  }
 
+  if (!strn_cmp(argument, "продать", strlen(argument)) || !strn_cmp(argument, "sell", strlen(argument))) {
+    if (!ch->has_horse(true)) {
+      act("$N засмеял$U : \"$n, ты не влезешь в мое стойло.\"", FALSE, ch, 0, victim, TO_CHAR);
+      return (TRUE);
+    }
+    if (ch->ahorse()) {
+      act("\"Я не собираюсь платить еще и за всадника.\"-усмехнул$U $N",
+          FALSE, ch, 0, victim, TO_CHAR);
+      return (TRUE);
+    }
 
-	if (!strn_cmp(argument, "продать", strlen(argument)) || !strn_cmp(argument, "sell", strlen(argument)))
-	{
-		if (!ch->has_horse(true))
-		{
-			act("$N засмеял$U : \"$n, ты не влезешь в мое стойло.\"", FALSE, ch, 0, victim, TO_CHAR);
-			return (TRUE);
-		}
-		if (ch->ahorse())
-		{
-			act("\"Я не собираюсь платить еще и за всадника.\"-усмехнул$U $N",
-				FALSE, ch, 0, victim, TO_CHAR);
-			return (TRUE);
-		}
+    if (!(horse = ch->get_horse()) || GET_MOB_VNUM(horse) != HORSE_VNUM) {
+      act("\"Извини, твой скакун мне не подходит.\"- заявил$G $N", FALSE, ch, 0, victim, TO_CHAR);
+      return (TRUE);
+    }
 
-		if (!(horse = ch->get_horse()) || GET_MOB_VNUM(horse) != HORSE_VNUM)
-		{
-			act("\"Извини, твой скакун мне не подходит.\"- заявил$G $N", FALSE, ch, 0, victim, TO_CHAR);
-			return (TRUE);
-		}
+    if (IN_ROOM(horse) != IN_ROOM(victim)) {
+      act("\"Извини, твой скакун где-то бродит.\"- заявил$G $N", FALSE, ch, 0, victim, TO_CHAR);
+      return (TRUE);
+    }
 
-		if (IN_ROOM(horse) != IN_ROOM(victim))
-		{
-			act("\"Извини, твой скакун где-то бродит.\"- заявил$G $N", FALSE, ch, 0, victim, TO_CHAR);
-			return (TRUE);
-		}
+    sprintf(buf, "$N расседлал$G %s и отвел$G %s в стойло.", GET_PAD(horse, 3), HSHR(horse));
+    act(buf, FALSE, ch, 0, victim, TO_CHAR);
+    sprintf(buf, "$N расседлал$G %s и отвел$G %s в стойло.", GET_PAD(horse, 3), HSHR(horse));
+    act(buf, FALSE, ch, 0, victim, TO_ROOM);
+    extract_char(horse, FALSE);
+    ch->add_gold((HORSE_COST >> 1));
+    PLR_FLAGS(ch).set(PLR_CRASH);
+    return (TRUE);
+  }
 
-		sprintf(buf, "$N расседлал$G %s и отвел$G %s в стойло.", GET_PAD(horse, 3), HSHR(horse));
-		act(buf, FALSE, ch, 0, victim, TO_CHAR);
-		sprintf(buf, "$N расседлал$G %s и отвел$G %s в стойло.", GET_PAD(horse, 3), HSHR(horse));
-		act(buf, FALSE, ch, 0, victim, TO_ROOM);
-		extract_char(horse, FALSE);
-		ch->add_gold((HORSE_COST >> 1));
-		PLR_FLAGS(ch).set(PLR_CRASH);
-		return (TRUE);
-	}
-
-	return (0);
+  return (0);
 }
 
+bool item_nouse(OBJ_DATA *obj) {
+  switch (GET_OBJ_TYPE(obj)) {
+    case OBJ_DATA::ITEM_LIGHT:
+      if (GET_OBJ_VAL(obj, 2) == 0) {
+        return true;
+      }
+      break;
 
+    case OBJ_DATA::ITEM_SCROLL:
+    case OBJ_DATA::ITEM_POTION:
+      if (!GET_OBJ_VAL(obj, 1)
+          && !GET_OBJ_VAL(obj, 2)
+          && !GET_OBJ_VAL(obj, 3)) {
+        return true;
+      }
+      break;
 
+    case OBJ_DATA::ITEM_STAFF:
+    case OBJ_DATA::ITEM_WAND:
+      if (!GET_OBJ_VAL(obj, 2)) {
+        return true;
+      }
+      break;
 
+    case OBJ_DATA::ITEM_CONTAINER:
+      if (!system_obj::is_purse(obj)) {
+        return true;
+      }
+      break;
 
+    case OBJ_DATA::ITEM_OTHER:
+    case OBJ_DATA::ITEM_TRASH:
+    case OBJ_DATA::ITEM_TRAP:
+    case OBJ_DATA::ITEM_NOTE:
+    case OBJ_DATA::ITEM_DRINKCON:
+    case OBJ_DATA::ITEM_FOOD:
+    case OBJ_DATA::ITEM_PEN:
+    case OBJ_DATA::ITEM_BOAT:
+    case OBJ_DATA::ITEM_FOUNTAIN:
+    case OBJ_DATA::ITEM_MING: return true;
 
-bool item_nouse(OBJ_DATA * obj)
-{
-	switch (GET_OBJ_TYPE(obj))
-	{
-	case OBJ_DATA::ITEM_LIGHT:
-		if (GET_OBJ_VAL(obj, 2) == 0)
-		{
-			return true;
-		}
-		break;
+    default: break;
+  }
 
-	case OBJ_DATA::ITEM_SCROLL:
-	case OBJ_DATA::ITEM_POTION:
-		if (!GET_OBJ_VAL(obj, 1)
-			&& !GET_OBJ_VAL(obj, 2)
-			&& !GET_OBJ_VAL(obj, 3))
-		{
-			return true;
-		}
-		break;
-
-	case OBJ_DATA::ITEM_STAFF:
-	case OBJ_DATA::ITEM_WAND:
-		if (!GET_OBJ_VAL(obj, 2))
-		{
-			return true;
-		}
-		break;
-
-	case OBJ_DATA::ITEM_CONTAINER:
-		if (!system_obj::is_purse(obj))
-		{
-			return true;
-		}
-		break;
-
-	case OBJ_DATA::ITEM_OTHER:
-	case OBJ_DATA::ITEM_TRASH:
-	case OBJ_DATA::ITEM_TRAP:
-	case OBJ_DATA::ITEM_NOTE:
-	case OBJ_DATA::ITEM_DRINKCON:
-	case OBJ_DATA::ITEM_FOOD:
-	case OBJ_DATA::ITEM_PEN:
-	case OBJ_DATA::ITEM_BOAT:
-	case OBJ_DATA::ITEM_FOUNTAIN:
-	case OBJ_DATA::ITEM_MING:
-		return true;
-
-	default:
-		break;
-	}
-
-	return false;
+  return false;
 }
 
-void npc_dropunuse(CHAR_DATA * ch)
-{
-	OBJ_DATA *obj, *nobj;
-	for (obj = ch->carrying; obj; obj = nobj)
-	{
-		nobj = obj->get_next_content();
-		if (item_nouse(obj))
-		{
-			act("$n выбросил$g $o3.", FALSE, ch, obj, 0, TO_ROOM);
-			obj_from_char(obj);
-			obj_to_room(obj, ch->in_room);
-		}
-	}
+void npc_dropunuse(CHAR_DATA *ch) {
+  OBJ_DATA *obj, *nobj;
+  for (obj = ch->carrying; obj; obj = nobj) {
+    nobj = obj->get_next_content();
+    if (item_nouse(obj)) {
+      act("$n выбросил$g $o3.", FALSE, ch, obj, 0, TO_ROOM);
+      obj_from_char(obj);
+      obj_to_room(obj, ch->in_room);
+    }
+  }
 }
 
-int npc_scavenge(CHAR_DATA * ch)
-{
-	int max = 1;
-	OBJ_DATA *obj, *best_obj, *cont, *best_cont, *cobj;
+int npc_scavenge(CHAR_DATA *ch) {
+  int max = 1;
+  OBJ_DATA *obj, *best_obj, *cont, *best_cont, *cobj;
 
-	if (!MOB_FLAGGED(ch, MOB_SCAVENGER))
-	{
-		return (FALSE);
-	}
+  if (!MOB_FLAGGED(ch, MOB_SCAVENGER)) {
+    return (FALSE);
+  }
 
-	if (IS_SHOPKEEPER(ch))
-	{
-		return (FALSE);
-	}
+  if (IS_SHOPKEEPER(ch)) {
+    return (FALSE);
+  }
 
-	npc_dropunuse(ch);
-	if (world[ch->in_room]->contents && number(0, 25) <= GET_REAL_INT(ch))
-	{
-		max = 1;
-		best_obj = NULL;
-		cont = NULL;
-		best_cont = NULL;
-		for (obj = world[ch->in_room]->contents; obj; obj = obj->get_next_content())
-		{
-			if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_MING
-				|| Clan::is_clan_chest(obj)
-				|| ClanSystem::is_ingr_chest(obj))
-			{
-				continue;
-			}
+  npc_dropunuse(ch);
+  if (world[ch->in_room]->contents && number(0, 25) <= GET_REAL_INT(ch)) {
+    max = 1;
+    best_obj = NULL;
+    cont = NULL;
+    best_cont = NULL;
+    for (obj = world[ch->in_room]->contents; obj; obj = obj->get_next_content()) {
+      if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_MING
+          || Clan::is_clan_chest(obj)
+          || ClanSystem::is_ingr_chest(obj)) {
+        continue;
+      }
 
-			if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_CONTAINER
-				&& !system_obj::is_purse(obj))
-			{
-				if (IS_CORPSE(obj))
-				{
-					continue;
-				}
+      if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_CONTAINER
+          && !system_obj::is_purse(obj)) {
+        if (IS_CORPSE(obj)) {
+          continue;
+        }
 
-				// Заперто, открываем, если есть ключ
-				if (OBJVAL_FLAGGED(obj, CONT_LOCKED)
-					&& has_key(ch, GET_OBJ_VAL(obj, 2)))
-				{
-					do_doorcmd(ch, obj, 0, SCMD_UNLOCK);
-				}
+        // Заперто, открываем, если есть ключ
+        if (OBJVAL_FLAGGED(obj, CONT_LOCKED)
+            && has_key(ch, GET_OBJ_VAL(obj, 2))) {
+          do_doorcmd(ch, obj, 0, SCMD_UNLOCK);
+        }
 
-				// Заперто, взламываем, если умеем
-				if (OBJVAL_FLAGGED(obj, CONT_LOCKED)
-					&& ch->get_skill(SKILL_PICK_LOCK)
-					&& ok_pick(ch, 0, obj, 0, SCMD_PICK))
-				{
-					do_doorcmd(ch, obj, 0, SCMD_PICK);
-				}
-				// Все равно заперто, ну тогда фиг с ним
-				if (OBJVAL_FLAGGED(obj, CONT_LOCKED))
-				{
-					continue;
-				}
+        // Заперто, взламываем, если умеем
+        if (OBJVAL_FLAGGED(obj, CONT_LOCKED)
+            && ch->get_skill(SKILL_PICK_LOCK)
+            && ok_pick(ch, 0, obj, 0, SCMD_PICK)) {
+          do_doorcmd(ch, obj, 0, SCMD_PICK);
+        }
+        // Все равно заперто, ну тогда фиг с ним
+        if (OBJVAL_FLAGGED(obj, CONT_LOCKED)) {
+          continue;
+        }
 
-				if (OBJVAL_FLAGGED(obj, CONT_CLOSED))
-				{
-					do_doorcmd(ch, obj, 0, SCMD_OPEN);
-				}
+        if (OBJVAL_FLAGGED(obj, CONT_CLOSED)) {
+          do_doorcmd(ch, obj, 0, SCMD_OPEN);
+        }
 
-				if (OBJVAL_FLAGGED(obj, CONT_CLOSED))
-				{
-					continue;
-				}
+        if (OBJVAL_FLAGGED(obj, CONT_CLOSED)) {
+          continue;
+        }
 
-				for (cobj = obj->get_contains(); cobj; cobj = cobj->get_next_content())
-				{
-					if (CAN_GET_OBJ(ch, cobj) && !item_nouse(cobj) && GET_OBJ_COST(cobj) > max)
-					{
-						cont = obj;
-						best_cont = best_obj = cobj;
-						max = GET_OBJ_COST(cobj);
-					}
-				}
-			}
-			else if (!IS_CORPSE(obj) &&
-				CAN_GET_OBJ(ch, obj) && GET_OBJ_COST(obj) > max && !item_nouse(obj))
-			{
-				best_obj = obj;
-				max = GET_OBJ_COST(obj);
-			}
-		}
-		if (best_obj != NULL)
-		{
-			if (best_obj != best_cont)
-			{
-				act("$n поднял$g $o3.", FALSE, ch, best_obj, 0, TO_ROOM);
-				if (GET_OBJ_TYPE(best_obj) == OBJ_DATA::ITEM_MONEY)
-				{
-					ch->add_gold(GET_OBJ_VAL(best_obj, 0));
-					extract_obj(best_obj);
-				}
-				else
-				{
-					obj_from_room(best_obj);
-					obj_to_char(best_obj, ch);
-				}
-			}
-			else
-			{
-				sprintf(buf, "$n достал$g $o3 из %s.", cont->get_PName(1).c_str());
-				act(buf, FALSE, ch, best_obj, 0, TO_ROOM);
-				if (GET_OBJ_TYPE(best_obj) == OBJ_DATA::ITEM_MONEY)
-				{
-					ch->add_gold(GET_OBJ_VAL(best_obj, 0));
-					extract_obj(best_obj);
-				}
-				else
-				{
-					obj_from_obj(best_obj);
-					obj_to_char(best_obj, ch);
-				}
-			}
-		}
-	}
-	return (max > 1);
+        for (cobj = obj->get_contains(); cobj; cobj = cobj->get_next_content()) {
+          if (CAN_GET_OBJ(ch, cobj) && !item_nouse(cobj) && GET_OBJ_COST(cobj) > max) {
+            cont = obj;
+            best_cont = best_obj = cobj;
+            max = GET_OBJ_COST(cobj);
+          }
+        }
+      } else if (!IS_CORPSE(obj) &&
+          CAN_GET_OBJ(ch, obj) && GET_OBJ_COST(obj) > max && !item_nouse(obj)) {
+        best_obj = obj;
+        max = GET_OBJ_COST(obj);
+      }
+    }
+    if (best_obj != NULL) {
+      if (best_obj != best_cont) {
+        act("$n поднял$g $o3.", FALSE, ch, best_obj, 0, TO_ROOM);
+        if (GET_OBJ_TYPE(best_obj) == OBJ_DATA::ITEM_MONEY) {
+          ch->add_gold(GET_OBJ_VAL(best_obj, 0));
+          extract_obj(best_obj);
+        } else {
+          obj_from_room(best_obj);
+          obj_to_char(best_obj, ch);
+        }
+      } else {
+        sprintf(buf, "$n достал$g $o3 из %s.", cont->get_PName(1).c_str());
+        act(buf, FALSE, ch, best_obj, 0, TO_ROOM);
+        if (GET_OBJ_TYPE(best_obj) == OBJ_DATA::ITEM_MONEY) {
+          ch->add_gold(GET_OBJ_VAL(best_obj, 0));
+          extract_obj(best_obj);
+        } else {
+          obj_from_obj(best_obj);
+          obj_to_char(best_obj, ch);
+        }
+      }
+    }
+  }
+  return (max > 1);
 }
 
-int npc_loot(CHAR_DATA * ch)
-{
-	int max = FALSE;
-	OBJ_DATA *obj, *loot_obj, *next_loot, *cobj, *cnext_obj;
+int npc_loot(CHAR_DATA *ch) {
+  int max = FALSE;
+  OBJ_DATA *obj, *loot_obj, *next_loot, *cobj, *cnext_obj;
 
-	if (!MOB_FLAGGED(ch, MOB_LOOTER))
-		return (FALSE);
-	if (IS_SHOPKEEPER(ch))
-		return (FALSE);
-	npc_dropunuse(ch);
-	if (world[ch->in_room]->contents && number(0, GET_REAL_INT(ch)) > 10)
-	{
-		for (obj = world[ch->in_room]->contents; obj; obj = obj->get_next_content())
-		{
-			if (CAN_SEE_OBJ(ch, obj) && IS_CORPSE(obj))
-			{
-				// Сначала лутим то, что не в контейнерах
-				for (loot_obj = obj->get_contains(); loot_obj; loot_obj = next_loot)
-				{
-					next_loot = loot_obj->get_next_content();
-					if ((GET_OBJ_TYPE(loot_obj) != OBJ_DATA::ITEM_CONTAINER
-							|| system_obj::is_purse(loot_obj))
-						&& CAN_GET_OBJ(ch, loot_obj)
-						&& !item_nouse(loot_obj))
-					{
-						sprintf(buf, "$n вытащил$g $o3 из %s.", obj->get_PName(1).c_str());
-						act(buf, FALSE, ch, loot_obj, 0, TO_ROOM);
-						if (GET_OBJ_TYPE(loot_obj) == OBJ_DATA::ITEM_MONEY)
-						{
-							ch->add_gold(GET_OBJ_VAL(loot_obj, 0));
-							extract_obj(loot_obj);
-						}
-						else
-						{
-							obj_from_obj(loot_obj);
-							obj_to_char(loot_obj, ch);
-							max++;
-						}
-					}
-				}
-				// Теперь не запертые контейнеры
-				for (loot_obj = obj->get_contains(); loot_obj; loot_obj = next_loot)
-				{
-					next_loot = loot_obj->get_next_content();
-					if (GET_OBJ_TYPE(loot_obj) == OBJ_DATA::ITEM_CONTAINER)
-					{
-						if (IS_CORPSE(loot_obj)
-							|| OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)
-							|| system_obj::is_purse(loot_obj))
-						{
-							continue;
-						}
-						auto value = loot_obj->get_val(1); //откроем контейнер
-						REMOVE_BIT(value, CONT_CLOSED);
-						loot_obj->set_val(1, value);
-						for (cobj = loot_obj->get_contains(); cobj; cobj = cnext_obj)
-						{
-							cnext_obj = cobj->get_next_content();
-							if (CAN_GET_OBJ(ch, cobj) && !item_nouse(cobj))
-							{
-								sprintf(buf, "$n вытащил$g $o3 из %s.", obj->get_PName(1).c_str());
-								act(buf, FALSE, ch, cobj, 0, TO_ROOM);
-								if (GET_OBJ_TYPE(cobj) == OBJ_DATA::ITEM_MONEY)
-								{
-									ch->add_gold(GET_OBJ_VAL(cobj, 0));
-									extract_obj(cobj);
-								}
-								else
-								{
-									obj_from_obj(cobj);
-									obj_to_char(cobj, ch);
-									max++;
-								}
-							}
-						}
-					}
-				}
-				// И наконец, лутим запертые контейнеры если есть ключ или можем взломать
-				for (loot_obj = obj->get_contains(); loot_obj; loot_obj = next_loot)
-				{
-					next_loot = loot_obj->get_next_content();
-					if (GET_OBJ_TYPE(loot_obj) == OBJ_DATA::ITEM_CONTAINER)
-					{
-						if (IS_CORPSE(loot_obj)
-							|| !OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)
-							|| system_obj::is_purse(loot_obj))
-						{
-							continue;
-						}
+  if (!MOB_FLAGGED(ch, MOB_LOOTER))
+    return (FALSE);
+  if (IS_SHOPKEEPER(ch))
+    return (FALSE);
+  npc_dropunuse(ch);
+  if (world[ch->in_room]->contents && number(0, GET_REAL_INT(ch)) > 10) {
+    for (obj = world[ch->in_room]->contents; obj; obj = obj->get_next_content()) {
+      if (CAN_SEE_OBJ(ch, obj) && IS_CORPSE(obj)) {
+        // Сначала лутим то, что не в контейнерах
+        for (loot_obj = obj->get_contains(); loot_obj; loot_obj = next_loot) {
+          next_loot = loot_obj->get_next_content();
+          if ((GET_OBJ_TYPE(loot_obj) != OBJ_DATA::ITEM_CONTAINER
+              || system_obj::is_purse(loot_obj))
+              && CAN_GET_OBJ(ch, loot_obj)
+              && !item_nouse(loot_obj)) {
+            sprintf(buf, "$n вытащил$g $o3 из %s.", obj->get_PName(1).c_str());
+            act(buf, FALSE, ch, loot_obj, 0, TO_ROOM);
+            if (GET_OBJ_TYPE(loot_obj) == OBJ_DATA::ITEM_MONEY) {
+              ch->add_gold(GET_OBJ_VAL(loot_obj, 0));
+              extract_obj(loot_obj);
+            } else {
+              obj_from_obj(loot_obj);
+              obj_to_char(loot_obj, ch);
+              max++;
+            }
+          }
+        }
+        // Теперь не запертые контейнеры
+        for (loot_obj = obj->get_contains(); loot_obj; loot_obj = next_loot) {
+          next_loot = loot_obj->get_next_content();
+          if (GET_OBJ_TYPE(loot_obj) == OBJ_DATA::ITEM_CONTAINER) {
+            if (IS_CORPSE(loot_obj)
+                || OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)
+                || system_obj::is_purse(loot_obj)) {
+              continue;
+            }
+            auto value = loot_obj->get_val(1); //откроем контейнер
+            REMOVE_BIT(value, CONT_CLOSED);
+            loot_obj->set_val(1, value);
+            for (cobj = loot_obj->get_contains(); cobj; cobj = cnext_obj) {
+              cnext_obj = cobj->get_next_content();
+              if (CAN_GET_OBJ(ch, cobj) && !item_nouse(cobj)) {
+                sprintf(buf, "$n вытащил$g $o3 из %s.", obj->get_PName(1).c_str());
+                act(buf, FALSE, ch, cobj, 0, TO_ROOM);
+                if (GET_OBJ_TYPE(cobj) == OBJ_DATA::ITEM_MONEY) {
+                  ch->add_gold(GET_OBJ_VAL(cobj, 0));
+                  extract_obj(cobj);
+                } else {
+                  obj_from_obj(cobj);
+                  obj_to_char(cobj, ch);
+                  max++;
+                }
+              }
+            }
+          }
+        }
+        // И наконец, лутим запертые контейнеры если есть ключ или можем взломать
+        for (loot_obj = obj->get_contains(); loot_obj; loot_obj = next_loot) {
+          next_loot = loot_obj->get_next_content();
+          if (GET_OBJ_TYPE(loot_obj) == OBJ_DATA::ITEM_CONTAINER) {
+            if (IS_CORPSE(loot_obj)
+                || !OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)
+                || system_obj::is_purse(loot_obj)) {
+              continue;
+            }
 
-						// Есть ключ?
-						if (OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)
-							&& has_key(ch, GET_OBJ_VAL(loot_obj, 2)))
-						{
-							loot_obj->toggle_val_bit(1, CONT_LOCKED);
-						}
+            // Есть ключ?
+            if (OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)
+                && has_key(ch, GET_OBJ_VAL(loot_obj, 2))) {
+              loot_obj->toggle_val_bit(1, CONT_LOCKED);
+            }
 
-						// ...или взломаем?
-						if (OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)
-							&& ch->get_skill(SKILL_PICK_LOCK)
-							&& ok_pick(ch, 0, loot_obj, 0, SCMD_PICK))
-						{
-							loot_obj->toggle_val_bit(1, CONT_LOCKED);
-						}
+            // ...или взломаем?
+            if (OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)
+                && ch->get_skill(SKILL_PICK_LOCK)
+                && ok_pick(ch, 0, loot_obj, 0, SCMD_PICK)) {
+              loot_obj->toggle_val_bit(1, CONT_LOCKED);
+            }
 
-						// Эх, не открыть. Ну ладно.
-						if (OBJVAL_FLAGGED(loot_obj, CONT_LOCKED))
-						{
-							continue;
-						}
+            // Эх, не открыть. Ну ладно.
+            if (OBJVAL_FLAGGED(loot_obj, CONT_LOCKED)) {
+              continue;
+            }
 
-						loot_obj->toggle_val_bit(1, CONT_CLOSED);
-						for (cobj = loot_obj->get_contains(); cobj; cobj = cnext_obj)
-						{
-							cnext_obj = cobj->get_next_content();
-							if (CAN_GET_OBJ(ch, cobj) && !item_nouse(cobj))
-							{
-								sprintf(buf, "$n вытащил$g $o3 из %s.", obj->get_PName(1).c_str());
-								act(buf, FALSE, ch, cobj, 0, TO_ROOM);
-								if (GET_OBJ_TYPE(cobj) == OBJ_DATA::ITEM_MONEY)
-								{
-									ch->add_gold(GET_OBJ_VAL(cobj, 0));
-									extract_obj(cobj);
-								}
-								else
-								{
-									obj_from_obj(cobj);
-									obj_to_char(cobj, ch);
-									max++;
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-	return (max);
+            loot_obj->toggle_val_bit(1, CONT_CLOSED);
+            for (cobj = loot_obj->get_contains(); cobj; cobj = cnext_obj) {
+              cnext_obj = cobj->get_next_content();
+              if (CAN_GET_OBJ(ch, cobj) && !item_nouse(cobj)) {
+                sprintf(buf, "$n вытащил$g $o3 из %s.", obj->get_PName(1).c_str());
+                act(buf, FALSE, ch, cobj, 0, TO_ROOM);
+                if (GET_OBJ_TYPE(cobj) == OBJ_DATA::ITEM_MONEY) {
+                  ch->add_gold(GET_OBJ_VAL(cobj, 0));
+                  extract_obj(cobj);
+                } else {
+                  obj_from_obj(cobj);
+                  obj_to_char(cobj, ch);
+                  max++;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return (max);
 }
 
-int npc_move(CHAR_DATA * ch, int dir, int/* need_specials_check*/)
-{
-	int need_close = FALSE, need_lock = FALSE;
-	int rev_dir[] = { SOUTH, WEST, NORTH, EAST, DOWN, UP };
-	int retval = FALSE;
+int npc_move(CHAR_DATA *ch, int dir, int/* need_specials_check*/) {
+  int need_close = FALSE, need_lock = FALSE;
+  int rev_dir[] = {SOUTH, WEST, NORTH, EAST, DOWN, UP};
+  int retval = FALSE;
 
-	if (ch == NULL || dir < 0 || dir >= NUM_OF_DIRS || ch->get_fighting())
-	{
-		return (FALSE);
-	}
-	else if (!EXIT(ch, dir) || EXIT(ch, dir)->to_room() == NOWHERE)
-	{
-		return (FALSE);
-	}
-	else if (ch->has_master()
-		&& ch->in_room == IN_ROOM(ch->get_master()))
-	{
-		return (FALSE);
-	}
-	else if (EXIT_FLAGGED(EXIT(ch, dir), EX_CLOSED))
-	{
-		if (!EXIT_FLAGGED(EXIT(ch, dir), EX_ISDOOR))
-		{
-			return (FALSE);
-		}
+  if (ch == NULL || dir < 0 || dir >= NUM_OF_DIRS || ch->get_fighting()) {
+    return (FALSE);
+  } else if (!EXIT(ch, dir) || EXIT(ch, dir)->to_room() == NOWHERE) {
+    return (FALSE);
+  } else if (ch->has_master()
+      && ch->in_room == IN_ROOM(ch->get_master())) {
+    return (FALSE);
+  } else if (EXIT_FLAGGED(EXIT(ch, dir), EX_CLOSED)) {
+    if (!EXIT_FLAGGED(EXIT(ch, dir), EX_ISDOOR)) {
+      return (FALSE);
+    }
 
-		const auto& rdata = EXIT(ch, dir);
+    const auto &rdata = EXIT(ch, dir);
 
-		if (EXIT_FLAGGED(rdata, EX_LOCKED))
-		{
-			if (has_key(ch, rdata->key)
-				|| (!EXIT_FLAGGED(rdata, EX_PICKPROOF)
-					&& !EXIT_FLAGGED(rdata, EX_BROKEN)
-					&& calculate_skill(ch, SKILL_PICK, 0) >= number(0, 100)))
-			{
-				do_doorcmd(ch, 0, dir, SCMD_UNLOCK);
-				need_lock = TRUE;
-			}
-			else
-			{
-				return (FALSE);
-			}
-		}
-		if (EXIT_FLAGGED(rdata, EX_CLOSED))
-		{
-			if (GET_REAL_INT(ch) >= 15
-				|| GET_DEST(ch) != NOWHERE
-				|| MOB_FLAGGED(ch, MOB_OPENDOOR))
-			{
-				do_doorcmd(ch, 0, dir, SCMD_OPEN);
-				need_close = TRUE;
-			}
-		}
-	}
+    if (EXIT_FLAGGED(rdata, EX_LOCKED)) {
+      if (has_key(ch, rdata->key)
+          || (!EXIT_FLAGGED(rdata, EX_PICKPROOF)
+              && !EXIT_FLAGGED(rdata, EX_BROKEN)
+              && CalcCurrentSkill(ch, SKILL_PICK, 0) >= number(0, 100))) {
+        do_doorcmd(ch, 0, dir, SCMD_UNLOCK);
+        need_lock = TRUE;
+      } else {
+        return (FALSE);
+      }
+    }
+    if (EXIT_FLAGGED(rdata, EX_CLOSED)) {
+      if (GET_REAL_INT(ch) >= 15
+          || GET_DEST(ch) != NOWHERE
+          || MOB_FLAGGED(ch, MOB_OPENDOOR)) {
+        do_doorcmd(ch, 0, dir, SCMD_OPEN);
+        need_close = TRUE;
+      }
+    }
+  }
 
-	retval = perform_move(ch, dir, 1, FALSE, 0);
+  retval = perform_move(ch, dir, 1, FALSE, 0);
 
-	if (need_close)
-	{
-		if (retval)
-			do_doorcmd(ch, 0, rev_dir[dir], SCMD_CLOSE);
-		else
-			do_doorcmd(ch, 0, dir, SCMD_CLOSE);
-	}
+  if (need_close) {
+    if (retval)
+      do_doorcmd(ch, 0, rev_dir[dir], SCMD_CLOSE);
+    else
+      do_doorcmd(ch, 0, dir, SCMD_CLOSE);
+  }
 
-	if (need_lock)
-	{
-		if (retval)
-			do_doorcmd(ch, 0, rev_dir[dir], SCMD_LOCK);
-		else
-			do_doorcmd(ch, 0, dir, SCMD_LOCK);
-	}
+  if (need_lock) {
+    if (retval)
+      do_doorcmd(ch, 0, rev_dir[dir], SCMD_LOCK);
+    else
+      do_doorcmd(ch, 0, dir, SCMD_LOCK);
+  }
 
-	return (retval);
+  return (retval);
 }
 
-int has_curse(OBJ_DATA * obj)
-{
-	for (const auto& i : weapon_affect)
-	{
-		// Замена выражения на макрос
-		if (i.aff_spell <= 0 || !IS_OBJ_AFF(obj, i.aff_pos))
-		{
-			continue;
-		}
-		if (IS_SET(spell_info[i.aff_spell].routines, NPC_AFFECT_PC | NPC_DAMAGE_PC))
-		{
-			return TRUE;
-		}
-	}
-	return FALSE;
+int has_curse(OBJ_DATA *obj) {
+  for (const auto &i : weapon_affect) {
+    // Замена выражения на макрос
+    if (i.aff_spell <= 0 || !IS_OBJ_AFF(obj, i.aff_pos)) {
+      continue;
+    }
+    if (IS_SET(spell_info[i.aff_spell].routines, NPC_AFFECT_PC | NPC_DAMAGE_PC)) {
+      return TRUE;
+    }
+  }
+  return FALSE;
 }
 
-int calculate_weapon_class(CHAR_DATA * ch, OBJ_DATA * weapon)
-{
-	int damage = 0, hits = 0, i;
+int calculate_weapon_class(CHAR_DATA *ch, OBJ_DATA *weapon) {
+  int damage = 0, hits = 0, i;
 
-	if (!weapon
-		|| GET_OBJ_TYPE(weapon) != OBJ_DATA::ITEM_WEAPON)
-	{
-		return 0;
-	}
+  if (!weapon
+      || GET_OBJ_TYPE(weapon) != OBJ_DATA::ITEM_WEAPON) {
+    return 0;
+  }
 
-	hits = calculate_skill(ch, static_cast<ESkill>(GET_OBJ_SKILL(weapon)), 0);
-	damage = (GET_OBJ_VAL(weapon, 1) + 1) * (GET_OBJ_VAL(weapon, 2)) / 2;
-	for (i = 0; i < MAX_OBJ_AFFECT; i++)
-	{
-		auto& affected = weapon->get_affected(i);
-		if (affected.location == APPLY_DAMROLL)
-		{
-			damage += affected.modifier;
-		}
+  hits = CalcCurrentSkill(ch, static_cast<ESkill>(GET_OBJ_SKILL(weapon)), 0);
+  damage = (GET_OBJ_VAL(weapon, 1) + 1) * (GET_OBJ_VAL(weapon, 2)) / 2;
+  for (i = 0; i < MAX_OBJ_AFFECT; i++) {
+    auto &affected = weapon->get_affected(i);
+    if (affected.location == APPLY_DAMROLL) {
+      damage += affected.modifier;
+    }
 
-		if (affected.location == APPLY_HITROLL)
-		{
-			hits += affected.modifier * 10;
-		}
-	}
+    if (affected.location == APPLY_HITROLL) {
+      hits += affected.modifier * 10;
+    }
+  }
 
-	if (has_curse(weapon))
-		return (0);
+  if (has_curse(weapon))
+    return (0);
 
-	return (damage + (hits > 200 ? 10 : hits / 20));
+  return (damage + (hits > 200 ? 10 : hits / 20));
 }
 
-void best_weapon(CHAR_DATA * ch, OBJ_DATA * sweapon, OBJ_DATA ** dweapon)
-{
-	if (*dweapon == NULL)
-	{
-		if (calculate_weapon_class(ch, sweapon) > 0)
-		{
-			*dweapon = sweapon;
-		}
-	}
-	else if (calculate_weapon_class(ch, sweapon) > calculate_weapon_class(ch, *dweapon))
-	{
-		*dweapon = sweapon;
-	}
+void best_weapon(CHAR_DATA *ch, OBJ_DATA *sweapon, OBJ_DATA **dweapon) {
+  if (*dweapon == NULL) {
+    if (calculate_weapon_class(ch, sweapon) > 0) {
+      *dweapon = sweapon;
+    }
+  } else if (calculate_weapon_class(ch, sweapon) > calculate_weapon_class(ch, *dweapon)) {
+    *dweapon = sweapon;
+  }
 }
 
-void npc_wield(CHAR_DATA * ch)
-{
-	OBJ_DATA *obj, *next, *right = NULL, *left = NULL, *both = NULL;
+void npc_wield(CHAR_DATA *ch) {
+  OBJ_DATA *obj, *next, *right = NULL, *left = NULL, *both = NULL;
 
-	if (!NPC_FLAGGED(ch, NPC_WIELDING))
-		return;
+  if (!NPC_FLAGGED(ch, NPC_WIELDING))
+    return;
 
-	if (ch->get_skill(SKILL_MIGHTHIT) > 0
-		&& ch->get_skill(SKILL_STUPOR) < ch->get_skill(SKILL_MIGHTHIT))
-	{
-		return;
-	}
+  if (ch->get_skill(SKILL_MIGHTHIT) > 0
+      && ch->get_skill(SKILL_STUPOR) < ch->get_skill(SKILL_MIGHTHIT)) {
+    return;
+  }
 
-	if (GET_REAL_INT(ch) < 10 || IS_SHOPKEEPER(ch))
-		return;
+  if (GET_REAL_INT(ch) < 10 || IS_SHOPKEEPER(ch))
+    return;
 
-	if (GET_EQ(ch, WEAR_HOLD)
-		&& GET_OBJ_TYPE(GET_EQ(ch, WEAR_HOLD)) == OBJ_DATA::ITEM_WEAPON)
-	{
-		left = GET_EQ(ch, WEAR_HOLD);
-	}
-	if (GET_EQ(ch, WEAR_WIELD)
-		&& GET_OBJ_TYPE(GET_EQ(ch, WEAR_WIELD)) == OBJ_DATA::ITEM_WEAPON)
-	{
-		right = GET_EQ(ch, WEAR_WIELD);
-	}
-	if (GET_EQ(ch, WEAR_BOTHS)
-		&& GET_OBJ_TYPE(GET_EQ(ch, WEAR_BOTHS)) == OBJ_DATA::ITEM_WEAPON)
-	{
-		both = GET_EQ(ch, WEAR_BOTHS);
-	}
+  if (GET_EQ(ch, WEAR_HOLD)
+      && GET_OBJ_TYPE(GET_EQ(ch, WEAR_HOLD)) == OBJ_DATA::ITEM_WEAPON) {
+    left = GET_EQ(ch, WEAR_HOLD);
+  }
+  if (GET_EQ(ch, WEAR_WIELD)
+      && GET_OBJ_TYPE(GET_EQ(ch, WEAR_WIELD)) == OBJ_DATA::ITEM_WEAPON) {
+    right = GET_EQ(ch, WEAR_WIELD);
+  }
+  if (GET_EQ(ch, WEAR_BOTHS)
+      && GET_OBJ_TYPE(GET_EQ(ch, WEAR_BOTHS)) == OBJ_DATA::ITEM_WEAPON) {
+    both = GET_EQ(ch, WEAR_BOTHS);
+  }
 
-	if (GET_REAL_INT(ch) < 15 && ((left && right) || (both)))
-		return;
+  if (GET_REAL_INT(ch) < 15 && ((left && right) || (both)))
+    return;
 
-	for (obj = ch->carrying; obj; obj = next)
-	{
-		next = obj->get_next_content();
-		if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON
-			|| GET_OBJ_UID(obj) != 0)
-		{
-			continue;
-		}
+  for (obj = ch->carrying; obj; obj = next) {
+    next = obj->get_next_content();
+    if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_WEAPON
+        || GET_OBJ_UID(obj) != 0) {
+      continue;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD)
-			&& OK_HELD(ch, obj))
-		{
-			best_weapon(ch, obj, &left);
-		}
-		else if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD)
-			&& OK_WIELD(ch, obj))
-		{
-			best_weapon(ch, obj, &right);
-		}
-		else if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)
-			&& OK_BOTH(ch, obj))
-		{
-			best_weapon(ch, obj, &both);
-		}
-	}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD)
+        && OK_HELD(ch, obj)) {
+      best_weapon(ch, obj, &left);
+    } else if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD)
+        && OK_WIELD(ch, obj)) {
+      best_weapon(ch, obj, &right);
+    } else if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)
+        && OK_BOTH(ch, obj)) {
+      best_weapon(ch, obj, &both);
+    }
+  }
 
-	if (both
-		&& calculate_weapon_class(ch, both) > calculate_weapon_class(ch, left) + calculate_weapon_class(ch, right))
-	{
-		if (both == GET_EQ(ch, WEAR_BOTHS))
-		{
-			return;
-		}
-		if (GET_EQ(ch, WEAR_BOTHS))
-		{
-			act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_BOTHS), 0, TO_ROOM);
-			obj_to_char(unequip_char(ch, WEAR_BOTHS | 0x40), ch);
-		}
-		if (GET_EQ(ch, WEAR_WIELD))
-		{
-			act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_WIELD), 0, TO_ROOM);
-			obj_to_char(unequip_char(ch, WEAR_WIELD | 0x40), ch);
-		}
-		if (GET_EQ(ch, WEAR_SHIELD))
-		{
-			act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_SHIELD), 0, TO_ROOM);
-			obj_to_char(unequip_char(ch, WEAR_SHIELD | 0x40), ch);
-		}
-		if (GET_EQ(ch, WEAR_HOLD))
-		{
-			act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_HOLD), 0, TO_ROOM);
-			obj_to_char(unequip_char(ch, WEAR_HOLD | 0x40), ch);
-		}
-		//obj_from_char(both);
-		equip_char(ch, both, WEAR_BOTHS | 0x100);
-	}
-	else
-	{
-		if (left && GET_EQ(ch, WEAR_HOLD) != left)
-		{
-			if (GET_EQ(ch, WEAR_BOTHS))
-			{
-				act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_BOTHS), 0, TO_ROOM);
-				obj_to_char(unequip_char(ch, WEAR_BOTHS | 0x40), ch);
-			}
-			if (GET_EQ(ch, WEAR_SHIELD))
-			{
-				act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_SHIELD), 0, TO_ROOM);
-				obj_to_char(unequip_char(ch, WEAR_SHIELD | 0x40), ch);
-			}
-			if (GET_EQ(ch, WEAR_HOLD))
-			{
-				act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_HOLD), 0, TO_ROOM);
-				obj_to_char(unequip_char(ch, WEAR_HOLD | 0x40), ch);
-			}
-			//obj_from_char(left);
-			equip_char(ch, left, WEAR_HOLD | 0x100);
-		}
-		if (right && GET_EQ(ch, WEAR_WIELD) != right)
-		{
-			if (GET_EQ(ch, WEAR_BOTHS))
-			{
-				act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_BOTHS), 0, TO_ROOM);
-				obj_to_char(unequip_char(ch, WEAR_BOTHS | 0x40), ch);
-			}
-			if (GET_EQ(ch, WEAR_WIELD))
-			{
-				act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_WIELD), 0, TO_ROOM);
-				obj_to_char(unequip_char(ch, WEAR_WIELD | 0x40), ch);
-			}
-			//obj_from_char(right);
-			equip_char(ch, right, WEAR_WIELD | 0x100);
-		}
-	}
+  if (both
+      && calculate_weapon_class(ch, both) > calculate_weapon_class(ch, left) + calculate_weapon_class(ch, right)) {
+    if (both == GET_EQ(ch, WEAR_BOTHS)) {
+      return;
+    }
+    if (GET_EQ(ch, WEAR_BOTHS)) {
+      act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_BOTHS), 0, TO_ROOM);
+      obj_to_char(unequip_char(ch, WEAR_BOTHS | 0x40), ch);
+    }
+    if (GET_EQ(ch, WEAR_WIELD)) {
+      act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_WIELD), 0, TO_ROOM);
+      obj_to_char(unequip_char(ch, WEAR_WIELD | 0x40), ch);
+    }
+    if (GET_EQ(ch, WEAR_SHIELD)) {
+      act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_SHIELD), 0, TO_ROOM);
+      obj_to_char(unequip_char(ch, WEAR_SHIELD | 0x40), ch);
+    }
+    if (GET_EQ(ch, WEAR_HOLD)) {
+      act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_HOLD), 0, TO_ROOM);
+      obj_to_char(unequip_char(ch, WEAR_HOLD | 0x40), ch);
+    }
+    //obj_from_char(both);
+    equip_char(ch, both, WEAR_BOTHS | 0x100);
+  } else {
+    if (left && GET_EQ(ch, WEAR_HOLD) != left) {
+      if (GET_EQ(ch, WEAR_BOTHS)) {
+        act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_BOTHS), 0, TO_ROOM);
+        obj_to_char(unequip_char(ch, WEAR_BOTHS | 0x40), ch);
+      }
+      if (GET_EQ(ch, WEAR_SHIELD)) {
+        act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_SHIELD), 0, TO_ROOM);
+        obj_to_char(unequip_char(ch, WEAR_SHIELD | 0x40), ch);
+      }
+      if (GET_EQ(ch, WEAR_HOLD)) {
+        act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_HOLD), 0, TO_ROOM);
+        obj_to_char(unequip_char(ch, WEAR_HOLD | 0x40), ch);
+      }
+      //obj_from_char(left);
+      equip_char(ch, left, WEAR_HOLD | 0x100);
+    }
+    if (right && GET_EQ(ch, WEAR_WIELD) != right) {
+      if (GET_EQ(ch, WEAR_BOTHS)) {
+        act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_BOTHS), 0, TO_ROOM);
+        obj_to_char(unequip_char(ch, WEAR_BOTHS | 0x40), ch);
+      }
+      if (GET_EQ(ch, WEAR_WIELD)) {
+        act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, WEAR_WIELD), 0, TO_ROOM);
+        obj_to_char(unequip_char(ch, WEAR_WIELD | 0x40), ch);
+      }
+      //obj_from_char(right);
+      equip_char(ch, right, WEAR_WIELD | 0x100);
+    }
+  }
 }
 
-void npc_armor(CHAR_DATA * ch)
-{
-	OBJ_DATA *obj, *next;
-	int where = 0;
+void npc_armor(CHAR_DATA *ch) {
+  OBJ_DATA *obj, *next;
+  int where = 0;
 
-	if (!NPC_FLAGGED(ch, NPC_ARMORING))
-		return;
+  if (!NPC_FLAGGED(ch, NPC_ARMORING))
+    return;
 
-	if (GET_REAL_INT(ch) < 10 || IS_SHOPKEEPER(ch))
-		return;
+  if (GET_REAL_INT(ch) < 10 || IS_SHOPKEEPER(ch))
+    return;
 
-	for (obj = ch->carrying; obj; obj = next)
-	{
-		next = obj->get_next_content();
+  for (obj = ch->carrying; obj; obj = next) {
+    next = obj->get_next_content();
 
-		if (!ObjSystem::is_armor_type(obj)
-			|| !no_bad_affects(obj))
-		{
-			continue;
-		}
+    if (!ObjSystem::is_armor_type(obj)
+        || !no_bad_affects(obj)) {
+      continue;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FINGER))
-		{
-			where = WEAR_FINGER_R;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FINGER)) {
+      where = WEAR_FINGER_R;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_NECK))
-		{
-			where = WEAR_NECK_1;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_NECK)) {
+      where = WEAR_NECK_1;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY))
-		{
-			where = WEAR_BODY;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BODY)) {
+      where = WEAR_BODY;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD))
-		{
-			where = WEAR_HEAD;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HEAD)) {
+      where = WEAR_HEAD;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS))
-		{
-			where = WEAR_LEGS;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_LEGS)) {
+      where = WEAR_LEGS;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET))
-		{
-			where = WEAR_FEET;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_FEET)) {
+      where = WEAR_FEET;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS))
-		{
-			where = WEAR_HANDS;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HANDS)) {
+      where = WEAR_HANDS;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS))
-		{
-			where = WEAR_ARMS;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ARMS)) {
+      where = WEAR_ARMS;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_SHIELD))
-		{
-			where = WEAR_SHIELD;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_SHIELD)) {
+      where = WEAR_SHIELD;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT))
-		{
-			where = WEAR_ABOUT;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_ABOUT)) {
+      where = WEAR_ABOUT;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WAIST))
-		{
-			where = WEAR_WAIST;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WAIST)) {
+      where = WEAR_WAIST;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_QUIVER))
-		{
-			where = WEAR_QUIVER;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_QUIVER)) {
+      where = WEAR_QUIVER;
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WRIST))
-		{
-			where = WEAR_WRIST_R;
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WRIST)) {
+      where = WEAR_WRIST_R;
+    }
 
-		if (!where)
-		{
-			continue;
-		}
+    if (!where) {
+      continue;
+    }
 
-		if ((where == WEAR_FINGER_R) || (where == WEAR_NECK_1) || (where == WEAR_WRIST_R))
-		{
-			if (GET_EQ(ch, where))
-			{
-				where++;
-			}
-		}
+    if ((where == WEAR_FINGER_R) || (where == WEAR_NECK_1) || (where == WEAR_WRIST_R)) {
+      if (GET_EQ(ch, where)) {
+        where++;
+      }
+    }
 
-		if (where == WEAR_SHIELD && (GET_EQ(ch, WEAR_BOTHS) || GET_EQ(ch, WEAR_HOLD)))
-		{
-			continue;
-		}
+    if (where == WEAR_SHIELD && (GET_EQ(ch, WEAR_BOTHS) || GET_EQ(ch, WEAR_HOLD))) {
+      continue;
+    }
 
-		if (GET_EQ(ch, where))
-		{
-			if (GET_REAL_INT(ch) < 15)
-			{
-				continue;
-			}
+    if (GET_EQ(ch, where)) {
+      if (GET_REAL_INT(ch) < 15) {
+        continue;
+      }
 
-			if (GET_OBJ_VAL(obj, 0) + GET_OBJ_VAL(obj, 1) * 3 <= GET_OBJ_VAL(GET_EQ(ch, where), 0) + GET_OBJ_VAL(GET_EQ(ch, where), 1) * 3
-				|| has_curse(obj))
-			{
-				continue;
-			}
-			act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, where), 0, TO_ROOM);
-			obj_to_char(unequip_char(ch, where | 0x40), ch);
-		}
-		//obj_from_char(obj);
-		equip_char(ch, obj, where | 0x100);
-		break;
-	}
+      if (GET_OBJ_VAL(obj, 0) + GET_OBJ_VAL(obj, 1) * 3
+          <= GET_OBJ_VAL(GET_EQ(ch, where), 0) + GET_OBJ_VAL(GET_EQ(ch, where), 1) * 3
+          || has_curse(obj)) {
+        continue;
+      }
+      act("$n прекратил$g использовать $o3.", FALSE, ch, GET_EQ(ch, where), 0, TO_ROOM);
+      obj_to_char(unequip_char(ch, where | 0x40), ch);
+    }
+    //obj_from_char(obj);
+    equip_char(ch, obj, where | 0x100);
+    break;
+  }
 }
 
-void npc_light(CHAR_DATA * ch)
-{
-	OBJ_DATA *obj, *next;
+void npc_light(CHAR_DATA *ch) {
+  OBJ_DATA *obj, *next;
 
-	if (GET_REAL_INT(ch) < 10 || IS_SHOPKEEPER(ch))
-		return;
+  if (GET_REAL_INT(ch) < 10 || IS_SHOPKEEPER(ch))
+    return;
 
-	if (AFF_FLAGGED(ch, EAffectFlag::AFF_INFRAVISION))
-		return;
+  if (AFF_FLAGGED(ch, EAffectFlag::AFF_INFRAVISION))
+    return;
 
-	if ((obj = GET_EQ(ch, WEAR_LIGHT)) && (GET_OBJ_VAL(obj, 2) == 0 || !IS_DARK(ch->in_room)))
-	{
-		act("$n прекратил$g использовать $o3.", FALSE, ch, obj, 0, TO_ROOM);
-		obj_to_char(unequip_char(ch, WEAR_LIGHT | 0x40), ch);
-	}
+  if ((obj = GET_EQ(ch, WEAR_LIGHT)) && (GET_OBJ_VAL(obj, 2) == 0 || !IS_DARK(ch->in_room))) {
+    act("$n прекратил$g использовать $o3.", FALSE, ch, obj, 0, TO_ROOM);
+    obj_to_char(unequip_char(ch, WEAR_LIGHT | 0x40), ch);
+  }
 
-	if (!GET_EQ(ch, WEAR_LIGHT) && IS_DARK(ch->in_room))
-	{
-		for (obj = ch->carrying; obj; obj = next)
-		{
-			next = obj->get_next_content();
-			if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_LIGHT)
-			{
-				continue;
-			}
-			if (GET_OBJ_VAL(obj, 2) == 0)
-			{
-				act("$n выбросил$g $o3.", FALSE, ch, obj, 0, TO_ROOM);
-				obj_from_char(obj);
-				obj_to_room(obj, ch->in_room);
-				continue;
-			}
-			//obj_from_char(obj);
-			equip_char(ch, obj, WEAR_LIGHT | 0x100);
-			return;
-		}
-	}
+  if (!GET_EQ(ch, WEAR_LIGHT) && IS_DARK(ch->in_room)) {
+    for (obj = ch->carrying; obj; obj = next) {
+      next = obj->get_next_content();
+      if (GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_LIGHT) {
+        continue;
+      }
+      if (GET_OBJ_VAL(obj, 2) == 0) {
+        act("$n выбросил$g $o3.", FALSE, ch, obj, 0, TO_ROOM);
+        obj_from_char(obj);
+        obj_to_room(obj, ch->in_room);
+        continue;
+      }
+      //obj_from_char(obj);
+      equip_char(ch, obj, WEAR_LIGHT | 0x100);
+      return;
+    }
+  }
 }
 
+int npc_battle_scavenge(CHAR_DATA *ch) {
+  int max = FALSE;
+  OBJ_DATA *obj, *next_obj = NULL;
 
-int npc_battle_scavenge(CHAR_DATA * ch)
-{
-	int max = FALSE;
-	OBJ_DATA *obj, *next_obj = NULL;
+  if (!MOB_FLAGGED(ch, MOB_SCAVENGER))
+    return (FALSE);
 
-	if (!MOB_FLAGGED(ch, MOB_SCAVENGER))
-		return (FALSE);
+  if (IS_SHOPKEEPER(ch))
+    return (FALSE);
 
-	if (IS_SHOPKEEPER(ch))
-		return (FALSE);
-
-	if (world[ch->in_room]->contents && number(0, GET_REAL_INT(ch)) > 10)
-		for (obj = world[ch->in_room]->contents; obj; obj = next_obj)
-		{
-			next_obj = obj->get_next_content();
-			if (CAN_GET_OBJ(ch, obj)
-				&& !has_curse(obj)
-				&& (ObjSystem::is_armor_type(obj)
-					|| GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON))
-			{
-				obj_from_room(obj);
-				obj_to_char(obj, ch);
-				act("$n поднял$g $o3.", FALSE, ch, obj, 0, TO_ROOM);
-				max = TRUE;
-			}
-		}
-	return (max);
+  if (world[ch->in_room]->contents && number(0, GET_REAL_INT(ch)) > 10)
+    for (obj = world[ch->in_room]->contents; obj; obj = next_obj) {
+      next_obj = obj->get_next_content();
+      if (CAN_GET_OBJ(ch, obj)
+          && !has_curse(obj)
+          && (ObjSystem::is_armor_type(obj)
+              || GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)) {
+        obj_from_room(obj);
+        obj_to_char(obj, ch);
+        act("$n поднял$g $o3.", FALSE, ch, obj, 0, TO_ROOM);
+        max = TRUE;
+      }
+    }
+  return (max);
 }
 
+int npc_walk(CHAR_DATA *ch) {
+  int rnum, door = BFS_ERROR;
 
-int npc_walk(CHAR_DATA * ch)
-{
-	int rnum, door = BFS_ERROR;
+  if (ch->in_room == NOWHERE)
+    return (BFS_ERROR);
 
-	if (ch->in_room == NOWHERE)
-		return (BFS_ERROR);
+  if (GET_DEST(ch) == NOWHERE || (rnum = real_room(GET_DEST(ch))) == NOWHERE)
+    return (BFS_ERROR);
 
-	if (GET_DEST(ch) == NOWHERE || (rnum = real_room(GET_DEST(ch))) == NOWHERE)
-		return (BFS_ERROR);
+  if (ch->in_room == rnum) {
+    if (ch->mob_specials.dest_count == 1)
+      return (BFS_ALREADY_THERE);
+    if (ch->mob_specials.dest_pos == ch->mob_specials.dest_count - 1 && ch->mob_specials.dest_dir >= 0)
+      ch->mob_specials.dest_dir = -1;
+    if (!ch->mob_specials.dest_pos && ch->mob_specials.dest_dir < 0)
+      ch->mob_specials.dest_dir = 0;
+    ch->mob_specials.dest_pos += ch->mob_specials.dest_dir >= 0 ? 1 : -1;
+    if (((rnum = real_room(GET_DEST(ch))) == NOWHERE)
+        || rnum == ch->in_room)
+      return (BFS_ERROR);
+    else
+      return (npc_walk(ch));
+  }
 
-	if (ch->in_room == rnum)
-	{
-		if (ch->mob_specials.dest_count == 1)
-			return (BFS_ALREADY_THERE);
-		if (ch->mob_specials.dest_pos == ch->mob_specials.dest_count - 1 && ch->mob_specials.dest_dir >= 0)
-			ch->mob_specials.dest_dir = -1;
-		if (!ch->mob_specials.dest_pos && ch->mob_specials.dest_dir < 0)
-			ch->mob_specials.dest_dir = 0;
-		ch->mob_specials.dest_pos += ch->mob_specials.dest_dir >= 0 ? 1 : -1;
-		if (((rnum = real_room(GET_DEST(ch))) == NOWHERE)
-				|| rnum == ch->in_room)
-			return (BFS_ERROR);
-		else
-			return (npc_walk(ch));
-	}
+  door = find_first_step(ch->in_room, real_room(GET_DEST(ch)), ch);
 
-	door = find_first_step(ch->in_room, real_room(GET_DEST(ch)), ch);
-
-	return (door);
+  return (door);
 }
 
-int do_npc_steal(CHAR_DATA * ch, CHAR_DATA * victim)
-{
-	OBJ_DATA *obj, *best = NULL;
-	int gold;
-	int max = 0;
+int do_npc_steal(CHAR_DATA *ch, CHAR_DATA *victim) {
+  OBJ_DATA *obj, *best = NULL;
+  int gold;
+  int max = 0;
 
-	if (!NPC_FLAGGED(ch, NPC_STEALING))
-		return (FALSE);
+  if (!NPC_FLAGGED(ch, NPC_STEALING))
+    return (FALSE);
 
-	if (ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL))
-		return (FALSE);
+  if (ROOM_FLAGGED(ch->in_room, ROOM_PEACEFUL))
+    return (FALSE);
 
-	if (IS_NPC(victim) || IS_SHOPKEEPER(ch) || victim->get_fighting())
-		return (FALSE);
+  if (IS_NPC(victim) || IS_SHOPKEEPER(ch) || victim->get_fighting())
+    return (FALSE);
 
-	if (GET_LEVEL(victim) >= LVL_IMMORT)
-		return (FALSE);
+  if (GET_LEVEL(victim) >= LVL_IMMORT)
+    return (FALSE);
 
-	if (!CAN_SEE(ch, victim))
-		return (FALSE);
+  if (!CAN_SEE(ch, victim))
+    return (FALSE);
 
-	if (AWAKE(victim) && (number(0, MAX(0, GET_LEVEL(ch) - int_app[GET_REAL_INT(victim)].observation)) == 0))
-	{
-		act("Вы обнаружили руку $n1 в своем кармане.", FALSE, ch, 0, victim, TO_VICT);
-		act("$n пытал$u обокрасть $N3.", TRUE, ch, 0, victim, TO_NOTVICT);
-	}
-	else  		// Steal some gold coins
-	{
-		gold = (int)((victim->get_gold() * number(1, 10)) / 100);
-		if (gold > 0)
-		{
-			ch->add_gold(gold);
-			victim->remove_gold(gold);
-		}
-		// Steal something from equipment
-		if (IS_CARRYING_N(ch) < CAN_CARRY_N(ch) && calculate_skill(ch, SKILL_STEAL, victim)
-			>= number(1, 100) - (AWAKE(victim) ? 100 : 0))
-		{
-			for (obj = victim->carrying; obj; obj = obj->get_next_content())
-				if (CAN_SEE_OBJ(ch, obj) && IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(obj)
-					<= CAN_CARRY_W(ch) && (!best || GET_OBJ_COST(obj) > GET_OBJ_COST(best)))
-					best = obj;
-			if (best)
-			{
-				obj_from_char(best);
-				obj_to_char(best, ch);
-				max++;
-			}
-		}
-	}
-	return (max);
+  if (AWAKE(victim) && (number(0, MAX(0, GET_LEVEL(ch) - int_app[GET_REAL_INT(victim)].observation)) == 0)) {
+    act("Вы обнаружили руку $n1 в своем кармане.", FALSE, ch, 0, victim, TO_VICT);
+    act("$n пытал$u обокрасть $N3.", TRUE, ch, 0, victim, TO_NOTVICT);
+  } else        // Steal some gold coins
+  {
+    gold = (int) ((victim->get_gold() * number(1, 10)) / 100);
+    if (gold > 0) {
+      ch->add_gold(gold);
+      victim->remove_gold(gold);
+    }
+    // Steal something from equipment
+    if (IS_CARRYING_N(ch) < CAN_CARRY_N(ch) && CalcCurrentSkill(ch, SKILL_STEAL, victim)
+        >= number(1, 100) - (AWAKE(victim) ? 100 : 0)) {
+      for (obj = victim->carrying; obj; obj = obj->get_next_content())
+        if (CAN_SEE_OBJ(ch, obj) && IS_CARRYING_W(ch) + GET_OBJ_WEIGHT(obj)
+            <= CAN_CARRY_W(ch) && (!best || GET_OBJ_COST(obj) > GET_OBJ_COST(best)))
+          best = obj;
+      if (best) {
+        obj_from_char(best);
+        obj_to_char(best, ch);
+        max++;
+      }
+    }
+  }
+  return (max);
 }
 
-int npc_steal(CHAR_DATA * ch)
-{
-	if (!NPC_FLAGGED(ch, NPC_STEALING))
-		return (FALSE);
+int npc_steal(CHAR_DATA *ch) {
+  if (!NPC_FLAGGED(ch, NPC_STEALING))
+    return (FALSE);
 
-	if (GET_POS(ch) != POS_STANDING || IS_SHOPKEEPER(ch) || ch->get_fighting())
-		return (FALSE);
+  if (GET_POS(ch) != POS_STANDING || IS_SHOPKEEPER(ch) || ch->get_fighting())
+    return (FALSE);
 
-	for (const auto cons : world[ch->in_room]->people)
-	{
-		if (!IS_NPC(cons)
-			&& !IS_IMMORTAL(cons)
-			&& (number(0, GET_REAL_INT(ch)) > 10))
-		{
-			return (do_npc_steal(ch, cons));
-		}
-	}
+  for (const auto cons : world[ch->in_room]->people) {
+    if (!IS_NPC(cons)
+        && !IS_IMMORTAL(cons)
+        && (number(0, GET_REAL_INT(ch)) > 10)) {
+      return (do_npc_steal(ch, cons));
+    }
+  }
 
-	return FALSE;
+  return FALSE;
 }
 
 #define ZONE(ch)  (GET_MOB_VNUM(ch) / 100)
 #define GROUP(ch) ((GET_MOB_VNUM(ch) % 100) / 10)
 
-void npc_group(CHAR_DATA * ch)
-{
-	CHAR_DATA *leader = NULL;
-	int zone = ZONE(ch), group = GROUP(ch), members = 0;
+void npc_group(CHAR_DATA *ch) {
+  CHAR_DATA *leader = NULL;
+  int zone = ZONE(ch), group = GROUP(ch), members = 0;
 
-	if (GET_DEST(ch) == NOWHERE || ch->in_room == NOWHERE)
-		return;
+  if (GET_DEST(ch) == NOWHERE || ch->in_room == NOWHERE)
+    return;
 
-	if (ch->has_master()
-		&& ch->in_room == IN_ROOM(ch->get_master()))
-	{
-		leader = ch->get_master();
-	}
+  if (ch->has_master()
+      && ch->in_room == IN_ROOM(ch->get_master())) {
+    leader = ch->get_master();
+  }
 
-	if (!ch->has_master())
-	{
-		leader = ch;
-	}
+  if (!ch->has_master()) {
+    leader = ch;
+  }
 
-	if (leader
-		&& (AFF_FLAGGED(leader, EAffectFlag::AFF_CHARM)
-			|| GET_POS(leader) < POS_SLEEPING))
-	{
-		leader = NULL;
-	}
+  if (leader
+      && (AFF_FLAGGED(leader, EAffectFlag::AFF_CHARM)
+          || GET_POS(leader) < POS_SLEEPING)) {
+    leader = NULL;
+  }
 
-	// Find leader
-	for (const auto vict : world[ch->in_room]->people)
-	{
-		if (!IS_NPC(vict)
-			|| GET_DEST(vict) != GET_DEST(ch)
-			|| zone != ZONE(vict)
-			|| group != GROUP(vict)
-			|| AFF_FLAGGED(vict, EAffectFlag::AFF_CHARM)
-			|| GET_POS(vict) < POS_SLEEPING)
-		{
-			continue;
-		}
+  // Find leader
+  for (const auto vict : world[ch->in_room]->people) {
+    if (!IS_NPC(vict)
+        || GET_DEST(vict) != GET_DEST(ch)
+        || zone != ZONE(vict)
+        || group != GROUP(vict)
+        || AFF_FLAGGED(vict, EAffectFlag::AFF_CHARM)
+        || GET_POS(vict) < POS_SLEEPING) {
+      continue;
+    }
 
-		members++;
+    members++;
 
-		if (!leader
-			|| GET_REAL_INT(vict) > GET_REAL_INT(leader))
-		{
-			leader = vict;
-		}
-	}
+    if (!leader
+        || GET_REAL_INT(vict) > GET_REAL_INT(leader)) {
+      leader = vict;
+    }
+  }
 
-	if (members <= 1)
-	{
-		if (ch->has_master())
-		{
-			stop_follower(ch, SF_EMPTY);
-		}
+  if (members <= 1) {
+    if (ch->has_master()) {
+      stop_follower(ch, SF_EMPTY);
+    }
 
-		return;
-	}
+    return;
+  }
 
-	if (leader->has_master())
-	{
-		stop_follower(leader, SF_EMPTY);
-	}
+  if (leader->has_master()) {
+    stop_follower(leader, SF_EMPTY);
+  }
 
-	// Assign leader
-	for (const auto vict : world[ch->in_room]->people)
-	{
-		if (!IS_NPC(vict)
-			|| GET_DEST(vict) != GET_DEST(ch)
-			|| zone != ZONE(vict)
-			|| group != GROUP(vict)
-			|| AFF_FLAGGED(vict, EAffectFlag::AFF_CHARM)
-			|| GET_POS(vict) < POS_SLEEPING)
-		{
-			continue;
-		}
+  // Assign leader
+  for (const auto vict : world[ch->in_room]->people) {
+    if (!IS_NPC(vict)
+        || GET_DEST(vict) != GET_DEST(ch)
+        || zone != ZONE(vict)
+        || group != GROUP(vict)
+        || AFF_FLAGGED(vict, EAffectFlag::AFF_CHARM)
+        || GET_POS(vict) < POS_SLEEPING) {
+      continue;
+    }
 
-		if (vict == leader)
-		{
-			AFF_FLAGS(vict).set(EAffectFlag::AFF_GROUP);
-			continue;
-		}
+    if (vict == leader) {
+      AFF_FLAGS(vict).set(EAffectFlag::AFF_GROUP);
+      continue;
+    }
 
-		if (!vict->has_master())
-		{
-			leader->add_follower(vict);
-		}
-		else if (vict->get_master() != leader)
-		{
-			stop_follower(vict, SF_EMPTY);
-			leader->add_follower(vict);
-		}
-		AFF_FLAGS(vict).set(EAffectFlag::AFF_GROUP);
-	}
+    if (!vict->has_master()) {
+      leader->add_follower(vict);
+    } else if (vict->get_master() != leader) {
+      stop_follower(vict, SF_EMPTY);
+      leader->add_follower(vict);
+    }
+    AFF_FLAGS(vict).set(EAffectFlag::AFF_GROUP);
+  }
 }
 
-void npc_groupbattle(CHAR_DATA * ch)
-{
-	struct follow_type *k;
-	CHAR_DATA *tch, *helper;
+void npc_groupbattle(CHAR_DATA *ch) {
+  struct follow_type *k;
+  CHAR_DATA *tch, *helper;
 
-	if (!IS_NPC(ch)
-		|| !ch->get_fighting()
-		|| AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
-		|| !ch->has_master()
-		|| ch->in_room == NOWHERE
-		|| !ch->followers)
-	{
-		return;
-	}
+  if (!IS_NPC(ch)
+      || !ch->get_fighting()
+      || AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM)
+      || !ch->has_master()
+      || ch->in_room == NOWHERE
+      || !ch->followers) {
+    return;
+  }
 
-	k = ch->has_master() ? ch->get_master()->followers : ch->followers;
-	tch = ch->has_master() ? ch->get_master() : ch;
-	for (; k; (k = tch ? k : k->next), tch = NULL)
-	{
-		helper = tch ? tch : k->follower;
-		if (ch->in_room == IN_ROOM(helper)
-			&& !helper->get_fighting()
-			&& !IS_NPC(helper)
-			&& GET_POS(helper) > POS_STUNNED)
-		{
-			GET_POS(helper) = POS_STANDING;
-			set_fighting(helper, ch->get_fighting());
-			act("$n вступил$u за $N3.", FALSE, helper, 0, ch, TO_ROOM);
-		}
-	}
+  k = ch->has_master() ? ch->get_master()->followers : ch->followers;
+  tch = ch->has_master() ? ch->get_master() : ch;
+  for (; k; (k = tch ? k : k->next), tch = NULL) {
+    helper = tch ? tch : k->follower;
+    if (ch->in_room == IN_ROOM(helper)
+        && !helper->get_fighting()
+        && !IS_NPC(helper)
+        && GET_POS(helper) > POS_STUNNED) {
+      GET_POS(helper) = POS_STANDING;
+      set_fighting(helper, ch->get_fighting());
+      act("$n вступил$u за $N3.", FALSE, helper, 0, ch, TO_ROOM);
+    }
+  }
 }
 
-int dump(CHAR_DATA *ch, void* /*me*/, int cmd, char* argument)
-{
-	OBJ_DATA *k;
-	int value = 0;
+int dump(CHAR_DATA *ch, void * /*me*/, int cmd, char *argument) {
+  OBJ_DATA *k;
+  int value = 0;
 
-	for (k = world[ch->in_room]->contents; k; k = world[ch->in_room]->contents)
-	{
-		act("$p рассыпал$U в прах!", FALSE, 0, k, 0, TO_ROOM);
-		extract_obj(k);
-	}
+  for (k = world[ch->in_room]->contents; k; k = world[ch->in_room]->contents) {
+    act("$p рассыпал$U в прах!", FALSE, 0, k, 0, TO_ROOM);
+    extract_obj(k);
+  }
 
-	if (!CMD_IS("drop") || !CMD_IS("бросить"))
-		return (0);
+  if (!CMD_IS("drop") || !CMD_IS("бросить"))
+    return (0);
 
-	do_drop(ch, argument, cmd, 0);
+  do_drop(ch, argument, cmd, 0);
 
-	for (k = world[ch->in_room]->contents; k; k = world[ch->in_room]->contents)
-	{
-		act("$p рассыпал$U в прах!", FALSE, 0, k, 0, TO_ROOM);
-		value += MAX(1, MIN(1, GET_OBJ_COST(k) / 10));
-		extract_obj(k);
-	}
+  for (k = world[ch->in_room]->contents; k; k = world[ch->in_room]->contents) {
+    act("$p рассыпал$U в прах!", FALSE, 0, k, 0, TO_ROOM);
+    value += MAX(1, MIN(1, GET_OBJ_COST(k) / 10));
+    extract_obj(k);
+  }
 
-	if (value)
-	{
-		send_to_char("Боги оценили вашу жертву.\r\n", ch);
-		act("$n оценен$y Богами.", TRUE, ch, 0, 0, TO_ROOM);
-		if (GET_LEVEL(ch) < 3)
-			gain_exp(ch, value);
-		else
-			ch->add_gold(value);
-	}
-	return (1);
+  if (value) {
+    send_to_char("Боги оценили вашу жертву.\r\n", ch);
+    act("$n оценен$y Богами.", TRUE, ch, 0, 0, TO_ROOM);
+    if (GET_LEVEL(ch) < 3)
+      gain_exp(ch, value);
+    else
+      ch->add_gold(value);
+  }
+  return (1);
 }
 
 #if 0
-void mayor(CHAR_DATA *ch, void *me, int cmd, char* argument)
+                                                                                                                        void mayor(CHAR_DATA *ch, void *me, int cmd, char* argument)
 {
 	const char open_path[] = "W3a3003b33000c111d0d111Oe333333Oe22c222112212111a1S.";
 	const char close_path[] = "W3a3003b33000c111d0d111CE333333CE22c222112212111a1S.";
@@ -3041,100 +2577,79 @@ void mayor(CHAR_DATA *ch, void *me, int cmd, char* argument)
 	return FALSE;
 }
 */
-int magic_user(CHAR_DATA *ch, void* /*me*/, int cmd, char* /*argument*/)
-{
-	if (cmd || GET_POS(ch) != POS_FIGHTING)
-	{
-		return (FALSE);
-	}
+int magic_user(CHAR_DATA *ch, void * /*me*/, int cmd, char * /*argument*/) {
+  if (cmd || GET_POS(ch) != POS_FIGHTING) {
+    return (FALSE);
+  }
 
-	CHAR_DATA *target = nullptr;
-	// pseudo-randomly choose someone in the room who is fighting me //
-	for (const auto vict : world[ch->in_room]->people)
-	{
-		if (vict->get_fighting() == ch
-			&& !number(0, 4))
-		{
-			target = vict;
+  CHAR_DATA *target = nullptr;
+  // pseudo-randomly choose someone in the room who is fighting me //
+  for (const auto vict : world[ch->in_room]->people) {
+    if (vict->get_fighting() == ch
+        && !number(0, 4)) {
+      target = vict;
 
-			break;
-		}
-	}
+      break;
+    }
+  }
 
-	// if I didn't pick any of those, then just slam the guy I'm fighting //
-	if (target == nullptr
-		&& IN_ROOM(ch->get_fighting()) == ch->in_room)
-	{
-		target = ch->get_fighting();
-	}
+  // if I didn't pick any of those, then just slam the guy I'm fighting //
+  if (target == nullptr
+      && IN_ROOM(ch->get_fighting()) == ch->in_room) {
+    target = ch->get_fighting();
+  }
 
-	// Hm...didn't pick anyone...I'll wait a round. //
-	if (target == nullptr)
-	{
-		return (TRUE);
-	}
+  // Hm...didn't pick anyone...I'll wait a round. //
+  if (target == nullptr) {
+    return (TRUE);
+  }
 
-	if ((GET_LEVEL(ch) > 13) && (number(0, 10) == 0))
-	{
-		cast_spell(ch, target, NULL, NULL, SPELL_SLEEP, SPELL_SLEEP);
-	}
+  if ((GET_LEVEL(ch) > 13) && (number(0, 10) == 0)) {
+    cast_spell(ch, target, NULL, NULL, SPELL_SLEEP, SPELL_SLEEP);
+  }
 
-	if ((GET_LEVEL(ch) > 7) && (number(0, 8) == 0))
-	{
-		cast_spell(ch, target, NULL, NULL, SPELL_BLINDNESS, SPELL_BLINDNESS);
-	}
+  if ((GET_LEVEL(ch) > 7) && (number(0, 8) == 0)) {
+    cast_spell(ch, target, NULL, NULL, SPELL_BLINDNESS, SPELL_BLINDNESS);
+  }
 
-	if ((GET_LEVEL(ch) > 12) && (number(0, 12) == 0))
-	{
-		if (IS_EVIL(ch))
-		{
-			cast_spell(ch, target, NULL, NULL, SPELL_ENERGY_DRAIN, SPELL_ENERGY_DRAIN);
-		}
-		else if (IS_GOOD(ch))
-		{
-			cast_spell(ch, target, NULL, NULL, SPELL_DISPEL_EVIL, SPELL_DISPEL_EVIL);
-		}
-	}
+  if ((GET_LEVEL(ch) > 12) && (number(0, 12) == 0)) {
+    if (IS_EVIL(ch)) {
+      cast_spell(ch, target, NULL, NULL, SPELL_ENERGY_DRAIN, SPELL_ENERGY_DRAIN);
+    } else if (IS_GOOD(ch)) {
+      cast_spell(ch, target, NULL, NULL, SPELL_DISPEL_EVIL, SPELL_DISPEL_EVIL);
+    }
+  }
 
-	if (number(0, 4))
-	{
-		return (TRUE);
-	}
+  if (number(0, 4)) {
+    return (TRUE);
+  }
 
-	switch (GET_LEVEL(ch))
-	{
-	case 4:
-	case 5:
-		cast_spell(ch, target, NULL, NULL, SPELL_MAGIC_MISSILE, SPELL_MAGIC_MISSILE);
-		break;
-	case 6:
-	case 7:
-		cast_spell(ch, target, NULL, NULL, SPELL_CHILL_TOUCH, SPELL_CHILL_TOUCH);
-		break;
-	case 8:
-	case 9:
-		cast_spell(ch, target, NULL, NULL, SPELL_BURNING_HANDS, SPELL_BURNING_HANDS);
-		break;
-	case 10:
-	case 11:
-		cast_spell(ch, target, NULL, NULL, SPELL_SHOCKING_GRASP, SPELL_SHOCKING_GRASP);
-		break;
-	case 12:
-	case 13:
-		cast_spell(ch, target, NULL, NULL, SPELL_LIGHTNING_BOLT, SPELL_LIGHTNING_BOLT);
-		break;
-	case 14:
-	case 15:
-	case 16:
-	case 17:
-		cast_spell(ch, target, NULL, NULL, SPELL_COLOR_SPRAY, SPELL_COLOR_SPRAY);
-		break;
-	default:
-		cast_spell(ch, target, NULL, NULL, SPELL_FIREBALL, SPELL_FIREBALL);
-		break;
-	}
+  switch (GET_LEVEL(ch)) {
+    case 4:
+    case 5: cast_spell(ch, target, NULL, NULL, SPELL_MAGIC_MISSILE, SPELL_MAGIC_MISSILE);
+      break;
+    case 6:
+    case 7: cast_spell(ch, target, NULL, NULL, SPELL_CHILL_TOUCH, SPELL_CHILL_TOUCH);
+      break;
+    case 8:
+    case 9: cast_spell(ch, target, NULL, NULL, SPELL_BURNING_HANDS, SPELL_BURNING_HANDS);
+      break;
+    case 10:
+    case 11: cast_spell(ch, target, NULL, NULL, SPELL_SHOCKING_GRASP, SPELL_SHOCKING_GRASP);
+      break;
+    case 12:
+    case 13: cast_spell(ch, target, NULL, NULL, SPELL_LIGHTNING_BOLT, SPELL_LIGHTNING_BOLT);
+      break;
+    case 14:
+    case 15:
+    case 16:
+    case 17: cast_spell(ch, target, NULL, NULL, SPELL_COLOR_SPRAY, SPELL_COLOR_SPRAY);
+      break;
+    default: cast_spell(ch, target, NULL, NULL, SPELL_FIREBALL, SPELL_FIREBALL);
+      break;
+  }
 
-	return (TRUE);
+  return (TRUE);
 }
 
 
@@ -3142,391 +2657,341 @@ int magic_user(CHAR_DATA *ch, void* /*me*/, int cmd, char* /*argument*/)
 // *  Special procedures for mobiles                                  *
 // ********************************************************************
 
-int guild_guard(CHAR_DATA *ch, void *me, int cmd, char* /*argument*/)
-{
-	int i;
-	CHAR_DATA *guard = (CHAR_DATA *) me;
-	const char *buf = "Охранник остановил вас, преградив дорогу.\r\n";
-	const char *buf2 = "Охранник остановил $n, преградив $m дорогу.";
+int guild_guard(CHAR_DATA *ch, void *me, int cmd, char * /*argument*/) {
+  int i;
+  CHAR_DATA *guard = (CHAR_DATA *) me;
+  const char *buf = "Охранник остановил вас, преградив дорогу.\r\n";
+  const char *buf2 = "Охранник остановил $n, преградив $m дорогу.";
 
-	if (!IS_MOVE(cmd) || AFF_FLAGGED(guard, EAffectFlag::AFF_BLIND)
-			|| AFF_FLAGGED(guard, EAffectFlag::AFF_HOLD))
-		return (FALSE);
+  if (!IS_MOVE(cmd) || AFF_FLAGGED(guard, EAffectFlag::AFF_BLIND)
+      || AFF_FLAGGED(guard, EAffectFlag::AFF_HOLD))
+    return (FALSE);
 
-	if (GET_LEVEL(ch) >= LVL_IMMORT)
-		return (FALSE);
+  if (GET_LEVEL(ch) >= LVL_IMMORT)
+    return (FALSE);
 
-	for (i = 0; guild_info[i][0] != -1; i++)
-	{
-		if ((IS_NPC(ch) || GET_CLASS(ch) != guild_info[i][0]) &&
-				GET_ROOM_VNUM(ch->in_room) == guild_info[i][1] && cmd == guild_info[i][2])
-		{
-			send_to_char(buf, ch);
-			act(buf2, FALSE, ch, 0, 0, TO_ROOM);
-			return (TRUE);
-		}
-	}
+  for (i = 0; guild_info[i][0] != -1; i++) {
+    if ((IS_NPC(ch) || GET_CLASS(ch) != guild_info[i][0]) &&
+        GET_ROOM_VNUM(ch->in_room) == guild_info[i][1] && cmd == guild_info[i][2]) {
+      send_to_char(buf, ch);
+      act(buf2, FALSE, ch, 0, 0, TO_ROOM);
+      return (TRUE);
+    }
+  }
 
-	return (FALSE);
+  return (FALSE);
 }
 
 // TODO: повырезать все это
-int puff(CHAR_DATA* /*ch*/, void* /*me*/, int/* cmd*/, char* /*argument*/)
-{
-	return 0;
+int puff(CHAR_DATA * /*ch*/, void * /*me*/, int/* cmd*/, char * /*argument*/) {
+  return 0;
 }
 
-int fido(CHAR_DATA *ch, void* /*me*/, int cmd, char* /*argument*/)
-{
-	OBJ_DATA *i, *temp, *next_obj;
+int fido(CHAR_DATA *ch, void * /*me*/, int cmd, char * /*argument*/) {
+  OBJ_DATA *i, *temp, *next_obj;
 
-	if (cmd || !AWAKE(ch))
-		return (FALSE);
+  if (cmd || !AWAKE(ch))
+    return (FALSE);
 
-	for (i = world[ch->in_room]->contents; i; i = i->get_next_content())
-	{
-		if (IS_CORPSE(i))
-		{
-			act("$n savagely devours a corpse.", FALSE, ch, 0, 0, TO_ROOM);
-			for (temp = i->get_contains(); temp; temp = next_obj)
-			{
-				next_obj = temp->get_next_content();
-				obj_from_obj(temp);
-				obj_to_room(temp, ch->in_room);
-			}
-			extract_obj(i);
-			return (TRUE);
-		}
-	}
-	return (FALSE);
+  for (i = world[ch->in_room]->contents; i; i = i->get_next_content()) {
+    if (IS_CORPSE(i)) {
+      act("$n savagely devours a corpse.", FALSE, ch, 0, 0, TO_ROOM);
+      for (temp = i->get_contains(); temp; temp = next_obj) {
+        next_obj = temp->get_next_content();
+        obj_from_obj(temp);
+        obj_to_room(temp, ch->in_room);
+      }
+      extract_obj(i);
+      return (TRUE);
+    }
+  }
+  return (FALSE);
 }
 
-int janitor(CHAR_DATA *ch, void* /*me*/, int cmd, char* /*argument*/)
-{
-	OBJ_DATA *i;
+int janitor(CHAR_DATA *ch, void * /*me*/, int cmd, char * /*argument*/) {
+  OBJ_DATA *i;
 
-	if (cmd || !AWAKE(ch))
-		return (FALSE);
+  if (cmd || !AWAKE(ch))
+    return (FALSE);
 
-	for (i = world[ch->in_room]->contents; i; i = i->get_next_content())
-	{
-		if (!CAN_WEAR(i, EWearFlag::ITEM_WEAR_TAKE))
-		{
-			continue;
-		}
+  for (i = world[ch->in_room]->contents; i; i = i->get_next_content()) {
+    if (!CAN_WEAR(i, EWearFlag::ITEM_WEAR_TAKE)) {
+      continue;
+    }
 
-		if (GET_OBJ_TYPE(i) != OBJ_DATA::ITEM_DRINKCON
-			&& GET_OBJ_COST(i) >= 15)
-		{
-			continue;
-		}
+    if (GET_OBJ_TYPE(i) != OBJ_DATA::ITEM_DRINKCON
+        && GET_OBJ_COST(i) >= 15) {
+      continue;
+    }
 
-		act("$n picks up some trash.", FALSE, ch, 0, 0, TO_ROOM);
-		obj_from_room(i);
-		obj_to_char(i, ch);
+    act("$n picks up some trash.", FALSE, ch, 0, 0, TO_ROOM);
+    obj_from_room(i);
+    obj_to_char(i, ch);
 
-		return TRUE;
-	}
+    return TRUE;
+  }
 
-	return FALSE;
+  return FALSE;
 }
 
-int cityguard(CHAR_DATA *ch, void* /*me*/, int cmd, char* /*argument*/)
-{
-	CHAR_DATA *evil;
-	int max_evil;
+int cityguard(CHAR_DATA *ch, void * /*me*/, int cmd, char * /*argument*/) {
+  CHAR_DATA *evil;
+  int max_evil;
 
-	if (cmd
-		|| !AWAKE(ch)
-		|| ch->get_fighting())
-	{
-		return (FALSE);
-	}
+  if (cmd
+      || !AWAKE(ch)
+      || ch->get_fighting()) {
+    return (FALSE);
+  }
 
-	max_evil = 1000;
-	evil = 0;
+  max_evil = 1000;
+  evil = 0;
 
-	for (const auto tch : world[ch->in_room]->people)
-	{
-		if (!IS_NPC(tch) && CAN_SEE(ch, tch) && PLR_FLAGGED(tch, PLR_KILLER))
-		{
-			act("$n screams 'HEY!!!  You're one of those PLAYER KILLERS!!!!!!'", FALSE, ch, 0, 0, TO_ROOM);
-			hit(ch, tch, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
+  for (const auto tch : world[ch->in_room]->people) {
+    if (!IS_NPC(tch) && CAN_SEE(ch, tch) && PLR_FLAGGED(tch, PLR_KILLER)) {
+      act("$n screams 'HEY!!!  You're one of those PLAYER KILLERS!!!!!!'", FALSE, ch, 0, 0, TO_ROOM);
+      hit(ch, tch, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
 
-			return (TRUE);
-		}
-	}
+      return (TRUE);
+    }
+  }
 
-	for (const auto tch : world[ch->in_room]->people)
-	{
-		if (!IS_NPC(tch) && CAN_SEE(ch, tch) && PLR_FLAGGED(tch, PLR_THIEF))
-		{
-			act("$n screams 'HEY!!!  You're one of those PLAYER THIEVES!!!!!!'", FALSE, ch, 0, 0, TO_ROOM);
-			hit(ch, tch, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
+  for (const auto tch : world[ch->in_room]->people) {
+    if (!IS_NPC(tch) && CAN_SEE(ch, tch) && PLR_FLAGGED(tch, PLR_THIEF)) {
+      act("$n screams 'HEY!!!  You're one of those PLAYER THIEVES!!!!!!'", FALSE, ch, 0, 0, TO_ROOM);
+      hit(ch, tch, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
 
-			return (TRUE);
-		}
-	}
+      return (TRUE);
+    }
+  }
 
-	for (const auto tch : world[ch->in_room]->people)
-	{
-		if (CAN_SEE(ch, tch) && tch->get_fighting())
-		{
-			if ((GET_ALIGNMENT(tch) < max_evil) && (IS_NPC(tch) || IS_NPC(tch->get_fighting())))
-			{
-				max_evil = GET_ALIGNMENT(tch);
-				evil = tch;
-			}
-		}
-	}
+  for (const auto tch : world[ch->in_room]->people) {
+    if (CAN_SEE(ch, tch) && tch->get_fighting()) {
+      if ((GET_ALIGNMENT(tch) < max_evil) && (IS_NPC(tch) || IS_NPC(tch->get_fighting()))) {
+        max_evil = GET_ALIGNMENT(tch);
+        evil = tch;
+      }
+    }
+  }
 
-	if (evil
-		&& (GET_ALIGNMENT(evil->get_fighting()) >= 0))
-	{
-		act("$n screams 'PROTECT THE INNOCENT!  BANZAI!  CHARGE!  ARARARAGGGHH!'", FALSE, ch, 0, 0, TO_ROOM);
-		hit(ch, evil, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
+  if (evil
+      && (GET_ALIGNMENT(evil->get_fighting()) >= 0)) {
+    act("$n screams 'PROTECT THE INNOCENT!  BANZAI!  CHARGE!  ARARARAGGGHH!'", FALSE, ch, 0, 0, TO_ROOM);
+    hit(ch, evil, ESkill::SKILL_UNDEF, FightSystem::MAIN_HAND);
 
-		return (TRUE);
-	}
+    return (TRUE);
+  }
 
-	return (FALSE);
+  return (FALSE);
 }
-
 
 #define PET_PRICE(pet) (GET_LEVEL(pet) * 300)
 
-int pet_shops(CHAR_DATA *ch, void* /*me*/, int cmd, char* argument)
-{
-	char buf[MAX_STRING_LENGTH], pet_name[256];
-	room_rnum pet_room;
-	CHAR_DATA *pet;
+int pet_shops(CHAR_DATA *ch, void * /*me*/, int cmd, char *argument) {
+  char buf[MAX_STRING_LENGTH], pet_name[256];
+  room_rnum pet_room;
+  CHAR_DATA *pet;
 
-	pet_room = ch->in_room + 1;
+  pet_room = ch->in_room + 1;
 
-	if (CMD_IS("list"))
-	{
-		send_to_char("Available pets are:\r\n", ch);
-		for (const auto pet : world[pet_room]->people)
-		{
-			sprintf(buf, "%8d - %s\r\n", PET_PRICE(pet), GET_NAME(pet));
-			send_to_char(buf, ch);
-		}
+  if (CMD_IS("list")) {
+    send_to_char("Available pets are:\r\n", ch);
+    for (const auto pet : world[pet_room]->people) {
+      sprintf(buf, "%8d - %s\r\n", PET_PRICE(pet), GET_NAME(pet));
+      send_to_char(buf, ch);
+    }
 
-		return (TRUE);
-	}
-	else if (CMD_IS("buy"))
-	{
-		two_arguments(argument, buf, pet_name);
+    return (TRUE);
+  } else if (CMD_IS("buy")) {
+    two_arguments(argument, buf, pet_name);
 
-		if (!(pet = get_char_room(buf, pet_room)))
-		{
-			send_to_char("There is no such pet!\r\n", ch);
-			return (TRUE);
-		}
-		if (ch->get_gold() < PET_PRICE(pet))
-		{
-			send_to_char("You don't have enough gold!\r\n", ch);
-			return (TRUE);
-		}
-		ch->remove_gold(PET_PRICE(pet));
+    if (!(pet = get_char_room(buf, pet_room))) {
+      send_to_char("There is no such pet!\r\n", ch);
+      return (TRUE);
+    }
+    if (ch->get_gold() < PET_PRICE(pet)) {
+      send_to_char("You don't have enough gold!\r\n", ch);
+      return (TRUE);
+    }
+    ch->remove_gold(PET_PRICE(pet));
 
-		pet = read_mobile(GET_MOB_RNUM(pet), REAL);
-		pet->set_exp(0);
-		AFF_FLAGS(pet).set(EAffectFlag::AFF_CHARM);
+    pet = read_mobile(GET_MOB_RNUM(pet), REAL);
+    pet->set_exp(0);
+    AFF_FLAGS(pet).set(EAffectFlag::AFF_CHARM);
 
-		if (*pet_name)
-		{
-			sprintf(buf, "%s %s", pet->get_pc_name().c_str(), pet_name);
-			// free(pet->get_pc_name()); don't free the prototype!
-			pet->set_pc_name(buf);
+    if (*pet_name) {
+      sprintf(buf, "%s %s", pet->get_pc_name().c_str(), pet_name);
+      // free(pet->get_pc_name()); don't free the prototype!
+      pet->set_pc_name(buf);
 
-			sprintf(buf,
-					"%sA small sign on a chain around the neck says 'My name is %s'\r\n",
-					pet->player_data.description.c_str(), pet_name);
-			// free(pet->player_data.description); don't free the prototype!
-			pet->player_data.description = str_dup(buf);
-		}
-		char_to_room(pet, ch->in_room);
-		ch->add_follower(pet);
-		load_mtrigger(pet);
+      sprintf(buf,
+              "%sA small sign on a chain around the neck says 'My name is %s'\r\n",
+              pet->player_data.description.c_str(), pet_name);
+      // free(pet->player_data.description); don't free the prototype!
+      pet->player_data.description = str_dup(buf);
+    }
+    char_to_room(pet, ch->in_room);
+    ch->add_follower(pet);
+    load_mtrigger(pet);
 
-		// Be certain that pets can't get/carry/use/wield/wear items
-		IS_CARRYING_W(pet) = 1000;
-		IS_CARRYING_N(pet) = 100;
+    // Be certain that pets can't get/carry/use/wield/wear items
+    IS_CARRYING_W(pet) = 1000;
+    IS_CARRYING_N(pet) = 100;
 
-		send_to_char("May you enjoy your pet.\r\n", ch);
-		act("$n buys $N as a pet.", FALSE, ch, 0, pet, TO_ROOM);
+    send_to_char("May you enjoy your pet.\r\n", ch);
+    act("$n buys $N as a pet.", FALSE, ch, 0, pet, TO_ROOM);
 
-		return (1);
-	}
+    return (1);
+  }
 
-	// All commands except list and buy
-	return (0);
+  // All commands except list and buy
+  return (0);
 }
 
+CHAR_DATA *get_player_of_name(const char *name) {
+  for (const auto &i : character_list) {
+    if (IS_NPC(i)) {
+      continue;
+    }
 
-CHAR_DATA *get_player_of_name(const char *name)
-{
-	for (const auto& i : character_list)
-	{
-		if (IS_NPC(i))
-		{
-			continue;
-		}
+    if (!isname(name, i->get_pc_name())) {
+      continue;
+    }
 
-		if (!isname(name, i->get_pc_name()))
-		{
-			continue;
-		}
+    return i.get();
+  }
 
-		return i.get();
-	}
-
-	return nullptr;
+  return nullptr;
 }
 
 // ********************************************************************
 // *  Special procedures for objects                                  *
 // ********************************************************************
-int bank(CHAR_DATA *ch, void* /*me*/, int cmd, char* argument)
-{
-	int amount;
-	CHAR_DATA *vict;
+int bank(CHAR_DATA *ch, void * /*me*/, int cmd, char *argument) {
+  int amount;
+  CHAR_DATA *vict;
 
-	if (CMD_IS("balance") || CMD_IS("баланс") || CMD_IS("сальдо"))
-	{
-		if (ch->get_bank() > 0)
-			sprintf(buf, "У вас на счету %ld %s.\r\n",
-					ch->get_bank(), desc_count(ch->get_bank(), WHAT_MONEYa));
-		else
-			sprintf(buf, "У вас нет денег.\r\n");
-		send_to_char(buf, ch);
-		return (1);
-	}
-	else if (CMD_IS("deposit") || CMD_IS("вложить") || CMD_IS("вклад"))
-	{
-		if ((amount = atoi(argument)) <= 0)
-		{
-			send_to_char("Сколько вы хотите вложить?\r\n", ch);
-			return (1);
-		}
-		if (ch->get_gold() < amount)
-		{
-			send_to_char("О такой сумме вы можете только мечтать!\r\n", ch);
-			return (1);
-		}
-		ch->remove_gold(amount, false);
-		ch->add_bank(amount, false);
-		sprintf(buf, "Вы вложили %d %s.\r\n", amount, desc_count(amount, WHAT_MONEYu));
-		send_to_char(buf, ch);
-		act("$n произвел$g финансовую операцию.", TRUE, ch, 0, FALSE, TO_ROOM);
-		return (1);
-	}
-	else if (CMD_IS("withdraw") || CMD_IS("получить"))
-	{
-		if ((amount = atoi(argument)) <= 0)
-		{
-			send_to_char("Уточните количество денег, которые вы хотите получить?\r\n", ch);
-			return (1);
-		}
-		if (ch->get_bank() < amount)
-		{
-			send_to_char("Да вы отродясь столько денег не видели!\r\n", ch);
-			return (1);
-		}
-		ch->add_gold(amount, false);
-		ch->remove_bank(amount, false);
-		sprintf(buf, "Вы сняли %d %s.\r\n", amount, desc_count(amount, WHAT_MONEYu));
-		send_to_char(buf, ch);
-		act("$n произвел$g финансовую операцию.", TRUE, ch, 0, FALSE, TO_ROOM);
-		return (1);
-	}
-	else if (CMD_IS("transfer") || CMD_IS("перевести"))
-	{
-		argument = one_argument(argument, arg);
-		amount = atoi(argument);
-		if (IS_GOD(ch) && !IS_IMPL(ch))
-		{
-			send_to_char("Почитить захотелось?\r\n", ch);
-			return (1);
+  if (CMD_IS("balance") || CMD_IS("баланс") || CMD_IS("сальдо")) {
+    if (ch->get_bank() > 0)
+      sprintf(buf, "У вас на счету %ld %s.\r\n",
+              ch->get_bank(), desc_count(ch->get_bank(), WHAT_MONEYa));
+    else
+      sprintf(buf, "У вас нет денег.\r\n");
+    send_to_char(buf, ch);
+    return (1);
+  } else if (CMD_IS("deposit") || CMD_IS("вложить") || CMD_IS("вклад")) {
+    if ((amount = atoi(argument)) <= 0) {
+      send_to_char("Сколько вы хотите вложить?\r\n", ch);
+      return (1);
+    }
+    if (ch->get_gold() < amount) {
+      send_to_char("О такой сумме вы можете только мечтать!\r\n", ch);
+      return (1);
+    }
+    ch->remove_gold(amount, false);
+    ch->add_bank(amount, false);
+    sprintf(buf, "Вы вложили %d %s.\r\n", amount, desc_count(amount, WHAT_MONEYu));
+    send_to_char(buf, ch);
+    act("$n произвел$g финансовую операцию.", TRUE, ch, 0, FALSE, TO_ROOM);
+    return (1);
+  } else if (CMD_IS("withdraw") || CMD_IS("получить")) {
+    if ((amount = atoi(argument)) <= 0) {
+      send_to_char("Уточните количество денег, которые вы хотите получить?\r\n", ch);
+      return (1);
+    }
+    if (ch->get_bank() < amount) {
+      send_to_char("Да вы отродясь столько денег не видели!\r\n", ch);
+      return (1);
+    }
+    ch->add_gold(amount, false);
+    ch->remove_bank(amount, false);
+    sprintf(buf, "Вы сняли %d %s.\r\n", amount, desc_count(amount, WHAT_MONEYu));
+    send_to_char(buf, ch);
+    act("$n произвел$g финансовую операцию.", TRUE, ch, 0, FALSE, TO_ROOM);
+    return (1);
+  } else if (CMD_IS("transfer") || CMD_IS("перевести")) {
+    argument = one_argument(argument, arg);
+    amount = atoi(argument);
+    if (IS_GOD(ch) && !IS_IMPL(ch)) {
+      send_to_char("Почитить захотелось?\r\n", ch);
+      return (1);
 
-		}
-		if (!*arg)
-		{
-			send_to_char("Уточните кому вы хотите перевести?\r\n", ch);
-			return (1);
-		}
-		if (amount <= 0)
-		{
-			send_to_char("Уточните количество денег, которые вы хотите получить?\r\n", ch);
-			return (1);
-		}
-		if (amount <= 100)
-		{
-                    if (ch->get_bank() < (amount + 5))
-                    {
-                        send_to_char("У вас не хватит денег на налоги!\r\n", ch);
-			return (1);
-                    }
-		}
+    }
+    if (!*arg) {
+      send_to_char("Уточните кому вы хотите перевести?\r\n", ch);
+      return (1);
+    }
+    if (amount <= 0) {
+      send_to_char("Уточните количество денег, которые вы хотите получить?\r\n", ch);
+      return (1);
+    }
+    if (amount <= 100) {
+      if (ch->get_bank() < (amount + 5)) {
+        send_to_char("У вас не хватит денег на налоги!\r\n", ch);
+        return (1);
+      }
+    }
 
-		if (ch->get_bank() < amount)
-		{
-			send_to_char("Да вы отродясь столько денег не видели!\r\n", ch);
-			return (1);
-		}
-		if (ch->get_bank() < amount + ((amount * 5) / 100))
-		{
-			send_to_char("У вас не хватит денег на налоги!\r\n", ch);
-			return (1);
-		}
+    if (ch->get_bank() < amount) {
+      send_to_char("Да вы отродясь столько денег не видели!\r\n", ch);
+      return (1);
+    }
+    if (ch->get_bank() < amount + ((amount * 5) / 100)) {
+      send_to_char("У вас не хватит денег на налоги!\r\n", ch);
+      return (1);
+    }
 
-		if ((vict = get_player_of_name(arg)))
-		{
-			ch->remove_bank(amount);
-                        if (amount <= 100) ch->remove_bank(5);
-                        else ch->remove_bank(((amount * 5) / 100));
-			sprintf(buf, "%sВы перевели %d кун %s%s.\r\n", CCWHT(ch, C_NRM), amount,
-					GET_PAD(vict, 2), CCNRM(ch, C_NRM));
-			send_to_char(buf, ch);
-			vict->add_bank(amount);
-			sprintf(buf, "%sВы получили %d кун банковским переводом от %s%s.\r\n", CCWHT(ch, C_NRM), amount,
-					GET_PAD(ch, 1), CCNRM(ch, C_NRM));
-			send_to_char(buf, vict);
-			sprintf(buf, "<%s> {%d} перевел %d кун банковским переводом %s.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), amount, GET_PAD(vict, 2));
-			mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-			return (1);
+    if ((vict = get_player_of_name(arg))) {
+      ch->remove_bank(amount);
+      if (amount <= 100) ch->remove_bank(5);
+      else ch->remove_bank(((amount * 5) / 100));
+      sprintf(buf, "%sВы перевели %d кун %s%s.\r\n", CCWHT(ch, C_NRM), amount,
+              GET_PAD(vict, 2), CCNRM(ch, C_NRM));
+      send_to_char(buf, ch);
+      vict->add_bank(amount);
+      sprintf(buf, "%sВы получили %d кун банковским переводом от %s%s.\r\n", CCWHT(ch, C_NRM), amount,
+              GET_PAD(ch, 1), CCNRM(ch, C_NRM));
+      send_to_char(buf, vict);
+      sprintf(buf,
+              "<%s> {%d} перевел %d кун банковским переводом %s.",
+              ch->get_name().c_str(),
+              GET_ROOM_VNUM(ch->in_room),
+              amount,
+              GET_PAD(vict, 2));
+      mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+      return (1);
 
-		}
-		else
-		{
-			vict = new Player; // TODO: переделать на стек
-			if (load_char(arg, vict) < 0)
-			{
-				send_to_char("Такого персонажа не существует.\r\n", ch);
-				delete vict;
-				return (1);
-			}
+    } else {
+      vict = new Player; // TODO: переделать на стек
+      if (load_char(arg, vict) < 0) {
+        send_to_char("Такого персонажа не существует.\r\n", ch);
+        delete vict;
+        return (1);
+      }
 
-			ch->remove_bank(amount);
-                        if (amount <= 100) ch->remove_bank(5);
-                        else ch->remove_bank(((amount * 5) / 100));
-			sprintf(buf, "%sВы перевели %d кун %s%s.\r\n", CCWHT(ch, C_NRM), amount,
-					GET_PAD(vict, 2), CCNRM(ch, C_NRM));
-			send_to_char(buf, ch);
-			sprintf(buf, "<%s> {%d} перевел %d кун банковским переводом %s.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), amount, GET_PAD(vict, 2));
-			mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
-			vict->add_bank(amount);
-			Depot::add_offline_money(GET_UNIQUE(vict), amount);
-			vict->save_char();
+      ch->remove_bank(amount);
+      if (amount <= 100) ch->remove_bank(5);
+      else ch->remove_bank(((amount * 5) / 100));
+      sprintf(buf, "%sВы перевели %d кун %s%s.\r\n", CCWHT(ch, C_NRM), amount,
+              GET_PAD(vict, 2), CCNRM(ch, C_NRM));
+      send_to_char(buf, ch);
+      sprintf(buf,
+              "<%s> {%d} перевел %d кун банковским переводом %s.",
+              ch->get_name().c_str(),
+              GET_ROOM_VNUM(ch->in_room),
+              amount,
+              GET_PAD(vict, 2));
+      mudlog(buf, NRM, LVL_GRGOD, MONEY_LOG, TRUE);
+      vict->add_bank(amount);
+      Depot::add_offline_money(GET_UNIQUE(vict), amount);
+      vict->save_char();
 
-			delete vict;
-			return (1);
-		}
-	}
-	else if (CMD_IS("казна"))
-		return (Clan::BankManage(ch, argument));
-	return 0;
+      delete vict;
+      return (1);
+    }
+  } else if (CMD_IS("казна"))
+    return (Clan::BankManage(ch, argument));
+  return 0;
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -1565,15 +1565,15 @@ void mort_show_char_values(CHAR_DATA *victim, CHAR_DATA *ch, int fullness) {
 
 void skill_identify(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj) {
   if (obj) {
-    mort_show_obj_values(obj, ch, calculate_skill(ch, SKILL_IDENTIFY, nullptr));
-    train_skill(ch, SKILL_IDENTIFY, true, nullptr);
+    mort_show_obj_values(obj, ch, CalcCurrentSkill(ch, SKILL_IDENTIFY, nullptr));
+    TrainSkill(ch, SKILL_IDENTIFY, true, nullptr);
   } else if (victim) {
     if (GET_LEVEL(victim) < 3) {
       send_to_char("Вы можете опознать только персонажа, достигнувшего третьего уровня.\r\n", ch);
       return;
     }
-    mort_show_char_values(victim, ch, calculate_skill(ch, SKILL_IDENTIFY, victim));
-    train_skill(ch, SKILL_IDENTIFY, true, victim);
+    mort_show_char_values(victim, ch, CalcCurrentSkill(ch, SKILL_IDENTIFY, victim));
+    TrainSkill(ch, SKILL_IDENTIFY, true, victim);
   }
 }
 
@@ -3103,8 +3103,8 @@ int check_recipe_items(CHAR_DATA *ch, int spellnum, int spelltype, int extract, 
       if (!obj) {
         return FALSE;
       } else {
-        percent = number(1, skill_info[skillnum].max_percent);
-        auto prob = calculate_skill(ch, skillnum, nullptr);
+        percent = number(1, skill_info[skillnum].fail_percent);
+        auto prob = CalcCurrentSkill(ch, skillnum, nullptr);
 
         if (skillnum > 0
             && percent > prob) {
@@ -3175,7 +3175,7 @@ int check_recipe_items(CHAR_DATA *ch, int spellnum, int spelltype, int extract, 
         act(buf, TRUE, ch, nullptr, nullptr, TO_ARENA_LISTEN);
         auto skillnum = get_magic_skill_number_by_spell(spellnum);
         if (skillnum > 0) {
-          train_skill(ch, skillnum, true, nullptr);
+          TrainSkill(ch, skillnum, true, nullptr);
         }
       }
     }

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -74,90 +74,77 @@ extern int top_imtypes;
 ESkill get_magic_skill_number_by_spell(int spellnum);
 bool can_get_spell(CHAR_DATA *ch, int spellnum);
 bool can_get_spell_with_req(CHAR_DATA *ch, int spellnum, int req_lvl);
-void weight_change_object(OBJ_DATA * obj, int weight);
-int compute_armor_class(CHAR_DATA * ch);
-char *diag_weapon_to_char(const CObjectPrototype* obj, int show_wear);
+void weight_change_object(OBJ_DATA *obj, int weight);
+int compute_armor_class(CHAR_DATA *ch);
+char *diag_weapon_to_char(const CObjectPrototype *obj, int show_wear);
 void create_rainsnow(int *wtype, int startvalue, int chance1, int chance2, int chance3);
-int calc_anti_savings(CHAR_DATA * ch);
+int calc_anti_savings(CHAR_DATA *ch);
 
 void do_tell(CHAR_DATA *ch, char *argument, int cmd, int subcmd);
 
-void perform_remove(CHAR_DATA * ch, int pos);
+void perform_remove(CHAR_DATA *ch, int pos);
 int get_zone_rooms(int, int *, int *);
 
-int pk_action_type_summon(CHAR_DATA * agressor, CHAR_DATA * victim);
-int pk_increment_revenge(CHAR_DATA * agressor, CHAR_DATA * victim);
+int pk_action_type_summon(CHAR_DATA *agressor, CHAR_DATA *victim);
+int pk_increment_revenge(CHAR_DATA *agressor, CHAR_DATA *victim);
 
 int what_sky = SKY_CLOUDLESS;
 // * Special spells appear below.
 
-ESkill get_magic_skill_number_by_spell(int spellnum)
-{
-	switch (spell_info[spellnum].spell_class)
-	{
-	case STYPE_AIR:
-		return SKILL_AIR_MAGIC;
-		break;
+ESkill get_magic_skill_number_by_spell(int spellnum) {
+  switch (spell_info[spellnum].spell_class) {
+    case STYPE_AIR: return SKILL_AIR_MAGIC;
+      break;
 
-	case STYPE_FIRE:
-		return SKILL_FIRE_MAGIC;
-		break;
+    case STYPE_FIRE: return SKILL_FIRE_MAGIC;
+      break;
 
-	case STYPE_WATER:
-		return SKILL_WATER_MAGIC;
-		break;
+    case STYPE_WATER: return SKILL_WATER_MAGIC;
+      break;
 
-	case STYPE_EARTH:
-		return SKILL_EARTH_MAGIC;
-		break;
+    case STYPE_EARTH: return SKILL_EARTH_MAGIC;
+      break;
 
-	case STYPE_LIGHT:
-		return SKILL_LIGHT_MAGIC;
-		break;
+    case STYPE_LIGHT: return SKILL_LIGHT_MAGIC;
+      break;
 
-	case STYPE_DARK:
-		return SKILL_DARK_MAGIC;
-		break;
+    case STYPE_DARK: return SKILL_DARK_MAGIC;
+      break;
 
-	case STYPE_MIND:
-		return SKILL_MIND_MAGIC;
-		break;
+    case STYPE_MIND: return SKILL_MIND_MAGIC;
+      break;
 
-	case STYPE_LIFE:
-		return SKILL_LIFE_MAGIC;
-		break;
+    case STYPE_LIFE: return SKILL_LIFE_MAGIC;
+      break;
 
-	case STYPE_NEUTRAL:
-	default:
-		return SKILL_INVALID;
-	}
+    case STYPE_NEUTRAL:
+    default: return SKILL_INVALID;
+  }
 }
 
 //Определим мин уровень для изучения спелла из книги
 //req_lvl - требуемый уровень из книги
-int min_spell_lvl_with_req(CHAR_DATA *ch, int spellnum, int req_lvl)
-{
-	int min_lvl = MAX(req_lvl, BASE_CAST_LEV(spell_info[spellnum], ch)) - (MAX(GET_REMORT(ch) - MIN_CAST_REM(spell_info[spellnum], ch), 0) / 3);
+int min_spell_lvl_with_req(CHAR_DATA *ch, int spellnum, int req_lvl) {
+  int min_lvl = MAX(req_lvl, BASE_CAST_LEV(spell_info[spellnum], ch))
+      - (MAX(GET_REMORT(ch) - MIN_CAST_REM(spell_info[spellnum], ch), 0) / 3);
 
-	return MAX(1, min_lvl);
+  return MAX(1, min_lvl);
 }
 
-bool can_get_spell_with_req(CHAR_DATA *ch, int spellnum, int req_lvl)
-{
-	if (min_spell_lvl_with_req(ch, spellnum, req_lvl) > GET_LEVEL(ch)
-		|| MIN_CAST_REM(spell_info[spellnum], ch) > GET_REMORT(ch))
-		return FALSE;
+bool can_get_spell_with_req(CHAR_DATA *ch, int spellnum, int req_lvl) {
+  if (min_spell_lvl_with_req(ch, spellnum, req_lvl) > GET_LEVEL(ch)
+      || MIN_CAST_REM(spell_info[spellnum], ch) > GET_REMORT(ch))
+    return FALSE;
 
-	return TRUE;
+  return TRUE;
 };
 
 // Функция определяет возможность изучения спелла из книги или в гильдии
-bool can_get_spell(CHAR_DATA *ch, int spellnum)
-{
-	if (MIN_CAST_LEV(spell_info[spellnum], ch) > GET_LEVEL(ch) || MIN_CAST_REM(spell_info[spellnum], ch) > GET_REMORT(ch))
-		return FALSE;
+bool can_get_spell(CHAR_DATA *ch, int spellnum) {
+  if (MIN_CAST_LEV(spell_info[spellnum], ch) > GET_LEVEL(ch) || MIN_CAST_REM(spell_info[spellnum], ch) > GET_REMORT(ch))
+    return FALSE;
 
-	return TRUE;
+  return TRUE;
 };
 
 typedef std::map<EIngredientFlag, std::string> EIngredientFlag_name_by_value_t;
@@ -165,84 +152,69 @@ typedef std::map<const std::string, EIngredientFlag> EIngredientFlag_value_by_na
 EIngredientFlag_name_by_value_t EIngredientFlag_name_by_value;
 EIngredientFlag_value_by_name_t EIngredientFlag_value_by_name;
 
-void init_EIngredientFlag_ITEM_NAMES()
-{
-	EIngredientFlag_name_by_value.clear();
-	EIngredientFlag_value_by_name.clear();
+void init_EIngredientFlag_ITEM_NAMES() {
+  EIngredientFlag_name_by_value.clear();
+  EIngredientFlag_value_by_name.clear();
 
-	EIngredientFlag_name_by_value[EIngredientFlag::ITEM_RUNES] = "ITEM_RUNES";
-	EIngredientFlag_name_by_value[EIngredientFlag::ITEM_CHECK_USES] = "ITEM_CHECK_USES";
-	EIngredientFlag_name_by_value[EIngredientFlag::ITEM_CHECK_LAG] = "ITEM_CHECK_LAG";
-	EIngredientFlag_name_by_value[EIngredientFlag::ITEM_CHECK_LEVEL] = "ITEM_CHECK_LEVEL";
-	EIngredientFlag_name_by_value[EIngredientFlag::ITEM_DECAY_EMPTY] = "ITEM_DECAY_EMPTY";
+  EIngredientFlag_name_by_value[EIngredientFlag::ITEM_RUNES] = "ITEM_RUNES";
+  EIngredientFlag_name_by_value[EIngredientFlag::ITEM_CHECK_USES] = "ITEM_CHECK_USES";
+  EIngredientFlag_name_by_value[EIngredientFlag::ITEM_CHECK_LAG] = "ITEM_CHECK_LAG";
+  EIngredientFlag_name_by_value[EIngredientFlag::ITEM_CHECK_LEVEL] = "ITEM_CHECK_LEVEL";
+  EIngredientFlag_name_by_value[EIngredientFlag::ITEM_DECAY_EMPTY] = "ITEM_DECAY_EMPTY";
 
-	for (const auto& i : EIngredientFlag_name_by_value)
-	{
-		EIngredientFlag_value_by_name[i.second] = i.first;
-	}
+  for (const auto &i : EIngredientFlag_name_by_value) {
+    EIngredientFlag_value_by_name[i.second] = i.first;
+  }
 }
 
-template <>
-EIngredientFlag ITEM_BY_NAME(const std::string& name)
-{
-	if (EIngredientFlag_name_by_value.empty())
-	{
-		init_EIngredientFlag_ITEM_NAMES();
-	}
-	return EIngredientFlag_value_by_name.at(name);
+template<>
+EIngredientFlag ITEM_BY_NAME(const std::string &name) {
+  if (EIngredientFlag_name_by_value.empty()) {
+    init_EIngredientFlag_ITEM_NAMES();
+  }
+  return EIngredientFlag_value_by_name.at(name);
 }
 
-template <>
-const std::string& NAME_BY_ITEM<EIngredientFlag>(const EIngredientFlag item)
-{
-	if (EIngredientFlag_name_by_value.empty())
-	{
-		init_EIngredientFlag_ITEM_NAMES();
-	}
-	return EIngredientFlag_name_by_value.at(item);
+template<>
+const std::string &NAME_BY_ITEM<EIngredientFlag>(const EIngredientFlag item) {
+  if (EIngredientFlag_name_by_value.empty()) {
+    init_EIngredientFlag_ITEM_NAMES();
+  }
+  return EIngredientFlag_name_by_value.at(item);
 }
 
-void spell_create_water(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* obj)
-{
-	int water;
-	if (ch == NULL || (obj == NULL && victim == NULL))
-		return;
-	// level = MAX(MIN(level, LVL_IMPL), 1);       - not used
+void spell_create_water(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj) {
+  int water;
+  if (ch == NULL || (obj == NULL && victim == NULL))
+    return;
+  // level = MAX(MIN(level, LVL_IMPL), 1);       - not used
 
-	if (obj
-		&& GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON)
-	{
-		if ((GET_OBJ_VAL(obj, 2) != LIQ_WATER) && (GET_OBJ_VAL(obj, 1) != 0))
-		{
-			send_to_char("Прекратите, ради бога, химичить.\r\n", ch);
-			return;
-		}
-		else
-		{
-			water = MAX(GET_OBJ_VAL(obj, 0) - GET_OBJ_VAL(obj, 1), 0);
-			if (water > 0)
-			{
-				if (GET_OBJ_VAL(obj, 1) >= 0)
-				{
-					name_from_drinkcon(obj);
-				}
-				obj->set_val(2, LIQ_WATER);
-				obj->add_val(1, water);
-				act("Вы наполнили $o3 водой.", FALSE, ch, obj, 0, TO_CHAR);
-				name_to_drinkcon(obj, LIQ_WATER);
-				weight_change_object(obj, water);
-			}
-		}
-	}
-	if (victim && !IS_NPC(victim) && !IS_IMMORTAL(victim))
-	{
-		GET_COND(victim, THIRST) = 0;
-		send_to_char("Вы полностью утолили жажду.\r\n", victim);
-		if (victim != ch)
-		{
-			act("Вы напоили $N3.", FALSE, ch, 0, victim, TO_CHAR);
-		}
-	}
+  if (obj
+      && GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_DRINKCON) {
+    if ((GET_OBJ_VAL(obj, 2) != LIQ_WATER) && (GET_OBJ_VAL(obj, 1) != 0)) {
+      send_to_char("Прекратите, ради бога, химичить.\r\n", ch);
+      return;
+    } else {
+      water = MAX(GET_OBJ_VAL(obj, 0) - GET_OBJ_VAL(obj, 1), 0);
+      if (water > 0) {
+        if (GET_OBJ_VAL(obj, 1) >= 0) {
+          name_from_drinkcon(obj);
+        }
+        obj->set_val(2, LIQ_WATER);
+        obj->add_val(1, water);
+        act("Вы наполнили $o3 водой.", FALSE, ch, obj, 0, TO_CHAR);
+        name_to_drinkcon(obj, LIQ_WATER);
+        weight_change_object(obj, water);
+      }
+    }
+  }
+  if (victim && !IS_NPC(victim) && !IS_IMMORTAL(victim)) {
+    GET_COND(victim, THIRST) = 0;
+    send_to_char("Вы полностью утолили жажду.\r\n", victim);
+    if (victim != ch) {
+      act("Вы напоили $N3.", FALSE, ch, 0, victim, TO_CHAR);
+    }
+  }
 }
 
 #define SUMMON_FAIL "Попытка перемещения не удалась.\r\n"
@@ -254,2917 +226,2710 @@ void spell_create_water(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DAT
 #define MAX_SUMMON_TRIES 2000
 
 // Поиск комнаты для перемещающего заклинания
-int get_teleport_target_room(CHAR_DATA * ch,	// ch - кого перемещают
-							 int rnum_start,	// rnum_start - первая комната диапазона
-							 int rnum_stop	// rnum_stop - последняя комната диапазона
-							)
-{
-	int *r_array;
-	int n, i, j;
-	int fnd_room = NOWHERE;
+int get_teleport_target_room(CHAR_DATA *ch,    // ch - кого перемещают
+                             int rnum_start,    // rnum_start - первая комната диапазона
+                             int rnum_stop    // rnum_stop - последняя комната диапазона
+) {
+  int *r_array;
+  int n, i, j;
+  int fnd_room = NOWHERE;
 
-	n = rnum_stop - rnum_start + 1;
+  n = rnum_stop - rnum_start + 1;
 
-	if (n <= 0)
-		return NOWHERE;
+  if (n <= 0)
+    return NOWHERE;
 
-	r_array = (int *) malloc(n * sizeof(int));
-	for (i = 0; i < n; ++i)
-		r_array[i] = rnum_start + i;
+  r_array = (int *) malloc(n * sizeof(int));
+  for (i = 0; i < n; ++i)
+    r_array[i] = rnum_start + i;
 
-	for (; n; --n)
-	{
-		j = number(0, n - 1);
-		fnd_room = r_array[j];
-		r_array[j] = r_array[n - 1];
+  for (; n; --n) {
+    j = number(0, n - 1);
+    fnd_room = r_array[j];
+    r_array[j] = r_array[n - 1];
 
-		if (SECT(fnd_room) != SECT_SECRET &&
-				!ROOM_FLAGGED(fnd_room, ROOM_DEATH) &&
-				!ROOM_FLAGGED(fnd_room, ROOM_TUNNEL) &&
-				!ROOM_FLAGGED(fnd_room, ROOM_NOTELEPORTIN) &&
-				!ROOM_FLAGGED(fnd_room, ROOM_SLOWDEATH) &&
-				!ROOM_FLAGGED(fnd_room, ROOM_ICEDEATH) &&
-				(!ROOM_FLAGGED(fnd_room, ROOM_GODROOM) || IS_IMMORTAL(ch)) &&
-				Clan::MayEnter(ch, fnd_room, HCE_PORTAL))
-			break;
-	}
+    if (SECT(fnd_room) != SECT_SECRET &&
+        !ROOM_FLAGGED(fnd_room, ROOM_DEATH) &&
+        !ROOM_FLAGGED(fnd_room, ROOM_TUNNEL) &&
+        !ROOM_FLAGGED(fnd_room, ROOM_NOTELEPORTIN) &&
+        !ROOM_FLAGGED(fnd_room, ROOM_SLOWDEATH) &&
+        !ROOM_FLAGGED(fnd_room, ROOM_ICEDEATH) &&
+        (!ROOM_FLAGGED(fnd_room, ROOM_GODROOM) || IS_IMMORTAL(ch)) &&
+        Clan::MayEnter(ch, fnd_room, HCE_PORTAL))
+      break;
+  }
 
-	free(r_array);
+  free(r_array);
 
-	return n ? fnd_room : NOWHERE;
+  return n ? fnd_room : NOWHERE;
 }
 
-void spell_recall(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* /* obj*/)
-{
-	room_rnum to_room = NOWHERE, fnd_room = NOWHERE;
-	room_rnum rnum_start, rnum_stop;
+void spell_recall(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA * /* obj*/) {
+  room_rnum to_room = NOWHERE, fnd_room = NOWHERE;
+  room_rnum rnum_start, rnum_stop;
 
-	if (!victim || IS_NPC(victim) || ch->in_room != IN_ROOM(victim) || GET_LEVEL(victim) >= LVL_IMMORT)
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (!victim || IS_NPC(victim) || ch->in_room != IN_ROOM(victim) || GET_LEVEL(victim) >= LVL_IMMORT) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	if (!IS_GOD(ch) && (ROOM_FLAGGED(IN_ROOM(victim), ROOM_NOTELEPORTOUT) || AFF_FLAGGED(victim, EAffectFlag::AFF_NOTELEPORT)))
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (!IS_GOD(ch)
+      && (ROOM_FLAGGED(IN_ROOM(victim), ROOM_NOTELEPORTOUT) || AFF_FLAGGED(victim, EAffectFlag::AFF_NOTELEPORT))) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	if (victim != ch)
-	{
-		if (same_group(ch, victim))
-		{
-			if (number(1, 100) <= 5 )
-			{
-				send_to_char(SUMMON_FAIL, ch);
-				return;
-			}
-		}
-		else if (!IS_NPC(ch) || (ch->has_master() && !IS_NPC(ch->get_master()))) // игроки не в группе и  чармисы по приказу не могут реколить свитком
-		{
-				send_to_char(SUMMON_FAIL, ch);
-				return;
-		}
+  if (victim != ch) {
+    if (same_group(ch, victim)) {
+      if (number(1, 100) <= 5) {
+        send_to_char(SUMMON_FAIL, ch);
+        return;
+      }
+    } else if (!IS_NPC(ch) || (ch->has_master()
+        && !IS_NPC(ch->get_master()))) // игроки не в группе и  чармисы по приказу не могут реколить свитком
+    {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
 
-		if ((IS_NPC(ch) && general_savingthrow(ch, victim, SAVING_WILL, GET_REAL_INT(ch))) || IS_GOD(victim))
-		{
-			return;
-		}
-	}
+    if ((IS_NPC(ch) && general_savingthrow(ch, victim, SAVING_WILL, GET_REAL_INT(ch))) || IS_GOD(victim)) {
+      return;
+    }
+  }
 
-	if ((to_room = real_room(GET_LOADROOM(victim))) == NOWHERE)
-		to_room = real_room(calc_loadroom(victim));
+  if ((to_room = real_room(GET_LOADROOM(victim))) == NOWHERE)
+    to_room = real_room(calc_loadroom(victim));
 
-	if (to_room == NOWHERE)
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (to_room == NOWHERE) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	(void) get_zone_rooms(world[to_room]->zone, &rnum_start, &rnum_stop);
-	fnd_room = get_teleport_target_room(victim, rnum_start, rnum_stop);
-	if (fnd_room == NOWHERE)
-	{
-		to_room = Clan::CloseRent(to_room);
-		(void) get_zone_rooms(world[to_room]->zone, &rnum_start, &rnum_stop);
-		fnd_room = get_teleport_target_room(victim, rnum_start, rnum_stop);
-	}
+  (void) get_zone_rooms(world[to_room]->zone, &rnum_start, &rnum_stop);
+  fnd_room = get_teleport_target_room(victim, rnum_start, rnum_stop);
+  if (fnd_room == NOWHERE) {
+    to_room = Clan::CloseRent(to_room);
+    (void) get_zone_rooms(world[to_room]->zone, &rnum_start, &rnum_stop);
+    fnd_room = get_teleport_target_room(victim, rnum_start, rnum_stop);
+  }
 
-	if (fnd_room == NOWHERE)
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (fnd_room == NOWHERE) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	if (victim->get_fighting() && (victim != ch))
-	{
-		if (!pk_agro_action(ch, victim->get_fighting()))
-			return;
-	}
+  if (victim->get_fighting() && (victim != ch)) {
+    if (!pk_agro_action(ch, victim->get_fighting()))
+      return;
+  }
 
-	act("$n исчез$q.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-	char_from_room(victim);
-	char_to_room(victim, fnd_room);
-	victim->dismount();
-	act("$n появил$u в центре комнаты.", TRUE, victim, 0, 0, TO_ROOM);
-	look_at_room(victim, 0);
-	greet_mtrigger(victim, -1);
-	greet_otrigger(victim, -1);
+  act("$n исчез$q.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  char_from_room(victim);
+  char_to_room(victim, fnd_room);
+  victim->dismount();
+  act("$n появил$u в центре комнаты.", TRUE, victim, 0, 0, TO_ROOM);
+  look_at_room(victim, 0);
+  greet_mtrigger(victim, -1);
+  greet_otrigger(victim, -1);
 }
 
 // ПРЫЖОК в рамках зоны
-void spell_teleport(int/* level*/, CHAR_DATA *ch, CHAR_DATA* /*victim*/, OBJ_DATA* /* obj*/)
-{
-	room_rnum in_room = ch->in_room, fnd_room = NOWHERE;
-	room_rnum rnum_start, rnum_stop;
+void spell_teleport(int/* level*/, CHAR_DATA *ch, CHAR_DATA * /*victim*/, OBJ_DATA * /* obj*/) {
+  room_rnum in_room = ch->in_room, fnd_room = NOWHERE;
+  room_rnum rnum_start, rnum_stop;
 
-	if (!IS_GOD(ch) && (ROOM_FLAGGED(in_room, ROOM_NOTELEPORTOUT) || AFF_FLAGGED(ch, EAffectFlag::AFF_NOTELEPORT)))
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (!IS_GOD(ch) && (ROOM_FLAGGED(in_room, ROOM_NOTELEPORTOUT) || AFF_FLAGGED(ch, EAffectFlag::AFF_NOTELEPORT))) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	get_zone_rooms(world[in_room]->zone, &rnum_start, &rnum_stop);
-	fnd_room = get_teleport_target_room(ch, rnum_start, rnum_stop);
-	if (fnd_room == NOWHERE)
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  get_zone_rooms(world[in_room]->zone, &rnum_start, &rnum_stop);
+  fnd_room = get_teleport_target_room(ch, rnum_start, rnum_stop);
+  if (fnd_room == NOWHERE) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	act("$n медленно исчез$q из виду.", FALSE, ch, 0, 0, TO_ROOM);
-	char_from_room(ch);
-	char_to_room(ch, fnd_room);
-	ch->dismount();
-	act("$n медленно появил$u откуда-то.", FALSE, ch, 0, 0, TO_ROOM);
-	look_at_room(ch, 0);
-	greet_mtrigger(ch, -1);
-	greet_otrigger(ch, -1);
+  act("$n медленно исчез$q из виду.", FALSE, ch, 0, 0, TO_ROOM);
+  char_from_room(ch);
+  char_to_room(ch, fnd_room);
+  ch->dismount();
+  act("$n медленно появил$u откуда-то.", FALSE, ch, 0, 0, TO_ROOM);
+  look_at_room(ch, 0);
+  greet_mtrigger(ch, -1);
+  greet_otrigger(ch, -1);
 }
 
 // ПЕРЕМЕСТИТЬСЯ
-void spell_relocate(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* /* obj*/)
-{
-	room_rnum to_room, fnd_room;
+void spell_relocate(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA * /* obj*/) {
+  room_rnum to_room, fnd_room;
 
-	if (victim == NULL)
-		return;
+  if (victim == NULL)
+    return;
 
-	// Если левел жертвы больше чем перемещяющегося - фейл
-	if (IS_NPC(victim) || (GET_LEVEL(victim) > GET_LEVEL(ch)) || IS_IMMORTAL(victim))
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  // Если левел жертвы больше чем перемещяющегося - фейл
+  if (IS_NPC(victim) || (GET_LEVEL(victim) > GET_LEVEL(ch)) || IS_IMMORTAL(victim)) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	// Для иммов обязательные для перемещения условия не существенны
-	if (!IS_GOD(ch))
-	{
-		// Нельзя перемещаться из клетки ROOM_NOTELEPORTOUT
-		if (ROOM_FLAGGED(ch->in_room, ROOM_NOTELEPORTOUT))
-		{
-			send_to_char(SUMMON_FAIL, ch);
-			return;
-		}
+  // Для иммов обязательные для перемещения условия не существенны
+  if (!IS_GOD(ch)) {
+    // Нельзя перемещаться из клетки ROOM_NOTELEPORTOUT
+    if (ROOM_FLAGGED(ch->in_room, ROOM_NOTELEPORTOUT)) {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
 
-		// Нельзя перемещаться после того, как попал под заклинание "приковать противника".
-		if (AFF_FLAGGED(ch, EAffectFlag::AFF_NOTELEPORT))
-		{
-			send_to_char(SUMMON_FAIL, ch);
-			return;
-		}
-	}
+    // Нельзя перемещаться после того, как попал под заклинание "приковать противника".
+    if (AFF_FLAGGED(ch, EAffectFlag::AFF_NOTELEPORT)) {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
+  }
 
-	to_room = IN_ROOM(victim);
+  to_room = IN_ROOM(victim);
 
-	if (to_room == NOWHERE)
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
-	// в случае, если жертва не может зайти в замок (по любой причине)
-	// прыжок в зону ближайшей ренты
-	if (!Clan::MayEnter(ch, to_room, HCE_PORTAL))
-		fnd_room = Clan::CloseRent(to_room);
-	else
-		fnd_room = to_room;
+  if (to_room == NOWHERE) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
+  // в случае, если жертва не может зайти в замок (по любой причине)
+  // прыжок в зону ближайшей ренты
+  if (!Clan::MayEnter(ch, to_room, HCE_PORTAL))
+    fnd_room = Clan::CloseRent(to_room);
+  else
+    fnd_room = to_room;
 
-	if (fnd_room != to_room && !IS_GOD(ch))
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (fnd_room != to_room && !IS_GOD(ch)) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	if (!IS_GOD(ch) &&
-			(SECT(fnd_room) == SECT_SECRET ||
-			 ROOM_FLAGGED(fnd_room, ROOM_DEATH) ||
-			 ROOM_FLAGGED(fnd_room, ROOM_SLOWDEATH) ||
-			 ROOM_FLAGGED(fnd_room, ROOM_TUNNEL) ||
-			 ROOM_FLAGGED(fnd_room, ROOM_NORELOCATEIN) ||
-			 ROOM_FLAGGED(fnd_room, ROOM_ICEDEATH) || (ROOM_FLAGGED(fnd_room, ROOM_GODROOM) && !IS_IMMORTAL(ch))))
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (!IS_GOD(ch) &&
+      (SECT(fnd_room) == SECT_SECRET ||
+          ROOM_FLAGGED(fnd_room, ROOM_DEATH) ||
+          ROOM_FLAGGED(fnd_room, ROOM_SLOWDEATH) ||
+          ROOM_FLAGGED(fnd_room, ROOM_TUNNEL) ||
+          ROOM_FLAGGED(fnd_room, ROOM_NORELOCATEIN) ||
+          ROOM_FLAGGED(fnd_room, ROOM_ICEDEATH) || (ROOM_FLAGGED(fnd_room, ROOM_GODROOM) && !IS_IMMORTAL(ch)))) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	act("$n медленно исчез$q из виду.", TRUE, ch, 0, 0, TO_ROOM);
-	send_to_char("Лазурные сполохи пронеслись перед вашими глазами.\r\n", ch);
-	char_from_room(ch);
-	char_to_room(ch, fnd_room);
-	ch->dismount();
-	act("$n медленно появил$u откуда-то.", TRUE, ch, 0, 0, TO_ROOM);
-	if (!(PRF_FLAGGED(victim, PRF_SUMMONABLE) || same_group(ch, victim) || IS_IMMORTAL(ch)))
-	{
-		send_to_char(ch, "%sВаш поступок был расценен как потенциально агрессивный.%s\r\n",
-			CCIRED(ch, C_NRM), CCINRM(ch, C_NRM));
-		pkPortal(ch);
-	}
-	look_at_room(ch, 0);
-	// Прыжок на чара в БД удваивает лаг
-	if (RENTABLE(victim))
-	{
-		WAIT_STATE(ch, 4 * PULSE_VIOLENCE);
-	}
-	else
-	{
-		WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
-	}
-	greet_mtrigger(ch, -1);
-	greet_otrigger(ch, -1);
+  act("$n медленно исчез$q из виду.", TRUE, ch, 0, 0, TO_ROOM);
+  send_to_char("Лазурные сполохи пронеслись перед вашими глазами.\r\n", ch);
+  char_from_room(ch);
+  char_to_room(ch, fnd_room);
+  ch->dismount();
+  act("$n медленно появил$u откуда-то.", TRUE, ch, 0, 0, TO_ROOM);
+  if (!(PRF_FLAGGED(victim, PRF_SUMMONABLE) || same_group(ch, victim) || IS_IMMORTAL(ch))) {
+    send_to_char(ch, "%sВаш поступок был расценен как потенциально агрессивный.%s\r\n",
+                 CCIRED(ch, C_NRM), CCINRM(ch, C_NRM));
+    pkPortal(ch);
+  }
+  look_at_room(ch, 0);
+  // Прыжок на чара в БД удваивает лаг
+  if (RENTABLE(victim)) {
+    WAIT_STATE(ch, 4 * PULSE_VIOLENCE);
+  } else {
+    WAIT_STATE(ch, 2 * PULSE_VIOLENCE);
+  }
+  greet_mtrigger(ch, -1);
+  greet_otrigger(ch, -1);
 }
 
-
-
-void check_auto_nosummon(CHAR_DATA *ch)
-{
-	if (PRF_FLAGGED(ch, PRF_AUTO_NOSUMMON) && PRF_FLAGGED(ch, PRF_SUMMONABLE))
-	{
-		PRF_FLAGS(ch).unset(PRF_SUMMONABLE);
-		send_to_char("Режим автопризыв: вы защищены от призыва.\r\n", ch);
-	}
+void check_auto_nosummon(CHAR_DATA *ch) {
+  if (PRF_FLAGGED(ch, PRF_AUTO_NOSUMMON) && PRF_FLAGGED(ch, PRF_SUMMONABLE)) {
+    PRF_FLAGS(ch).unset(PRF_SUMMONABLE);
+    send_to_char("Режим автопризыв: вы защищены от призыва.\r\n", ch);
+  }
 }
 
-void spell_portal(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* /* obj*/)
-{
-	room_rnum to_room, fnd_room;
+void spell_portal(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA * /* obj*/) {
+  room_rnum to_room, fnd_room;
 
-	if (victim == NULL)
-		return;
-	if (GET_LEVEL(victim) > GET_LEVEL(ch) && !PRF_FLAGGED(victim, PRF_SUMMONABLE) && !same_group(ch, victim))
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
-	// пентить чаров <=10 уровня, нельзя так-же нельзя пентать иммов
-	if (!IS_GOD(ch))
-	{
-		if ((!IS_NPC(victim) && GET_LEVEL(victim) <= 10) || IS_IMMORTAL(victim) || AFF_FLAGGED(victim, EAffectFlag::AFF_NOTELEPORT))
-		{
-			send_to_char(SUMMON_FAIL, ch);
-			return;
-		}
-	}
-	if (IS_NPC(victim))
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (victim == NULL)
+    return;
+  if (GET_LEVEL(victim) > GET_LEVEL(ch) && !PRF_FLAGGED(victim, PRF_SUMMONABLE) && !same_group(ch, victim)) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
+  // пентить чаров <=10 уровня, нельзя так-же нельзя пентать иммов
+  if (!IS_GOD(ch)) {
+    if ((!IS_NPC(victim) && GET_LEVEL(victim) <= 10) || IS_IMMORTAL(victim)
+        || AFF_FLAGGED(victim, EAffectFlag::AFF_NOTELEPORT)) {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
+  }
+  if (IS_NPC(victim)) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	fnd_room = IN_ROOM(victim);
-	if (fnd_room == NOWHERE)
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
-	// обработка NOTELEPORTIN и NOTELEPORTOUT теперь происходит при входе в портал
-	if (!IS_GOD(ch) && ( //ROOM_FLAGGED(ch->in_room, ROOM_NOTELEPORTOUT)||
-				//ROOM_FLAGGED(ch->in_room, ROOM_NOTELEPORTIN)||
-				SECT(fnd_room) == SECT_SECRET || ROOM_FLAGGED(fnd_room, ROOM_DEATH) || ROOM_FLAGGED(fnd_room, ROOM_SLOWDEATH) || ROOM_FLAGGED(fnd_room, ROOM_ICEDEATH) || ROOM_FLAGGED(fnd_room, ROOM_TUNNEL) || ROOM_FLAGGED(fnd_room, ROOM_GODROOM)	//||
-				//ROOM_FLAGGED(fnd_room, ROOM_NOTELEPORTOUT) ||
-				//ROOM_FLAGGED(fnd_room, ROOM_NOTELEPORTIN)
-			))
-	{
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  fnd_room = IN_ROOM(victim);
+  if (fnd_room == NOWHERE) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
+  // обработка NOTELEPORTIN и NOTELEPORTOUT теперь происходит при входе в портал
+  if (!IS_GOD(ch) && ( //ROOM_FLAGGED(ch->in_room, ROOM_NOTELEPORTOUT)||
+      //ROOM_FLAGGED(ch->in_room, ROOM_NOTELEPORTIN)||
+      SECT(fnd_room) == SECT_SECRET || ROOM_FLAGGED(fnd_room, ROOM_DEATH) || ROOM_FLAGGED(fnd_room, ROOM_SLOWDEATH)
+          || ROOM_FLAGGED(fnd_room, ROOM_ICEDEATH) || ROOM_FLAGGED(fnd_room, ROOM_TUNNEL)
+          || ROOM_FLAGGED(fnd_room, ROOM_GODROOM)    //||
+      //ROOM_FLAGGED(fnd_room, ROOM_NOTELEPORTOUT) ||
+      //ROOM_FLAGGED(fnd_room, ROOM_NOTELEPORTIN)
+  )) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	//Юзабилити фикс: не ставим пенту в одну клетку с кастующим
-	if (ch->in_room == fnd_room)
-	{
-		send_to_char("Может вам лучше просто потоптаться на месте?\r\n", ch);
-		return;
-	}
+  //Юзабилити фикс: не ставим пенту в одну клетку с кастующим
+  if (ch->in_room == fnd_room) {
+    send_to_char("Может вам лучше просто потоптаться на месте?\r\n", ch);
+    return;
+  }
 
-	if (world[fnd_room]->portal_time)
-	{
-		if (world[world[fnd_room]->portal_room]->portal_room == fnd_room && world[world[fnd_room]->portal_room]->portal_time)
-			decay_portal(world[fnd_room]->portal_room);
-		decay_portal(fnd_room);
-	}
-	if (world[ch->in_room]->portal_time)
-	{
-		if (world[world[ch->in_room]->portal_room]->portal_room == ch->in_room && world[world[ch->in_room]->portal_room]->portal_time)
-			decay_portal(world[ch->in_room]->portal_room);
-		decay_portal(ch->in_room);
-	}
-	bool pkPortal = pk_action_type_summon(ch, victim) == PK_ACTION_REVENGE ||
-			pk_action_type_summon(ch, victim) == PK_ACTION_FIGHT;
+  if (world[fnd_room]->portal_time) {
+    if (world[world[fnd_room]->portal_room]->portal_room == fnd_room
+        && world[world[fnd_room]->portal_room]->portal_time)
+      decay_portal(world[fnd_room]->portal_room);
+    decay_portal(fnd_room);
+  }
+  if (world[ch->in_room]->portal_time) {
+    if (world[world[ch->in_room]->portal_room]->portal_room == ch->in_room
+        && world[world[ch->in_room]->portal_room]->portal_time)
+      decay_portal(world[ch->in_room]->portal_room);
+    decay_portal(ch->in_room);
+  }
+  bool pkPortal = pk_action_type_summon(ch, victim) == PK_ACTION_REVENGE ||
+      pk_action_type_summon(ch, victim) == PK_ACTION_FIGHT;
 
-	if (IS_IMMORTAL(ch) || GET_GOD_FLAG(victim, GF_GODSCURSE)
-			// раньше было <= PK_ACTION_REVENGE, что вызывало абьюз при пенте на чара на арене,
-			// или пенте кидаемой с арены т.к. в данном случае использовалось PK_ACTION_NO которое меньше PK_ACTION_REVENGE
-			   || pkPortal || ((!IS_NPC(victim) || IS_CHARMICE(ch)) && PRF_FLAGGED(victim, PRF_SUMMONABLE))
-			|| same_group(ch, victim))
-	{
-		if (pkPortal) {
-			pk_increment_revenge(ch, victim);
-		}
+  if (IS_IMMORTAL(ch) || GET_GOD_FLAG(victim, GF_GODSCURSE)
+      // раньше было <= PK_ACTION_REVENGE, что вызывало абьюз при пенте на чара на арене,
+      // или пенте кидаемой с арены т.к. в данном случае использовалось PK_ACTION_NO которое меньше PK_ACTION_REVENGE
+      || pkPortal || ((!IS_NPC(victim) || IS_CHARMICE(ch)) && PRF_FLAGGED(victim, PRF_SUMMONABLE))
+      || same_group(ch, victim)) {
+    if (pkPortal) {
+      pk_increment_revenge(ch, victim);
+    }
 
-		to_room = ch->in_room;
-		world[fnd_room]->portal_room = to_room;
-		world[fnd_room]->portal_time = 1;
-		if (pkPortal) world[fnd_room]->pkPenterUnique = GET_UNIQUE(ch);
+    to_room = ch->in_room;
+    world[fnd_room]->portal_room = to_room;
+    world[fnd_room]->portal_time = 1;
+    if (pkPortal) world[fnd_room]->pkPenterUnique = GET_UNIQUE(ch);
 
-		if (pkPortal)
-		{
-			act("Лазурная пентаграмма с кровавым отблеском возникла в воздухе.", FALSE, world[fnd_room]->first_character(), 0, 0, TO_CHAR);
-			act("Лазурная пентаграмма с кровавым отблеском возникла в воздухе.", FALSE, world[fnd_room]->first_character(), 0, 0, TO_ROOM);
-		}else
-		{
-			act("Лазурная пентаграмма возникла в воздухе.", FALSE, world[fnd_room]->first_character(), 0, 0, TO_CHAR);
-			act("Лазурная пентаграмма возникла в воздухе.", FALSE, world[fnd_room]->first_character(), 0, 0, TO_ROOM);
-		}
-		check_auto_nosummon(victim);
+    if (pkPortal) {
+      act("Лазурная пентаграмма с кровавым отблеском возникла в воздухе.",
+          FALSE,
+          world[fnd_room]->first_character(),
+          0,
+          0,
+          TO_CHAR);
+      act("Лазурная пентаграмма с кровавым отблеском возникла в воздухе.",
+          FALSE,
+          world[fnd_room]->first_character(),
+          0,
+          0,
+          TO_ROOM);
+    } else {
+      act("Лазурная пентаграмма возникла в воздухе.", FALSE, world[fnd_room]->first_character(), 0, 0, TO_CHAR);
+      act("Лазурная пентаграмма возникла в воздухе.", FALSE, world[fnd_room]->first_character(), 0, 0, TO_ROOM);
+    }
+    check_auto_nosummon(victim);
 
-		// если пенту ставит имм с привилегией arena (и находясь на арене), то пента получается односторонняя
-		if (Privilege::check_flag(ch, Privilege::ARENA_MASTER) && ROOM_FLAGGED(ch->in_room, ROOM_ARENA))
-			return;
+    // если пенту ставит имм с привилегией arena (и находясь на арене), то пента получается односторонняя
+    if (Privilege::check_flag(ch, Privilege::ARENA_MASTER) && ROOM_FLAGGED(ch->in_room, ROOM_ARENA))
+      return;
 
-		world[to_room]->portal_room = fnd_room;
-		world[to_room]->portal_time = 1;
-		if (pkPortal) world[to_room]->pkPenterUnique = GET_UNIQUE(ch);
+    world[to_room]->portal_room = fnd_room;
+    world[to_room]->portal_time = 1;
+    if (pkPortal) world[to_room]->pkPenterUnique = GET_UNIQUE(ch);
 
-		if (pkPortal)
-		{
-			act("Лазурная пентаграмма с кровавым отблеском возникла в воздухе.", FALSE, world[to_room]->first_character(), 0, 0, TO_CHAR);
-			act("Лазурная пентаграмма с кровавым отблеском возникла в воздухе.", FALSE, world[to_room]->first_character(), 0, 0, TO_ROOM);
-		}else
-		{
-			act("Лазурная пентаграмма возникла в воздухе.", FALSE, world[to_room]->first_character(), 0, 0, TO_CHAR);
-			act("Лазурная пентаграмма возникла в воздухе.", FALSE, world[to_room]->first_character(), 0, 0, TO_ROOM);
-		}
-	}
+    if (pkPortal) {
+      act("Лазурная пентаграмма с кровавым отблеском возникла в воздухе.",
+          FALSE,
+          world[to_room]->first_character(),
+          0,
+          0,
+          TO_CHAR);
+      act("Лазурная пентаграмма с кровавым отблеском возникла в воздухе.",
+          FALSE,
+          world[to_room]->first_character(),
+          0,
+          0,
+          TO_ROOM);
+    } else {
+      act("Лазурная пентаграмма возникла в воздухе.", FALSE, world[to_room]->first_character(), 0, 0, TO_CHAR);
+      act("Лазурная пентаграмма возникла в воздухе.", FALSE, world[to_room]->first_character(), 0, 0, TO_ROOM);
+    }
+  }
 }
 
-void spell_summon(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* /* obj*/)
-{
-	room_rnum ch_room, vic_room;
-	struct follow_type *k, *k_next;
+void spell_summon(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA * /* obj*/) {
+  room_rnum ch_room, vic_room;
+  struct follow_type *k, *k_next;
 
-	if (ch == NULL || victim == NULL || ch == victim) {
-		return;
-	}
+  if (ch == NULL || victim == NULL || ch == victim) {
+    return;
+  }
 
-	ch_room = ch->in_room;
-	vic_room = IN_ROOM(victim);
+  ch_room = ch->in_room;
+  vic_room = IN_ROOM(victim);
 
-	if (ch_room == NOWHERE || vic_room == NOWHERE) {
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (ch_room == NOWHERE || vic_room == NOWHERE) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	if (IS_NPC(ch) && IS_NPC(victim)) {
-		send_to_char(SUMMON_FAIL, ch);
-		return;
-	}
+  if (IS_NPC(ch) && IS_NPC(victim)) {
+    send_to_char(SUMMON_FAIL, ch);
+    return;
+  }
 
-	if (IS_IMMORTAL(victim)) {
-		if (IS_NPC(ch) || (!IS_NPC(ch) && GET_LEVEL(ch) < GET_LEVEL(victim))) {
-			send_to_char(SUMMON_FAIL, ch);
-			return;
-		}
-	}
+  if (IS_IMMORTAL(victim)) {
+    if (IS_NPC(ch) || (!IS_NPC(ch) && GET_LEVEL(ch) < GET_LEVEL(victim))) {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
+  }
 
-	if (!IS_NPC(ch) && IS_NPC(victim)) {
-		if (victim->get_master() != ch
-			|| !AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM)
-			|| AFF_FLAGGED(victim, EAffectFlag::AFF_HELPER)
-			|| victim->get_fighting()
-			|| GET_POS(victim) < POS_RESTING) {
-			send_to_char(SUMMON_FAIL, ch);
-			return;
-		}
-	}
+  if (!IS_NPC(ch) && IS_NPC(victim)) {
+    if (victim->get_master() != ch
+        || !AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM)
+        || AFF_FLAGGED(victim, EAffectFlag::AFF_HELPER)
+        || victim->get_fighting()
+        || GET_POS(victim) < POS_RESTING) {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
+  }
 
+  if (!IS_IMMORTAL(ch)) {
+    if (!IS_NPC(ch) || IS_CHARMICE(ch)) {
+      if (AFF_FLAGGED(ch, EAffectFlag::AFF_SHIELD)) {
+        send_to_char(SUMMON_FAIL3, ch);
+        return;
+      }
+      if (!PRF_FLAGGED(victim, PRF_SUMMONABLE) && !same_group(ch, victim)) {
+        send_to_char(SUMMON_FAIL2, ch);
+        return;
+      }
+      if (RENTABLE(victim)) {
+        send_to_char(SUMMON_FAIL, ch);
+        return;
+      }
+      if (victim->get_fighting()) {
+        send_to_char(SUMMON_FAIL4, ch);
+        return;
+      }
+    }
+    if (GET_WAIT(victim) > 0) {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
+    if (!IS_NPC(ch) && !IS_NPC(victim) && GET_LEVEL(victim) <= 10) {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
 
-	if (!IS_IMMORTAL(ch)) {
-		if (!IS_NPC(ch) || IS_CHARMICE(ch)) {
-			if (AFF_FLAGGED(ch, EAffectFlag::AFF_SHIELD)) {
-				send_to_char(SUMMON_FAIL3, ch);
-				return;
-			}
-			if (!PRF_FLAGGED(victim, PRF_SUMMONABLE) && !same_group(ch, victim)) {
-				send_to_char(SUMMON_FAIL2, ch);
-				return;
-			}
-			if (RENTABLE(victim)) {
-				send_to_char(SUMMON_FAIL, ch);
-				return;
-			}
-			if (victim->get_fighting()) {
-				send_to_char(SUMMON_FAIL4, ch);
-				return;
-			}
-		}
-		if (GET_WAIT(victim) > 0) {
-			send_to_char(SUMMON_FAIL, ch);
-			return;
-		}
-		if (!IS_NPC(ch) && !IS_NPC(victim) && GET_LEVEL(victim) <= 10) {
-			send_to_char(SUMMON_FAIL, ch);
-			return;
-		}
+    if (ROOM_FLAGGED(ch_room, ROOM_NOSUMMON)
+        || ROOM_FLAGGED(ch_room, ROOM_DEATH)
+        || ROOM_FLAGGED(ch_room, ROOM_SLOWDEATH)
+        || ROOM_FLAGGED(ch_room, ROOM_TUNNEL)
+        || ROOM_FLAGGED(ch_room, ROOM_NOBATTLE)
+        || ROOM_FLAGGED(ch_room, ROOM_GODROOM)
+        || !Clan::MayEnter(victim, ch_room, HCE_PORTAL)
+        || SECT(ch->in_room) == SECT_SECRET
+        || (!same_group(ch, victim) && (ROOM_FLAGGED(ch_room, ROOM_PEACEFUL) || ROOM_FLAGGED(ch_room, ROOM_ARENA)))) {
+      send_to_char(SUMMON_FAIL, ch);
+      return;
+    }
 
-		if (ROOM_FLAGGED(ch_room, ROOM_NOSUMMON)
-			|| ROOM_FLAGGED(ch_room, ROOM_DEATH)
-			|| ROOM_FLAGGED(ch_room, ROOM_SLOWDEATH)
-			|| ROOM_FLAGGED(ch_room, ROOM_TUNNEL)
-			|| ROOM_FLAGGED(ch_room, ROOM_NOBATTLE)
-			|| ROOM_FLAGGED(ch_room, ROOM_GODROOM)
-			|| !Clan::MayEnter(victim, ch_room, HCE_PORTAL)
-			|| SECT(ch->in_room) == SECT_SECRET
-			|| (!same_group(ch, victim) && (ROOM_FLAGGED(ch_room, ROOM_PEACEFUL) || ROOM_FLAGGED(ch_room, ROOM_ARENA)))) {
-			send_to_char(SUMMON_FAIL, ch);
-			return;
-		}
+    if (!IS_NPC(ch)) {
+      if (ROOM_FLAGGED(vic_room, ROOM_NOSUMMON)
+          || ROOM_FLAGGED(vic_room, ROOM_GODROOM)
+          || !Clan::MayEnter(ch, vic_room, HCE_PORTAL)
+          || AFF_FLAGGED(victim, EAffectFlag::AFF_NOTELEPORT)
+          || (!same_group(ch, victim) && (ROOM_FLAGGED(vic_room, ROOM_TUNNEL) || ROOM_FLAGGED(vic_room, ROOM_ARENA)))) {
+        send_to_char(SUMMON_FAIL, ch);
+        return;
+      }
+    } else {
+      if (ROOM_FLAGGED(vic_room, ROOM_NOSUMMON) || AFF_FLAGGED(victim, EAffectFlag::AFF_NOTELEPORT)) {
+        send_to_char(SUMMON_FAIL, ch);
+        return;
+      }
+    }
 
-		if (!IS_NPC(ch)) {
-			if (ROOM_FLAGGED(vic_room, ROOM_NOSUMMON)
-				|| ROOM_FLAGGED(vic_room, ROOM_GODROOM)
-				|| !Clan::MayEnter(ch, vic_room, HCE_PORTAL)
-				|| AFF_FLAGGED(victim, EAffectFlag::AFF_NOTELEPORT)
-				|| (!same_group(ch, victim) && (ROOM_FLAGGED(vic_room, ROOM_TUNNEL) || ROOM_FLAGGED(vic_room, ROOM_ARENA)))) {
-				send_to_char(SUMMON_FAIL, ch);
-				return;
-			}
-		} else {
-			if (ROOM_FLAGGED(vic_room, ROOM_NOSUMMON) || AFF_FLAGGED(victim, EAffectFlag::AFF_NOTELEPORT)) 	{
-				send_to_char(SUMMON_FAIL, ch);
-				return;
-			}
-		}
+    if (IS_NPC(ch) && number(1, 100) < 30) {
+      return;
+    }
+  }
 
-		if (IS_NPC(ch) && number(1, 100) < 30) {
-			return;
-		}
-	}
+  act("$n растворил$u на ваших глазах.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  char_from_room(victim);
+  char_to_room(victim, ch_room);
+  victim->dismount();
+  act("$n прибыл$g по вызову.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  act("$n призвал$g вас!", FALSE, ch, 0, victim, TO_VICT);
+  check_auto_nosummon(victim);
+  GET_POS(victim) = POS_STANDING;
+  look_at_room(victim, 0);
+  // призываем чармисов
+  for (k = victim->followers; k; k = k_next) {
+    k_next = k->next;
+    if (IN_ROOM(k->follower) == vic_room) {
+      if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_CHARM)) {
+        if (!k->follower->get_fighting()) {
+          act("$n растворил$u на ваших глазах.", TRUE, k->follower, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+          char_from_room(k->follower);
+          char_to_room(k->follower, ch_room);
+          act("$n прибыл$g за хозяином.", TRUE, k->follower, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+          act("$n призвал$g вас!", FALSE, ch, 0, k->follower, TO_VICT);
+        }
+      }
+    }
+  }
 
-	act("$n растворил$u на ваших глазах.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-	char_from_room(victim);
-	char_to_room(victim, ch_room);
-    victim->dismount();
-	act("$n прибыл$g по вызову.", TRUE, victim, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-	act("$n призвал$g вас!", FALSE, ch, 0, victim, TO_VICT);
-	check_auto_nosummon(victim);
-	GET_POS(victim) = POS_STANDING;
-	look_at_room(victim, 0);
-	// призываем чармисов
-	for (k = victim->followers; k; k = k_next) {
-		k_next = k->next;
-		if (IN_ROOM(k->follower) == vic_room) {
-			if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_CHARM)) {
-				if (!k->follower->get_fighting()) {
-					act("$n растворил$u на ваших глазах.", TRUE, k->follower, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-					char_from_room(k->follower);
-					char_to_room(k->follower, ch_room);
-					act("$n прибыл$g за хозяином.", TRUE, k->follower, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-					act("$n призвал$g вас!", FALSE, ch, 0, k->follower, TO_VICT);
-				}
-			}
-		}
-	}
-
-	greet_mtrigger(victim, -1);	// УЖАС!!! Не стоит в эту функцию передавать -1 :)
-	greet_otrigger(victim, -1);	// УЖАС!!! Не стоит в эту функцию передавать -1 :)
-	return;
+  greet_mtrigger(victim, -1);    // УЖАС!!! Не стоит в эту функцию передавать -1 :)
+  greet_otrigger(victim, -1);    // УЖАС!!! Не стоит в эту функцию передавать -1 :)
+  return;
 }
 
-
-
-void spell_locate_object(int level, CHAR_DATA *ch, CHAR_DATA* /*victim*/, OBJ_DATA* obj)
-{
-	/*
+void spell_locate_object(int level, CHAR_DATA *ch, CHAR_DATA * /*victim*/, OBJ_DATA *obj) {
+  /*
 	 * FIXME: This is broken.  The spell parser routines took the argument
 	 * the player gave to the spell and located an object with that keyword.
 	 * Since we're passed the object and not the keyword we can only guess
 	 * at what the player originally meant to search for. -gg
 	 */
-	if (!obj)
-	{
-		return;
-	}
+  if (!obj) {
+    return;
+  }
 
-	char name[MAX_INPUT_LENGTH];
-	bool bloody_corpse = false;
-	strcpy(name, cast_argument);
+  char name[MAX_INPUT_LENGTH];
+  bool bloody_corpse = false;
+  strcpy(name, cast_argument);
 
-	int tmp_lvl = (IS_GOD(ch)) ? 300 : level;
-	unsigned count = tmp_lvl;
-	const auto result = world_objects.find_if_and_dec_number([&](const OBJ_DATA::shared_ptr& i)
-	{
-		const auto obj_ptr = world_objects.get_by_raw_ptr(i.get());
-		if (!obj_ptr)
-		{
-			sprintf(buf, "SYSERR: Illegal object iterator while locate");
-			mudlog(buf, BRF, LVL_IMPL, SYSLOG, TRUE);
+  int tmp_lvl = (IS_GOD(ch)) ? 300 : level;
+  unsigned count = tmp_lvl;
+  const auto result = world_objects.find_if_and_dec_number([&](const OBJ_DATA::shared_ptr &i) {
+    const auto obj_ptr = world_objects.get_by_raw_ptr(i.get());
+    if (!obj_ptr) {
+      sprintf(buf, "SYSERR: Illegal object iterator while locate");
+      mudlog(buf, BRF, LVL_IMPL, SYSLOG, TRUE);
 
-			return false;
-		}
+      return false;
+    }
 
-		bloody_corpse = false;
-		if (!IS_GOD(ch))
-		{
-			if (number(1, 100) > (40 + MAX((GET_REAL_INT(ch) - 25) * 2, 0)))
-			{
-				return false;
-			}
+    bloody_corpse = false;
+    if (!IS_GOD(ch)) {
+      if (number(1, 100) > (40 + MAX((GET_REAL_INT(ch) - 25) * 2, 0))) {
+        return false;
+      }
 
-			if (IS_CORPSE(i))
-			{
-				bloody_corpse = catch_bloody_corpse(i.get());
-				if (!bloody_corpse)
-				{
-					return false;
-				}
-			}
-		}
+      if (IS_CORPSE(i)) {
+        bloody_corpse = catch_bloody_corpse(i.get());
+        if (!bloody_corpse) {
+          return false;
+        }
+      }
+    }
 
-		if (i->get_extra_flag(EExtraFlag::ITEM_NOLOCATE) && i->get_carried_by() != ch)
-		{
-			// !локейт стаф может локейтить только имм или тот кто его держит
-			return false;
-		}
+    if (i->get_extra_flag(EExtraFlag::ITEM_NOLOCATE) && i->get_carried_by() != ch) {
+      // !локейт стаф может локейтить только имм или тот кто его держит
+      return false;
+    }
 
-		if (SECT(i->get_in_room()) == SECT_SECRET)
-		{
-			return false;
-		}
+    if (SECT(i->get_in_room()) == SECT_SECRET) {
+      return false;
+    }
 
-		if (i->get_carried_by())
-		{
-			const auto carried_by = i->get_carried_by();
-			const auto carried_by_ptr = character_list.get_character_by_address(carried_by);
+    if (i->get_carried_by()) {
+      const auto carried_by = i->get_carried_by();
+      const auto carried_by_ptr = character_list.get_character_by_address(carried_by);
 
-			if (!carried_by_ptr)
-			{
-				sprintf(buf, "SYSERR: Illegal carried_by ptr. Создана кора для исследований");
-				mudlog(buf, BRF, LVL_IMPL, SYSLOG, TRUE);
-				return false;
-			}
+      if (!carried_by_ptr) {
+        sprintf(buf, "SYSERR: Illegal carried_by ptr. Создана кора для исследований");
+        mudlog(buf, BRF, LVL_IMPL, SYSLOG, TRUE);
+        return false;
+      }
 
-			if (!VALID_RNUM(IN_ROOM(carried_by)))
-			{
-				sprintf(buf, "SYSERR: Illegal room %d, char %s. Создана кора для исследований", IN_ROOM(carried_by), carried_by->get_name().c_str());
-				mudlog(buf, BRF, LVL_IMPL, SYSLOG, TRUE);
-				return false;
-			}
+      if (!VALID_RNUM(IN_ROOM(carried_by))) {
+        sprintf(buf,
+                "SYSERR: Illegal room %d, char %s. Создана кора для исследований",
+                IN_ROOM(carried_by),
+                carried_by->get_name().c_str());
+        mudlog(buf, BRF, LVL_IMPL, SYSLOG, TRUE);
+        return false;
+      }
 
-			if (SECT(IN_ROOM(carried_by)) == SECT_SECRET || IS_IMMORTAL(carried_by)) {
-				return false;
-			}
-		}
+      if (SECT(IN_ROOM(carried_by)) == SECT_SECRET || IS_IMMORTAL(carried_by)) {
+        return false;
+      }
+    }
 
-		if (!isname(name, i->get_aliases())) {
-			return false;
-		}
-		if (i->get_carried_by()) {
-			const auto carried_by = i->get_carried_by();
-			const auto same_zone = world[ch->in_room]->zone == world[carried_by->in_room]->zone;
-			if (!IS_NPC(carried_by) || same_zone || bloody_corpse) {
-				sprintf(buf, "%s наход%sся у %s в инвентаре.\r\n", i->get_short_description().c_str(),
-					GET_OBJ_POLY_1(ch, i), PERS(carried_by, ch, 1));
-			} else {
-				return false;
-			}
-		}
-		else if (i->get_in_room() != NOWHERE && i->get_in_room()) {
-			const auto room = i->get_in_room();
-			const auto same_zone = world[ch->in_room]->zone == world[room]->zone;
-			if (same_zone) {
-				sprintf(buf, "%s наход%sся в комнате '%s'\r\n",
-					i->get_short_description().c_str(), GET_OBJ_POLY_1(ch, i), world[room]->name);
-			} else {
-				return false;
-			}
-		}
-		else if (i->get_in_obj())
-		{
-			if (Clan::is_clan_chest(i->get_in_obj()))
-			{
-				return false; // шоб не забивало локейт на мобах/плеерах - по кланам проходим ниже отдельно
-			}
-			else
-			{
-				if (!IS_GOD(ch))
-				{
-					if (i->get_in_obj()->get_carried_by()) {
-						if (IS_NPC(i->get_in_obj()->get_carried_by()) && i->get_extra_flag(EExtraFlag::ITEM_NOLOCATE)) {
-							return false;
-						}
-					}
-					if (i->get_in_obj()->get_in_room() != NOWHERE
-						&& i->get_in_obj()->get_in_room()) {
-						if (i->get_extra_flag(EExtraFlag::ITEM_NOLOCATE) && !bloody_corpse) {
-							return false;
-						}
-					}
-					if (i->get_in_obj()->get_worn_by()) {
-						const auto worn_by = i->get_in_obj()->get_worn_by();
-						if (IS_NPC(worn_by) && i->get_extra_flag(EExtraFlag::ITEM_NOLOCATE) && !bloody_corpse) {
-							return false;
-						}
-					}
-				}
-				sprintf(buf, "%s наход%sся в %s.\r\n",
-					i->get_short_description().c_str(),
-					GET_OBJ_POLY_1(ch, i),
-					i->get_in_obj()->get_PName(5).c_str());
-			}
-		}
-		else if (i->get_worn_by()) {
-			const auto worn_by = i->get_worn_by();
-			const auto same_zone = world[ch->in_room]->zone == world[worn_by->in_room]->zone;
-			if (!IS_NPC(worn_by) || same_zone || bloody_corpse) {
-				sprintf(buf, "%s надет%s на %s.\r\n", i->get_short_description().c_str(),
-					GET_OBJ_SUF_6(i), PERS(worn_by, ch, 3));
-			} else {
-				return false;
-			}
-		}
-		else {
-			sprintf(buf, "Местоположение %s неопределимо.\r\n", OBJN(i.get(), ch, 1));
-		}
+    if (!isname(name, i->get_aliases())) {
+      return false;
+    }
+    if (i->get_carried_by()) {
+      const auto carried_by = i->get_carried_by();
+      const auto same_zone = world[ch->in_room]->zone == world[carried_by->in_room]->zone;
+      if (!IS_NPC(carried_by) || same_zone || bloody_corpse) {
+        sprintf(buf, "%s наход%sся у %s в инвентаре.\r\n", i->get_short_description().c_str(),
+                GET_OBJ_POLY_1(ch, i), PERS(carried_by, ch, 1));
+      } else {
+        return false;
+      }
+    } else if (i->get_in_room() != NOWHERE && i->get_in_room()) {
+      const auto room = i->get_in_room();
+      const auto same_zone = world[ch->in_room]->zone == world[room]->zone;
+      if (same_zone) {
+        sprintf(buf, "%s наход%sся в комнате '%s'\r\n",
+                i->get_short_description().c_str(), GET_OBJ_POLY_1(ch, i), world[room]->name);
+      } else {
+        return false;
+      }
+    } else if (i->get_in_obj()) {
+      if (Clan::is_clan_chest(i->get_in_obj())) {
+        return false; // шоб не забивало локейт на мобах/плеерах - по кланам проходим ниже отдельно
+      } else {
+        if (!IS_GOD(ch)) {
+          if (i->get_in_obj()->get_carried_by()) {
+            if (IS_NPC(i->get_in_obj()->get_carried_by()) && i->get_extra_flag(EExtraFlag::ITEM_NOLOCATE)) {
+              return false;
+            }
+          }
+          if (i->get_in_obj()->get_in_room() != NOWHERE
+              && i->get_in_obj()->get_in_room()) {
+            if (i->get_extra_flag(EExtraFlag::ITEM_NOLOCATE) && !bloody_corpse) {
+              return false;
+            }
+          }
+          if (i->get_in_obj()->get_worn_by()) {
+            const auto worn_by = i->get_in_obj()->get_worn_by();
+            if (IS_NPC(worn_by) && i->get_extra_flag(EExtraFlag::ITEM_NOLOCATE) && !bloody_corpse) {
+              return false;
+            }
+          }
+        }
+        sprintf(buf, "%s наход%sся в %s.\r\n",
+                i->get_short_description().c_str(),
+                GET_OBJ_POLY_1(ch, i),
+                i->get_in_obj()->get_PName(5).c_str());
+      }
+    } else if (i->get_worn_by()) {
+      const auto worn_by = i->get_worn_by();
+      const auto same_zone = world[ch->in_room]->zone == world[worn_by->in_room]->zone;
+      if (!IS_NPC(worn_by) || same_zone || bloody_corpse) {
+        sprintf(buf, "%s надет%s на %s.\r\n", i->get_short_description().c_str(),
+                GET_OBJ_SUF_6(i), PERS(worn_by, ch, 3));
+      } else {
+        return false;
+      }
+    } else {
+      sprintf(buf, "Местоположение %s неопределимо.\r\n", OBJN(i.get(), ch, 1));
+    }
 
 //		CAP(buf); issue #59
-		send_to_char(buf, ch);
+    send_to_char(buf, ch);
 
-		return true;
-	}, count);
+    return true;
+  }, count);
 
-	int j = count;
-	if (j > 0)
-	{
-		j = Clan::print_spell_locate_object(ch, j, std::string(name));
-	}
+  int j = count;
+  if (j > 0) {
+    j = Clan::print_spell_locate_object(ch, j, std::string(name));
+  }
 
-	if (j > 0)
-	{
-		j = Depot::print_spell_locate_object(ch, j, std::string(name));
-	}
+  if (j > 0) {
+    j = Depot::print_spell_locate_object(ch, j, std::string(name));
+  }
 
-	if (j > 0)
-	{
-		j = Parcel::print_spell_locate_object(ch, j, std::string(name));
-	}
+  if (j > 0) {
+    j = Parcel::print_spell_locate_object(ch, j, std::string(name));
+  }
 
-	if (j == tmp_lvl)
-	{
-		send_to_char("Вы ничего не чувствуете.\r\n", ch);
-	}
+  if (j == tmp_lvl) {
+    send_to_char("Вы ничего не чувствуете.\r\n", ch);
+  }
 }
 
-bool catch_bloody_corpse(OBJ_DATA * l)
-{
-	bool temp_bloody = false;
-	OBJ_DATA* next_element;
+bool catch_bloody_corpse(OBJ_DATA *l) {
+  bool temp_bloody = false;
+  OBJ_DATA *next_element;
 
-	if (!l->get_contains())
-	{
-		return false;
-	}
+  if (!l->get_contains()) {
+    return false;
+  }
 
-	if (bloody::is_bloody(l->get_contains()))
-	{
-		return true;
-	}
+  if (bloody::is_bloody(l->get_contains())) {
+    return true;
+  }
 
-	if (!l->get_contains()->get_next_content())
-	{
-		return false;
-	}
+  if (!l->get_contains()->get_next_content()) {
+    return false;
+  }
 
-	next_element = l->get_contains()->get_next_content();
-	while (next_element)
-	{
-		if (next_element->get_contains())
-		{
-			temp_bloody = catch_bloody_corpse(next_element->get_contains());
-			if (temp_bloody)
-			{
-				return true;
-			}
-		}
+  next_element = l->get_contains()->get_next_content();
+  while (next_element) {
+    if (next_element->get_contains()) {
+      temp_bloody = catch_bloody_corpse(next_element->get_contains());
+      if (temp_bloody) {
+        return true;
+      }
+    }
 
-		if (bloody::is_bloody(next_element))
-		{
-			return true;
-		}
+    if (bloody::is_bloody(next_element)) {
+      return true;
+    }
 
-		next_element = next_element->get_contains();
-	}
+    next_element = next_element->get_contains();
+  }
 
-	return false;
+  return false;
 }
 
-void spell_create_weapon(int/* level*/, CHAR_DATA* /*ch*/, CHAR_DATA* /*victim*/, OBJ_DATA* /* obj*/)
-{				//go_create_weapon(ch,NULL,what_sky);
+void spell_create_weapon(int/* level*/,
+                         CHAR_DATA * /*ch*/,
+                         CHAR_DATA * /*victim*/,
+                         OBJ_DATA * /* obj*/) {                //go_create_weapon(ch,NULL,what_sky);
 // отключено, так как не реализовано
 }
 
+int check_charmee(CHAR_DATA *ch, CHAR_DATA *victim, int spellnum) {
+  struct follow_type *k;
+  int cha_summ = 0, reformed_hp_summ = 0;
+  bool undead_in_group = FALSE, living_in_group = FALSE;
 
-int check_charmee(CHAR_DATA * ch, CHAR_DATA * victim, int spellnum)
-{
-	struct follow_type *k;
-	int cha_summ = 0, reformed_hp_summ = 0;
-	bool undead_in_group = FALSE, living_in_group = FALSE;
-
-	for (k = ch->followers; k; k = k->next)
-	{
-		if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_CHARM)
-			&& k->follower->get_master() == ch)
-		{
-			cha_summ++;
-			//hp_summ += GET_REAL_MAX_HIT(k->follower);
-			reformed_hp_summ += get_reformed_charmice_hp(ch, k->follower, spellnum);
+  for (k = ch->followers; k; k = k->next) {
+    if (AFF_FLAGGED(k->follower, EAffectFlag::AFF_CHARM)
+        && k->follower->get_master() == ch) {
+      cha_summ++;
+      //hp_summ += GET_REAL_MAX_HIT(k->follower);
+      reformed_hp_summ += get_reformed_charmice_hp(ch, k->follower, spellnum);
 // Проверка на тип последователей -- некрасиво, зато эффективно
-			if (MOB_FLAGGED(k->follower, MOB_CORPSE))
-			{
-				undead_in_group = TRUE;
-			}
-			else
-			{
-				living_in_group = TRUE;
-			}
-		}
-	}
+      if (MOB_FLAGGED(k->follower, MOB_CORPSE)) {
+        undead_in_group = TRUE;
+      } else {
+        living_in_group = TRUE;
+      }
+    }
+  }
 
-	if (undead_in_group && living_in_group)
-	{
-		mudlog("SYSERR: Undead and living in group simultaniously", NRM, LVL_GOD, ERRLOG, TRUE);
-		return (FALSE);
-	}
+  if (undead_in_group && living_in_group) {
+    mudlog("SYSERR: Undead and living in group simultaniously", NRM, LVL_GOD, ERRLOG, TRUE);
+    return (FALSE);
+  }
 
-	if (spellnum == SPELL_CHARM && undead_in_group)
-	{
-		send_to_char("Ваша жертва боится ваших последователей.\r\n", ch);
-		return (FALSE);
-	}
+  if (spellnum == SPELL_CHARM && undead_in_group) {
+    send_to_char("Ваша жертва боится ваших последователей.\r\n", ch);
+    return (FALSE);
+  }
 
-	if (spellnum != SPELL_CHARM && living_in_group)
-	{
-		send_to_char("Ваш последователь мешает вам произнести это заклинание.\r\n", ch);
-		return (FALSE);
-	}
+  if (spellnum != SPELL_CHARM && living_in_group) {
+    send_to_char("Ваш последователь мешает вам произнести это заклинание.\r\n", ch);
+    return (FALSE);
+  }
 
-	if (spellnum == SPELL_CLONE && cha_summ >= MAX(1, (GET_LEVEL(ch) + 4) / 5 - 2))
-	{
-		send_to_char("Вы не сможете управлять столькими последователями.\r\n", ch);
-		return (FALSE);
-	}
+  if (spellnum == SPELL_CLONE && cha_summ >= MAX(1, (GET_LEVEL(ch) + 4) / 5 - 2)) {
+    send_to_char("Вы не сможете управлять столькими последователями.\r\n", ch);
+    return (FALSE);
+  }
 
-	if (spellnum != SPELL_CLONE && cha_summ >= (GET_LEVEL(ch) + 9) / 10)
-	{
-		send_to_char("Вы не сможете управлять столькими последователями.\r\n", ch);
-		return (FALSE);
-	}
+  if (spellnum != SPELL_CLONE && cha_summ >= (GET_LEVEL(ch) + 9) / 10) {
+    send_to_char("Вы не сможете управлять столькими последователями.\r\n", ch);
+    return (FALSE);
+  }
 
-	if (spellnum != SPELL_CLONE &&
-			reformed_hp_summ + get_reformed_charmice_hp(ch, victim, spellnum) >= get_player_charms(ch, spellnum))
-	{
-		send_to_char("Вам не под силу управлять такой боевой мощью.\r\n", ch);
-		return (FALSE);
-	}
-	return (TRUE);
+  if (spellnum != SPELL_CLONE &&
+      reformed_hp_summ + get_reformed_charmice_hp(ch, victim, spellnum) >= get_player_charms(ch, spellnum)) {
+    send_to_char("Вам не под силу управлять такой боевой мощью.\r\n", ch);
+    return (FALSE);
+  }
+  return (TRUE);
 }
 
-void spell_charm(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* /* obj*/)
-{
-	if (victim == NULL || ch == NULL)
-		return;
+void spell_charm(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA * /* obj*/) {
+  if (victim == NULL || ch == NULL)
+    return;
 
-	if (victim == ch)
-		send_to_char("Вы просто очарованы своим внешним видом!\r\n", ch);
-	else if (!IS_NPC(victim))
-	{
-		send_to_char("Вы не можете очаровать реального игрока!\r\n", ch);
-		if (!pk_agro_action(ch, victim))
-			return;
-	}
-	else if (!IS_IMMORTAL(ch) && (AFF_FLAGGED(victim, EAffectFlag::AFF_SANCTUARY) || MOB_FLAGGED(victim, MOB_PROTECT)))
-		send_to_char("Ваша жертва освящена Богами!\r\n", ch);
+  if (victim == ch)
+    send_to_char("Вы просто очарованы своим внешним видом!\r\n", ch);
+  else if (!IS_NPC(victim)) {
+    send_to_char("Вы не можете очаровать реального игрока!\r\n", ch);
+    if (!pk_agro_action(ch, victim))
+      return;
+  } else if (!IS_IMMORTAL(ch) && (AFF_FLAGGED(victim, EAffectFlag::AFF_SANCTUARY) || MOB_FLAGGED(victim, MOB_PROTECT)))
+    send_to_char("Ваша жертва освящена Богами!\r\n", ch);
 // shapirus: нельзя почармить моба под ЗБ
-	else if (!IS_IMMORTAL(ch) && (AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD) || MOB_FLAGGED(victim, MOB_PROTECT)))
-		send_to_char("Ваша жертва защищена Богами!\r\n", ch);
-	else if (!IS_IMMORTAL(ch) && MOB_FLAGGED(victim, MOB_NOCHARM))
-		send_to_char("Ваша жертва устойчива к этому!\r\n", ch);
-	else if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM))
-		send_to_char("Вы сами очарованы кем-то и не можете иметь последователей.\r\n", ch);
-	else if (AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM)
-			 || MOB_FLAGGED(victim, MOB_AGGRESSIVE)
-			 || MOB_FLAGGED(victim, MOB_AGGRMONO)
-			 || MOB_FLAGGED(victim, MOB_AGGRPOLY)
-			 || MOB_FLAGGED(victim, MOB_AGGR_DAY)
-			 || MOB_FLAGGED(victim, MOB_AGGR_NIGHT)
-			 || MOB_FLAGGED(victim, MOB_AGGR_FULLMOON)
-			 || MOB_FLAGGED(victim, MOB_AGGR_WINTER)
-			 || MOB_FLAGGED(victim, MOB_AGGR_SPRING)
-			 || MOB_FLAGGED(victim, MOB_AGGR_SUMMER)
-			 || MOB_FLAGGED(victim, MOB_AGGR_AUTUMN))
-		send_to_char("Ваша магия потерпела неудачу.\r\n", ch);
-	else if (IS_HORSE(victim))
-		send_to_char("Это боевой скакун, а не хухры-мухры.\r\n", ch);
-	else if (victim->get_fighting() || GET_POS(victim) < POS_RESTING)
-		act("$M сейчас, похоже, не до вас.", FALSE, ch, 0, victim, TO_CHAR);
-	else if (circle_follow(victim, ch))
-		send_to_char("Следование по кругу запрещено.\r\n", ch);
-	else if (!IS_IMMORTAL(ch) && general_savingthrow(ch, victim, SAVING_WILL, (GET_REAL_CHA(ch) - 10) * 4 + GET_REMORT(ch) * 3))
-		send_to_char("Ваша магия потерпела неудачу.\r\n", ch);
-	else
-	{
-		if (!check_charmee(ch, victim, SPELL_CHARM))
-		{
-			return;
-		}
+  else if (!IS_IMMORTAL(ch) && (AFF_FLAGGED(victim, EAffectFlag::AFF_SHIELD) || MOB_FLAGGED(victim, MOB_PROTECT)))
+    send_to_char("Ваша жертва защищена Богами!\r\n", ch);
+  else if (!IS_IMMORTAL(ch) && MOB_FLAGGED(victim, MOB_NOCHARM))
+    send_to_char("Ваша жертва устойчива к этому!\r\n", ch);
+  else if (AFF_FLAGGED(ch, EAffectFlag::AFF_CHARM))
+    send_to_char("Вы сами очарованы кем-то и не можете иметь последователей.\r\n", ch);
+  else if (AFF_FLAGGED(victim, EAffectFlag::AFF_CHARM)
+      || MOB_FLAGGED(victim, MOB_AGGRESSIVE)
+      || MOB_FLAGGED(victim, MOB_AGGRMONO)
+      || MOB_FLAGGED(victim, MOB_AGGRPOLY)
+      || MOB_FLAGGED(victim, MOB_AGGR_DAY)
+      || MOB_FLAGGED(victim, MOB_AGGR_NIGHT)
+      || MOB_FLAGGED(victim, MOB_AGGR_FULLMOON)
+      || MOB_FLAGGED(victim, MOB_AGGR_WINTER)
+      || MOB_FLAGGED(victim, MOB_AGGR_SPRING)
+      || MOB_FLAGGED(victim, MOB_AGGR_SUMMER)
+      || MOB_FLAGGED(victim, MOB_AGGR_AUTUMN))
+    send_to_char("Ваша магия потерпела неудачу.\r\n", ch);
+  else if (IS_HORSE(victim))
+    send_to_char("Это боевой скакун, а не хухры-мухры.\r\n", ch);
+  else if (victim->get_fighting() || GET_POS(victim) < POS_RESTING)
+    act("$M сейчас, похоже, не до вас.", FALSE, ch, 0, victim, TO_CHAR);
+  else if (circle_follow(victim, ch))
+    send_to_char("Следование по кругу запрещено.\r\n", ch);
+  else if (!IS_IMMORTAL(ch)
+      && general_savingthrow(ch, victim, SAVING_WILL, (GET_REAL_CHA(ch) - 10) * 4 + GET_REMORT(ch) * 3))
+    send_to_char("Ваша магия потерпела неудачу.\r\n", ch);
+  else {
+    if (!check_charmee(ch, victim, SPELL_CHARM)) {
+      return;
+    }
 
-		// Левая проверка
-		if (victim->has_master())
-		{
-			if (stop_follower(victim, SF_MASTERDIE))
-			{
-				return;
-			}
-		}
+    // Левая проверка
+    if (victim->has_master()) {
+      if (stop_follower(victim, SF_MASTERDIE)) {
+        return;
+      }
+    }
 
-		if (CAN_SEE(victim, ch)) {
-			mobRemember(victim, ch);
-		}
+    if (CAN_SEE(victim, ch)) {
+      mobRemember(victim, ch);
+    }
 
-		if (MOB_FLAGGED(victim, MOB_NOGROUP))
-			MOB_FLAGS(victim).unset(MOB_NOGROUP);
+    if (MOB_FLAGGED(victim, MOB_NOGROUP))
+      MOB_FLAGS(victim).unset(MOB_NOGROUP);
 
-		affect_from_char(victim, SPELL_CHARM);
-		ch->add_follower(victim);
-		AFFECT_DATA<EApplyLocation> af;
-		af.type = SPELL_CHARM;
+    affect_from_char(victim, SPELL_CHARM);
+    ch->add_follower(victim);
+    AFFECT_DATA<EApplyLocation> af;
+    af.type = SPELL_CHARM;
 
-		if (GET_REAL_INT(victim) > GET_REAL_INT(ch)) {
-			af.duration = pc_duration(victim, GET_REAL_CHA(ch), 0, 0, 0, 0);
-		}
-		else
-		{
-			af.duration = pc_duration(victim, GET_REAL_CHA(ch) + number(1, 10) + GET_REMORT(ch) * 2, 0, 0, 0, 0);
-		}
+    if (GET_REAL_INT(victim) > GET_REAL_INT(ch)) {
+      af.duration = pc_duration(victim, GET_REAL_CHA(ch), 0, 0, 0, 0);
+    } else {
+      af.duration = pc_duration(victim, GET_REAL_CHA(ch) + number(1, 10) + GET_REMORT(ch) * 2, 0, 0, 0, 0);
+    }
 
-		af.modifier = 0;
-		af.location = APPLY_NONE;
-		af.bitvector = to_underlying(EAffectFlag::AFF_CHARM);
-		af.battleflag = 0;
-		affect_to_char(victim, af);
+    af.modifier = 0;
+    af.location = APPLY_NONE;
+    af.bitvector = to_underlying(EAffectFlag::AFF_CHARM);
+    af.battleflag = 0;
+    affect_to_char(victim, af);
 
-		if (GET_HELPER(victim)) {
-			GET_HELPER(victim) = NULL;
-		}
+    if (GET_HELPER(victim)) {
+      GET_HELPER(victim) = NULL;
+    }
 
-		act("$n покорил$g ваше сердце настолько, что вы готовы на все ради н$s.", FALSE, ch, 0, victim, TO_VICT);
-		if (IS_NPC(victim)) {
+    act("$n покорил$g ваше сердце настолько, что вы готовы на все ради н$s.", FALSE, ch, 0, victim, TO_VICT);
+    if (IS_NPC(victim)) {
 //Eli. Раздеваемся.
-			for (int i = 0; i < NUM_WEARS; i++) {
-				if (GET_EQ(victim, i)) {
-					if (!remove_otrigger(GET_EQ(victim, i), victim)) {
-						continue;
-					}
+      for (int i = 0; i < NUM_WEARS; i++) {
+        if (GET_EQ(victim, i)) {
+          if (!remove_otrigger(GET_EQ(victim, i), victim)) {
+            continue;
+          }
 
-					act("Вы прекратили использовать $o3.", FALSE, victim, GET_EQ(victim, i), 0, TO_CHAR);
-					act("$n прекратил$g использовать $o3.", TRUE, victim, GET_EQ(victim, i), 0, TO_ROOM);
-					obj_to_char(unequip_char(victim, i | 0x40), victim);
-				}
-			}
+          act("Вы прекратили использовать $o3.", FALSE, victim, GET_EQ(victim, i), 0, TO_CHAR);
+          act("$n прекратил$g использовать $o3.", TRUE, victim, GET_EQ(victim, i), 0, TO_ROOM);
+          obj_to_char(unequip_char(victim, i | 0x40), victim);
+        }
+      }
 
 //Eli закончили раздеваться.
-			MOB_FLAGS(victim).unset(MOB_AGGRESSIVE);
-			MOB_FLAGS(victim).unset(MOB_SPEC);
-			PRF_FLAGS(victim).unset(PRF_PUNCTUAL);
+      MOB_FLAGS(victim).unset(MOB_AGGRESSIVE);
+      MOB_FLAGS(victim).unset(MOB_SPEC);
+      PRF_FLAGS(victim).unset(PRF_PUNCTUAL);
 // shapirus: !train для чармисов
-			MOB_FLAGS(victim).set(MOB_NOTRAIN);
-			victim->set_skill(SKILL_PUNCTUAL, 0);
-			// по идее при речарме и последующем креше можно оказаться с сейвом без шмота на чармисе -- Krodo
-			ch->updateCharmee(GET_MOB_VNUM(victim), 0);
-			Crash_crashsave(ch);
-			ch->save_char();
-		}
-	}
+      MOB_FLAGS(victim).set(MOB_NOTRAIN);
+      victim->set_skill(SKILL_PUNCTUAL, 0);
+      // по идее при речарме и последующем креше можно оказаться с сейвом без шмота на чармисе -- Krodo
+      ch->updateCharmee(GET_MOB_VNUM(victim), 0);
+      Crash_crashsave(ch);
+      ch->save_char();
+    }
+  }
 }
 
-void show_weapon(CHAR_DATA * ch, OBJ_DATA * obj)
-{
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON)
-	{
-		*buf = '\0';
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD))
-		{
-			sprintf(buf, "Можно взять %s в правую руку.\r\n", OBJN(obj, ch, 3));
-		}
+void show_weapon(CHAR_DATA *ch, OBJ_DATA *obj) {
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_WEAPON) {
+    *buf = '\0';
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_WIELD)) {
+      sprintf(buf, "Можно взять %s в правую руку.\r\n", OBJN(obj, ch, 3));
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD))
-		{
-			sprintf(buf + strlen(buf), "Можно взять %s в левую руку.\r\n", OBJN(obj, ch, 3));
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_HOLD)) {
+      sprintf(buf + strlen(buf), "Можно взять %s в левую руку.\r\n", OBJN(obj, ch, 3));
+    }
 
-		if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS))
-		{
-			sprintf(buf + strlen(buf), "Можно взять %s в обе руки.\r\n", OBJN(obj, ch, 3));
-		}
+    if (CAN_WEAR(obj, EWearFlag::ITEM_WEAR_BOTHS)) {
+      sprintf(buf + strlen(buf), "Можно взять %s в обе руки.\r\n", OBJN(obj, ch, 3));
+    }
 
-		if (*buf)
-		{
-			send_to_char(buf, ch);
-		}
-	}
+    if (*buf) {
+      send_to_char(buf, ch);
+    }
+  }
 }
 
-void print_book_uprgd_skill(CHAR_DATA *ch, const OBJ_DATA *obj)
-{
-	const int skill_num = GET_OBJ_VAL(obj, 1);
-	if (skill_num < 1 || skill_num >= MAX_SKILL_NUM)
-	{
-		log("SYSERR: invalid skill_num: %d, ch_name=%s, obj_vnum=%d (%s %s %d)",
-			skill_num,
-			ch->get_name().c_str(),
-			GET_OBJ_VNUM(obj),
-			__FILE__,
-			__func__,
-			__LINE__);
-		return;
-	}
-	if (GET_OBJ_VAL(obj, 3) > 0)
-	{
-		send_to_char(ch, "повышает умение \"%s\" (максимум %d)\r\n",
-			skill_info[skill_num].name, GET_OBJ_VAL(obj, 3));
-	}
-	else
-	{
-		send_to_char(ch, "повышает умение \"%s\" (не больше максимума текущего перевоплощения)\r\n",
-			skill_info[skill_num].name);
-	}
+void print_book_uprgd_skill(CHAR_DATA *ch, const OBJ_DATA *obj) {
+  const int skill_num = GET_OBJ_VAL(obj, 1);
+  if (skill_num < 1 || skill_num >= MAX_SKILL_NUM) {
+    log("SYSERR: invalid skill_num: %d, ch_name=%s, obj_vnum=%d (%s %s %d)",
+        skill_num,
+        ch->get_name().c_str(),
+        GET_OBJ_VNUM(obj),
+        __FILE__,
+        __func__,
+        __LINE__);
+    return;
+  }
+  if (GET_OBJ_VAL(obj, 3) > 0) {
+    send_to_char(ch, "повышает умение \"%s\" (максимум %d)\r\n",
+                 skill_info[skill_num].name, GET_OBJ_VAL(obj, 3));
+  } else {
+    send_to_char(ch, "повышает умение \"%s\" (не больше максимума текущего перевоплощения)\r\n",
+                 skill_info[skill_num].name);
+  }
 }
 
-void mort_show_obj_values(const OBJ_DATA * obj, CHAR_DATA * ch, int fullness)
-{
-	int i, found, drndice = 0, drsdice = 0, j;
-	long int li;
+void mort_show_obj_values(const OBJ_DATA *obj, CHAR_DATA *ch, int fullness) {
+  int i, found, drndice = 0, drsdice = 0, j;
+  long int li;
 
-	send_to_char("Вы узнали следующее:\r\n", ch);
-	sprintf(buf, "Предмет \"%s\", тип : ", obj->get_short_description().c_str());
-	sprinttype(GET_OBJ_TYPE(obj), item_types, buf2);
-	strcat(buf, buf2);
-	strcat(buf, "\r\n");
-	send_to_char(buf, ch);
+  send_to_char("Вы узнали следующее:\r\n", ch);
+  sprintf(buf, "Предмет \"%s\", тип : ", obj->get_short_description().c_str());
+  sprinttype(GET_OBJ_TYPE(obj), item_types, buf2);
+  strcat(buf, buf2);
+  strcat(buf, "\r\n");
+  send_to_char(buf, ch);
 
-	strcpy(buf, diag_weapon_to_char(obj, 2));
-	if (*buf)
-		send_to_char(buf, ch);
+  strcpy(buf, diag_weapon_to_char(obj, 2));
+  if (*buf)
+    send_to_char(buf, ch);
 
-	if (fullness < 20)
-		return;
+  if (fullness < 20)
+    return;
 
-	//show_weapon(ch, obj);
+  //show_weapon(ch, obj);
 
-	sprintf(buf, "Вес: %d, Цена: %d, Рента: %d(%d)\r\n",
-			GET_OBJ_WEIGHT(obj), GET_OBJ_COST(obj), GET_OBJ_RENT(obj), GET_OBJ_RENTEQ(obj));
-	send_to_char(buf, ch);
+  sprintf(buf, "Вес: %d, Цена: %d, Рента: %d(%d)\r\n",
+          GET_OBJ_WEIGHT(obj), GET_OBJ_COST(obj), GET_OBJ_RENT(obj), GET_OBJ_RENTEQ(obj));
+  send_to_char(buf, ch);
 
-	if (fullness < 30)
-		return;
-	sprinttype(obj->get_material(), material_name, buf2);
-	snprintf(buf, MAX_STRING_LENGTH, "Материал : %s, макс.прочность : %d, тек.прочность : %d\r\n", buf2, 
-		obj->get_maximum_durability(), obj->get_current_durability());
-	send_to_char(buf, ch);
-	send_to_char(CCNRM(ch, C_NRM), ch);
+  if (fullness < 30)
+    return;
+  sprinttype(obj->get_material(), material_name, buf2);
+  snprintf(buf, MAX_STRING_LENGTH, "Материал : %s, макс.прочность : %d, тек.прочность : %d\r\n", buf2,
+           obj->get_maximum_durability(), obj->get_current_durability());
+  send_to_char(buf, ch);
+  send_to_char(CCNRM(ch, C_NRM), ch);
 
-	if (fullness < 40)
-		return;
+  if (fullness < 40)
+    return;
 
-	send_to_char("Неудобен : ", ch);
-	send_to_char(CCCYN(ch, C_NRM), ch);
-	obj->get_no_flags().sprintbits(no_bits, buf, ",",IS_IMMORTAL(ch)?4:0);
-	strcat(buf, "\r\n");
-	send_to_char(buf, ch);
-	send_to_char(CCNRM(ch, C_NRM), ch);
+  send_to_char("Неудобен : ", ch);
+  send_to_char(CCCYN(ch, C_NRM), ch);
+  obj->get_no_flags().sprintbits(no_bits, buf, ",", IS_IMMORTAL(ch) ? 4 : 0);
+  strcat(buf, "\r\n");
+  send_to_char(buf, ch);
+  send_to_char(CCNRM(ch, C_NRM), ch);
 
-	if (fullness < 50)
-		return;
+  if (fullness < 50)
+    return;
 
-	send_to_char("Недоступен : ", ch);
-	send_to_char(CCCYN(ch, C_NRM), ch);
-	obj->get_anti_flags().sprintbits(anti_bits, buf, ",",IS_IMMORTAL(ch)?4:0);
-	strcat(buf, "\r\n");
-	send_to_char(buf, ch);
-	send_to_char(CCNRM(ch, C_NRM), ch);
+  send_to_char("Недоступен : ", ch);
+  send_to_char(CCCYN(ch, C_NRM), ch);
+  obj->get_anti_flags().sprintbits(anti_bits, buf, ",", IS_IMMORTAL(ch) ? 4 : 0);
+  strcat(buf, "\r\n");
+  send_to_char(buf, ch);
+  send_to_char(CCNRM(ch, C_NRM), ch);
 
-	if (obj->get_auto_mort_req() > 0)
-	{
-		send_to_char(ch, "Требует перевоплощений : %s%d%s\r\n",
-			CCCYN(ch, C_NRM), obj->get_auto_mort_req(), CCNRM(ch, C_NRM));
-	}
-	else if (obj->get_auto_mort_req() < -1)
-	{
-		send_to_char(ch, "Максимальное количество перевоплощение : %s%d%s\r\n",
-			CCCYN(ch, C_NRM), abs(obj->get_minimum_remorts()), CCNRM(ch, C_NRM));
-	}
+  if (obj->get_auto_mort_req() > 0) {
+    send_to_char(ch, "Требует перевоплощений : %s%d%s\r\n",
+                 CCCYN(ch, C_NRM), obj->get_auto_mort_req(), CCNRM(ch, C_NRM));
+  } else if (obj->get_auto_mort_req() < -1) {
+    send_to_char(ch, "Максимальное количество перевоплощение : %s%d%s\r\n",
+                 CCCYN(ch, C_NRM), abs(obj->get_minimum_remorts()), CCNRM(ch, C_NRM));
+  }
 
-	if (fullness < 60)
-		return;
+  if (fullness < 60)
+    return;
 
-	send_to_char("Имеет экстрафлаги: ", ch);
-	send_to_char(CCCYN(ch, C_NRM), ch);
-	GET_OBJ_EXTRA(obj).sprintbits(extra_bits, buf, ",",IS_IMMORTAL(ch)?4:0);
-	strcat(buf, "\r\n");
-	send_to_char(buf, ch);
-	send_to_char(CCNRM(ch, C_NRM), ch);
+  send_to_char("Имеет экстрафлаги: ", ch);
+  send_to_char(CCCYN(ch, C_NRM), ch);
+  GET_OBJ_EXTRA(obj).sprintbits(extra_bits, buf, ",", IS_IMMORTAL(ch) ? 4 : 0);
+  strcat(buf, "\r\n");
+  send_to_char(buf, ch);
+  send_to_char(CCNRM(ch, C_NRM), ch);
 
-	if (fullness < 75)
-		return;
+  if (fullness < 75)
+    return;
 
-	switch (GET_OBJ_TYPE(obj))
-	{
-	case OBJ_DATA::ITEM_SCROLL:
-	case OBJ_DATA::ITEM_POTION:
-		sprintf(buf, "Содержит заклинания: ");
-		if (GET_OBJ_VAL(obj, 1) >= 1 && GET_OBJ_VAL(obj, 1) < MAX_SPELLS)
-			sprintf(buf + strlen(buf), " %s", spell_name(GET_OBJ_VAL(obj, 1)));
-		if (GET_OBJ_VAL(obj, 2) >= 1 && GET_OBJ_VAL(obj, 2) < MAX_SPELLS)
-			sprintf(buf + strlen(buf), " %s", spell_name(GET_OBJ_VAL(obj, 2)));
-		if (GET_OBJ_VAL(obj, 3) >= 1 && GET_OBJ_VAL(obj, 3) < MAX_SPELLS)
-			sprintf(buf + strlen(buf), " %s", spell_name(GET_OBJ_VAL(obj, 3)));
-		strcat(buf, "\r\n");
-		send_to_char(buf, ch);
-		break;
+  switch (GET_OBJ_TYPE(obj)) {
+    case OBJ_DATA::ITEM_SCROLL:
+    case OBJ_DATA::ITEM_POTION: sprintf(buf, "Содержит заклинания: ");
+      if (GET_OBJ_VAL(obj, 1) >= 1 && GET_OBJ_VAL(obj, 1) < MAX_SPELLS)
+        sprintf(buf + strlen(buf), " %s", spell_name(GET_OBJ_VAL(obj, 1)));
+      if (GET_OBJ_VAL(obj, 2) >= 1 && GET_OBJ_VAL(obj, 2) < MAX_SPELLS)
+        sprintf(buf + strlen(buf), " %s", spell_name(GET_OBJ_VAL(obj, 2)));
+      if (GET_OBJ_VAL(obj, 3) >= 1 && GET_OBJ_VAL(obj, 3) < MAX_SPELLS)
+        sprintf(buf + strlen(buf), " %s", spell_name(GET_OBJ_VAL(obj, 3)));
+      strcat(buf, "\r\n");
+      send_to_char(buf, ch);
+      break;
 
-	case OBJ_DATA::ITEM_WAND:
-	case OBJ_DATA::ITEM_STAFF:
-		sprintf(buf, "Вызывает заклинания: ");
-		if (GET_OBJ_VAL(obj, 3) >= 1 && GET_OBJ_VAL(obj, 3) < MAX_SPELLS)
-			sprintf(buf + strlen(buf), " %s\r\n", spell_name(GET_OBJ_VAL(obj, 3)));
-		sprintf(buf + strlen(buf), "Зарядов %d (осталось %d).\r\n", GET_OBJ_VAL(obj, 1), GET_OBJ_VAL(obj, 2));
-		send_to_char(buf, ch);
-		break;
+    case OBJ_DATA::ITEM_WAND:
+    case OBJ_DATA::ITEM_STAFF: sprintf(buf, "Вызывает заклинания: ");
+      if (GET_OBJ_VAL(obj, 3) >= 1 && GET_OBJ_VAL(obj, 3) < MAX_SPELLS)
+        sprintf(buf + strlen(buf), " %s\r\n", spell_name(GET_OBJ_VAL(obj, 3)));
+      sprintf(buf + strlen(buf), "Зарядов %d (осталось %d).\r\n", GET_OBJ_VAL(obj, 1), GET_OBJ_VAL(obj, 2));
+      send_to_char(buf, ch);
+      break;
 
-	case OBJ_DATA::ITEM_WEAPON:
-		drndice = GET_OBJ_VAL(obj, 1);
-		drsdice = GET_OBJ_VAL(obj, 2);
-		sprintf(buf, "Наносимые повреждения '%dD%d'", drndice, drsdice);
-		sprintf(buf + strlen(buf), " среднее %.1f.\r\n", ((drsdice + 1) * drndice / 2.0));
-		send_to_char(buf, ch);
-		break;
+    case OBJ_DATA::ITEM_WEAPON: drndice = GET_OBJ_VAL(obj, 1);
+      drsdice = GET_OBJ_VAL(obj, 2);
+      sprintf(buf, "Наносимые повреждения '%dD%d'", drndice, drsdice);
+      sprintf(buf + strlen(buf), " среднее %.1f.\r\n", ((drsdice + 1) * drndice / 2.0));
+      send_to_char(buf, ch);
+      break;
 
-	case OBJ_DATA::ITEM_ARMOR:
-	case OBJ_DATA::ITEM_ARMOR_LIGHT:
-	case OBJ_DATA::ITEM_ARMOR_MEDIAN:
-	case OBJ_DATA::ITEM_ARMOR_HEAVY:
-		drndice = GET_OBJ_VAL(obj, 0);
-		drsdice = GET_OBJ_VAL(obj, 1);
-		sprintf(buf, "защита (AC) : %d\r\n", drndice);
-		send_to_char(buf, ch);
-		sprintf(buf, "броня       : %d\r\n", drsdice);
-		send_to_char(buf, ch);
-		break;
+    case OBJ_DATA::ITEM_ARMOR:
+    case OBJ_DATA::ITEM_ARMOR_LIGHT:
+    case OBJ_DATA::ITEM_ARMOR_MEDIAN:
+    case OBJ_DATA::ITEM_ARMOR_HEAVY: drndice = GET_OBJ_VAL(obj, 0);
+      drsdice = GET_OBJ_VAL(obj, 1);
+      sprintf(buf, "защита (AC) : %d\r\n", drndice);
+      send_to_char(buf, ch);
+      sprintf(buf, "броня       : %d\r\n", drsdice);
+      send_to_char(buf, ch);
+      break;
 
-	case OBJ_DATA::ITEM_BOOK:
-		switch (GET_OBJ_VAL(obj, 0))
-		{
-		case BOOK_SPELL:
-			if (GET_OBJ_VAL(obj, 1) >= 1 && GET_OBJ_VAL(obj, 1) < MAX_SPELLS)
-			{
-				drndice = GET_OBJ_VAL(obj, 1);
-				if (MIN_CAST_REM(spell_info[GET_OBJ_VAL(obj, 1)], ch) > GET_REMORT(ch))
-					drsdice = 34;
-				else
-					drsdice = min_spell_lvl_with_req(ch, GET_OBJ_VAL(obj, 1), GET_OBJ_VAL(obj, 2));
-				sprintf(buf, "содержит заклинание        : \"%s\"\r\n", spell_info[drndice].name);
-				send_to_char(buf, ch);
-				sprintf(buf, "уровень изучения (для вас) : %d\r\n", drsdice);
-				send_to_char(buf, ch);
-			}
-			break;
+    case OBJ_DATA::ITEM_BOOK:
+      switch (GET_OBJ_VAL(obj, 0)) {
+        case BOOK_SPELL:
+          if (GET_OBJ_VAL(obj, 1) >= 1 && GET_OBJ_VAL(obj, 1) < MAX_SPELLS) {
+            drndice = GET_OBJ_VAL(obj, 1);
+            if (MIN_CAST_REM(spell_info[GET_OBJ_VAL(obj, 1)], ch) > GET_REMORT(ch))
+              drsdice = 34;
+            else
+              drsdice = min_spell_lvl_with_req(ch, GET_OBJ_VAL(obj, 1), GET_OBJ_VAL(obj, 2));
+            sprintf(buf, "содержит заклинание        : \"%s\"\r\n", spell_info[drndice].name);
+            send_to_char(buf, ch);
+            sprintf(buf, "уровень изучения (для вас) : %d\r\n", drsdice);
+            send_to_char(buf, ch);
+          }
+          break;
 
-		case BOOK_SKILL:
-			if (GET_OBJ_VAL(obj, 1) >= 1 && GET_OBJ_VAL(obj, 1) < MAX_SKILL_NUM)
-			{
-				drndice = GET_OBJ_VAL(obj, 1);
-				if (skill_info[drndice].classknow[(int) GET_CLASS(ch)][(int) GET_KIN(ch)] == KNOW_SKILL)
-				{
-					drsdice = min_skill_level_with_req(ch, drndice, GET_OBJ_VAL(obj, 2));
-				}
-				else
-				{
-					drsdice = LVL_IMPL;
-				}
-				sprintf(buf, "содержит секрет умения     : \"%s\"\r\n", skill_info[drndice].name);
-				send_to_char(buf, ch);
-				sprintf(buf, "уровень изучения (для вас) : %d\r\n", drsdice);
-				send_to_char(buf, ch);
-			}
-			break;
+        case BOOK_SKILL:
+          if (GET_OBJ_VAL(obj, 1) >= 1 && GET_OBJ_VAL(obj, 1) < MAX_SKILL_NUM) {
+            drndice = GET_OBJ_VAL(obj, 1);
+            if (skill_info[drndice].classknow[(int) GET_CLASS(ch)][(int) GET_KIN(ch)] == KNOW_SKILL) {
+              drsdice = min_skill_level_with_req(ch, drndice, GET_OBJ_VAL(obj, 2));
+            } else {
+              drsdice = LVL_IMPL;
+            }
+            sprintf(buf, "содержит секрет умения     : \"%s\"\r\n", skill_info[drndice].name);
+            send_to_char(buf, ch);
+            sprintf(buf, "уровень изучения (для вас) : %d\r\n", drsdice);
+            send_to_char(buf, ch);
+          }
+          break;
 
-		case BOOK_UPGRD:
-			print_book_uprgd_skill(ch, obj);
-			break;
+        case BOOK_UPGRD: print_book_uprgd_skill(ch, obj);
+          break;
 
-		case BOOK_RECPT:
-			drndice = im_get_recipe(GET_OBJ_VAL(obj, 1));
-			if (drndice >= 0)
-			{
-				drsdice = MAX(GET_OBJ_VAL(obj, 2), imrecipes[drndice].level);
-				int count = imrecipes[drndice].remort;
-				if (imrecipes[drndice].classknow[(int) GET_CLASS(ch)] != KNOW_RECIPE)
-					drsdice = LVL_IMPL;
-				sprintf(buf, "содержит рецепт отвара     : \"%s\"\r\n", imrecipes[drndice].name);
-				send_to_char(buf, ch);
-				if (drsdice == -1 || count == -1)
-				{
-					send_to_char(CCIRED(ch, C_NRM), ch);
-					send_to_char("Некорректная запись рецепта для вашего класса - сообщите Богам.\r\n", ch);
-					send_to_char(CCNRM(ch, C_NRM), ch);
-				}
-				else if (drsdice == LVL_IMPL)
-				{
-					sprintf(buf, "уровень изучения (количество ремортов) : %d (--)\r\n", drsdice);
-					send_to_char(buf, ch);
-				}
-				else
-				{
-					sprintf(buf, "уровень изучения (количество ремортов) : %d (%d)\r\n", drsdice, count);
-					send_to_char(buf, ch);
-				}
-			}
-			break;
+        case BOOK_RECPT: drndice = im_get_recipe(GET_OBJ_VAL(obj, 1));
+          if (drndice >= 0) {
+            drsdice = MAX(GET_OBJ_VAL(obj, 2), imrecipes[drndice].level);
+            int count = imrecipes[drndice].remort;
+            if (imrecipes[drndice].classknow[(int) GET_CLASS(ch)] != KNOW_RECIPE)
+              drsdice = LVL_IMPL;
+            sprintf(buf, "содержит рецепт отвара     : \"%s\"\r\n", imrecipes[drndice].name);
+            send_to_char(buf, ch);
+            if (drsdice == -1 || count == -1) {
+              send_to_char(CCIRED(ch, C_NRM), ch);
+              send_to_char("Некорректная запись рецепта для вашего класса - сообщите Богам.\r\n", ch);
+              send_to_char(CCNRM(ch, C_NRM), ch);
+            } else if (drsdice == LVL_IMPL) {
+              sprintf(buf, "уровень изучения (количество ремортов) : %d (--)\r\n", drsdice);
+              send_to_char(buf, ch);
+            } else {
+              sprintf(buf, "уровень изучения (количество ремортов) : %d (%d)\r\n", drsdice, count);
+              send_to_char(buf, ch);
+            }
+          }
+          break;
 
-		case BOOK_FEAT:
-			if (GET_OBJ_VAL(obj, 1) >= 1 && GET_OBJ_VAL(obj, 1) < MAX_FEATS)
-			{
-				drndice = GET_OBJ_VAL(obj, 1);
-				if (can_get_feat(ch, drndice))
-				{
-					drsdice = feat_info[drndice].slot[(int) GET_CLASS(ch)][(int) GET_KIN(ch)];
-				}
-				else
-				{
-					drsdice = LVL_IMPL;
-				}
-				sprintf(buf, "содержит секрет способности : \"%s\"\r\n", feat_info[drndice].name);
-				send_to_char(buf, ch);
-				sprintf(buf, "уровень изучения (для вас) : %d\r\n", drsdice);
-				send_to_char(buf, ch);
-			}
-			break;
+        case BOOK_FEAT:
+          if (GET_OBJ_VAL(obj, 1) >= 1 && GET_OBJ_VAL(obj, 1) < MAX_FEATS) {
+            drndice = GET_OBJ_VAL(obj, 1);
+            if (can_get_feat(ch, drndice)) {
+              drsdice = feat_info[drndice].slot[(int) GET_CLASS(ch)][(int) GET_KIN(ch)];
+            } else {
+              drsdice = LVL_IMPL;
+            }
+            sprintf(buf, "содержит секрет способности : \"%s\"\r\n", feat_info[drndice].name);
+            send_to_char(buf, ch);
+            sprintf(buf, "уровень изучения (для вас) : %d\r\n", drsdice);
+            send_to_char(buf, ch);
+          }
+          break;
 
-		default:
-			send_to_char(CCIRED(ch, C_NRM), ch);
-			send_to_char("НЕВЕРНО УКАЗАН ТИП КНИГИ - сообщите Богам\r\n", ch);
-			send_to_char(CCNRM(ch, C_NRM), ch);
-			break;
-		}
-		break;
+        default: send_to_char(CCIRED(ch, C_NRM), ch);
+          send_to_char("НЕВЕРНО УКАЗАН ТИП КНИГИ - сообщите Богам\r\n", ch);
+          send_to_char(CCNRM(ch, C_NRM), ch);
+          break;
+      }
+      break;
 
-	case OBJ_DATA::ITEM_INGREDIENT:
-		sprintbit(GET_OBJ_SKILL(obj), ingradient_bits, buf2);
-		snprintf(buf, MAX_STRING_LENGTH, "%s\r\n", buf2);
-		send_to_char(buf, ch);
+    case OBJ_DATA::ITEM_INGREDIENT: sprintbit(GET_OBJ_SKILL(obj), ingradient_bits, buf2);
+      snprintf(buf, MAX_STRING_LENGTH, "%s\r\n", buf2);
+      send_to_char(buf, ch);
 
-		if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_USES))
-		{
-			sprintf(buf, "можно применить %d раз\r\n", GET_OBJ_VAL(obj, 2));
-			send_to_char(buf, ch);
-		}
+      if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_USES)) {
+        sprintf(buf, "можно применить %d раз\r\n", GET_OBJ_VAL(obj, 2));
+        send_to_char(buf, ch);
+      }
 
-		if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_LAG))
-		{
-			sprintf(buf, "можно применить 1 раз в %d сек", (i = GET_OBJ_VAL(obj, 0) & 0xFF));
-			if (GET_OBJ_VAL(obj, 3) == 0 || GET_OBJ_VAL(obj, 3) + i < time(NULL))
-				strcat(buf, "(можно применять).\r\n");
-			else
-			{
-				li = GET_OBJ_VAL(obj, 3) + i - time(NULL);
-				sprintf(buf + strlen(buf), "(осталось %ld сек).\r\n", li);
-			}
-			send_to_char(buf, ch);
-		}
+      if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_LAG)) {
+        sprintf(buf, "можно применить 1 раз в %d сек", (i = GET_OBJ_VAL(obj, 0) & 0xFF));
+        if (GET_OBJ_VAL(obj, 3) == 0 || GET_OBJ_VAL(obj, 3) + i < time(NULL))
+          strcat(buf, "(можно применять).\r\n");
+        else {
+          li = GET_OBJ_VAL(obj, 3) + i - time(NULL);
+          sprintf(buf + strlen(buf), "(осталось %ld сек).\r\n", li);
+        }
+        send_to_char(buf, ch);
+      }
 
-		if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_LEVEL))
-		{
-			sprintf(buf, "можно применить с %d уровня.\r\n", (GET_OBJ_VAL(obj, 0) >> 8) & 0x1F);
-			send_to_char(buf, ch);
-		}
+      if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_LEVEL)) {
+        sprintf(buf, "можно применить с %d уровня.\r\n", (GET_OBJ_VAL(obj, 0) >> 8) & 0x1F);
+        send_to_char(buf, ch);
+      }
 
-		if ((i = real_object(GET_OBJ_VAL(obj, 1))) >= 0)
-		{
-			sprintf(buf, "прототип %s%s%s.\r\n",
-				CCICYN(ch, C_NRM), obj_proto[i]->get_PName(0).c_str(), CCNRM(ch, C_NRM));
-			send_to_char(buf, ch);
-		}
-		break;
+      if ((i = real_object(GET_OBJ_VAL(obj, 1))) >= 0) {
+        sprintf(buf, "прототип %s%s%s.\r\n",
+                CCICYN(ch, C_NRM), obj_proto[i]->get_PName(0).c_str(), CCNRM(ch, C_NRM));
+        send_to_char(buf, ch);
+      }
+      break;
 
-	case OBJ_DATA::ITEM_MING:
-		for (j = 0; imtypes[j].id != GET_OBJ_VAL(obj, IM_TYPE_SLOT) && j <= top_imtypes;)
-		{
-			j++;
-		}
-		sprintf(buf, "Это ингредиент вида '%s%s%s'\r\n", CCCYN(ch, C_NRM), imtypes[j].name, CCNRM(ch, C_NRM));
-		send_to_char(buf, ch);
-		i = GET_OBJ_VAL(obj, IM_POWER_SLOT);
-		if (i > 30)
-		{
-			send_to_char("Вы не в состоянии определить качество этого ингредиента.\r\n", ch);
-		}
-		else
-		{
-			sprintf(buf, "Качество ингредиента ");
-			if (i > 40)
-				strcat(buf, "божественное.\r\n");
-			else if (i > 35)
-				strcat(buf, "идеальное.\r\n");
-			else if (i > 30)
-				strcat(buf, "наилучшее.\r\n");
-			else if (i > 25)
-				strcat(buf, "превосходное.\r\n");
-			else if (i > 20)
-				strcat(buf, "отличное.\r\n");
-			else if (i > 15)
-				strcat(buf, "очень хорошее.\r\n");
-			else if (i > 10)
-				strcat(buf, "выше среднего.\r\n");
-			else if (i > 5)
-				strcat(buf, "весьма посредственное.\r\n");
-			else
-				strcat(buf, "хуже не бывает.\r\n");
-			send_to_char(buf, ch);
-		}
-		break;
+    case OBJ_DATA::ITEM_MING:
+      for (j = 0; imtypes[j].id != GET_OBJ_VAL(obj, IM_TYPE_SLOT) && j <= top_imtypes;) {
+        j++;
+      }
+      sprintf(buf, "Это ингредиент вида '%s%s%s'\r\n", CCCYN(ch, C_NRM), imtypes[j].name, CCNRM(ch, C_NRM));
+      send_to_char(buf, ch);
+      i = GET_OBJ_VAL(obj, IM_POWER_SLOT);
+      if (i > 30) {
+        send_to_char("Вы не в состоянии определить качество этого ингредиента.\r\n", ch);
+      } else {
+        sprintf(buf, "Качество ингредиента ");
+        if (i > 40)
+          strcat(buf, "божественное.\r\n");
+        else if (i > 35)
+          strcat(buf, "идеальное.\r\n");
+        else if (i > 30)
+          strcat(buf, "наилучшее.\r\n");
+        else if (i > 25)
+          strcat(buf, "превосходное.\r\n");
+        else if (i > 20)
+          strcat(buf, "отличное.\r\n");
+        else if (i > 15)
+          strcat(buf, "очень хорошее.\r\n");
+        else if (i > 10)
+          strcat(buf, "выше среднего.\r\n");
+        else if (i > 5)
+          strcat(buf, "весьма посредственное.\r\n");
+        else
+          strcat(buf, "хуже не бывает.\r\n");
+        send_to_char(buf, ch);
+      }
+      break;
 
-	//Информация о контейнерах (Купала)
-	case OBJ_DATA::ITEM_CONTAINER:
-		sprintf(buf, "Максимально вместимый вес: %d.\r\n", GET_OBJ_VAL(obj, 0));
-		send_to_char(buf, ch);
-		break;
+      //Информация о контейнерах (Купала)
+    case OBJ_DATA::ITEM_CONTAINER: sprintf(buf, "Максимально вместимый вес: %d.\r\n", GET_OBJ_VAL(obj, 0));
+      send_to_char(buf, ch);
+      break;
 
-	//Информация о емкостях (Купала)
-	case OBJ_DATA::ITEM_DRINKCON:
-		drinkcon::identify(ch, obj);
-		break;
+      //Информация о емкостях (Купала)
+    case OBJ_DATA::ITEM_DRINKCON: drinkcon::identify(ch, obj);
+      break;
 
-	case OBJ_DATA::ITEM_MAGIC_ARROW:
-	case OBJ_DATA::ITEM_MAGIC_CONTAINER:
-		sprintf(buf, "Может вместить стрел: %d.\r\n", GET_OBJ_VAL(obj, 1));
-		sprintf(buf, "Осталось стрел: %s%d&n.\r\n",
-			GET_OBJ_VAL(obj, 2) > 3 ? "&G" : "&R", GET_OBJ_VAL(obj, 2));
-		send_to_char(buf, ch);
-		break;
+    case OBJ_DATA::ITEM_MAGIC_ARROW:
+    case OBJ_DATA::ITEM_MAGIC_CONTAINER: sprintf(buf, "Может вместить стрел: %d.\r\n", GET_OBJ_VAL(obj, 1));
+      sprintf(buf, "Осталось стрел: %s%d&n.\r\n",
+              GET_OBJ_VAL(obj, 2) > 3 ? "&G" : "&R", GET_OBJ_VAL(obj, 2));
+      send_to_char(buf, ch);
+      break;
 
-	default:
-		break;
-	} // switch
+    default: break;
+  } // switch
 
-	if (fullness < 90)
-	{
-		return;
-	}
+  if (fullness < 90) {
+    return;
+  }
 
-	send_to_char("Накладывает на вас аффекты: ", ch);
-	send_to_char(CCCYN(ch, C_NRM), ch);
-	obj->get_affect_flags().sprintbits(weapon_affects, buf, ",",IS_IMMORTAL(ch)?4:0);
-	strcat(buf, "\r\n");
-	send_to_char(buf, ch);
-	send_to_char(CCNRM(ch, C_NRM), ch);
+  send_to_char("Накладывает на вас аффекты: ", ch);
+  send_to_char(CCCYN(ch, C_NRM), ch);
+  obj->get_affect_flags().sprintbits(weapon_affects, buf, ",", IS_IMMORTAL(ch) ? 4 : 0);
+  strcat(buf, "\r\n");
+  send_to_char(buf, ch);
+  send_to_char(CCNRM(ch, C_NRM), ch);
 
-	if (fullness < 100)
-	{
-		return;
-	}
+  if (fullness < 100) {
+    return;
+  }
 
-	found = FALSE;
-	for (i = 0; i < MAX_OBJ_AFFECT; i++)
-	{
-		if (obj->get_affected(i).location != APPLY_NONE
-			&& obj->get_affected(i).modifier != 0)
-		{
-			if (!found)
-			{
-				send_to_char("Дополнительные свойства :\r\n", ch);
-				found = TRUE;
-			}
-			print_obj_affects(ch, obj->get_affected(i));
-		}
-	}
+  found = FALSE;
+  for (i = 0; i < MAX_OBJ_AFFECT; i++) {
+    if (obj->get_affected(i).location != APPLY_NONE
+        && obj->get_affected(i).modifier != 0) {
+      if (!found) {
+        send_to_char("Дополнительные свойства :\r\n", ch);
+        found = TRUE;
+      }
+      print_obj_affects(ch, obj->get_affected(i));
+    }
+  }
 
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_ENCHANT
-		&& GET_OBJ_VAL(obj, 0) != 0)
-	{
-		if (!found)
-		{
-			send_to_char("Дополнительные свойства :\r\n", ch);
-			found = TRUE;
-		}
-		send_to_char(ch, "%s   %s вес предмета на %d%s\r\n", CCCYN(ch, C_NRM),
-			GET_OBJ_VAL(obj, 0) > 0 ? "увеличивает" : "уменьшает",
-			abs(GET_OBJ_VAL(obj, 0)), CCNRM(ch, C_NRM));
-	}
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_ENCHANT
+      && GET_OBJ_VAL(obj, 0) != 0) {
+    if (!found) {
+      send_to_char("Дополнительные свойства :\r\n", ch);
+      found = TRUE;
+    }
+    send_to_char(ch, "%s   %s вес предмета на %d%s\r\n", CCCYN(ch, C_NRM),
+                 GET_OBJ_VAL(obj, 0) > 0 ? "увеличивает" : "уменьшает",
+                 abs(GET_OBJ_VAL(obj, 0)), CCNRM(ch, C_NRM));
+  }
 
-	if (obj->has_skills())
-	{
-		send_to_char("Меняет умения :\r\n", ch);
-		CObjectPrototype::skills_t skills;
-		obj->get_skills(skills);
-		int skill_num;
-		int percent;
-		for (const auto& it : skills)
-		{
-			skill_num = it.first;
-			percent = it.second;
+  if (obj->has_skills()) {
+    send_to_char("Меняет умения :\r\n", ch);
+    CObjectPrototype::skills_t skills;
+    obj->get_skills(skills);
+    int skill_num;
+    int percent;
+    for (const auto &it : skills) {
+      skill_num = it.first;
+      percent = it.second;
 
-			if (percent == 0) // TODO: такого не должно быть?
-				continue;
+      if (percent == 0) // TODO: такого не должно быть?
+        continue;
 
-			sprintf(buf, "   %s%s%s%s%s%d%%%s\r\n",
-				CCCYN(ch, C_NRM), skill_info[skill_num].name, CCNRM(ch, C_NRM),
-				CCCYN(ch, C_NRM),
-				percent < 0 ? " ухудшает на " : " улучшает на ", abs(percent), CCNRM(ch, C_NRM));
-			send_to_char(buf, ch);
-		}
-	}
+      sprintf(buf, "   %s%s%s%s%s%d%%%s\r\n",
+              CCCYN(ch, C_NRM), skill_info[skill_num].name, CCNRM(ch, C_NRM),
+              CCCYN(ch, C_NRM),
+              percent < 0 ? " ухудшает на " : " улучшает на ", abs(percent), CCNRM(ch, C_NRM));
+      send_to_char(buf, ch);
+    }
+  }
 
-	id_to_set_info_map::iterator it = OBJ_DATA::set_table.begin();
-	if (obj->get_extra_flag(EExtraFlag::ITEM_SETSTUFF))
-	{
-		for (; it != OBJ_DATA::set_table.end(); it++)
-		{
-			if (it->second.find(GET_OBJ_VNUM(obj)) != it->second.end())
-			{
-				sprintf(buf, "Часть набора предметов: %s%s%s\r\n", CCNRM(ch, C_NRM), it->second.get_name().c_str(), CCNRM(ch, C_NRM));
-				send_to_char(buf, ch);
-				for (set_info::iterator vnum = it->second.begin(), iend = it->second.end(); vnum != iend; ++vnum)
-				{
-					const int r_num = real_object(vnum->first);
-					if (r_num < 0)
-					{
-						send_to_char("Неизвестный объект!!!\r\n", ch);
-						continue;
-					}
-					sprintf(buf, "   %s\r\n", obj_proto[r_num]->get_short_description().c_str());
-					send_to_char(buf, ch);
-				}
-				break;
-			}
-		}
-	}
+  id_to_set_info_map::iterator it = OBJ_DATA::set_table.begin();
+  if (obj->get_extra_flag(EExtraFlag::ITEM_SETSTUFF)) {
+    for (; it != OBJ_DATA::set_table.end(); it++) {
+      if (it->second.find(GET_OBJ_VNUM(obj)) != it->second.end()) {
+        sprintf(buf,
+                "Часть набора предметов: %s%s%s\r\n",
+                CCNRM(ch, C_NRM),
+                it->second.get_name().c_str(),
+                CCNRM(ch, C_NRM));
+        send_to_char(buf, ch);
+        for (set_info::iterator vnum = it->second.begin(), iend = it->second.end(); vnum != iend; ++vnum) {
+          const int r_num = real_object(vnum->first);
+          if (r_num < 0) {
+            send_to_char("Неизвестный объект!!!\r\n", ch);
+            continue;
+          }
+          sprintf(buf, "   %s\r\n", obj_proto[r_num]->get_short_description().c_str());
+          send_to_char(buf, ch);
+        }
+        break;
+      }
+    }
+  }
 
-	if (!obj->get_enchants().empty())
-	{
-		obj->get_enchants().print(ch);
-	}
-	obj_sets::print_identify(ch, obj);
+  if (!obj->get_enchants().empty()) {
+    obj->get_enchants().print(ch);
+  }
+  obj_sets::print_identify(ch, obj);
 }
-
 
 #define IDENT_SELF_LEVEL 6
 
-void mort_show_char_values(CHAR_DATA * victim, CHAR_DATA * ch, int fullness)
-{
-	int val0, val1, val2;
+void mort_show_char_values(CHAR_DATA *victim, CHAR_DATA *ch, int fullness) {
+  int val0, val1, val2;
 
-	sprintf(buf, "Имя: %s\r\n", GET_NAME(victim));
-	send_to_char(buf, ch);
-	if (!IS_NPC(victim) && victim == ch)
-	{
-		sprintf(buf, "Написание : %s/%s/%s/%s/%s/%s\r\n",
-				GET_PAD(victim, 0), GET_PAD(victim, 1), GET_PAD(victim, 2),
-				GET_PAD(victim, 3), GET_PAD(victim, 4), GET_PAD(victim, 5));
-		send_to_char(buf, ch);
-	}
+  sprintf(buf, "Имя: %s\r\n", GET_NAME(victim));
+  send_to_char(buf, ch);
+  if (!IS_NPC(victim) && victim == ch) {
+    sprintf(buf, "Написание : %s/%s/%s/%s/%s/%s\r\n",
+            GET_PAD(victim, 0), GET_PAD(victim, 1), GET_PAD(victim, 2),
+            GET_PAD(victim, 3), GET_PAD(victim, 4), GET_PAD(victim, 5));
+    send_to_char(buf, ch);
+  }
 
-	if (!IS_NPC(victim) && victim == ch)
-	{
-		sprintf(buf,
-				"Возраст %s  : %d лет, %d месяцев, %d дней и %d часов.\r\n",
-				GET_PAD(victim, 1), age(victim)->year, age(victim)->month,
-				age(victim)->day, age(victim)->hours);
-		send_to_char(buf, ch);
-	}
-	if (fullness < 20 && ch != victim)
-		return;
+  if (!IS_NPC(victim) && victim == ch) {
+    sprintf(buf,
+            "Возраст %s  : %d лет, %d месяцев, %d дней и %d часов.\r\n",
+            GET_PAD(victim, 1), age(victim)->year, age(victim)->month,
+            age(victim)->day, age(victim)->hours);
+    send_to_char(buf, ch);
+  }
+  if (fullness < 20 && ch != victim)
+    return;
 
-	val0 = GET_HEIGHT(victim);
-	val1 = GET_WEIGHT(victim);
-	val2 = GET_SIZE(victim);
-	sprintf(buf, /*"Рост %d , */ " Вес %d, Размер %d\r\n", /*val0, */ val1,
-			val2);
-	send_to_char(buf, ch);
-	if (fullness < 60 && ch != victim)
-		return;
+  val0 = GET_HEIGHT(victim);
+  val1 = GET_WEIGHT(victim);
+  val2 = GET_SIZE(victim);
+  sprintf(buf, /*"Рост %d , */ " Вес %d, Размер %d\r\n", /*val0, */ val1,
+          val2);
+  send_to_char(buf, ch);
+  if (fullness < 60 && ch != victim)
+    return;
 
-	val0 = GET_LEVEL(victim);
-	val1 = GET_HIT(victim);
-	val2 = GET_REAL_MAX_HIT(victim);
-	sprintf(buf, "Уровень : %d, может выдержать повреждений : %d(%d), ", val0, val1, val2);
-	send_to_char(buf, ch);
-	send_to_char(ch, "Перевоплощений : %d\r\n", victim->get_remort());
-	val0 = MIN(GET_AR(victim), 100);
-	val1 = MIN(GET_MR(victim), 100);
-	val2 = MIN(GET_PR(victim), 100);
-	sprintf(buf, "Защита от чар : %d, Защита от магических повреждений : %d, Защита от физических повреждений : %d\r\n", val0, val1, val2);
-	send_to_char(buf, ch);
-	if (fullness < 90 && ch != victim)
-		return;
+  val0 = GET_LEVEL(victim);
+  val1 = GET_HIT(victim);
+  val2 = GET_REAL_MAX_HIT(victim);
+  sprintf(buf, "Уровень : %d, может выдержать повреждений : %d(%d), ", val0, val1, val2);
+  send_to_char(buf, ch);
+  send_to_char(ch, "Перевоплощений : %d\r\n", victim->get_remort());
+  val0 = MIN(GET_AR(victim), 100);
+  val1 = MIN(GET_MR(victim), 100);
+  val2 = MIN(GET_PR(victim), 100);
+  sprintf(buf,
+          "Защита от чар : %d, Защита от магических повреждений : %d, Защита от физических повреждений : %d\r\n",
+          val0,
+          val1,
+          val2);
+  send_to_char(buf, ch);
+  if (fullness < 90 && ch != victim)
+    return;
 
-	send_to_char(ch, "Атака : %d, Повреждения : %d\r\n",
-		GET_HR(victim), GET_DR(victim));
-	send_to_char(ch, "Защита : %d, Броня : %d, Поглощение : %d\r\n",
-		compute_armor_class(victim), GET_ARMOUR(victim), GET_ABSORBE(victim));
+  send_to_char(ch, "Атака : %d, Повреждения : %d\r\n",
+               GET_HR(victim), GET_DR(victim));
+  send_to_char(ch, "Защита : %d, Броня : %d, Поглощение : %d\r\n",
+               compute_armor_class(victim), GET_ARMOUR(victim), GET_ABSORBE(victim));
 
-	if (fullness < 100 || (ch != victim && !IS_NPC(victim)))
-		return;
+  if (fullness < 100 || (ch != victim && !IS_NPC(victim)))
+    return;
 
-	val0 = victim->get_str();
-	val1 = victim->get_int();
-	val2 = victim->get_wis();
-	sprintf(buf, "Сила: %d, Ум: %d, Муд: %d, ", val0, val1, val2);
-	val0 = victim->get_dex();
-	val1 = victim->get_con();
-	val2 = victim->get_cha();
-	sprintf(buf + strlen(buf), "Ловк: %d, Тел: %d, Обаян: %d\r\n", val0, val1, val2);
-	send_to_char(buf, ch);
+  val0 = victim->get_str();
+  val1 = victim->get_int();
+  val2 = victim->get_wis();
+  sprintf(buf, "Сила: %d, Ум: %d, Муд: %d, ", val0, val1, val2);
+  val0 = victim->get_dex();
+  val1 = victim->get_con();
+  val2 = victim->get_cha();
+  sprintf(buf + strlen(buf), "Ловк: %d, Тел: %d, Обаян: %d\r\n", val0, val1, val2);
+  send_to_char(buf, ch);
 
-	if (fullness < 120 || (ch != victim && !IS_NPC(victim)))
-		return;
+  if (fullness < 120 || (ch != victim && !IS_NPC(victim)))
+    return;
 
-	int found = FALSE;
-	for (const auto& aff : victim->affected)
-	{
-		if (aff->location != APPLY_NONE && aff->modifier != 0)
-		{
-			if (!found)
-			{
-				send_to_char("Дополнительные свойства :\r\n", ch);
-				found = TRUE;
-				send_to_char(CCIRED(ch, C_NRM), ch);
-			}
-			sprinttype(aff->location, apply_types, buf2);
-			snprintf(buf, MAX_STRING_LENGTH, "   %s изменяет на %s%d\r\n", buf2, aff->modifier > 0 ? "+" : "", aff->modifier);
-			send_to_char(buf, ch);
-		}
-	}
-	send_to_char(CCNRM(ch, C_NRM), ch);
+  int found = FALSE;
+  for (const auto &aff : victim->affected) {
+    if (aff->location != APPLY_NONE && aff->modifier != 0) {
+      if (!found) {
+        send_to_char("Дополнительные свойства :\r\n", ch);
+        found = TRUE;
+        send_to_char(CCIRED(ch, C_NRM), ch);
+      }
+      sprinttype(aff->location, apply_types, buf2);
+      snprintf(buf, MAX_STRING_LENGTH, "   %s изменяет на %s%d\r\n", buf2, aff->modifier > 0 ? "+" : "", aff->modifier);
+      send_to_char(buf, ch);
+    }
+  }
+  send_to_char(CCNRM(ch, C_NRM), ch);
 
-	send_to_char("Аффекты :\r\n", ch);
-	send_to_char(CCICYN(ch, C_NRM), ch);
-	victim->char_specials.saved.affected_by.sprintbits(affected_bits, buf2, "\r\n",IS_IMMORTAL(ch)?4:0);
-	snprintf(buf, MAX_STRING_LENGTH, "%s\r\n", buf2);
-	send_to_char(buf, ch);
-	send_to_char(CCNRM(ch, C_NRM), ch);
+  send_to_char("Аффекты :\r\n", ch);
+  send_to_char(CCICYN(ch, C_NRM), ch);
+  victim->char_specials.saved.affected_by.sprintbits(affected_bits, buf2, "\r\n", IS_IMMORTAL(ch) ? 4 : 0);
+  snprintf(buf, MAX_STRING_LENGTH, "%s\r\n", buf2);
+  send_to_char(buf, ch);
+  send_to_char(CCNRM(ch, C_NRM), ch);
 }
 
 void skill_identify(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj) {
-	if (obj) {
-		mort_show_obj_values(obj, ch, train_skill(ch, SKILL_IDENTIFY, skill_info[SKILL_IDENTIFY].max_percent, 0));
-	}
-	else if (victim) {
-		if (GET_LEVEL(victim) < 3) {
-			send_to_char("Вы можете опознать только персонажа, достигнувшего третьего уровня.\r\n", ch);
-			return;
-		}
-		mort_show_char_values(victim, ch,
-							  train_skill(ch, SKILL_IDENTIFY, skill_info[SKILL_IDENTIFY].max_percent, victim));
-	}
+  if (obj) {
+    mort_show_obj_values(obj, ch, calculate_skill(ch, SKILL_IDENTIFY, nullptr));
+    train_skill(ch, SKILL_IDENTIFY, true, nullptr);
+  } else if (victim) {
+    if (GET_LEVEL(victim) < 3) {
+      send_to_char("Вы можете опознать только персонажа, достигнувшего третьего уровня.\r\n", ch);
+      return;
+    }
+    mort_show_char_values(victim, ch, calculate_skill(ch, SKILL_IDENTIFY, victim));
+    train_skill(ch, SKILL_IDENTIFY, true, victim);
+  }
 }
 
-void spell_identify(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj)
-{
-	if (obj)
-		mort_show_obj_values(obj, ch, 100);
-	else if (victim)
-	{
-		if (victim != ch)
-		{
-			send_to_char("С помощью магии нельзя опознать другое существо.\r\n", ch);
-			return;
-		}
-		if (GET_LEVEL(victim) < 3)
-		{
-			send_to_char("Вы можете опознать себя только достигнув третьего уровня.\r\n", ch);
-			return;
-		}
-		mort_show_char_values(victim, ch, 100);
-	}
+void spell_identify(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA *obj) {
+  if (obj)
+    mort_show_obj_values(obj, ch, 100);
+  else if (victim) {
+    if (victim != ch) {
+      send_to_char("С помощью магии нельзя опознать другое существо.\r\n", ch);
+      return;
+    }
+    if (GET_LEVEL(victim) < 3) {
+      send_to_char("Вы можете опознать себя только достигнув третьего уровня.\r\n", ch);
+      return;
+    }
+    mort_show_char_values(victim, ch, 100);
+  }
 }
 
-void spell_control_weather(int/* level*/, CHAR_DATA *ch, CHAR_DATA* /*victim*/, OBJ_DATA* /*obj*/)
-{
-	const char *sky_info = 0;
-	int i, duration, zone, sky_type = 0;
+void spell_control_weather(int/* level*/, CHAR_DATA *ch, CHAR_DATA * /*victim*/, OBJ_DATA * /*obj*/) {
+  const char *sky_info = 0;
+  int i, duration, zone, sky_type = 0;
 
-	if (what_sky > SKY_LIGHTNING)
-		what_sky = SKY_LIGHTNING;
+  if (what_sky > SKY_LIGHTNING)
+    what_sky = SKY_LIGHTNING;
 
-	switch (what_sky)
-	{
-	case SKY_CLOUDLESS:
-		sky_info = "Небо покрылось облаками.";
-		break;
-	case SKY_CLOUDY:
-		sky_info = "Небо покрылось тяжелыми тучами.";
-		break;
-	case SKY_RAINING:
-		if (time_info.month >= MONTH_MAY && time_info.month <= MONTH_OCTOBER)
-		{
-			sky_info = "Начался проливной дождь.";
-			create_rainsnow(&sky_type, WEATHER_LIGHTRAIN, 0, 50, 50);
-		}
-		else if (time_info.month >= MONTH_DECEMBER || time_info.month <= MONTH_FEBRUARY)
-		{
-			sky_info = "Повалил снег.";
-			create_rainsnow(&sky_type, WEATHER_LIGHTSNOW, 0, 50, 50);
-		}
-		else if (time_info.month == MONTH_MART || time_info.month == MONTH_NOVEMBER)
-		{
-			if (weather_info.temperature > 2)
-			{
-				sky_info = "Начался проливной дождь.";
-				create_rainsnow(&sky_type, WEATHER_LIGHTRAIN, 0, 50, 50);
-			}
-			else
-			{
-				sky_info = "Повалил снег.";
-				create_rainsnow(&sky_type, WEATHER_LIGHTSNOW, 0, 50, 50);
-			}
-		}
-		break;
-	case SKY_LIGHTNING:
-		sky_info = "На небе не осталось ни единого облачка.";
-		break;
-	default:
-		break;
-	}
+  switch (what_sky) {
+    case SKY_CLOUDLESS: sky_info = "Небо покрылось облаками.";
+      break;
+    case SKY_CLOUDY: sky_info = "Небо покрылось тяжелыми тучами.";
+      break;
+    case SKY_RAINING:
+      if (time_info.month >= MONTH_MAY && time_info.month <= MONTH_OCTOBER) {
+        sky_info = "Начался проливной дождь.";
+        create_rainsnow(&sky_type, WEATHER_LIGHTRAIN, 0, 50, 50);
+      } else if (time_info.month >= MONTH_DECEMBER || time_info.month <= MONTH_FEBRUARY) {
+        sky_info = "Повалил снег.";
+        create_rainsnow(&sky_type, WEATHER_LIGHTSNOW, 0, 50, 50);
+      } else if (time_info.month == MONTH_MART || time_info.month == MONTH_NOVEMBER) {
+        if (weather_info.temperature > 2) {
+          sky_info = "Начался проливной дождь.";
+          create_rainsnow(&sky_type, WEATHER_LIGHTRAIN, 0, 50, 50);
+        } else {
+          sky_info = "Повалил снег.";
+          create_rainsnow(&sky_type, WEATHER_LIGHTSNOW, 0, 50, 50);
+        }
+      }
+      break;
+    case SKY_LIGHTNING: sky_info = "На небе не осталось ни единого облачка.";
+      break;
+    default: break;
+  }
 
-	if (sky_info)
-	{
-		duration = MAX(GET_LEVEL(ch) / 8, 2);
-		zone = world[ch->in_room]->zone;
-		for (i = FIRST_ROOM; i <= top_of_world; i++)
-			if (world[i]->zone == zone && SECT(i) != SECT_INSIDE && SECT(i) != SECT_CITY)
-			{
-				world[i]->weather.sky = what_sky;
-				world[i]->weather.weather_type = sky_type;
-				world[i]->weather.duration = duration;
-				if (world[i]->first_character())
-				{
-					act(sky_info, FALSE, world[i]->first_character(), 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-					act(sky_info, FALSE, world[i]->first_character(), 0, 0, TO_CHAR);
-				}
-			}
-	}
+  if (sky_info) {
+    duration = MAX(GET_LEVEL(ch) / 8, 2);
+    zone = world[ch->in_room]->zone;
+    for (i = FIRST_ROOM; i <= top_of_world; i++)
+      if (world[i]->zone == zone && SECT(i) != SECT_INSIDE && SECT(i) != SECT_CITY) {
+        world[i]->weather.sky = what_sky;
+        world[i]->weather.weather_type = sky_type;
+        world[i]->weather.duration = duration;
+        if (world[i]->first_character()) {
+          act(sky_info, FALSE, world[i]->first_character(), 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+          act(sky_info, FALSE, world[i]->first_character(), 0, 0, TO_CHAR);
+        }
+      }
+  }
 }
 
-void spell_fear(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* /*obj*/)
-{
-	int modi = 0;
-	if (ch != victim)
-	{
-		modi = calc_anti_savings(ch);
-		if (!pk_agro_action(ch, victim))
-			return;
-	}
-	if (!IS_NPC(ch) && (GET_LEVEL(ch) > 10))
-		modi += (GET_LEVEL(ch) - 10);
-	if (PRF_FLAGGED(ch, PRF_AWAKE))
-		modi = modi - 50;
-	if (AFF_FLAGGED(victim, EAffectFlag::AFF_BLESS))
-		modi -= 25;
+void spell_fear(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA * /*obj*/) {
+  int modi = 0;
+  if (ch != victim) {
+    modi = calc_anti_savings(ch);
+    if (!pk_agro_action(ch, victim))
+      return;
+  }
+  if (!IS_NPC(ch) && (GET_LEVEL(ch) > 10))
+    modi += (GET_LEVEL(ch) - 10);
+  if (PRF_FLAGGED(ch, PRF_AWAKE))
+    modi = modi - 50;
+  if (AFF_FLAGGED(victim, EAffectFlag::AFF_BLESS))
+    modi -= 25;
 
-	if (!MOB_FLAGGED(victim, MOB_NOFEAR) && !general_savingthrow(ch, victim, SAVING_WILL, modi))
-		go_flee(victim);
+  if (!MOB_FLAGGED(victim, MOB_NOFEAR) && !general_savingthrow(ch, victim, SAVING_WILL, modi))
+    go_flee(victim);
 }
 
-void spell_energydrain(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* /*obj*/)
-{
-	// истощить энергию - круг 28 уровень 9 (1)
-	// для всех
-	int modi = 0;
-	if (ch != victim)
-	{
-		modi = calc_anti_savings(ch);
-		if (!pk_agro_action(ch, victim))
-			return;
-	}
-	if (!IS_NPC(ch) && (GET_LEVEL(ch) > 10))
-		modi += (GET_LEVEL(ch) - 10);
-	if (PRF_FLAGGED(ch, PRF_AWAKE))
-		modi = modi - 50;
+void spell_energydrain(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA * /*obj*/) {
+  // истощить энергию - круг 28 уровень 9 (1)
+  // для всех
+  int modi = 0;
+  if (ch != victim) {
+    modi = calc_anti_savings(ch);
+    if (!pk_agro_action(ch, victim))
+      return;
+  }
+  if (!IS_NPC(ch) && (GET_LEVEL(ch) > 10))
+    modi += (GET_LEVEL(ch) - 10);
+  if (PRF_FLAGGED(ch, PRF_AWAKE))
+    modi = modi - 50;
 
-	if (ch == victim || !general_savingthrow(ch, victim, SAVING_WILL, CALC_SUCCESS(modi, 33)))
-	{
-		int i;
-		for (i = 0; i <= MAX_SPELLS; GET_SPELL_MEM(victim, i++) = 0);
-		GET_CASTER(victim) = 0;
-		send_to_char("Внезапно вы осознали, что у вас напрочь отшибло память.\r\n", victim);
-	}
-	else
-		send_to_char(NOEFFECT, ch);
+  if (ch == victim || !general_savingthrow(ch, victim, SAVING_WILL, CALC_SUCCESS(modi, 33))) {
+    int i;
+    for (i = 0; i <= MAX_SPELLS; GET_SPELL_MEM(victim, i++) = 0);
+    GET_CASTER(victim) = 0;
+    send_to_char("Внезапно вы осознали, что у вас напрочь отшибло память.\r\n", victim);
+  } else
+    send_to_char(NOEFFECT, ch);
 }
 
 // накачка хитов
-void do_sacrifice(CHAR_DATA * ch, int dam)
-{
+void do_sacrifice(CHAR_DATA *ch, int dam) {
 //MZ.overflow_fix
-	GET_HIT(ch) = MAX(GET_HIT(ch), MIN(GET_HIT(ch) + MAX(1, dam), GET_REAL_MAX_HIT(ch)
-									   + GET_REAL_MAX_HIT(ch) * GET_LEVEL(ch) / 10));
+  GET_HIT(ch) = MAX(GET_HIT(ch), MIN(GET_HIT(ch) + MAX(1, dam), GET_REAL_MAX_HIT(ch)
+      + GET_REAL_MAX_HIT(ch) * GET_LEVEL(ch) / 10));
 //-MZ.overflow_fix
-	update_pos(ch);
+  update_pos(ch);
 }
 
-void spell_sacrifice(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA* /*obj*/)
-{
-	int dam, d0 = GET_HIT(victim);
-	struct follow_type *f;
+void spell_sacrifice(int/* level*/, CHAR_DATA *ch, CHAR_DATA *victim, OBJ_DATA * /*obj*/) {
+  int dam, d0 = GET_HIT(victim);
+  struct follow_type *f;
 
-	// Высосать жизнь - некроманы - уровень 18 круг 6й (5)
-	// *** мин 54 макс 66 (330)
+  // Высосать жизнь - некроманы - уровень 18 круг 6й (5)
+  // *** мин 54 макс 66 (330)
 
-	if (WAITLESS(victim) || victim == ch || IS_CHARMICE(victim))
-	{
-		send_to_char(NOEFFECT, ch);
-		return;
-	}
+  if (WAITLESS(victim) || victim == ch || IS_CHARMICE(victim)) {
+    send_to_char(NOEFFECT, ch);
+    return;
+  }
 
-	dam = mag_damage(GET_LEVEL(ch), ch, victim, SPELL_SACRIFICE, SAVING_STABILITY);
-	// victim может быть спуржен
+  dam = mag_damage(GET_LEVEL(ch), ch, victim, SPELL_SACRIFICE, SAVING_STABILITY);
+  // victim может быть спуржен
 
-	if (dam < 0)
-		dam = d0;
-	if (dam > d0)
-		dam = d0;
-	if (dam <= 0)
-		return;
+  if (dam < 0)
+    dam = d0;
+  if (dam > d0)
+    dam = d0;
+  if (dam <= 0)
+    return;
 
-	do_sacrifice(ch, dam);
-	if (!IS_NPC(ch))
-	{
-		for (f = ch->followers; f; f = f->next)
-		{
-			if (IS_NPC(f->follower)
-				&& AFF_FLAGGED(f->follower, EAffectFlag::AFF_CHARM)
-				&& MOB_FLAGGED(f->follower, MOB_CORPSE)
-				&& ch->in_room == IN_ROOM(f->follower))
-			{
-				do_sacrifice(f->follower, dam);
-			}
-		}
-	}
+  do_sacrifice(ch, dam);
+  if (!IS_NPC(ch)) {
+    for (f = ch->followers; f; f = f->next) {
+      if (IS_NPC(f->follower)
+          && AFF_FLAGGED(f->follower, EAffectFlag::AFF_CHARM)
+          && MOB_FLAGGED(f->follower, MOB_CORPSE)
+          && ch->in_room == IN_ROOM(f->follower)) {
+        do_sacrifice(f->follower, dam);
+      }
+    }
+  }
 }
 
-void spell_holystrike(int/* level*/, CHAR_DATA *ch, CHAR_DATA* /*victim*/, OBJ_DATA* /*obj*/)
-{
-	const char *msg1 = "Земля под вами засветилась и всех поглотил плотный туман.";
-	const char *msg2 = "Вдруг туман стал уходить обратно в землю, забирая с собой тела поверженных.";
+void spell_holystrike(int/* level*/, CHAR_DATA *ch, CHAR_DATA * /*victim*/, OBJ_DATA * /*obj*/) {
+  const char *msg1 = "Земля под вами засветилась и всех поглотил плотный туман.";
+  const char *msg2 = "Вдруг туман стал уходить обратно в землю, забирая с собой тела поверженных.";
 
-	act(msg1, FALSE, ch, 0, 0, TO_CHAR);
-	act(msg1, FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  act(msg1, FALSE, ch, 0, 0, TO_CHAR);
+  act(msg1, FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
 
-	const auto people_copy = world[ch->in_room]->people;
-	for (const auto tch : people_copy)
-	{
-		if (IS_NPC(tch))
-		{
-			if (!MOB_FLAGGED(tch, MOB_CORPSE)
-				&& GET_RACE(tch) != NPC_RACE_ZOMBIE
-				&& GET_RACE(tch) != NPC_RACE_EVIL_SPIRIT)
-			{
-				continue;
-			}
-		}
-		else
-		{
-			//Чуток нелогично, но раз зомби гоняет -- сам немного мертвяк. :)
-			//Тут сам спелл бредовый... Но пока на скорую руку.
-			if (!can_use_feat(tch, ZOMBIE_DROVER_FEAT))
-			{
-				continue;
-			}
-		}
+  const auto people_copy = world[ch->in_room]->people;
+  for (const auto tch : people_copy) {
+    if (IS_NPC(tch)) {
+      if (!MOB_FLAGGED(tch, MOB_CORPSE)
+          && GET_RACE(tch) != NPC_RACE_ZOMBIE
+          && GET_RACE(tch) != NPC_RACE_EVIL_SPIRIT) {
+        continue;
+      }
+    } else {
+      //Чуток нелогично, но раз зомби гоняет -- сам немного мертвяк. :)
+      //Тут сам спелл бредовый... Но пока на скорую руку.
+      if (!can_use_feat(tch, ZOMBIE_DROVER_FEAT)) {
+        continue;
+      }
+    }
 
-		mag_affects(GET_LEVEL(ch), ch, tch, SPELL_HOLYSTRIKE, SAVING_STABILITY);
-		mag_damage(GET_LEVEL(ch), ch, tch, SPELL_HOLYSTRIKE, SAVING_STABILITY);
-	}
+    mag_affects(GET_LEVEL(ch), ch, tch, SPELL_HOLYSTRIKE, SAVING_STABILITY);
+    mag_damage(GET_LEVEL(ch), ch, tch, SPELL_HOLYSTRIKE, SAVING_STABILITY);
+  }
 
-	act(msg2, FALSE, ch, 0, 0, TO_CHAR);
-	act(msg2, FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  act(msg2, FALSE, ch, 0, 0, TO_CHAR);
+  act(msg2, FALSE, ch, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
 
-	OBJ_DATA *o = nullptr;
-	do
-	{
-		for (o = world[ch->in_room]->contents; o; o = o->get_next_content())
-		{
-			if (!IS_CORPSE(o))
-			{
-				continue;
-			}
+  OBJ_DATA *o = nullptr;
+  do {
+    for (o = world[ch->in_room]->contents; o; o = o->get_next_content()) {
+      if (!IS_CORPSE(o)) {
+        continue;
+      }
 
-			extract_obj(o);
+      extract_obj(o);
 
-			break;
-		}
-	} while (o);
+      break;
+    }
+  } while (o);
 }
 
-void spell_angel(int/* level*/, CHAR_DATA *ch, CHAR_DATA* /*victim*/, OBJ_DATA* /*obj*/)
-{
-	mob_vnum mob_num = 108;
-	//int modifier = 0;
-	CHAR_DATA *mob = NULL;
-	struct follow_type *k, *k_next;
+void spell_angel(int/* level*/, CHAR_DATA *ch, CHAR_DATA * /*victim*/, OBJ_DATA * /*obj*/) {
+  mob_vnum mob_num = 108;
+  //int modifier = 0;
+  CHAR_DATA *mob = NULL;
+  struct follow_type *k, *k_next;
 
-	auto eff_cha = get_effective_cha(ch);
+  auto eff_cha = get_effective_cha(ch);
 
-	for (k = ch->followers; k; k = k_next)
-	{
-		k_next = k->next;
-		if (MOB_FLAGGED(k->follower, MOB_ANGEL))  	//send_to_char("Боги не обратили на вас никакого внимания!\r\n", ch);
-		{
-			//return;
-			//пуржим старого ангела
-			stop_follower(k->follower, SF_CHARMLOST);
-		}
-	}
+  for (k = ch->followers; k; k = k_next) {
+    k_next = k->next;
+    if (MOB_FLAGGED(k->follower, MOB_ANGEL))    //send_to_char("Боги не обратили на вас никакого внимания!\r\n", ch);
+    {
+      //return;
+      //пуржим старого ангела
+      stop_follower(k->follower, SF_CHARMLOST);
+    }
+  }
 
-	float base_success = 26.0;
-	float additional_success_for_charisma = 1.5; // 50 at 16 charisma, 101 at 50 charisma
+  float base_success = 26.0;
+  float additional_success_for_charisma = 1.5; // 50 at 16 charisma, 101 at 50 charisma
 
-	if (number(1, 100) > floorf(base_success + additional_success_for_charisma * eff_cha))
-	{
-		send_to_room("Яркая вспышка света! Несколько белых перьев кружась легли на землю...", ch->in_room, true);
-		return;
-	};
-	if (!(mob = read_mobile(-mob_num, VIRTUAL)))
-	{
-		send_to_char("Вы точно не помните, как создать данного монстра.\r\n", ch);
-		return;
-	}
+  if (number(1, 100) > floorf(base_success + additional_success_for_charisma * eff_cha)) {
+    send_to_room("Яркая вспышка света! Несколько белых перьев кружась легли на землю...", ch->in_room, true);
+    return;
+  };
+  if (!(mob = read_mobile(-mob_num, VIRTUAL))) {
+    send_to_char("Вы точно не помните, как создать данного монстра.\r\n", ch);
+    return;
+  }
 
-	int base_hp = 360;
-	int additional_hp_for_charisma = 40;
-	float base_shields = 0.0;
-	float additional_shields_for_charisma = 0.0454; // 0.72 shield at 16 charisma, 1 shield at 23 charisma. 45 for 2 shields
-	float base_awake = 2;
-	float additional_awake_for_charisma = 4; // 64 awake on 16 charisma, 202 awake at 50 charisma
-	float base_multiparry = 2;
-	float additional_multiparry_for_charisma = 2; // 34 multiparry on 16 charisma, 102 multiparry at 50 charisma;
-	float base_rescue = 20.0;
-	float additional_rescue_for_charisma = 2.5; // 60 rescue at 16 charisma, 135 rescue at 50 charisma;
-	float base_heal = 0;
-	float additional_heal_for_charisma = 0.12; // 1 heal at 16 charisma,  6 heal at 50 charisma;
-	float base_ttl = 10.0;
-	float additional_ttl_for_charisma = 0.25; // 14 min at 16 chsrisma, 22 min at 50 charisma;
-	float base_ac = 100;
-	float additional_ac_for_charisma = -2.5; //
-	float base_armour = 0;
-	float additional_armour_for_charisma = 0.5; // 8 armour for 16 charisma, 25 armour for 50 charisma
+  int base_hp = 360;
+  int additional_hp_for_charisma = 40;
+  float base_shields = 0.0;
+  float
+      additional_shields_for_charisma = 0.0454; // 0.72 shield at 16 charisma, 1 shield at 23 charisma. 45 for 2 shields
+  float base_awake = 2;
+  float additional_awake_for_charisma = 4; // 64 awake on 16 charisma, 202 awake at 50 charisma
+  float base_multiparry = 2;
+  float additional_multiparry_for_charisma = 2; // 34 multiparry on 16 charisma, 102 multiparry at 50 charisma;
+  float base_rescue = 20.0;
+  float additional_rescue_for_charisma = 2.5; // 60 rescue at 16 charisma, 135 rescue at 50 charisma;
+  float base_heal = 0;
+  float additional_heal_for_charisma = 0.12; // 1 heal at 16 charisma,  6 heal at 50 charisma;
+  float base_ttl = 10.0;
+  float additional_ttl_for_charisma = 0.25; // 14 min at 16 chsrisma, 22 min at 50 charisma;
+  float base_ac = 100;
+  float additional_ac_for_charisma = -2.5; //
+  float base_armour = 0;
+  float additional_armour_for_charisma = 0.5; // 8 armour for 16 charisma, 25 armour for 50 charisma
 
-	clear_char_skills(mob);
-	AFFECT_DATA<EApplyLocation> af;
-	af.type = SPELL_CHARM;
-	af.duration = pc_duration(mob, floorf(base_ttl + additional_ttl_for_charisma * eff_cha), 0, 0, 0, 0);
-	af.modifier = 0;
-	af.location = EApplyLocation::APPLY_NONE;
-	af.battleflag = 0;
-	af.bitvector = to_underlying(EAffectFlag::AFF_HELPER);
-	affect_to_char(mob, af);
+  clear_char_skills(mob);
+  AFFECT_DATA<EApplyLocation> af;
+  af.type = SPELL_CHARM;
+  af.duration = pc_duration(mob, floorf(base_ttl + additional_ttl_for_charisma * eff_cha), 0, 0, 0, 0);
+  af.modifier = 0;
+  af.location = EApplyLocation::APPLY_NONE;
+  af.battleflag = 0;
+  af.bitvector = to_underlying(EAffectFlag::AFF_HELPER);
+  affect_to_char(mob, af);
 
-	af.bitvector = to_underlying(EAffectFlag::AFF_FLY);
-	affect_to_char(mob, af);
+  af.bitvector = to_underlying(EAffectFlag::AFF_FLY);
+  affect_to_char(mob, af);
 
-	af.bitvector = to_underlying(EAffectFlag::AFF_INFRAVISION);
-	affect_to_char(mob, af);
+  af.bitvector = to_underlying(EAffectFlag::AFF_INFRAVISION);
+  affect_to_char(mob, af);
 
-	af.bitvector = to_underlying(EAffectFlag::AFF_SANCTUARY);
-	affect_to_char(mob, af);
+  af.bitvector = to_underlying(EAffectFlag::AFF_SANCTUARY);
+  affect_to_char(mob, af);
 
-	//Set shields
-	int count_shields = base_shields + floorf(eff_cha * additional_shields_for_charisma) ;
-	if (count_shields>0) {
-		af.bitvector = to_underlying(EAffectFlag::AFF_AIRSHIELD);
-		affect_to_char(mob, af);
-	}
-	if (count_shields>1)
-	{
-		af.bitvector = to_underlying(EAffectFlag::AFF_ICESHIELD);
-		affect_to_char(mob, af);
-	}
-	if (count_shields>2)
-	{
-		af.bitvector = to_underlying(EAffectFlag::AFF_FIRESHIELD);
-		affect_to_char(mob, af);
-	}
+  //Set shields
+  int count_shields = base_shields + floorf(eff_cha * additional_shields_for_charisma);
+  if (count_shields > 0) {
+    af.bitvector = to_underlying(EAffectFlag::AFF_AIRSHIELD);
+    affect_to_char(mob, af);
+  }
+  if (count_shields > 1) {
+    af.bitvector = to_underlying(EAffectFlag::AFF_ICESHIELD);
+    affect_to_char(mob, af);
+  }
+  if (count_shields > 2) {
+    af.bitvector = to_underlying(EAffectFlag::AFF_FIRESHIELD);
+    affect_to_char(mob, af);
+  }
 
-	if (IS_FEMALE(ch))
-	{
-		mob->set_sex(ESex::SEX_MALE);
-		mob->set_pc_name("Небесный защитник");
-		mob->player_data.PNames[0] = "Небесный защитник";
-		mob->player_data.PNames[1] = "Небесного защитника";
-		mob->player_data.PNames[2] = "Небесному защитнику";
-		mob->player_data.PNames[3] = "Небесного защитника";
-		mob->player_data.PNames[4] = "Небесным защитником";
-		mob->player_data.PNames[5] = "Небесном защитнике";
-		mob->set_npc_name("Небесный защитник");
-		mob->player_data.long_descr = str_dup("Небесный защитник летает тут.\r\n");
-		mob->player_data.description = str_dup("Сияющая призрачная фигура о двух крылах.\r\n");
-	}
-	else
-	{
-		mob->set_sex(ESex::SEX_FEMALE);
-		mob->set_pc_name("Небесная защитница");
-		mob->player_data.PNames[0] = "Небесная защитница";
-		mob->player_data.PNames[1] = "Небесной защитницы";
-		mob->player_data.PNames[2] = "Небесной защитнице";
-		mob->player_data.PNames[3] = "Небесную защитницу";
-		mob->player_data.PNames[4] = "Небесной защитницей";
-		mob->player_data.PNames[5] = "Небесной защитнице";
-		mob->set_npc_name("Небесная защитница");
-		mob->player_data.long_descr = str_dup("Небесная защитница летает тут.\r\n");
-		mob->player_data.description = str_dup("Сияющая призрачная фигура о двух крылах.\r\n");
-	}
+  if (IS_FEMALE(ch)) {
+    mob->set_sex(ESex::SEX_MALE);
+    mob->set_pc_name("Небесный защитник");
+    mob->player_data.PNames[0] = "Небесный защитник";
+    mob->player_data.PNames[1] = "Небесного защитника";
+    mob->player_data.PNames[2] = "Небесному защитнику";
+    mob->player_data.PNames[3] = "Небесного защитника";
+    mob->player_data.PNames[4] = "Небесным защитником";
+    mob->player_data.PNames[5] = "Небесном защитнике";
+    mob->set_npc_name("Небесный защитник");
+    mob->player_data.long_descr = str_dup("Небесный защитник летает тут.\r\n");
+    mob->player_data.description = str_dup("Сияющая призрачная фигура о двух крылах.\r\n");
+  } else {
+    mob->set_sex(ESex::SEX_FEMALE);
+    mob->set_pc_name("Небесная защитница");
+    mob->player_data.PNames[0] = "Небесная защитница";
+    mob->player_data.PNames[1] = "Небесной защитницы";
+    mob->player_data.PNames[2] = "Небесной защитнице";
+    mob->player_data.PNames[3] = "Небесную защитницу";
+    mob->player_data.PNames[4] = "Небесной защитницей";
+    mob->player_data.PNames[5] = "Небесной защитнице";
+    mob->set_npc_name("Небесная защитница");
+    mob->player_data.long_descr = str_dup("Небесная защитница летает тут.\r\n");
+    mob->player_data.description = str_dup("Сияющая призрачная фигура о двух крылах.\r\n");
+  }
 
-	float additional_str_for_charisma = 0.6875;
-	float additional_dex_for_charisma = 1.0;
-	float additional_con_for_charisma = 1.0625;
-	float additional_int_for_charisma = 1.5625;
-	float additional_wis_for_charisma = 0.6;
-	float additional_cha_for_charisma = 1.375;
+  float additional_str_for_charisma = 0.6875;
+  float additional_dex_for_charisma = 1.0;
+  float additional_con_for_charisma = 1.0625;
+  float additional_int_for_charisma = 1.5625;
+  float additional_wis_for_charisma = 0.6;
+  float additional_cha_for_charisma = 1.375;
 
-	mob->set_str(1 + floorf( additional_str_for_charisma * eff_cha ));
-	mob->set_dex(1 + floorf( additional_dex_for_charisma * eff_cha ));
-	mob->set_con(1 + floorf( additional_con_for_charisma * eff_cha ));
-	mob->set_int(1 + floorf( additional_int_for_charisma * eff_cha ));
-	mob->set_wis(1 + floorf( additional_wis_for_charisma * eff_cha ));
-	mob->set_cha(1 + floorf( additional_cha_for_charisma * eff_cha ));
+  mob->set_str(1 + floorf(additional_str_for_charisma * eff_cha));
+  mob->set_dex(1 + floorf(additional_dex_for_charisma * eff_cha));
+  mob->set_con(1 + floorf(additional_con_for_charisma * eff_cha));
+  mob->set_int(1 + floorf(additional_int_for_charisma * eff_cha));
+  mob->set_wis(1 + floorf(additional_wis_for_charisma * eff_cha));
+  mob->set_cha(1 + floorf(additional_cha_for_charisma * eff_cha));
 
-	GET_WEIGHT(mob) = 150;
-	GET_HEIGHT(mob) = 200;
-	GET_SIZE(mob) = 65;
+  GET_WEIGHT(mob) = 150;
+  GET_HEIGHT(mob) = 200;
+  GET_SIZE(mob) = 65;
 
-	GET_HR(mob) = 1;
-	GET_AC(mob) = floorf( base_ac + additional_ac_for_charisma * eff_cha);
-	GET_DR(mob) = 0;
-	GET_ARMOUR(mob) = floorf(base_armour +  additional_armour_for_charisma * eff_cha );
+  GET_HR(mob) = 1;
+  GET_AC(mob) = floorf(base_ac + additional_ac_for_charisma * eff_cha);
+  GET_DR(mob) = 0;
+  GET_ARMOUR(mob) = floorf(base_armour + additional_armour_for_charisma * eff_cha);
 
-	mob->mob_specials.damnodice = 1;
-	mob->mob_specials.damsizedice = 1;
-	mob->mob_specials.ExtraAttack = 0;
+  mob->mob_specials.damnodice = 1;
+  mob->mob_specials.damsizedice = 1;
+  mob->mob_specials.ExtraAttack = 0;
 
-	mob->set_exp(0);
+  mob->set_exp(0);
 
-	GET_MAX_HIT(mob) = floorf( base_hp + additional_hp_for_charisma * eff_cha);
-	GET_HIT(mob) = GET_MAX_HIT(mob);
-	mob->set_gold(0);
-	GET_GOLD_NoDs(mob) = 0;
-	GET_GOLD_SiDs(mob) = 0;
+  GET_MAX_HIT(mob) = floorf(base_hp + additional_hp_for_charisma * eff_cha);
+  GET_HIT(mob) = GET_MAX_HIT(mob);
+  mob->set_gold(0);
+  GET_GOLD_NoDs(mob) = 0;
+  GET_GOLD_SiDs(mob) = 0;
 
-	GET_POS(mob) = POS_STANDING;
-	GET_DEFAULT_POS(mob) = POS_STANDING;
+  GET_POS(mob) = POS_STANDING;
+  GET_DEFAULT_POS(mob) = POS_STANDING;
 
-	mob->set_skill(SKILL_RESCUE, floorf( base_rescue +additional_rescue_for_charisma * eff_cha));
-	mob->set_skill(SKILL_AWAKE, floorf( base_awake +additional_awake_for_charisma * eff_cha ));
-	mob->set_skill(SKILL_MULTYPARRY, floorf( base_multiparry + additional_multiparry_for_charisma * eff_cha ));
+  mob->set_skill(SKILL_RESCUE, floorf(base_rescue + additional_rescue_for_charisma * eff_cha));
+  mob->set_skill(SKILL_AWAKE, floorf(base_awake + additional_awake_for_charisma * eff_cha));
+  mob->set_skill(SKILL_MULTYPARRY, floorf(base_multiparry + additional_multiparry_for_charisma * eff_cha));
 
-	SET_SPELL(mob, SPELL_CURE_BLIND, 1);
-	SET_SPELL(mob, SPELL_REMOVE_HOLD, 1);
-	SET_SPELL(mob, SPELL_REMOVE_POISON, 1);
-	SET_SPELL(mob, SPELL_HEAL, floorf( base_heal + additional_heal_for_charisma * eff_cha));
+  SET_SPELL(mob, SPELL_CURE_BLIND, 1);
+  SET_SPELL(mob, SPELL_REMOVE_HOLD, 1);
+  SET_SPELL(mob, SPELL_REMOVE_POISON, 1);
+  SET_SPELL(mob, SPELL_HEAL, floorf(base_heal + additional_heal_for_charisma * eff_cha));
 
-	if (mob->get_skill(SKILL_AWAKE))
-	{
-		PRF_FLAGS(mob).set(PRF_AWAKE);
-	}
+  if (mob->get_skill(SKILL_AWAKE)) {
+    PRF_FLAGS(mob).set(PRF_AWAKE);
+  }
 
-	GET_LIKES(mob) = 100;
-	IS_CARRYING_W(mob) = 0;
-	IS_CARRYING_N(mob) = 0;
+  GET_LIKES(mob) = 100;
+  IS_CARRYING_W(mob) = 0;
+  IS_CARRYING_N(mob) = 0;
 
-	MOB_FLAGS(mob).set(MOB_CORPSE);
-	MOB_FLAGS(mob).set(MOB_ANGEL);
-	MOB_FLAGS(mob).set(MOB_LIGHTBREATH);
+  MOB_FLAGS(mob).set(MOB_CORPSE);
+  MOB_FLAGS(mob).set(MOB_ANGEL);
+  MOB_FLAGS(mob).set(MOB_LIGHTBREATH);
 
-	mob->set_level(ch->get_level());
+  mob->set_level(ch->get_level());
 
-	char_to_room(mob, ch->in_room);
+  char_to_room(mob, ch->in_room);
 
-	if (IS_FEMALE(mob))
-	{
-		act("Небесная защитница появилась в яркой вспышке света!", TRUE, mob, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-	}
-	else
-	{
-		act("Небесный защитник появился в яркой вспышке света!", TRUE, mob, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
-	}
-	ch->add_follower(mob);
-	return;
+  if (IS_FEMALE(mob)) {
+    act("Небесная защитница появилась в яркой вспышке света!", TRUE, mob, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  } else {
+    act("Небесный защитник появился в яркой вспышке света!", TRUE, mob, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  }
+  ch->add_follower(mob);
+  return;
 }
 
-void spell_vampire(int/* level*/, CHAR_DATA* /*ch*/, CHAR_DATA* /*victim*/, OBJ_DATA* /*obj*/)
-{
+void spell_vampire(int/* level*/, CHAR_DATA * /*ch*/, CHAR_DATA * /*victim*/, OBJ_DATA * /*obj*/) {
 }
 
-void spell_mental_shadow(int/* level*/, CHAR_DATA* ch, CHAR_DATA* /*victim*/, OBJ_DATA* /*obj*/)
-{
-	// подготовка контейнера для создания заклинания ментальная тень
-	// все предложения пишем мад почтой
+void spell_mental_shadow(int/* level*/, CHAR_DATA *ch, CHAR_DATA * /*victim*/, OBJ_DATA * /*obj*/) {
+  // подготовка контейнера для создания заклинания ментальная тень
+  // все предложения пишем мад почтой
 
-	mob_vnum mob_num = MOB_MENTAL_SHADOW;
+  mob_vnum mob_num = MOB_MENTAL_SHADOW;
 
-	CHAR_DATA *mob = NULL;
-	struct follow_type *k, *k_next;
-	for (k = ch->followers; k; k = k_next)
-	{
-		k_next = k->next;
-		if (MOB_FLAGGED(k->follower, MOB_GHOST))
-		{
-			stop_follower(k->follower, FALSE);
-		}
-	}
-	if (get_effective_int(ch) < 26 && !IS_IMMORTAL(ch))
-	{
-		send_to_char("Головные боли мешают работать!\r\n", ch);
-		return;
-	};
+  CHAR_DATA *mob = NULL;
+  struct follow_type *k, *k_next;
+  for (k = ch->followers; k; k = k_next) {
+    k_next = k->next;
+    if (MOB_FLAGGED(k->follower, MOB_GHOST)) {
+      stop_follower(k->follower, FALSE);
+    }
+  }
+  if (get_effective_int(ch) < 26 && !IS_IMMORTAL(ch)) {
+    send_to_char("Головные боли мешают работать!\r\n", ch);
+    return;
+  };
 
-	if (!(mob = read_mobile(-mob_num, VIRTUAL)))
-	{
-		send_to_char("Вы точно не помните, как создать данного монстра.\r\n", ch);
-		return;
-	}
-	AFFECT_DATA<EApplyLocation> af;
-	af.type = SPELL_CHARM;
-	af.duration =
-		pc_duration(mob, 5 + (int) VPOSI<float>((get_effective_int(ch) - 16.0) / 2, 0, 50), 0, 0, 0, 0);
-	af.modifier = 0;
-	af.location = APPLY_NONE;
-	af.bitvector = to_underlying(EAffectFlag::AFF_HELPER);
-	af.battleflag = 0;
-	affect_to_char(mob, af);
+  if (!(mob = read_mobile(-mob_num, VIRTUAL))) {
+    send_to_char("Вы точно не помните, как создать данного монстра.\r\n", ch);
+    return;
+  }
+  AFFECT_DATA<EApplyLocation> af;
+  af.type = SPELL_CHARM;
+  af.duration =
+      pc_duration(mob, 5 + (int) VPOSI<float>((get_effective_int(ch) - 16.0) / 2, 0, 50), 0, 0, 0, 0);
+  af.modifier = 0;
+  af.location = APPLY_NONE;
+  af.bitvector = to_underlying(EAffectFlag::AFF_HELPER);
+  af.battleflag = 0;
+  affect_to_char(mob, af);
 
-	char_to_room(mob, IN_ROOM(ch));
-	mob->set_protecting(ch);
-	MOB_FLAGS(mob).set(MOB_CORPSE);
-	MOB_FLAGS(mob).set(MOB_GHOST);
+  char_to_room(mob, IN_ROOM(ch));
+  mob->set_protecting(ch);
+  MOB_FLAGS(mob).set(MOB_CORPSE);
+  MOB_FLAGS(mob).set(MOB_GHOST);
 
-	act("Мимолётное наваждение воплотилось в призрачную тень.", TRUE, mob, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
+  act("Мимолётное наваждение воплотилось в призрачную тень.", TRUE, mob, 0, 0, TO_ROOM | TO_ARENA_LISTEN);
 
-	ch->add_follower(mob);
-	return;
+  ch->add_follower(mob);
+  return;
 }
 
-const char* spell_wear_off_msg_t::DEFAULT_MESSAGE = "!нет сообщения при спадении аффекта под номером %d!";
+const char *spell_wear_off_msg_t::DEFAULT_MESSAGE = "!нет сообщения при спадении аффекта под номером %d!";
 char spell_wear_off_msg_t::MESSAGE_BUFFER[spell_wear_off_msg_t::MESSAGE_BUFFER_LENGTH];
 const spell_wear_off_msg_t spell_wear_off_msg =
-{
-	"RESERVED DB.C",	// 0
-	"Вы почувствовали себя менее защищенно.",	// 1
-	"!Teleport!",
-	"Вы почувствовали себя менее доблестно.",
-	"Вы вновь можете видеть.",
-	"!Burning Hands!",	// 5
-	"!Call Lightning",
-	"Вы подчиняетесь теперь только себе.",
-	"Вы отметили, что силы вернулись к вам.",
-	"!Clone!",
-	"!Color Spray!",	// 10
-	"!Control Weather!",
-	"!Create Food!",
-	"!Create Water!",
-	"!Cure Blind!",
-	"!Cure Critic!",	// 15
-	"!Cure Light!",
-	"Вы почувствовали себя более уверенно.",
-	"Вы более не можете определять наклонности.",
-	"Вы не в состоянии больше видеть невидимых.",
-	"Вы не в состоянии более определять магию.",	// 20
-	"Вы не в состоянии более определять яды.",
-	"!Dispel Evil!",
-	"!Earthquake!",
-	"!Enchant Weapon!",
-	"!Energy Drain!",	// 25
-	"!Fireball!",
-	"!Harm!",
-	"!Heal!",
-	"Вы вновь видимы.",
-	"!Lightning Bolt!",	// 30
-	"!Locate object!",
-	"!Magic Missile!",
-	"В вашей крови не осталось ни капельки яда.",
-	"Вы вновь ощущаете страх перед тьмой.",
-	"!Remove Curse!",	// 35
-	"Белая аура вокруг вашего тела угасла.",
-	"!Shocking Grasp!",
-	"Вы не чувствуете сонливости.",
-	"Вы чувствуете себя немного слабее.",
-	"!Summon!",		// 40
-	"Вы утратили покровительство высших сил.",
-	"!Word of Recall!",
-	"!Remove Poison!",
-	"Вы больше не можете чувствовать жизнь.",
-	"!Animate Dead!",	// 45
-	"!Dispel Good!",
-	"!Group Armor!",
-	"!Group Heal!",
-	"!Group Recall!",
-	"Вы больше не можете видеть ночью.",	// 50
-	"Вы больше не можете ходить по воде.",
-	"!SPELL CURE SERIOUS!",
-	"!SPELL GROUP STRENGTH!",
-	"К вам вернулась способность двигаться.",
-	"!SPELL POWER HOLD!",	// 55
-	"!SPELL MASS HOLD!",
-	"Вы приземлились на землю.",
-	"Вы вновь стали уязвимы для оцепенения.",
-	"Вы опять можете сбежать с поля боя.",
-	"!SPELL CREATE LIGHT!",	// 60
-	"Облако тьмы, окружающее вас, спало.",
-	"Ваша кожа вновь стала мягкой и бархатистой.",
-	"Ваши очертания приобрели отчетливость.",
-	"Теперь вы можете болтать, все что думаете.",
-	"Ваше тело перестало светиться.",	// 65
-	"!SPELL CHAIN LIGHTNING!",
-	"!SPELL FIREBLAST!",
-	"!SPELL IMPLOSION!",
-	"Силы вернулись к вам.",
-	"!SPELL GROUP INVISIBLE!",	// 70
-	"Ваша теневая мантия замерцала и растаяла.",
-	"!SPELL ACID!",
-	"!SPELL REPAIR!",
-	"Ваши размеры стали прежними.",
-	"!SPELL FEAR!",		// 75
-	"!SPELL SACRIFICE!",
-	"Магическая сеть, покрывавшая вас, исчезла.",
-	"Вы перестали мигать.",
-	"!SPELL REMOVE HOLD!",
-	"Вы стали вновь похожи сами на себя.",	// 80
-	"!SPELL POWER BLINDNESS!",
-	"!SPELL MASS BLINDNESS!",
-	"!SPELL POWER SIELENCE!",
-	"!SPELL EXTRA HITS!",
-	"!SPELL RESSURECTION!",	// 85
-	"Ваш волшебный щит рассеялся.",
-	"Магия, запечатывающая входы, пропала.",
-	"!SPELL MASS SIELENCE!",
-	"!SPELL REMOVE SIELENCE!",
-	"!SPELL DAMAGE LIGHT!",	// 90
-	"!SPELL DAMAGE SERIOUS!",
-	"!SPELL DAMAGE CRITIC!",
-	"!SPELL MASS CURSE!",
-	"!SPELL ARMAGEDDON!",
-	"!SPELL GROUP FLY!",	// 95
-	"!SPELL GROUP BLESS!",
-	"!SPELL REFRESH!",
-	"!SPELL STUNNING!",
-	"Вы стали заметны окружающим.",
-	"Ваши передвижения стали заметны.",	// 100
-	"Кураж прошел. Мама, лучше бы я умер$q вчера.",
-	"А головка ваша уже не болит.",
-	"Вам снова захотелось жареного, да с дымком.",
-	"Вы согрелись и подвижность вернулась к вам.",
-	"К вам вернулась способность нормально сражаться.",	// 105
-	"Ваши кровоточащие раны затянулись.",
-	"Вы успокоились.",
-	"Вы более не способны дышать водой.",
-	"Медлительность исчезла.",
-	"Вы стали более медлительны.",	// 110
-	"!SPELL MASS SLOW!",
-	"!SPELL MASS HASTE!",
-	"Голубой кокон вокруг вашего тела угас.",
-	"Лихорадка прекратилась.",
-	"!SPELL CURE PLAQUE!",	// 115
-	"Вы стали менее внимательны.",
-	"Вы утратили расположение Богов.",
-	"Ваш воздушный щит исчез.",
-	"!PORTAL!",
-	"!DISPELL MAGIC!",	// 120
-	"!SUMMON KEEPER!",
-	"Живительная сила покинула вас.",
-	"!CREATE WEAPON!",
-	"Огненный щит вокруг вашего тела исчез.",
-	"!RELOCATE!",		// 125
-	"!SUMMON FIREKEEPER!",
-	"Ледяной щит вокруг вашего тела исчез.",
-	"Ваши мышцы оттаяли и вы снова можете двигаться.",
-	"Ваши размеры вновь стали прежними.",
-	"!SHINE LIGHT!",	// 130
-	"Безумие боя отпустило вас.",
-	"!GROUP MAGICGLASS!",
-	"Облако стрел вокруг вас рассеялось.",
-	"!VACUUM!",
-	"Последний громовой камень грянул в землю и все стихло.",	// 135 SPELL_METEORSTORM
-	"Ваши руки вернулись к прежнему состоянию.",
-	"Ваш разум просветлел.",
-	"Призматическая аура вокруг вашего тела угасла.",
-	"Силы зла оставили вас.",
-	"Воздушная аура вокруг вас исчезла.",	// 140
-	"Огненная аура вокруг вас исчезла.",
-	"Ледяная аура вокруг вас исчезла.",
-	"!SHOCK!",
-	"Вы вновь чувствительны к магическим поражениям.",
-	"!SPELL GROUP SANCTUARY!",	// 145
-	"!SPELL GROUP PRISMATICAURA!",
-	"Вы вновь можете слышать.",
-	"!SPELL_POWER_DEAFNESS!",
-	"!SPELL_REMOVE_DEAFNESS!",
-	"!SPELL_MASS_DEAFNESS!",	// 150
-	"!SPELL_DUSTSTORM!",
-	"!SPELL_EARTHFALL!",
-	"!SPELL_SONICWAVE!",
-	"!SPELL_HOLYSTRIKE!",
-	"!SPELL_SPELL_ANGEL!",                 // 155
-	"!SPELL_SPELL_MASS_FEAR!",
-	"Ваша красота куда-то пропала.",
-	"Ваша душа успокоилась.",
-	"!SPELL_OBLIVION!",
-	"!SPELL_BURDEN_OF_TIME!",        // 160
-	"!SPELL_GROUP_REFRESH!",
-	"Смирение в вашей душе вдруг куда-то исчезло.",
-	"К вам вернулась способность нормально сражаться.",
-	"Неистовство оставило вас.",
-	"!stone bones!",               // 165
-	"Колдовской свет угас.",          // SPELL_ROOM_LIGHT - строка при снятии аффекта
-	"Порыв ветра развеял ядовитый туман.",   // SPELL_POISONED_FOG - строка при снятии аффекта
-	"Ветер прогнал грозовые тучи.",		 // SPELL_THUNDERSTORM - строка при снятии аффекта
-	"Ваши следы вновь стали заметны.",
-	"Удача вновь вернулась к вам.",		// 170
-	"Магические чары ослабели со временем и покинули вас.",
-	"Покрывавшая вас блестящая пыль осыпалась и растаяла в воздухе.", // SPELL_GLITTERDUST
-	"Леденящий душу испуг отпустил вас.",
-	"Ваши движения утратили прежнюю колдовскую ловкость.",
-	"Ваше телосложение вновь стало обычным.",
-	"Вы утратили навеянную магией мудрость.",
-	"Навеянная магией хитрость покинула вас.",
-	"!SPELL_WC_OF_CHALLENGE!",
-	"",		// SPELL_WC_OF_MENACE
-	"!SPELL_WC_OF_RAGE!",
-	"",		// SPELL_WC_OF_MADNESS
-	"!SPELL_WC_OF_THUNDER!",
-	"Действие клича 'призыв к обороне' закончилось.", //SPELL_WC_OF_DEFENSE
-	"Действие клича битвы закончилось.",		// SPELL_WC_OF_BATTLE
-	"Действие клича мощи закончилось.",		// SPELL_WC_OF_POWER
-	"Действие клича доблести закончилось.",		// SPELL_WC_OF_BLESS
-	"Действие клича отваги закончилось.",		// SPELL_WC_OF_COURAGE
-	"Магические письмена на земле угасли.",         // SPELL_RUNE_LABEL
-	"В вашей крови не осталось ни капельки яда.", // SPELL_ACONITUM_POISON
-	"В вашей крови не осталось ни капельки яда.", // SPELL_SCOPOLIA_POISON
-	"В вашей крови не осталось ни капельки яда.", // SPELL_BELENA_POISON
-	"В вашей крови не осталось ни капельки яда.",  // SPELL_DATURA_POISON
-	"SPELL_TIMER_REPAIR",
-	"!SPELL_LACKY!",
-	"Вы аккуратно перевязали свои раны.",
-	"Вы снова можете перевязывать свои раны.",
-	"!SPELL_CAPABLE!",
-	"Удушье отпустило вас, и вы вздохнули полной грудью.", //SPELL_STRANGLE
-	"Вам стало не на чем концентрироваться.", //SPELL_RECALL_SPELLS
-	"Плывший в воздухе огненный узор потускнел и растаял струйками дыма.", //SPELL_HYPNOTIC_PATTERN
-	"Одна из наград прекратила действовать.", //SPELL_SOLOBONUS
-	"!SPELL_VAMPIRE!",
-	"!SPELLS_RESTORATION!",
-	"Силы нави покинули вас.",
-	"!SPELL_RECOVERY!",
-	"!SPELL_MASS_RECOVERY!",
-	"Аура зла больше не помогает вам.",
-	"!SPELL_MENTAL_SHADOW!",                 // 208
-	"Жуткие черные руки побледнели и расплылись зловонной дымкой.", //209 SPELL_EVARDS_BLACK_TENTACLES
-	"!SPELL_WHIRLWIND!", //210
-	"Каменные зубы исчезли, возвратив способность двигаться.",
-	"!SPELL_MELFS_ACID_ARROW!",
-	"!SPELL_THUNDERSTONE!",
-	"!SPELL_CLOD!",
-	"Эффект боевого приема завершился.",
-	"!SPELL SIGHT OF DARKNESS!",
-	"!SPELL GENERAL SINCERITY!",
-	"!SPELL MAGICAL GAZE!",
-	"!SPELL ALL SEEING EYE!",
-	"!SPELL EYE OF GODS!", //220
-	"!SPELL BREATHING AT DEPTH!",
-	"!SPELL GENERAL RECOVERY!",
-	"!SPELL COMMON MEAL!",
-	"!SPELL STONE WALL!",
-	"!SPELL SNAKE EYES!",
-	"Матушка земля забыла про Вас.",
-	"Вы вновь ощущаете страх перед тьмой.",
-	"!NONE",
-	"!NONE",
-	"!NONE", //230
-	"!NONE",
-	"!NONE",
-	"*Боевое воодушевление угасло, а с ним и вся жажда подвигов!",
-	"Вы стали менее шустрым.",
-	"!NONE",//    SPELL_GROUP_BLINK = 235, // групповая мигалка
-	"!NONE",//    SPELL_GROUP_CLOUDLY = 236, // группповое затуманивание
-	"!NONE",//    SPELL_GROUP_AWARNESS = 237, // групповая внимательность
-	"Действие клича 'обучение' закончилось.",
-	"Действие клича 'везение' закончилось.",
-	"Действие клича 'точность' закончилось.",
-	"Удача снова повернулась к вам лицом... и залепила пощечину.", // SPELL_MASS_FAILURE !взор Велеса!
-	"Покрывавшие вас сети колдовской западни растаяли." // SPELL_MASS_NOFLEE !западня!
+    {
+        "RESERVED DB.C",    // 0
+        "Вы почувствовали себя менее защищенно.",    // 1
+        "!Teleport!",
+        "Вы почувствовали себя менее доблестно.",
+        "Вы вновь можете видеть.",
+        "!Burning Hands!",    // 5
+        "!Call Lightning",
+        "Вы подчиняетесь теперь только себе.",
+        "Вы отметили, что силы вернулись к вам.",
+        "!Clone!",
+        "!Color Spray!",    // 10
+        "!Control Weather!",
+        "!Create Food!",
+        "!Create Water!",
+        "!Cure Blind!",
+        "!Cure Critic!",    // 15
+        "!Cure Light!",
+        "Вы почувствовали себя более уверенно.",
+        "Вы более не можете определять наклонности.",
+        "Вы не в состоянии больше видеть невидимых.",
+        "Вы не в состоянии более определять магию.",    // 20
+        "Вы не в состоянии более определять яды.",
+        "!Dispel Evil!",
+        "!Earthquake!",
+        "!Enchant Weapon!",
+        "!Energy Drain!",    // 25
+        "!Fireball!",
+        "!Harm!",
+        "!Heal!",
+        "Вы вновь видимы.",
+        "!Lightning Bolt!",    // 30
+        "!Locate object!",
+        "!Magic Missile!",
+        "В вашей крови не осталось ни капельки яда.",
+        "Вы вновь ощущаете страх перед тьмой.",
+        "!Remove Curse!",    // 35
+        "Белая аура вокруг вашего тела угасла.",
+        "!Shocking Grasp!",
+        "Вы не чувствуете сонливости.",
+        "Вы чувствуете себя немного слабее.",
+        "!Summon!",        // 40
+        "Вы утратили покровительство высших сил.",
+        "!Word of Recall!",
+        "!Remove Poison!",
+        "Вы больше не можете чувствовать жизнь.",
+        "!Animate Dead!",    // 45
+        "!Dispel Good!",
+        "!Group Armor!",
+        "!Group Heal!",
+        "!Group Recall!",
+        "Вы больше не можете видеть ночью.",    // 50
+        "Вы больше не можете ходить по воде.",
+        "!SPELL CURE SERIOUS!",
+        "!SPELL GROUP STRENGTH!",
+        "К вам вернулась способность двигаться.",
+        "!SPELL POWER HOLD!",    // 55
+        "!SPELL MASS HOLD!",
+        "Вы приземлились на землю.",
+        "Вы вновь стали уязвимы для оцепенения.",
+        "Вы опять можете сбежать с поля боя.",
+        "!SPELL CREATE LIGHT!",    // 60
+        "Облако тьмы, окружающее вас, спало.",
+        "Ваша кожа вновь стала мягкой и бархатистой.",
+        "Ваши очертания приобрели отчетливость.",
+        "Теперь вы можете болтать, все что думаете.",
+        "Ваше тело перестало светиться.",    // 65
+        "!SPELL CHAIN LIGHTNING!",
+        "!SPELL FIREBLAST!",
+        "!SPELL IMPLOSION!",
+        "Силы вернулись к вам.",
+        "!SPELL GROUP INVISIBLE!",    // 70
+        "Ваша теневая мантия замерцала и растаяла.",
+        "!SPELL ACID!",
+        "!SPELL REPAIR!",
+        "Ваши размеры стали прежними.",
+        "!SPELL FEAR!",        // 75
+        "!SPELL SACRIFICE!",
+        "Магическая сеть, покрывавшая вас, исчезла.",
+        "Вы перестали мигать.",
+        "!SPELL REMOVE HOLD!",
+        "Вы стали вновь похожи сами на себя.",    // 80
+        "!SPELL POWER BLINDNESS!",
+        "!SPELL MASS BLINDNESS!",
+        "!SPELL POWER SIELENCE!",
+        "!SPELL EXTRA HITS!",
+        "!SPELL RESSURECTION!",    // 85
+        "Ваш волшебный щит рассеялся.",
+        "Магия, запечатывающая входы, пропала.",
+        "!SPELL MASS SIELENCE!",
+        "!SPELL REMOVE SIELENCE!",
+        "!SPELL DAMAGE LIGHT!",    // 90
+        "!SPELL DAMAGE SERIOUS!",
+        "!SPELL DAMAGE CRITIC!",
+        "!SPELL MASS CURSE!",
+        "!SPELL ARMAGEDDON!",
+        "!SPELL GROUP FLY!",    // 95
+        "!SPELL GROUP BLESS!",
+        "!SPELL REFRESH!",
+        "!SPELL STUNNING!",
+        "Вы стали заметны окружающим.",
+        "Ваши передвижения стали заметны.",    // 100
+        "Кураж прошел. Мама, лучше бы я умер$q вчера.",
+        "А головка ваша уже не болит.",
+        "Вам снова захотелось жареного, да с дымком.",
+        "Вы согрелись и подвижность вернулась к вам.",
+        "К вам вернулась способность нормально сражаться.",    // 105
+        "Ваши кровоточащие раны затянулись.",
+        "Вы успокоились.",
+        "Вы более не способны дышать водой.",
+        "Медлительность исчезла.",
+        "Вы стали более медлительны.",    // 110
+        "!SPELL MASS SLOW!",
+        "!SPELL MASS HASTE!",
+        "Голубой кокон вокруг вашего тела угас.",
+        "Лихорадка прекратилась.",
+        "!SPELL CURE PLAQUE!",    // 115
+        "Вы стали менее внимательны.",
+        "Вы утратили расположение Богов.",
+        "Ваш воздушный щит исчез.",
+        "!PORTAL!",
+        "!DISPELL MAGIC!",    // 120
+        "!SUMMON KEEPER!",
+        "Живительная сила покинула вас.",
+        "!CREATE WEAPON!",
+        "Огненный щит вокруг вашего тела исчез.",
+        "!RELOCATE!",        // 125
+        "!SUMMON FIREKEEPER!",
+        "Ледяной щит вокруг вашего тела исчез.",
+        "Ваши мышцы оттаяли и вы снова можете двигаться.",
+        "Ваши размеры вновь стали прежними.",
+        "!SHINE LIGHT!",    // 130
+        "Безумие боя отпустило вас.",
+        "!GROUP MAGICGLASS!",
+        "Облако стрел вокруг вас рассеялось.",
+        "!VACUUM!",
+        "Последний громовой камень грянул в землю и все стихло.",    // 135 SPELL_METEORSTORM
+        "Ваши руки вернулись к прежнему состоянию.",
+        "Ваш разум просветлел.",
+        "Призматическая аура вокруг вашего тела угасла.",
+        "Силы зла оставили вас.",
+        "Воздушная аура вокруг вас исчезла.",    // 140
+        "Огненная аура вокруг вас исчезла.",
+        "Ледяная аура вокруг вас исчезла.",
+        "!SHOCK!",
+        "Вы вновь чувствительны к магическим поражениям.",
+        "!SPELL GROUP SANCTUARY!",    // 145
+        "!SPELL GROUP PRISMATICAURA!",
+        "Вы вновь можете слышать.",
+        "!SPELL_POWER_DEAFNESS!",
+        "!SPELL_REMOVE_DEAFNESS!",
+        "!SPELL_MASS_DEAFNESS!",    // 150
+        "!SPELL_DUSTSTORM!",
+        "!SPELL_EARTHFALL!",
+        "!SPELL_SONICWAVE!",
+        "!SPELL_HOLYSTRIKE!",
+        "!SPELL_SPELL_ANGEL!",                 // 155
+        "!SPELL_SPELL_MASS_FEAR!",
+        "Ваша красота куда-то пропала.",
+        "Ваша душа успокоилась.",
+        "!SPELL_OBLIVION!",
+        "!SPELL_BURDEN_OF_TIME!",        // 160
+        "!SPELL_GROUP_REFRESH!",
+        "Смирение в вашей душе вдруг куда-то исчезло.",
+        "К вам вернулась способность нормально сражаться.",
+        "Неистовство оставило вас.",
+        "!stone bones!",               // 165
+        "Колдовской свет угас.",          // SPELL_ROOM_LIGHT - строка при снятии аффекта
+        "Порыв ветра развеял ядовитый туман.",   // SPELL_POISONED_FOG - строка при снятии аффекта
+        "Ветер прогнал грозовые тучи.",         // SPELL_THUNDERSTORM - строка при снятии аффекта
+        "Ваши следы вновь стали заметны.",
+        "Удача вновь вернулась к вам.",        // 170
+        "Магические чары ослабели со временем и покинули вас.",
+        "Покрывавшая вас блестящая пыль осыпалась и растаяла в воздухе.", // SPELL_GLITTERDUST
+        "Леденящий душу испуг отпустил вас.",
+        "Ваши движения утратили прежнюю колдовскую ловкость.",
+        "Ваше телосложение вновь стало обычным.",
+        "Вы утратили навеянную магией мудрость.",
+        "Навеянная магией хитрость покинула вас.",
+        "!SPELL_WC_OF_CHALLENGE!",
+        "",        // SPELL_WC_OF_MENACE
+        "!SPELL_WC_OF_RAGE!",
+        "",        // SPELL_WC_OF_MADNESS
+        "!SPELL_WC_OF_THUNDER!",
+        "Действие клича 'призыв к обороне' закончилось.", //SPELL_WC_OF_DEFENSE
+        "Действие клича битвы закончилось.",        // SPELL_WC_OF_BATTLE
+        "Действие клича мощи закончилось.",        // SPELL_WC_OF_POWER
+        "Действие клича доблести закончилось.",        // SPELL_WC_OF_BLESS
+        "Действие клича отваги закончилось.",        // SPELL_WC_OF_COURAGE
+        "Магические письмена на земле угасли.",         // SPELL_RUNE_LABEL
+        "В вашей крови не осталось ни капельки яда.", // SPELL_ACONITUM_POISON
+        "В вашей крови не осталось ни капельки яда.", // SPELL_SCOPOLIA_POISON
+        "В вашей крови не осталось ни капельки яда.", // SPELL_BELENA_POISON
+        "В вашей крови не осталось ни капельки яда.",  // SPELL_DATURA_POISON
+        "SPELL_TIMER_REPAIR",
+        "!SPELL_LACKY!",
+        "Вы аккуратно перевязали свои раны.",
+        "Вы снова можете перевязывать свои раны.",
+        "!SPELL_CAPABLE!",
+        "Удушье отпустило вас, и вы вздохнули полной грудью.", //SPELL_STRANGLE
+        "Вам стало не на чем концентрироваться.", //SPELL_RECALL_SPELLS
+        "Плывший в воздухе огненный узор потускнел и растаял струйками дыма.", //SPELL_HYPNOTIC_PATTERN
+        "Одна из наград прекратила действовать.", //SPELL_SOLOBONUS
+        "!SPELL_VAMPIRE!",
+        "!SPELLS_RESTORATION!",
+        "Силы нави покинули вас.",
+        "!SPELL_RECOVERY!",
+        "!SPELL_MASS_RECOVERY!",
+        "Аура зла больше не помогает вам.",
+        "!SPELL_MENTAL_SHADOW!",                 // 208
+        "Жуткие черные руки побледнели и расплылись зловонной дымкой.", //209 SPELL_EVARDS_BLACK_TENTACLES
+        "!SPELL_WHIRLWIND!", //210
+        "Каменные зубы исчезли, возвратив способность двигаться.",
+        "!SPELL_MELFS_ACID_ARROW!",
+        "!SPELL_THUNDERSTONE!",
+        "!SPELL_CLOD!",
+        "Эффект боевого приема завершился.",
+        "!SPELL SIGHT OF DARKNESS!",
+        "!SPELL GENERAL SINCERITY!",
+        "!SPELL MAGICAL GAZE!",
+        "!SPELL ALL SEEING EYE!",
+        "!SPELL EYE OF GODS!", //220
+        "!SPELL BREATHING AT DEPTH!",
+        "!SPELL GENERAL RECOVERY!",
+        "!SPELL COMMON MEAL!",
+        "!SPELL STONE WALL!",
+        "!SPELL SNAKE EYES!",
+        "Матушка земля забыла про Вас.",
+        "Вы вновь ощущаете страх перед тьмой.",
+        "!NONE",
+        "!NONE",
+        "!NONE", //230
+        "!NONE",
+        "!NONE",
+        "*Боевое воодушевление угасло, а с ним и вся жажда подвигов!",
+        "Вы стали менее шустрым.",
+        "!NONE",//    SPELL_GROUP_BLINK = 235, // групповая мигалка
+        "!NONE",//    SPELL_GROUP_CLOUDLY = 236, // группповое затуманивание
+        "!NONE",//    SPELL_GROUP_AWARNESS = 237, // групповая внимательность
+        "Действие клича 'обучение' закончилось.",
+        "Действие клича 'везение' закончилось.",
+        "Действие клича 'точность' закончилось.",
+        "Удача снова повернулась к вам лицом... и залепила пощечину.", // SPELL_MASS_FAILURE !взор Велеса!
+        "Покрывавшие вас сети колдовской западни растаяли." // SPELL_MASS_NOFLEE !западня!
 
 // * в начале строки значит не выводить текст окончания заклинания см void show_spell_off
-};
+    };
 
 /**
 ** Only for debug purposes: to trace values of the spell_wear_off_msg array.
 */
-void output_spell_wear_off_msg()
-{
-	unsigned n = 0;
-	for (const auto i : spell_wear_off_msg)
-	{
-		const size_t BUFFER_LENGTH = 4096;
-		char buffer[BUFFER_LENGTH];
-		const size_t length = std::min(BUFFER_LENGTH, strlen(i));
-		strncpy(buffer, i, length + 1);
-		koi_to_alt(buffer, static_cast<int>(length));
-		printf("%d. %s\n", n++, buffer);
-	}
+void output_spell_wear_off_msg() {
+  unsigned n = 0;
+  for (const auto i : spell_wear_off_msg) {
+    const size_t BUFFER_LENGTH = 4096;
+    char buffer[BUFFER_LENGTH];
+    const size_t length = std::min(BUFFER_LENGTH, strlen(i));
+    strncpy(buffer, i, length + 1);
+    koi_to_alt(buffer, static_cast<int>(length));
+    printf("%d. %s\n", n++, buffer);
+  }
 }
 
 const cast_phrases_t cast_phrase =
-{
-	cast_phrase_t{ "\nRESERVED DB.C", "\n" },	// 0
-	cast_phrase_t{ "буде во прибежище", "... Он - помощь наша и защита наша." },
-	cast_phrase_t{ "несите ветры", "... дух поднял меня и перенес меня." },
-	cast_phrase_t{ "истягну умь крепостию", "... даст блага просящим у Него." },
-	cast_phrase_t{ "Чтоб твои зенки вылезли!", "... поразит тебя Господь слепотою." },
-	cast_phrase_t{ "узри огонь!", "... простер руку свою к огню." },	// 5
-	cast_phrase_t{ "Разрази тебя Перун!", "... и путь для громоносной молнии." },
-	cast_phrase_t{ "умь полонить", "... слушай пастыря сваего, и уразумей." },
-	cast_phrase_t{ "хладну персты воскладаше", "... которые черны от льда." },
-	cast_phrase_t{ "пусть будет много меня", "... и плодились, и весьма умножились." },
-	cast_phrase_t{ "хлад и мраз исторгнути", "... и из воды делается лед." },	// 10
-	cast_phrase_t{ "стихия подкоряшися", "... власть затворить небо, чтобы не шел дождь." },
-	cast_phrase_t{ "будовати снедь", "... это хлеб, который Господь дал вам в пищу." },
-	cast_phrase_t{ "напоиши влагой", "... и потекло много воды." },
-	cast_phrase_t{ "зряще узрите", "... и прозрят из тьмы и мрака глаза слепых." },
-	cast_phrase_t{ "гой еси", "... да зарубцуются гноища твои." },	// 15
-	cast_phrase_t{ "малейше целити раны", "... да затянутся раны твои." },
-	cast_phrase_t{ "порча", "... проклят ты пред всеми скотами." },
-	cast_phrase_t{ "узряще норов", "... и отделит одних от других, как пастырь отделяет овец от козлов." },
-	cast_phrase_t{ "взор мечетный", "... ибо нет ничего тайного, что не сделалось бы явным." },
-	cast_phrase_t{ "зряще ворожбу", "... покажись, ересь богопротивная." },	// 20
-	cast_phrase_t{ "зряще трутизну", "... по плодам их узнаете их." },
-	cast_phrase_t{ "долой нощи", "... грешников преследует зло, а праведникам воздается добром." },
-	cast_phrase_t{ "земля тутнет", "... в тот же час произошло великое землетрясение." },
-	cast_phrase_t{ "ницовати стружие", "... укрепи сталь Божьим перстом." },
-	cast_phrase_t{ "преторгоста", "... да иссякнут соки, питающие тело."},	// 25
-	cast_phrase_t{ "огненну солнце", "... да ниспадет огонь с неба, и пожрет их." },
-	cast_phrase_t{ "згола скверна", "... и жестокою болью во всех костях твоих." },
-	cast_phrase_t{ "згола гой еси", "... тебе говорю, встань." },
-	cast_phrase_t{ "низовати мечетно", "... ибо видимое временно, а невидимое вечно." },
-	cast_phrase_t{ "грянет гром", "... и были громы и молнии." },	// 30
-	cast_phrase_t{ "рища, летая умом под облакы", "... ибо всякий просящий получает, и ищущий находит." },
-	cast_phrase_t{ "ворожья стрела", "... остры стрелы Твои." },
-	cast_phrase_t{ "трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле." },
-	cast_phrase_t{ "супостат нощи", "... свет, который в тебе, да убоится тьма." },
-	cast_phrase_t{ "изыде порча", "... да простятся тебе прегрешения твои." },	// 35
-	cast_phrase_t{ "иже во святых", "... буде святым, аки Господь наш свят." },
-	cast_phrase_t{ "воскладше огненну персты", "... и дано буде жечь врагов огнем." },
-	cast_phrase_t{ "иже дремлет", "... на веки твои тяжесть покладет." },
-	cast_phrase_t{ "будет силен", "... и человек разумный укрепляет силу свою." },
-	cast_phrase_t{ "кличу-велю", "... и послали за ним и призвали его." },	// 40
-	cast_phrase_t{ "ибо будет угоден Богам", "... ибо спасет людей Своих от грехов их." },
-	cast_phrase_t{ "с глаз долой исчезни", "... ступай с миром." },
-	cast_phrase_t{ "изыде трутизна", "... именем Божьим, изгнати сгниенье из тела." },
-	cast_phrase_t{ "зряще живота", "... ибо нет ничего сокровенного, что не обнаружилось бы." },
-	cast_phrase_t{ "живот изо праха створисте", "... и земля извергнет мертвецов." },	// 45
-	cast_phrase_t{ "свет сгинь", "... и тьма свет накроет." },
-	cast_phrase_t{ "прибежище други", "... ибо кто Бог, кроме Господа, и кто защита, кроме Бога нашего?" },
-	cast_phrase_t{ "други, гой еси", "... вам говорю, встаньте." },
-	cast_phrase_t{ "исчезните с глаз моих", "... вам говорю, ступайте с миром." },
-	cast_phrase_t{ "в нощи зряще", "...ибо ни днем, ни ночью сна не знают очи." },	// 50 - INFRAVISION
-	cast_phrase_t{ "по воде аки по суху", "... поднимись и ввергнись в море." },
-	cast_phrase_t{ "целите раны", "... да уменьшатся раны твои." },
-	cast_phrase_t{ "други сильны", "... и даст нам Господь силу." },
-	cast_phrase_t{ "аки околел", "... замри." },
-	cast_phrase_t{ "згола аки околел", "... замри надолго." },	// 55
-	cast_phrase_t{ "их окалеть", "... замрите." },
-	cast_phrase_t{ "летать зегзицею", "... и полетел, и понесся на крыльях ветра." },
-	cast_phrase_t{ "вериги и цепи железные изорву", "... и цепи упали с рук его." },
-	cast_phrase_t{ "опуташа в путины железны", "... да поищешь уйти, да не возможешь." },
-	cast_phrase_t{ "будовати светоч", "... да будет свет." },	// 60
-	cast_phrase_t{ "тьмою прикрыты", "... тьма покроет землю." },
-	cast_phrase_t{ "буде тверд аки камень", "... твердость ли камней твердость твоя?" },
-	cast_phrase_t{ "мгла покрыла", "... будут как утренний туман." },
-	cast_phrase_t{ "типун тебе на язык!", "... да замкнутся уста твои." },
-	cast_phrase_t{ "буде аки светоч", "... и да воссияет над ним свет!" },	// 65
-	cast_phrase_t{ "глаголят небеса", "... понесутся меткие стрелы молний из облаков." },
-	cast_phrase_t{ "створисте огненну струя", "... и ввергне их в озеро огненное." },
-	cast_phrase_t{ "гнев божиа не минути", "... и воспламенится гнев Господа, и Он скоро истребит тебя." },
-	cast_phrase_t{ "буде чахнуть", "... и силу могучих ослабляет." },
-	cast_phrase_t{ "други, низовати мечетны", "... возвещай всем великую силу Бога. И, сказав сие, они стали невидимы." },	// 70
-	cast_phrase_t{ "будут тени и туман, и мрак ночной", "... распростираются вечерние тени." },
-	cast_phrase_t{ "жги аки смола горячая", "... подобно мучению от скорпиона." },
-	cast_phrase_t{ "будь целым, аки прежде", "... заделаю трещины в ней и разрушенное восстановлю." },
-	cast_phrase_t{ "возросши к небу", "... и плоть выросла." },
-	cast_phrase_t{ "падоша в тернии", "... убойся того, кто по убиении ввергнет в геенну." },	// 75
-	cast_phrase_t{ "да коснется тебя Чернобог", "... плоть твоя и тело твое будут истощены." },
-	cast_phrase_t{ "сети ловчи", "... терны и сети на пути коварного." },
-	cast_phrase_t{ "от стрел укрытие и от меча оборона", "...да защитит он себя." },
-	cast_phrase_t{ "буде быстр аки прежде", "... встань, и ходи." },
-	cast_phrase_t{ "\n!Маскировка!", "\n" },	// 80
-	cast_phrase_t{ "згола застить очеса", "... поразит тебя Господь слепотою навечно." },
-	cast_phrase_t{ "их очеса непотребны", "... и Он поразил их слепотою." },
-	cast_phrase_t{ "згола не прерчет", "... исходящее из уст твоих, да не осквернит слуха." },
-	cast_phrase_t{ "буде полон здоровья", "... крепкое тело лучше несметного богатства." },
-	cast_phrase_t{ "воскресе из мертвых", "... оживут мертвецы Твои, восстанут мертвые тела!" },	// 85
-	cast_phrase_t{ "и ворога оберегись", "... руками своими да защитит он себя" },
-	cast_phrase_t{ "вороги не войдут", "... ибо положена печать, и никто не возвращается." },
-	cast_phrase_t{ "их уста непотребны", "... да замкнутся уста ваши." },
-	cast_phrase_t{ "глаголите", "... слова из уст мудрого - благодать." },
-	cast_phrase_t{ "падош", "... будет чувствовать боль." },	// 90
-	cast_phrase_t{ "скверна", "... постигнут тебя муки." },
-	cast_phrase_t{ "сильна скверна", "... боль и муки схватили." },
-	cast_phrase_t{ "порча их", "... прокляты вы пред всеми скотами." },
-	cast_phrase_t{ "суд божиа не минути", "... какою мерою мерите, такою отмерено будет и вам." },
-	cast_phrase_t{ "крыла им створисте", "... и все летающие по роду их." },	// 95
-	cast_phrase_t{ "други, наполнися ратнаго духа", "... блажены те, слышащие слово Божие." },
-	cast_phrase_t{ "буде свеж", "... не будет у него ни усталого, ни изнемогающего." },
-	cast_phrase_t{ "да обратит тебя Чернобог в мертвый камень!", "... и проклял его именем Господним." },
-	cast_phrase_t{ "\n!Спрятался!", "\n" },
-	cast_phrase_t{ "\n!Крадется!", "\n" },	// 100
-	cast_phrase_t{ "\n!Опьянение!", "\n" },
-	cast_phrase_t{ "\n!Абстиненция!", "\n" },
-	cast_phrase_t{ "брюхо полно", "... душа больше пищи, и тело - одежды." },
-	cast_phrase_t{ "веют ветры", "... подует северный холодный ветер." },
-	cast_phrase_t{ "\n!Получил в бою!", "\n" },	// 105
-	cast_phrase_t{ "\n!Кровотечение!", "\n" },
-	cast_phrase_t{ "\n!Ярость!", "\n" },
-	cast_phrase_t{ "не затвори темне березе", "... дух дышит, где хочет." },
-	cast_phrase_t{ "немочь", "...и помедлил еще семь дней других." },
-	cast_phrase_t{ "скор аки ястреб", "... поднимет его ветер и понесет, и он быстро побежит от него." },	// 110
-	cast_phrase_t{ "тернии им", "... загорожу путь их тернами." },
-	cast_phrase_t{ "быстры аки ястребов стая", "... и они быстры как серны на горах." },
-	cast_phrase_t{ "Живый в помощи Вышняго", "... благословен буде Грядый во имя Господне." },
-	cast_phrase_t{ "нутро снеде", "... и сделаются жестокие и кровавые язвы." },
-	cast_phrase_t{ "Навь, очисти тело", "... хочу, очистись." },	// 115
-	cast_phrase_t{ "око недреманно", "... не дам сна очам моим и веждам моим - дремания." },
-	cast_phrase_t{ "\n!молитва или жертва!", "\n" },
-	cast_phrase_t{ "Стрибог, даруй прибежище", "... защита от ветра и покров от непогоды." },
-	cast_phrase_t{ "буде путь короток", "... входите во врата Его." },
-	cast_phrase_t{ "изыде ворожба", "... выйди, дух нечистый." },	// 120
-	cast_phrase_t{ "Сварог, даруй защитника", "... и благословен защитник мой!" },
-	cast_phrase_t{ "заживет, аки на собаке", "... нет богатства лучше телесного здоровья." },
-	cast_phrase_t{ "будовати стружие", "...вооружите из себя людей на войну" },
-	cast_phrase_t{ "Хорс, даруй прибежище", "... душа горячая, как пылающий огонь." },
-	cast_phrase_t{ "Стрибог, укажи путь...", "... указывай им путь, по которому они должны идти." },	// 125
-	cast_phrase_t{ "Дажьбог, даруй защитника", "... Ангел Мой с вами, и он защитник душ ваших." },
-	cast_phrase_t{ "Морена, даруй прибежище", "... а снег и лед выдерживали огонь и не таяли." },
-	cast_phrase_t{ "торже, яко вихор", "... и град, величиною в талант, падет с неба." },
-	cast_phrase_t{ "буде мал аки мышь", "... плоть на нем пропадает." },
-	cast_phrase_t{ "засти очи им", "... свет пламени из средины огня." }, // 130
-	cast_phrase_t{ "згола яростен", "... и ярость его загорелась в нем." },
-	cast_phrase_t{ "гладь воды отразит", "... воздай им по делам их, по злым поступкам их." },
-	cast_phrase_t{ "и будут стрелы молний, и зарницы в высях", "... соберу на них бедствия и истощу на них стрелы Мои." },
-	cast_phrase_t{ "Умри!", "... и услышав слова сии - пал бездыханен." },
-	cast_phrase_t{ "идти дождю стрелами", "... и камни, величиною в талант, падут с неба." }, // 135
-	cast_phrase_t{ "сильны велетов руки", "... рука Моя пребудет с ним, и мышца Моя укрепит его." },
-	cast_phrase_t{ "разум аки мутный омут", "... и безумие его с ним." },
-	cast_phrase_t{ "окружен радугой", "... явится радуга в облаке." },
-	cast_phrase_t{ "зло творяще", "... и ты воздашь им злом." },
-	cast_phrase_t{ "Мать-земля, даруй защиту.", "... поклон тебе матушка земля." },	// 140
-	cast_phrase_t{ "Сварог, даруй защиту.", "... и огонь низводит с неба." },
-	cast_phrase_t{ "Морена, даруй защиту.", "... текущие холодные воды." },
-	cast_phrase_t{ "будет слеп и глух, аки мертвец", "... кто делает или глухим, или слепым." },
-	cast_phrase_t{ "Аз воздам!", "... и воздам каждому из вас." },
-	cast_phrase_t{ "иже во святых, други", "... будьте святы, аки Господь наш свят." },
-	cast_phrase_t{ "други, буде окружены радугой", "... взгляни на радугу, и прославь Сотворившего ее." },
-	cast_phrase_t{ "оглохни", "... и глухота поразит тебя." },	//SPELL_DEAFNESS
-	cast_phrase_t{ "да застит уши твои", "... и будь глухим надолго." },	//SPELL_POWER_DEAFNESS
-	cast_phrase_t{ "слушай глас мой", "... услышь слово Его." },	//SPELL_REMOVE_DEAFNESS
-	cast_phrase_t{ "будьте глухи", "... и не будут слышать уши ваши." },	//SPELL_MASS_DEAFNESS
-	cast_phrase_t{ "пыль поднимется столбами", "... и пыль поглотит вас." },	//SPELL_DUSTSTORM
-	cast_phrase_t{ "пусть каменья падут", "... и обрушатся камни с небес." },	//SPELL_EARTHFALL
-	cast_phrase_t{ "да невзлюбит тебя воздух", "... и даже воздух покарает тебя." },	//SPELL_SONICWAVE
-	cast_phrase_t{ "Велес, упокой мертвых", "... и предоставь мертвым погребать своих мертвецов." },	//SPELL_HOLYSTRIKE
-	cast_phrase_t{ "Боги, даруйте защитника", "... дабы уберег он меня от зла." },	//SPELL_ANGEL
-	cast_phrase_t{ "Поврещу сташивые души их в скарядие!", "... и затмил ужас разум их." },	//SPELL_MASS_FEAR
-	cast_phrase_t{ "Да пребудет с тобой вся краса мира!", "... и омолодил он, и украсил их." },
-	cast_phrase_t{ "Будут слезы твои, аки камень на сердце", "... и постигнет твой дух угнетение вечное." },	//SPELL_CRYING
-	cast_phrase_t{ "будь живот аки буява с шерстнями.", /* Добавлено. Далим. */ "... опадет на тебя чернь страшная." },	// SPELL_OBLIVION
-	cast_phrase_t{ "Яко небытие нещадно к вам, али время вернулось вспять.",	/* Добавлено. Далим. */ "... и время не властно над ними." },	// SPELL_BURDEN_OF_TIME
-	cast_phrase_t{ "Исполняше други силою!", "...да не останется ни обделенного, ни обессиленного." },	//SPELL_GROUP_REFRESH
-	cast_phrase_t{ "Избавь речь свою от недобрых слов, а ум - от крамольных мыслей.", "... любите врагов ваших и благотворите ненавидящим вас." },
-	cast_phrase_t{ "\n!получил в бою!", "\n" },
-	cast_phrase_t{ "\n!Предсмертная ярость!", "\n" },
-	cast_phrase_t{ "Обращу кости их в твердый камень.", "...и тот, кто упадет на камень сей, разобьется." }, // SPELL_STONE_BONE
-	cast_phrase_t{ "Да буде СВЕТ !!!", "...ибо сказал МОНТЕР !!!" }, // SPELL_ROOM_LIGHT
-	cast_phrase_t{ "Порчу воздух !!!", "...и зловонное дыхание его." }, // SPELL_POISONED_FOG
-	cast_phrase_t{ "Абие велий вихрь деяти!", "...творит молнии при дожде, изводит ветер из хранилищ Своих." }, // SPELL_THUNDERSTORM
-	cast_phrase_t{ "\n!легкая поступь!", "\n" },
-	cast_phrase_t{ "аще доля зла и удача немилостива", ".. и несчастен, и жалок, и нищ." },
-	cast_phrase_t{ "\n!кланаффект!", "\n" },
-	cast_phrase_t{ "зрети супостат охабиша", "...и бросали пыль на воздух." }, //SPELL_GLITTERDUST
-	cast_phrase_t{ "язвень голки уведати", "...но в полночь раздался крик." }, //SPELL_SCREAM
-	cast_phrase_t{ "ристати споро", "...и не уязвит враг того, кто скор." }, //SPELL_CATS_GRACE
-	cast_phrase_t{ "руци яре ворога супротив", "...и мощь звериная жила в теле его." },
-	cast_phrase_t{ "веси и зрети стези отай", "...и даровал мудрость ему." },
-	cast_phrase_t{ "клюка вящего улучити", "...ибо кто познал ум Господень?" },
-	cast_phrase_t{ "Эй, псы шелудивые, керасти плешивые, ослопы беспорточные, мшицы задочные!", "Эй, псы шелудивые, керасти плешивые, ослопы беспорточные, мшицы задочные!" },	// клич вызова
-	cast_phrase_t{ "Покрошу-изувечу, душу выну и в блины закатаю!", "Покрошу-изувечу, душу выну и в блины закатаю!" }, // клич угрозы
-	cast_phrase_t{ "Не отступим, други, они наше сало сперли!", "Не отступим, други, они наше сало сперли!" }, // клич ярости
-	cast_phrase_t{ "Всех убью, а сам$g останусь!", "Всех убью, а сам$g останусь!" },	// клич устрашения
-	cast_phrase_t{ "Шоб вас приподняло, да шлепнуло!!!", "Шоб вас приподняло да шлепнуло!!!" },
-	cast_phrase_t{ "В строй други, защитим животами Русь нашу!", "В строй други, защитим животами Русь нашу!" }, // клич призыв к обороне
-	cast_phrase_t{ "Дер-ржать строй, волчьи хвосты!", "Дер-ржать строй, волчьи хвосты!" },	// клич битвы
-	cast_phrase_t{ "Сарынь на кичку!", "Сарынь на кичку!" },
-	cast_phrase_t{ "Стоять крепко! За нами Киев, Подол и трактир с пивом!!!", "Стоять крепко! За нами Киев, Подол и трактир с пивом!!!" },
-	cast_phrase_t{ "Орлы! Будем биться как львы!", "Орлы! Будем биться как львы!" }, //SPELL_WC_OF_COURAGE
-	cast_phrase_t{ "...пьсати черты и резы.", "...и Сам отошел от них на вержение камня." }, // SPELL_MAGIC_LABEL
-	cast_phrase_t{ "трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле." }, // SPELL_ACONITUM_POISON
-	cast_phrase_t{ "трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле." }, // SPELL_SCOPOLIA_POISON
-	cast_phrase_t{ "трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле." }, // SPELL_BELENA_POISON
-	cast_phrase_t{ "трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле." }, // SPELL_DATURA_POISON
-	cast_phrase_t{ "\n", "\n" }, // SPELL_TIMER_REPAIR
-	cast_phrase_t{ "\n", "\n" }, // SPELL_LACKY
-	cast_phrase_t{ "\n", "\n" }, // SPELL_BANDAGE
-	cast_phrase_t{ "\n", "\n" }, // SPELL_NO_BANDAGE
-	cast_phrase_t{ "\n", "\n" }, // SPELL_CAPABLE
-	cast_phrase_t{ "\n", "\n" }, // SPELL_STRANGLE
-	cast_phrase_t{ "\n", "\n" }, // SPELL_RECALL_SPELLS
-	cast_phrase_t{ "ажбо супостаты блазнити да клюковати", "...и утроба его приготовляет обман." }, //SPELL_HYPNOTIC_PATTERN
-	cast_phrase_t{ "\n", "\n" }, // SPELL_SOLOBONUS
-	cast_phrase_t{ "\n", "\n" }, // SPELL_VAMPIRE
-	cast_phrase_t{ "Да прими вид прежний, якой был.", ".. Воззри на предмет сей Отче и верни ему силу прежнюю." }, // SPELLS_RESTORATION
-	cast_phrase_t{ "Надели силою своею Навь, дабы собрать урожай тебе.", "...налякай ворогов наших и покарай их немощью." }, // SPELL_AURA_DEATH
-	cast_phrase_t{ "Обрасти плотью сызнова.", "... прости Господи грехи, верни плоть созданию." }, // SPELL_RECOVERY
-	cast_phrase_t{ "Обрастите плотью сызнова.", "... прости Господи грехи, верни плоть созданиям." }, // SPELL_MASS_RECOVERY
-	cast_phrase_t{ "Возьми личину зла для жатвы славной.", "Надели силой злою во благо." }, // SPELL_AURA_EVIL
-	cast_phrase_t{ "Силою мысли защиту будую себе.", "Даруй Отче защиту, силой разума воздвигнутую." }, // SPELL_MENTAL_SHADOW
-	cast_phrase_t{ "Ато егоже руци попасти.", "И он не знает, что мертвецы там и что в глубине..." }, // SPELL_EVARDS_BLACK_TENTACLES
-	cast_phrase_t{ "Вждати бурю обло створити.", "И поднялась великая буря..." }, // SPELL_WHIRLWIND
-	cast_phrase_t{ "Идеже индрика зубы супостаты изъмати.", "Есть род, у которого зубы - мечи и челюсти - ножи..." }, // SPELL_WHIRLWIND
-	cast_phrase_t{ "Варно сожжет струя!", "...и на коже его сделаются как бы язвы проказы" }, // SPELL_MELFS_ACID_ARROW
-	cast_phrase_t{ "Небесе тутнет!", "...и взял оттуда камень, и бросил из пращи." }, // SPELL_THUNDERSTONE
-	cast_phrase_t{ "Онома утес низринется!", "...доколе камень не оторвался от горы без содействия рук." }, // SPELL_CLODd
-	cast_phrase_t{ "!Применил боевой прием!", "!use battle expedient!" }, // SPELL_EXPEDIENT (set by program)
-	cast_phrase_t{ "Что свет, что тьма - глазу одинаково.", "Станьте зрячи в тьме кромешной!" }, // SPELL_SIGHT_OF_DARKNESS
-	cast_phrase_t{ "...да не скроются намерения.", "И узрим братья намерения окружающих." }, // SPELL_GENERAL_SINCERITY
-	cast_phrase_t{ "Узрим же все, что с магией навкруги нас.", "Покажи, Спаситель, магические силы братии." }, // SPELL_MAGICAL_GAZE
-	cast_phrase_t{ "Все тайное станет явным.", "Не спрячется, не скроется, ни заяц, ни блоха." }, // SPELL_ALL_SEEING_EYE
-	cast_phrase_t{ "Осязаемое откройся взору!", "Да не скроется от взора вашего, ни одна живая душа." }, // SPELL_EYE_OF_GODS
-	cast_phrase_t{ "Аки стайка рыбок, плывите вместе.", "Что в воде, что на земле, воздух свежим будет." }, // SPELL_BREATHING_AT_DEPTH
-	cast_phrase_t{ "...дабы пройти вместе не одну сотню верст", "Сохрани Отче от усталости детей своих!" }, // SPELL_GENERAL_RECOVERY
-	cast_phrase_t{ "Благодарите богов за хлеб и соль!", "...дабы не осталось голодающих на свете белом" }, // SPELL_COMMON_MEAL
-	cast_phrase_t{ "Станем други крепки як николы!", "Укрепим тела наши перед битвой!" }, // SPELL_STONE_WALL
-	cast_phrase_t{ "Что яд, а что мед. Не обманемся!", "...и самый сильный яд станет вам виден." }, // SPELL_SNAKE_EYES
-	cast_phrase_t{ "Велес, даруй защиту.", "... земля благословенна твоя." }, // SPELL_EARTH_AURA
-	cast_phrase_t{ "други, супостат нощи", "други, свет который в тебе, да убоится тьма." }, // SPELL_GROUP_PROT_FROM_EVIL
-	cast_phrase_t{ "!магический выстрел!", "!use battle expedient!" }, // SPELL_ARROWS_FIRE (set by program)
-	cast_phrase_t{ "!магический выстрел!", "!use battle expedient!" }, // SPELL_ARROWS_ (set by program)
-	cast_phrase_t{ "!магический выстрел!", "!use battle expedient!" }, // SPELL_ARROWS_ (set by program)
-	cast_phrase_t{ "!магический выстрел!", "!use battle expedient!" }, // SPELL_ARROWS_ (set by program)
-	cast_phrase_t{ "!магический выстрел!", "!use battle expedient!" }, // SPELL_ARROWS_DEATH (set by program)
-	cast_phrase_t{ "\n", "\n"}, // воодушевление
-	cast_phrase_t{ "будет ловким", "... и человек разумный укрепляет ловкость свою."}, //ловкость
-	cast_phrase_t{ "защити нас от железа разящего", "... ни стрела, ни меч не пронзят печень вашу." }, // груп мигание
-	cast_phrase_t{ "огрожу беззакония их туманом", "...да защитит и покроет рассветная пелена тела ваши." }, // груп затуманивание
-	cast_phrase_t{ "буде вежды ваши открыты", "... и забота о ближнем отгоняет сон от очей их." },
-	cast_phrase_t{ "найдем новизну в рутине сражений!", "найдем новизну в рутине сражений!" }, // опыт на группу
-	cast_phrase_t{ "и пусть удача будет нашей спутницей!", "и пусть удача будет нашей спутницей!" }, // клич на удачу
-	cast_phrase_t{ "бей в глаз, не порти шкуру", "бей в глаз, не порти шкуру." }, // клич на дамагу
-	cast_phrase_t{ "...отче Велес, очи отвержеши!", "...надежда тщетна: не упадешь ли от одного взгляда его?" }, // SPELL_MASS_FAILURE
-	cast_phrase_t{ "Заклинати поврещение в сети заскопиены!", "...будет трапеза их сетью им, и мирное пиршество их - западнею." } // SPELL_MASS_NOFLEE
-};
+    {
+        cast_phrase_t{"\nRESERVED DB.C", "\n"},    // 0
+        cast_phrase_t{"буде во прибежище", "... Он - помощь наша и защита наша."},
+        cast_phrase_t{"несите ветры", "... дух поднял меня и перенес меня."},
+        cast_phrase_t{"истягну умь крепостию", "... даст блага просящим у Него."},
+        cast_phrase_t{"Чтоб твои зенки вылезли!", "... поразит тебя Господь слепотою."},
+        cast_phrase_t{"узри огонь!", "... простер руку свою к огню."},    // 5
+        cast_phrase_t{"Разрази тебя Перун!", "... и путь для громоносной молнии."},
+        cast_phrase_t{"умь полонить", "... слушай пастыря сваего, и уразумей."},
+        cast_phrase_t{"хладну персты воскладаше", "... которые черны от льда."},
+        cast_phrase_t{"пусть будет много меня", "... и плодились, и весьма умножились."},
+        cast_phrase_t{"хлад и мраз исторгнути", "... и из воды делается лед."},    // 10
+        cast_phrase_t{"стихия подкоряшися", "... власть затворить небо, чтобы не шел дождь."},
+        cast_phrase_t{"будовати снедь", "... это хлеб, который Господь дал вам в пищу."},
+        cast_phrase_t{"напоиши влагой", "... и потекло много воды."},
+        cast_phrase_t{"зряще узрите", "... и прозрят из тьмы и мрака глаза слепых."},
+        cast_phrase_t{"гой еси", "... да зарубцуются гноища твои."},    // 15
+        cast_phrase_t{"малейше целити раны", "... да затянутся раны твои."},
+        cast_phrase_t{"порча", "... проклят ты пред всеми скотами."},
+        cast_phrase_t{"узряще норов", "... и отделит одних от других, как пастырь отделяет овец от козлов."},
+        cast_phrase_t{"взор мечетный", "... ибо нет ничего тайного, что не сделалось бы явным."},
+        cast_phrase_t{"зряще ворожбу", "... покажись, ересь богопротивная."},    // 20
+        cast_phrase_t{"зряще трутизну", "... по плодам их узнаете их."},
+        cast_phrase_t{"долой нощи", "... грешников преследует зло, а праведникам воздается добром."},
+        cast_phrase_t{"земля тутнет", "... в тот же час произошло великое землетрясение."},
+        cast_phrase_t{"ницовати стружие", "... укрепи сталь Божьим перстом."},
+        cast_phrase_t{"преторгоста", "... да иссякнут соки, питающие тело."},    // 25
+        cast_phrase_t{"огненну солнце", "... да ниспадет огонь с неба, и пожрет их."},
+        cast_phrase_t{"згола скверна", "... и жестокою болью во всех костях твоих."},
+        cast_phrase_t{"згола гой еси", "... тебе говорю, встань."},
+        cast_phrase_t{"низовати мечетно", "... ибо видимое временно, а невидимое вечно."},
+        cast_phrase_t{"грянет гром", "... и были громы и молнии."},    // 30
+        cast_phrase_t{"рища, летая умом под облакы", "... ибо всякий просящий получает, и ищущий находит."},
+        cast_phrase_t{"ворожья стрела", "... остры стрелы Твои."},
+        cast_phrase_t{"трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле."},
+        cast_phrase_t{"супостат нощи", "... свет, который в тебе, да убоится тьма."},
+        cast_phrase_t{"изыде порча", "... да простятся тебе прегрешения твои."},    // 35
+        cast_phrase_t{"иже во святых", "... буде святым, аки Господь наш свят."},
+        cast_phrase_t{"воскладше огненну персты", "... и дано буде жечь врагов огнем."},
+        cast_phrase_t{"иже дремлет", "... на веки твои тяжесть покладет."},
+        cast_phrase_t{"будет силен", "... и человек разумный укрепляет силу свою."},
+        cast_phrase_t{"кличу-велю", "... и послали за ним и призвали его."},    // 40
+        cast_phrase_t{"ибо будет угоден Богам", "... ибо спасет людей Своих от грехов их."},
+        cast_phrase_t{"с глаз долой исчезни", "... ступай с миром."},
+        cast_phrase_t{"изыде трутизна", "... именем Божьим, изгнати сгниенье из тела."},
+        cast_phrase_t{"зряще живота", "... ибо нет ничего сокровенного, что не обнаружилось бы."},
+        cast_phrase_t{"живот изо праха створисте", "... и земля извергнет мертвецов."},    // 45
+        cast_phrase_t{"свет сгинь", "... и тьма свет накроет."},
+        cast_phrase_t{"прибежище други", "... ибо кто Бог, кроме Господа, и кто защита, кроме Бога нашего?"},
+        cast_phrase_t{"други, гой еси", "... вам говорю, встаньте."},
+        cast_phrase_t{"исчезните с глаз моих", "... вам говорю, ступайте с миром."},
+        cast_phrase_t{"в нощи зряще", "...ибо ни днем, ни ночью сна не знают очи."},    // 50 - INFRAVISION
+        cast_phrase_t{"по воде аки по суху", "... поднимись и ввергнись в море."},
+        cast_phrase_t{"целите раны", "... да уменьшатся раны твои."},
+        cast_phrase_t{"други сильны", "... и даст нам Господь силу."},
+        cast_phrase_t{"аки околел", "... замри."},
+        cast_phrase_t{"згола аки околел", "... замри надолго."},    // 55
+        cast_phrase_t{"их окалеть", "... замрите."},
+        cast_phrase_t{"летать зегзицею", "... и полетел, и понесся на крыльях ветра."},
+        cast_phrase_t{"вериги и цепи железные изорву", "... и цепи упали с рук его."},
+        cast_phrase_t{"опуташа в путины железны", "... да поищешь уйти, да не возможешь."},
+        cast_phrase_t{"будовати светоч", "... да будет свет."},    // 60
+        cast_phrase_t{"тьмою прикрыты", "... тьма покроет землю."},
+        cast_phrase_t{"буде тверд аки камень", "... твердость ли камней твердость твоя?"},
+        cast_phrase_t{"мгла покрыла", "... будут как утренний туман."},
+        cast_phrase_t{"типун тебе на язык!", "... да замкнутся уста твои."},
+        cast_phrase_t{"буде аки светоч", "... и да воссияет над ним свет!"},    // 65
+        cast_phrase_t{"глаголят небеса", "... понесутся меткие стрелы молний из облаков."},
+        cast_phrase_t{"створисте огненну струя", "... и ввергне их в озеро огненное."},
+        cast_phrase_t{"гнев божиа не минути", "... и воспламенится гнев Господа, и Он скоро истребит тебя."},
+        cast_phrase_t{"буде чахнуть", "... и силу могучих ослабляет."},
+        cast_phrase_t{"други, низовати мечетны",
+                      "... возвещай всем великую силу Бога. И, сказав сие, они стали невидимы."},    // 70
+        cast_phrase_t{"будут тени и туман, и мрак ночной", "... распростираются вечерние тени."},
+        cast_phrase_t{"жги аки смола горячая", "... подобно мучению от скорпиона."},
+        cast_phrase_t{"будь целым, аки прежде", "... заделаю трещины в ней и разрушенное восстановлю."},
+        cast_phrase_t{"возросши к небу", "... и плоть выросла."},
+        cast_phrase_t{"падоша в тернии", "... убойся того, кто по убиении ввергнет в геенну."},    // 75
+        cast_phrase_t{"да коснется тебя Чернобог", "... плоть твоя и тело твое будут истощены."},
+        cast_phrase_t{"сети ловчи", "... терны и сети на пути коварного."},
+        cast_phrase_t{"от стрел укрытие и от меча оборона", "...да защитит он себя."},
+        cast_phrase_t{"буде быстр аки прежде", "... встань, и ходи."},
+        cast_phrase_t{"\n!Маскировка!", "\n"},    // 80
+        cast_phrase_t{"згола застить очеса", "... поразит тебя Господь слепотою навечно."},
+        cast_phrase_t{"их очеса непотребны", "... и Он поразил их слепотою."},
+        cast_phrase_t{"згола не прерчет", "... исходящее из уст твоих, да не осквернит слуха."},
+        cast_phrase_t{"буде полон здоровья", "... крепкое тело лучше несметного богатства."},
+        cast_phrase_t{"воскресе из мертвых", "... оживут мертвецы Твои, восстанут мертвые тела!"},    // 85
+        cast_phrase_t{"и ворога оберегись", "... руками своими да защитит он себя"},
+        cast_phrase_t{"вороги не войдут", "... ибо положена печать, и никто не возвращается."},
+        cast_phrase_t{"их уста непотребны", "... да замкнутся уста ваши."},
+        cast_phrase_t{"глаголите", "... слова из уст мудрого - благодать."},
+        cast_phrase_t{"падош", "... будет чувствовать боль."},    // 90
+        cast_phrase_t{"скверна", "... постигнут тебя муки."},
+        cast_phrase_t{"сильна скверна", "... боль и муки схватили."},
+        cast_phrase_t{"порча их", "... прокляты вы пред всеми скотами."},
+        cast_phrase_t{"суд божиа не минути", "... какою мерою мерите, такою отмерено будет и вам."},
+        cast_phrase_t{"крыла им створисте", "... и все летающие по роду их."},    // 95
+        cast_phrase_t{"други, наполнися ратнаго духа", "... блажены те, слышащие слово Божие."},
+        cast_phrase_t{"буде свеж", "... не будет у него ни усталого, ни изнемогающего."},
+        cast_phrase_t{"да обратит тебя Чернобог в мертвый камень!", "... и проклял его именем Господним."},
+        cast_phrase_t{"\n!Спрятался!", "\n"},
+        cast_phrase_t{"\n!Крадется!", "\n"},    // 100
+        cast_phrase_t{"\n!Опьянение!", "\n"},
+        cast_phrase_t{"\n!Абстиненция!", "\n"},
+        cast_phrase_t{"брюхо полно", "... душа больше пищи, и тело - одежды."},
+        cast_phrase_t{"веют ветры", "... подует северный холодный ветер."},
+        cast_phrase_t{"\n!Получил в бою!", "\n"},    // 105
+        cast_phrase_t{"\n!Кровотечение!", "\n"},
+        cast_phrase_t{"\n!Ярость!", "\n"},
+        cast_phrase_t{"не затвори темне березе", "... дух дышит, где хочет."},
+        cast_phrase_t{"немочь", "...и помедлил еще семь дней других."},
+        cast_phrase_t{"скор аки ястреб", "... поднимет его ветер и понесет, и он быстро побежит от него."},    // 110
+        cast_phrase_t{"тернии им", "... загорожу путь их тернами."},
+        cast_phrase_t{"быстры аки ястребов стая", "... и они быстры как серны на горах."},
+        cast_phrase_t{"Живый в помощи Вышняго", "... благословен буде Грядый во имя Господне."},
+        cast_phrase_t{"нутро снеде", "... и сделаются жестокие и кровавые язвы."},
+        cast_phrase_t{"Навь, очисти тело", "... хочу, очистись."},    // 115
+        cast_phrase_t{"око недреманно", "... не дам сна очам моим и веждам моим - дремания."},
+        cast_phrase_t{"\n!молитва или жертва!", "\n"},
+        cast_phrase_t{"Стрибог, даруй прибежище", "... защита от ветра и покров от непогоды."},
+        cast_phrase_t{"буде путь короток", "... входите во врата Его."},
+        cast_phrase_t{"изыде ворожба", "... выйди, дух нечистый."},    // 120
+        cast_phrase_t{"Сварог, даруй защитника", "... и благословен защитник мой!"},
+        cast_phrase_t{"заживет, аки на собаке", "... нет богатства лучше телесного здоровья."},
+        cast_phrase_t{"будовати стружие", "...вооружите из себя людей на войну"},
+        cast_phrase_t{"Хорс, даруй прибежище", "... душа горячая, как пылающий огонь."},
+        cast_phrase_t{"Стрибог, укажи путь...", "... указывай им путь, по которому они должны идти."},    // 125
+        cast_phrase_t{"Дажьбог, даруй защитника", "... Ангел Мой с вами, и он защитник душ ваших."},
+        cast_phrase_t{"Морена, даруй прибежище", "... а снег и лед выдерживали огонь и не таяли."},
+        cast_phrase_t{"торже, яко вихор", "... и град, величиною в талант, падет с неба."},
+        cast_phrase_t{"буде мал аки мышь", "... плоть на нем пропадает."},
+        cast_phrase_t{"засти очи им", "... свет пламени из средины огня."}, // 130
+        cast_phrase_t{"згола яростен", "... и ярость его загорелась в нем."},
+        cast_phrase_t{"гладь воды отразит", "... воздай им по делам их, по злым поступкам их."},
+        cast_phrase_t{"и будут стрелы молний, и зарницы в высях",
+                      "... соберу на них бедствия и истощу на них стрелы Мои."},
+        cast_phrase_t{"Умри!", "... и услышав слова сии - пал бездыханен."},
+        cast_phrase_t{"идти дождю стрелами", "... и камни, величиною в талант, падут с неба."}, // 135
+        cast_phrase_t{"сильны велетов руки", "... рука Моя пребудет с ним, и мышца Моя укрепит его."},
+        cast_phrase_t{"разум аки мутный омут", "... и безумие его с ним."},
+        cast_phrase_t{"окружен радугой", "... явится радуга в облаке."},
+        cast_phrase_t{"зло творяще", "... и ты воздашь им злом."},
+        cast_phrase_t{"Мать-земля, даруй защиту.", "... поклон тебе матушка земля."},    // 140
+        cast_phrase_t{"Сварог, даруй защиту.", "... и огонь низводит с неба."},
+        cast_phrase_t{"Морена, даруй защиту.", "... текущие холодные воды."},
+        cast_phrase_t{"будет слеп и глух, аки мертвец", "... кто делает или глухим, или слепым."},
+        cast_phrase_t{"Аз воздам!", "... и воздам каждому из вас."},
+        cast_phrase_t{"иже во святых, други", "... будьте святы, аки Господь наш свят."},
+        cast_phrase_t{"други, буде окружены радугой", "... взгляни на радугу, и прославь Сотворившего ее."},
+        cast_phrase_t{"оглохни", "... и глухота поразит тебя."},    //SPELL_DEAFNESS
+        cast_phrase_t{"да застит уши твои", "... и будь глухим надолго."},    //SPELL_POWER_DEAFNESS
+        cast_phrase_t{"слушай глас мой", "... услышь слово Его."},    //SPELL_REMOVE_DEAFNESS
+        cast_phrase_t{"будьте глухи", "... и не будут слышать уши ваши."},    //SPELL_MASS_DEAFNESS
+        cast_phrase_t{"пыль поднимется столбами", "... и пыль поглотит вас."},    //SPELL_DUSTSTORM
+        cast_phrase_t{"пусть каменья падут", "... и обрушатся камни с небес."},    //SPELL_EARTHFALL
+        cast_phrase_t{"да невзлюбит тебя воздух", "... и даже воздух покарает тебя."},    //SPELL_SONICWAVE
+        cast_phrase_t{"Велес, упокой мертвых",
+                      "... и предоставь мертвым погребать своих мертвецов."},    //SPELL_HOLYSTRIKE
+        cast_phrase_t{"Боги, даруйте защитника", "... дабы уберег он меня от зла."},    //SPELL_ANGEL
+        cast_phrase_t{"Поврещу сташивые души их в скарядие!", "... и затмил ужас разум их."},    //SPELL_MASS_FEAR
+        cast_phrase_t{"Да пребудет с тобой вся краса мира!", "... и омолодил он, и украсил их."},
+        cast_phrase_t{"Будут слезы твои, аки камень на сердце",
+                      "... и постигнет твой дух угнетение вечное."},    //SPELL_CRYING
+        cast_phrase_t{"будь живот аки буява с шерстнями.", /* Добавлено. Далим. */
+                      "... опадет на тебя чернь страшная."},    // SPELL_OBLIVION
+        cast_phrase_t{"Яко небытие нещадно к вам, али время вернулось вспять.",    /* Добавлено. Далим. */
+                      "... и время не властно над ними."},    // SPELL_BURDEN_OF_TIME
+        cast_phrase_t{"Исполняше други силою!",
+                      "...да не останется ни обделенного, ни обессиленного."},    //SPELL_GROUP_REFRESH
+        cast_phrase_t{"Избавь речь свою от недобрых слов, а ум - от крамольных мыслей.",
+                      "... любите врагов ваших и благотворите ненавидящим вас."},
+        cast_phrase_t{"\n!получил в бою!", "\n"},
+        cast_phrase_t{"\n!Предсмертная ярость!", "\n"},
+        cast_phrase_t{"Обращу кости их в твердый камень.",
+                      "...и тот, кто упадет на камень сей, разобьется."}, // SPELL_STONE_BONE
+        cast_phrase_t{"Да буде СВЕТ !!!", "...ибо сказал МОНТЕР !!!"}, // SPELL_ROOM_LIGHT
+        cast_phrase_t{"Порчу воздух !!!", "...и зловонное дыхание его."}, // SPELL_POISONED_FOG
+        cast_phrase_t{"Абие велий вихрь деяти!",
+                      "...творит молнии при дожде, изводит ветер из хранилищ Своих."}, // SPELL_THUNDERSTORM
+        cast_phrase_t{"\n!легкая поступь!", "\n"},
+        cast_phrase_t{"аще доля зла и удача немилостива", ".. и несчастен, и жалок, и нищ."},
+        cast_phrase_t{"\n!кланаффект!", "\n"},
+        cast_phrase_t{"зрети супостат охабиша", "...и бросали пыль на воздух."}, //SPELL_GLITTERDUST
+        cast_phrase_t{"язвень голки уведати", "...но в полночь раздался крик."}, //SPELL_SCREAM
+        cast_phrase_t{"ристати споро", "...и не уязвит враг того, кто скор."}, //SPELL_CATS_GRACE
+        cast_phrase_t{"руци яре ворога супротив", "...и мощь звериная жила в теле его."},
+        cast_phrase_t{"веси и зрети стези отай", "...и даровал мудрость ему."},
+        cast_phrase_t{"клюка вящего улучити", "...ибо кто познал ум Господень?"},
+        cast_phrase_t{"Эй, псы шелудивые, керасти плешивые, ослопы беспорточные, мшицы задочные!",
+                      "Эй, псы шелудивые, керасти плешивые, ослопы беспорточные, мшицы задочные!"},    // клич вызова
+        cast_phrase_t{"Покрошу-изувечу, душу выну и в блины закатаю!",
+                      "Покрошу-изувечу, душу выну и в блины закатаю!"}, // клич угрозы
+        cast_phrase_t{"Не отступим, други, они наше сало сперли!",
+                      "Не отступим, други, они наше сало сперли!"}, // клич ярости
+        cast_phrase_t{"Всех убью, а сам$g останусь!", "Всех убью, а сам$g останусь!"},    // клич устрашения
+        cast_phrase_t{"Шоб вас приподняло, да шлепнуло!!!", "Шоб вас приподняло да шлепнуло!!!"},
+        cast_phrase_t{"В строй други, защитим животами Русь нашу!",
+                      "В строй други, защитим животами Русь нашу!"}, // клич призыв к обороне
+        cast_phrase_t{"Дер-ржать строй, волчьи хвосты!", "Дер-ржать строй, волчьи хвосты!"},    // клич битвы
+        cast_phrase_t{"Сарынь на кичку!", "Сарынь на кичку!"},
+        cast_phrase_t{"Стоять крепко! За нами Киев, Подол и трактир с пивом!!!",
+                      "Стоять крепко! За нами Киев, Подол и трактир с пивом!!!"},
+        cast_phrase_t{"Орлы! Будем биться как львы!", "Орлы! Будем биться как львы!"}, //SPELL_WC_OF_COURAGE
+        cast_phrase_t{"...пьсати черты и резы.", "...и Сам отошел от них на вержение камня."}, // SPELL_MAGIC_LABEL
+        cast_phrase_t{"трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле."}, // SPELL_ACONITUM_POISON
+        cast_phrase_t{"трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле."}, // SPELL_SCOPOLIA_POISON
+        cast_phrase_t{"трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле."}, // SPELL_BELENA_POISON
+        cast_phrase_t{"трутизна", "... и пошлю на них зубы зверей и яд ползающих по земле."}, // SPELL_DATURA_POISON
+        cast_phrase_t{"\n", "\n"}, // SPELL_TIMER_REPAIR
+        cast_phrase_t{"\n", "\n"}, // SPELL_LACKY
+        cast_phrase_t{"\n", "\n"}, // SPELL_BANDAGE
+        cast_phrase_t{"\n", "\n"}, // SPELL_NO_BANDAGE
+        cast_phrase_t{"\n", "\n"}, // SPELL_CAPABLE
+        cast_phrase_t{"\n", "\n"}, // SPELL_STRANGLE
+        cast_phrase_t{"\n", "\n"}, // SPELL_RECALL_SPELLS
+        cast_phrase_t{"ажбо супостаты блазнити да клюковати",
+                      "...и утроба его приготовляет обман."}, //SPELL_HYPNOTIC_PATTERN
+        cast_phrase_t{"\n", "\n"}, // SPELL_SOLOBONUS
+        cast_phrase_t{"\n", "\n"}, // SPELL_VAMPIRE
+        cast_phrase_t{"Да прими вид прежний, якой был.",
+                      ".. Воззри на предмет сей Отче и верни ему силу прежнюю."}, // SPELLS_RESTORATION
+        cast_phrase_t{"Надели силою своею Навь, дабы собрать урожай тебе.",
+                      "...налякай ворогов наших и покарай их немощью."}, // SPELL_AURA_DEATH
+        cast_phrase_t{"Обрасти плотью сызнова.", "... прости Господи грехи, верни плоть созданию."}, // SPELL_RECOVERY
+        cast_phrase_t{"Обрастите плотью сызнова.",
+                      "... прости Господи грехи, верни плоть созданиям."}, // SPELL_MASS_RECOVERY
+        cast_phrase_t{"Возьми личину зла для жатвы славной.", "Надели силой злою во благо."}, // SPELL_AURA_EVIL
+        cast_phrase_t{"Силою мысли защиту будую себе.",
+                      "Даруй Отче защиту, силой разума воздвигнутую."}, // SPELL_MENTAL_SHADOW
+        cast_phrase_t{"Ато егоже руци попасти.",
+                      "И он не знает, что мертвецы там и что в глубине..."}, // SPELL_EVARDS_BLACK_TENTACLES
+        cast_phrase_t{"Вждати бурю обло створити.", "И поднялась великая буря..."}, // SPELL_WHIRLWIND
+        cast_phrase_t{"Идеже индрика зубы супостаты изъмати.",
+                      "Есть род, у которого зубы - мечи и челюсти - ножи..."}, // SPELL_WHIRLWIND
+        cast_phrase_t{"Варно сожжет струя!",
+                      "...и на коже его сделаются как бы язвы проказы"}, // SPELL_MELFS_ACID_ARROW
+        cast_phrase_t{"Небесе тутнет!", "...и взял оттуда камень, и бросил из пращи."}, // SPELL_THUNDERSTONE
+        cast_phrase_t{"Онома утес низринется!",
+                      "...доколе камень не оторвался от горы без содействия рук."}, // SPELL_CLODd
+        cast_phrase_t{"!Применил боевой прием!", "!use battle expedient!"}, // SPELL_EXPEDIENT (set by program)
+        cast_phrase_t{"Что свет, что тьма - глазу одинаково.",
+                      "Станьте зрячи в тьме кромешной!"}, // SPELL_SIGHT_OF_DARKNESS
+        cast_phrase_t{"...да не скроются намерения.",
+                      "И узрим братья намерения окружающих."}, // SPELL_GENERAL_SINCERITY
+        cast_phrase_t{"Узрим же все, что с магией навкруги нас.",
+                      "Покажи, Спаситель, магические силы братии."}, // SPELL_MAGICAL_GAZE
+        cast_phrase_t{"Все тайное станет явным.",
+                      "Не спрячется, не скроется, ни заяц, ни блоха."}, // SPELL_ALL_SEEING_EYE
+        cast_phrase_t{"Осязаемое откройся взору!",
+                      "Да не скроется от взора вашего, ни одна живая душа."}, // SPELL_EYE_OF_GODS
+        cast_phrase_t{"Аки стайка рыбок, плывите вместе.",
+                      "Что в воде, что на земле, воздух свежим будет."}, // SPELL_BREATHING_AT_DEPTH
+        cast_phrase_t{"...дабы пройти вместе не одну сотню верст",
+                      "Сохрани Отче от усталости детей своих!"}, // SPELL_GENERAL_RECOVERY
+        cast_phrase_t{"Благодарите богов за хлеб и соль!",
+                      "...дабы не осталось голодающих на свете белом"}, // SPELL_COMMON_MEAL
+        cast_phrase_t{"Станем други крепки як николы!", "Укрепим тела наши перед битвой!"}, // SPELL_STONE_WALL
+        cast_phrase_t{"Что яд, а что мед. Не обманемся!",
+                      "...и самый сильный яд станет вам виден."}, // SPELL_SNAKE_EYES
+        cast_phrase_t{"Велес, даруй защиту.", "... земля благословенна твоя."}, // SPELL_EARTH_AURA
+        cast_phrase_t{"други, супостат нощи",
+                      "други, свет который в тебе, да убоится тьма."}, // SPELL_GROUP_PROT_FROM_EVIL
+        cast_phrase_t{"!магический выстрел!", "!use battle expedient!"}, // SPELL_ARROWS_FIRE (set by program)
+        cast_phrase_t{"!магический выстрел!", "!use battle expedient!"}, // SPELL_ARROWS_ (set by program)
+        cast_phrase_t{"!магический выстрел!", "!use battle expedient!"}, // SPELL_ARROWS_ (set by program)
+        cast_phrase_t{"!магический выстрел!", "!use battle expedient!"}, // SPELL_ARROWS_ (set by program)
+        cast_phrase_t{"!магический выстрел!", "!use battle expedient!"}, // SPELL_ARROWS_DEATH (set by program)
+        cast_phrase_t{"\n", "\n"}, // воодушевление
+        cast_phrase_t{"будет ловким", "... и человек разумный укрепляет ловкость свою."}, //ловкость
+        cast_phrase_t{"защити нас от железа разящего", "... ни стрела, ни меч не пронзят печень вашу."}, // груп мигание
+        cast_phrase_t{"огрожу беззакония их туманом",
+                      "...да защитит и покроет рассветная пелена тела ваши."}, // груп затуманивание
+        cast_phrase_t{"буде вежды ваши открыты", "... и забота о ближнем отгоняет сон от очей их."},
+        cast_phrase_t{"найдем новизну в рутине сражений!", "найдем новизну в рутине сражений!"}, // опыт на группу
+        cast_phrase_t{"и пусть удача будет нашей спутницей!", "и пусть удача будет нашей спутницей!"}, // клич на удачу
+        cast_phrase_t{"бей в глаз, не порти шкуру", "бей в глаз, не порти шкуру."}, // клич на дамагу
+        cast_phrase_t{"...отче Велес, очи отвержеши!",
+                      "...надежда тщетна: не упадешь ли от одного взгляда его?"}, // SPELL_MASS_FAILURE
+        cast_phrase_t{"Заклинати поврещение в сети заскопиены!",
+                      "...будет трапеза их сетью им, и мирное пиршество их - западнею."} // SPELL_MASS_NOFLEE
+    };
 
 typedef std::map<ESpell, std::string> ESpell_name_by_value_t;
 typedef std::map<const std::string, ESpell> ESpell_value_by_name_t;
 ESpell_name_by_value_t ESpell_name_by_value;
 ESpell_value_by_name_t ESpell_value_by_name;
-void init_ESpell_ITEM_NAMES()
-{
-	ESpell_value_by_name.clear();
-	ESpell_name_by_value.clear();
+void init_ESpell_ITEM_NAMES() {
+  ESpell_value_by_name.clear();
+  ESpell_name_by_value.clear();
 
-	ESpell_name_by_value[ESpell::SPELL_NO_SPELL] = "SPELL_NO_SPELL";
-	ESpell_name_by_value[ESpell::SPELL_ARMOR] = "SPELL_ARMOR";
-	ESpell_name_by_value[ESpell::SPELL_TELEPORT] = "SPELL_TELEPORT";
-	ESpell_name_by_value[ESpell::SPELL_BLESS] = "SPELL_BLESS";
-	ESpell_name_by_value[ESpell::SPELL_BLINDNESS] = "SPELL_BLINDNESS";
-	ESpell_name_by_value[ESpell::SPELL_BURNING_HANDS] = "SPELL_BURNING_HANDS";
-	ESpell_name_by_value[ESpell::SPELL_CALL_LIGHTNING] = "SPELL_CALL_LIGHTNING";
-	ESpell_name_by_value[ESpell::SPELL_CHARM] = "SPELL_CHARM";
-	ESpell_name_by_value[ESpell::SPELL_CHILL_TOUCH] = "SPELL_CHILL_TOUCH";
-	ESpell_name_by_value[ESpell::SPELL_CLONE] = "SPELL_CLONE";
-	ESpell_name_by_value[ESpell::SPELL_COLOR_SPRAY] = "SPELL_COLOR_SPRAY";
-	ESpell_name_by_value[ESpell::SPELL_CONTROL_WEATHER] = "SPELL_CONTROL_WEATHER";
-	ESpell_name_by_value[ESpell::SPELL_CREATE_FOOD] = "SPELL_CREATE_FOOD";
-	ESpell_name_by_value[ESpell::SPELL_CREATE_WATER] = "SPELL_CREATE_WATER";
-	ESpell_name_by_value[ESpell::SPELL_CURE_BLIND] = "SPELL_CURE_BLIND";
-	ESpell_name_by_value[ESpell::SPELL_CURE_CRITIC] = "SPELL_CURE_CRITIC";
-	ESpell_name_by_value[ESpell::SPELL_CURE_LIGHT] = "SPELL_CURE_LIGHT";
-	ESpell_name_by_value[ESpell::SPELL_CURSE] = "SPELL_CURSE";
-	ESpell_name_by_value[ESpell::SPELL_DETECT_ALIGN] = "SPELL_DETECT_ALIGN";
-	ESpell_name_by_value[ESpell::SPELL_DETECT_INVIS] = "SPELL_DETECT_INVIS";
-	ESpell_name_by_value[ESpell::SPELL_DETECT_MAGIC] = "SPELL_DETECT_MAGIC";
-	ESpell_name_by_value[ESpell::SPELL_DETECT_POISON] = "SPELL_DETECT_POISON";
-	ESpell_name_by_value[ESpell::SPELL_DISPEL_EVIL] = "SPELL_DISPEL_EVIL";
-	ESpell_name_by_value[ESpell::SPELL_EARTHQUAKE] = "SPELL_EARTHQUAKE";
-	ESpell_name_by_value[ESpell::SPELL_ENCHANT_WEAPON] = "SPELL_ENCHANT_WEAPON";
-	ESpell_name_by_value[ESpell::SPELL_ENERGY_DRAIN] = "SPELL_ENERGY_DRAIN";
-	ESpell_name_by_value[ESpell::SPELL_FIREBALL] = "SPELL_FIREBALL";
-	ESpell_name_by_value[ESpell::SPELL_HARM] = "SPELL_HARM";
-	ESpell_name_by_value[ESpell::SPELL_HEAL] = "SPELL_HEAL";
-	ESpell_name_by_value[ESpell::SPELL_INVISIBLE] = "SPELL_INVISIBLE";
-	ESpell_name_by_value[ESpell::SPELL_LIGHTNING_BOLT] = "SPELL_LIGHTNING_BOLT";
-	ESpell_name_by_value[ESpell::SPELL_LOCATE_OBJECT] = "SPELL_LOCATE_OBJECT";
-	ESpell_name_by_value[ESpell::SPELL_MAGIC_MISSILE] = "SPELL_MAGIC_MISSILE";
-	ESpell_name_by_value[ESpell::SPELL_POISON] = "SPELL_POISON";
-	ESpell_name_by_value[ESpell::SPELL_PROT_FROM_EVIL] = "SPELL_PROT_FROM_EVIL";
-	ESpell_name_by_value[ESpell::SPELL_REMOVE_CURSE] = "SPELL_REMOVE_CURSE";
-	ESpell_name_by_value[ESpell::SPELL_SANCTUARY] = "SPELL_SANCTUARY";
-	ESpell_name_by_value[ESpell::SPELL_SHOCKING_GRASP] = "SPELL_SHOCKING_GRASP";
-	ESpell_name_by_value[ESpell::SPELL_SLEEP] = "SPELL_SLEEP";
-	ESpell_name_by_value[ESpell::SPELL_STRENGTH] = "SPELL_STRENGTH";
-	ESpell_name_by_value[ESpell::SPELL_SUMMON] = "SPELL_SUMMON";
-	ESpell_name_by_value[ESpell::SPELL_PATRONAGE] = "SPELL_PATRONAGE";
-	ESpell_name_by_value[ESpell::SPELL_WORD_OF_RECALL] = "SPELL_WORD_OF_RECALL";
-	ESpell_name_by_value[ESpell::SPELL_REMOVE_POISON] = "SPELL_REMOVE_POISON";
-	ESpell_name_by_value[ESpell::SPELL_SENSE_LIFE] = "SPELL_SENSE_LIFE";
-	ESpell_name_by_value[ESpell::SPELL_ANIMATE_DEAD] = "SPELL_ANIMATE_DEAD";
-	ESpell_name_by_value[ESpell::SPELL_DISPEL_GOOD] = "SPELL_DISPEL_GOOD";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_ARMOR] = "SPELL_GROUP_ARMOR";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_HEAL] = "SPELL_GROUP_HEAL";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_RECALL] = "SPELL_GROUP_RECALL";
-	ESpell_name_by_value[ESpell::SPELL_INFRAVISION] = "SPELL_INFRAVISION";
-	ESpell_name_by_value[ESpell::SPELL_WATERWALK] = "SPELL_WATERWALK";
-	ESpell_name_by_value[ESpell::SPELL_CURE_SERIOUS] = "SPELL_CURE_SERIOUS";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_STRENGTH] = "SPELL_GROUP_STRENGTH";
-	ESpell_name_by_value[ESpell::SPELL_HOLD] = "SPELL_HOLD";
-	ESpell_name_by_value[ESpell::SPELL_POWER_HOLD] = "SPELL_POWER_HOLD";
-	ESpell_name_by_value[ESpell::SPELL_MASS_HOLD] = "SPELL_MASS_HOLD";
-	ESpell_name_by_value[ESpell::SPELL_FLY] = "SPELL_FLY";
-	ESpell_name_by_value[ESpell::SPELL_BROKEN_CHAINS] = "SPELL_BROKEN_CHAINS";
-	ESpell_name_by_value[ESpell::SPELL_NOFLEE] = "SPELL_NOFLEE";
-	ESpell_name_by_value[ESpell::SPELL_CREATE_LIGHT] = "SPELL_CREATE_LIGHT";
-	ESpell_name_by_value[ESpell::SPELL_DARKNESS] = "SPELL_DARKNESS";
-	ESpell_name_by_value[ESpell::SPELL_STONESKIN] = "SPELL_STONESKIN";
-	ESpell_name_by_value[ESpell::SPELL_CLOUDLY] = "SPELL_CLOUDLY";
-	ESpell_name_by_value[ESpell::SPELL_SILENCE] = "SPELL_SILENCE";
-	ESpell_name_by_value[ESpell::SPELL_LIGHT] = "SPELL_LIGHT";
-	ESpell_name_by_value[ESpell::SPELL_CHAIN_LIGHTNING] = "SPELL_CHAIN_LIGHTNING";
-	ESpell_name_by_value[ESpell::SPELL_FIREBLAST] = "SPELL_FIREBLAST";
-	ESpell_name_by_value[ESpell::SPELL_IMPLOSION] = "SPELL_IMPLOSION";
-	ESpell_name_by_value[ESpell::SPELL_WEAKNESS] = "SPELL_WEAKNESS";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_INVISIBLE] = "SPELL_GROUP_INVISIBLE";
-	ESpell_name_by_value[ESpell::SPELL_SHADOW_CLOAK] = "SPELL_SHADOW_CLOAK";
-	ESpell_name_by_value[ESpell::SPELL_ACID] = "SPELL_ACID";
-	ESpell_name_by_value[ESpell::SPELL_REPAIR] = "SPELL_REPAIR";
-	ESpell_name_by_value[ESpell::SPELL_ENLARGE] = "SPELL_ENLARGE";
-	ESpell_name_by_value[ESpell::SPELL_FEAR] = "SPELL_FEAR";
-	ESpell_name_by_value[ESpell::SPELL_SACRIFICE] = "SPELL_SACRIFICE";
-	ESpell_name_by_value[ESpell::SPELL_WEB] = "SPELL_WEB";
-	ESpell_name_by_value[ESpell::SPELL_BLINK] = "SPELL_BLINK";
-	ESpell_name_by_value[ESpell::SPELL_REMOVE_HOLD] = "SPELL_REMOVE_HOLD";
-	ESpell_name_by_value[ESpell::SPELL_CAMOUFLAGE] = "SPELL_CAMOUFLAGE";
-	ESpell_name_by_value[ESpell::SPELL_POWER_BLINDNESS] = "SPELL_POWER_BLINDNESS";
-	ESpell_name_by_value[ESpell::SPELL_MASS_BLINDNESS] = "SPELL_MASS_BLINDNESS";
-	ESpell_name_by_value[ESpell::SPELL_POWER_SILENCE] = "SPELL_POWER_SILENCE";
-	ESpell_name_by_value[ESpell::SPELL_EXTRA_HITS] = "SPELL_EXTRA_HITS";
-	ESpell_name_by_value[ESpell::SPELL_RESSURECTION] = "SPELL_RESSURECTION";
-	ESpell_name_by_value[ESpell::SPELL_MAGICSHIELD] = "SPELL_MAGICSHIELD";
-	ESpell_name_by_value[ESpell::SPELL_FORBIDDEN] = "SPELL_FORBIDDEN";
-	ESpell_name_by_value[ESpell::SPELL_MASS_SILENCE] = "SPELL_MASS_SILENCE";
-	ESpell_name_by_value[ESpell::SPELL_REMOVE_SILENCE] = "SPELL_REMOVE_SILENCE";
-	ESpell_name_by_value[ESpell::SPELL_DAMAGE_LIGHT] = "SPELL_DAMAGE_LIGHT";
-	ESpell_name_by_value[ESpell::SPELL_DAMAGE_SERIOUS] = "SPELL_DAMAGE_SERIOUS";
-	ESpell_name_by_value[ESpell::SPELL_DAMAGE_CRITIC] = "SPELL_DAMAGE_CRITIC";
-	ESpell_name_by_value[ESpell::SPELL_MASS_CURSE] = "SPELL_MASS_CURSE";
-	ESpell_name_by_value[ESpell::SPELL_ARMAGEDDON] = "SPELL_ARMAGEDDON";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_FLY] = "SPELL_GROUP_FLY";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_BLESS] = "SPELL_GROUP_BLESS";
-	ESpell_name_by_value[ESpell::SPELL_REFRESH] = "SPELL_REFRESH";
-	ESpell_name_by_value[ESpell::SPELL_STUNNING] = "SPELL_STUNNING";
-	ESpell_name_by_value[ESpell::SPELL_HIDE] = "SPELL_HIDE";
-	ESpell_name_by_value[ESpell::SPELL_SNEAK] = "SPELL_SNEAK";
-	ESpell_name_by_value[ESpell::SPELL_DRUNKED] = "SPELL_DRUNKED";
-	ESpell_name_by_value[ESpell::SPELL_ABSTINENT] = "SPELL_ABSTINENT";
-	ESpell_name_by_value[ESpell::SPELL_FULL] = "SPELL_FULL";
-	ESpell_name_by_value[ESpell::SPELL_CONE_OF_COLD] = "SPELL_CONE_OF_COLD";
-	ESpell_name_by_value[ESpell::SPELL_BATTLE] = "SPELL_BATTLE";
-	ESpell_name_by_value[ESpell::SPELL_HAEMORRAGIA] = "SPELL_HAEMORRAGIA";
-	ESpell_name_by_value[ESpell::SPELL_COURAGE] = "SPELL_COURAGE";
-	ESpell_name_by_value[ESpell::SPELL_WATERBREATH] = "SPELL_WATERBREATH";
-	ESpell_name_by_value[ESpell::SPELL_SLOW] = "SPELL_SLOW";
-	ESpell_name_by_value[ESpell::SPELL_HASTE] = "SPELL_HASTE";
-	ESpell_name_by_value[ESpell::SPELL_MASS_SLOW] = "SPELL_MASS_SLOW";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_HASTE] = "SPELL_GROUP_HASTE";
-	ESpell_name_by_value[ESpell::SPELL_SHIELD] = "SPELL_SHIELD";
-	ESpell_name_by_value[ESpell::SPELL_PLAQUE] = "SPELL_PLAQUE";
-	ESpell_name_by_value[ESpell::SPELL_CURE_PLAQUE] = "SPELL_CURE_PLAQUE";
-	ESpell_name_by_value[ESpell::SPELL_AWARNESS] = "SPELL_AWARNESS";
-	ESpell_name_by_value[ESpell::SPELL_RELIGION] = "SPELL_RELIGION";
-	ESpell_name_by_value[ESpell::SPELL_AIR_SHIELD] = "SPELL_AIR_SHIELD";
-	ESpell_name_by_value[ESpell::SPELL_PORTAL] = "SPELL_PORTAL";
-	ESpell_name_by_value[ESpell::SPELL_DISPELL_MAGIC] = "SPELL_DISPELL_MAGIC";
-	ESpell_name_by_value[ESpell::SPELL_SUMMON_KEEPER] = "SPELL_SUMMON_KEEPER";
-	ESpell_name_by_value[ESpell::SPELL_FAST_REGENERATION] = "SPELL_FAST_REGENERATION";
-	ESpell_name_by_value[ESpell::SPELL_CREATE_WEAPON] = "SPELL_CREATE_WEAPON";
-	ESpell_name_by_value[ESpell::SPELL_FIRE_SHIELD] = "SPELL_FIRE_SHIELD";
-	ESpell_name_by_value[ESpell::SPELL_RELOCATE] = "SPELL_RELOCATE";
-	ESpell_name_by_value[ESpell::SPELL_SUMMON_FIREKEEPER] = "SPELL_SUMMON_FIREKEEPER";
-	ESpell_name_by_value[ESpell::SPELL_ICE_SHIELD] = "SPELL_ICE_SHIELD";
-	ESpell_name_by_value[ESpell::SPELL_ICESTORM] = "SPELL_ICESTORM";
-	ESpell_name_by_value[ESpell::SPELL_ENLESS] = "SPELL_ENLESS";
-	ESpell_name_by_value[ESpell::SPELL_SHINEFLASH] = "SPELL_SHINEFLASH";
-	ESpell_name_by_value[ESpell::SPELL_MADNESS] = "SPELL_MADNESS";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_MAGICGLASS] = "SPELL_GROUP_MAGICGLASS";
-	ESpell_name_by_value[ESpell::SPELL_CLOUD_OF_ARROWS] = "SPELL_CLOUD_OF_ARROWS";
-	ESpell_name_by_value[ESpell::SPELL_VACUUM] = "SPELL_VACUUM";
-	ESpell_name_by_value[ESpell::SPELL_METEORSTORM] = "SPELL_METEORSTORM";
-	ESpell_name_by_value[ESpell::SPELL_STONEHAND] = "SPELL_STONEHAND";
-	ESpell_name_by_value[ESpell::SPELL_MINDLESS] = "SPELL_MINDLESS";
-	ESpell_name_by_value[ESpell::SPELL_PRISMATICAURA] = "SPELL_PRISMATICAURA";
-	ESpell_name_by_value[ESpell::SPELL_EVILESS] = "SPELL_EVILESS";
-	ESpell_name_by_value[ESpell::SPELL_AIR_AURA] = "SPELL_AIR_AURA";
-	ESpell_name_by_value[ESpell::SPELL_FIRE_AURA] = "SPELL_FIRE_AURA";
-	ESpell_name_by_value[ESpell::SPELL_ICE_AURA] = "SPELL_ICE_AURA";
-	ESpell_name_by_value[ESpell::SPELL_SHOCK] = "SPELL_SHOCK";
-	ESpell_name_by_value[ESpell::SPELL_MAGICGLASS] = "SPELL_MAGICGLASS";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_SANCTUARY] = "SPELL_GROUP_SANCTUARY";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_PRISMATICAURA] = "SPELL_GROUP_PRISMATICAURA";
-	ESpell_name_by_value[ESpell::SPELL_DEAFNESS] = "SPELL_DEAFNESS";
-	ESpell_name_by_value[ESpell::SPELL_POWER_DEAFNESS] = "SPELL_POWER_DEAFNESS";
-	ESpell_name_by_value[ESpell::SPELL_REMOVE_DEAFNESS] = "SPELL_REMOVE_DEAFNESS";
-	ESpell_name_by_value[ESpell::SPELL_MASS_DEAFNESS] = "SPELL_MASS_DEAFNESS";
-	ESpell_name_by_value[ESpell::SPELL_DUSTSTORM] = "SPELL_DUSTSTORM";
-	ESpell_name_by_value[ESpell::SPELL_EARTHFALL] = "SPELL_EARTHFALL";
-	ESpell_name_by_value[ESpell::SPELL_SONICWAVE] = "SPELL_SONICWAVE";
-	ESpell_name_by_value[ESpell::SPELL_HOLYSTRIKE] = "SPELL_HOLYSTRIKE";
-	ESpell_name_by_value[ESpell::SPELL_ANGEL] = "SPELL_ANGEL";
-	ESpell_name_by_value[ESpell::SPELL_MASS_FEAR] = "SPELL_MASS_FEAR";
-	ESpell_name_by_value[ESpell::SPELL_FASCINATION] = "SPELL_FASCINATION";
-	ESpell_name_by_value[ESpell::SPELL_CRYING] = "SPELL_CRYING";
-	ESpell_name_by_value[ESpell::SPELL_OBLIVION] = "SPELL_OBLIVION";
-	ESpell_name_by_value[ESpell::SPELL_BURDEN_OF_TIME] = "SPELL_BURDEN_OF_TIME";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_REFRESH] = "SPELL_GROUP_REFRESH";
-	ESpell_name_by_value[ESpell::SPELL_PEACEFUL] = "SPELL_PEACEFUL";
-	ESpell_name_by_value[ESpell::SPELL_MAGICBATTLE] = "SPELL_MAGICBATTLE";
-	ESpell_name_by_value[ESpell::SPELL_BERSERK] = "SPELL_BERSERK";
-	ESpell_name_by_value[ESpell::SPELL_STONEBONES] = "SPELL_STONEBONES";
-	ESpell_name_by_value[ESpell::SPELL_ROOM_LIGHT] = "SPELL_ROOM_LIGHT";
-	ESpell_name_by_value[ESpell::SPELL_POISONED_FOG] = "SPELL_POISONED_FOG";
-	ESpell_name_by_value[ESpell::SPELL_THUNDERSTORM] = "SPELL_THUNDERSTORM";
-	ESpell_name_by_value[ESpell::SPELL_LIGHT_WALK] = "SPELL_LIGHT_WALK";
-	ESpell_name_by_value[ESpell::SPELL_FAILURE] = "SPELL_FAILURE";
-	ESpell_name_by_value[ESpell::SPELL_CLANPRAY] = "SPELL_CLANPRAY";
-	ESpell_name_by_value[ESpell::SPELL_GLITTERDUST] = "SPELL_GLITTERDUST";
-	ESpell_name_by_value[ESpell::SPELL_SCREAM] = "SPELL_SCREAM";
-	ESpell_name_by_value[ESpell::SPELL_CATS_GRACE] = "SPELL_CATS_GRACE";
-	ESpell_name_by_value[ESpell::SPELL_BULL_BODY] = "SPELL_BULL_BODY";
-	ESpell_name_by_value[ESpell::SPELL_SNAKE_WISDOM] = "SPELL_SNAKE_WISDOM";
-	ESpell_name_by_value[ESpell::SPELL_GIMMICKRY] = "SPELL_GIMMICKRY";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_CHALLENGE] = "SPELL_WC_OF_CHALLENGE";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_MENACE] = "SPELL_WC_OF_MENACE";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_RAGE] = "SPELL_WC_OF_RAGE";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_MADNESS] = "SPELL_WC_OF_MADNESS";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_THUNDER] = "SPELL_WC_OF_THUNDER";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_DEFENSE] = "SPELL_WC_OF_DEFENSE";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_BATTLE] = "SPELL_WC_OF_BATTLE";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_POWER] = "SPELL_WC_OF_POWER";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_BLESS] = "SPELL_WC_OF_BLESS";
-	ESpell_name_by_value[ESpell::SPELL_WC_OF_COURAGE] = "SPELL_WC_OF_COURAGE";
-	ESpell_name_by_value[ESpell::SPELL_RUNE_LABEL] = "SPELL_RUNE_LABEL";
-	ESpell_name_by_value[ESpell::SPELL_ACONITUM_POISON] = "SPELL_ACONITUM_POISON";
-	ESpell_name_by_value[ESpell::SPELL_SCOPOLIA_POISON] = "SPELL_SCOPOLIA_POISON";
-	ESpell_name_by_value[ESpell::SPELL_BELENA_POISON] = "SPELL_BELENA_POISON";
-	ESpell_name_by_value[ESpell::SPELL_DATURA_POISON] = "SPELL_DATURA_POISON";
-	ESpell_name_by_value[ESpell::SPELL_TIMER_REPAIR] = "SPELL_TIMER_REPAIR";
-	ESpell_name_by_value[ESpell::SPELL_LACKY] = "SPELL_LACKY";
-	ESpell_name_by_value[ESpell::SPELL_BANDAGE] = "SPELL_BANDAGE";
-	ESpell_name_by_value[ESpell::SPELL_NO_BANDAGE] = "SPELL_NO_BANDAGE";
-	ESpell_name_by_value[ESpell::SPELL_CAPABLE] = "SPELL_CAPABLE";
-	ESpell_name_by_value[ESpell::SPELL_STRANGLE] = "SPELL_STRANGLE";
-	ESpell_name_by_value[ESpell::SPELL_RECALL_SPELLS] = "SPELL_RECALL_SPELLS";
-	ESpell_name_by_value[ESpell::SPELL_HYPNOTIC_PATTERN] = "SPELL_HYPNOTIC_PATTERN";
-	ESpell_name_by_value[ESpell::SPELL_SOLOBONUS] = "SPELL_SOLOBONUS";
-	ESpell_name_by_value[ESpell::SPELL_VAMPIRE] = "SPELL_VAMPIRE";
-	ESpell_name_by_value[ESpell::SPELLS_RESTORATION] = "SPELLS_RESTORATION";
-	ESpell_name_by_value[ESpell::SPELL_AURA_DEATH] = "SPELL_AURA_DEATH";
-	ESpell_name_by_value[ESpell::SPELL_RECOVERY] = "SPELL_RECOVERY";
-	ESpell_name_by_value[ESpell::SPELL_MASS_RECOVERY] = "SPELL_MASS_RECOVERY";
-	ESpell_name_by_value[ESpell::SPELL_AURA_EVIL] = "SPELL_AURA_EVIL";
-	ESpell_name_by_value[ESpell::SPELL_MENTAL_SHADOW] = "SPELL_MENTAL_SHADOW";
-	ESpell_name_by_value[ESpell::SPELL_EVARDS_BLACK_TENTACLES] = "SPELL_EVARDS_BLACK_TENTACLES";
-	ESpell_name_by_value[ESpell::SPELL_WHIRLWIND] = "SPELL_WHIRLWIND";
-	ESpell_name_by_value[ESpell::SPELL_INDRIKS_TEETH] = "SPELL_INDRIKS_TEETH";
-	ESpell_name_by_value[ESpell::SPELL_MELFS_ACID_ARROW] = "SPELL_MELFS_ACID_ARROW";
-	ESpell_name_by_value[ESpell::SPELL_THUNDERSTONE] = "SPELL_THUNDERSTONE";
-	ESpell_name_by_value[ESpell::SPELL_CLOD] = "SPELL_CLOD";
-	ESpell_name_by_value[ESpell::SPELL_EXPEDIENT] = "SPELL_EXPEDIENT";
-	ESpell_name_by_value[ESpell::SPELL_SIGHT_OF_DARKNESS] = "SPELL_SIGHT_OF_DARKNESS";
-	ESpell_name_by_value[ESpell::SPELL_GENERAL_SINCERITY] = "SPELL_GENERAL_SINCERITY";
-	ESpell_name_by_value[ESpell::SPELL_MAGICAL_GAZE] = "SPELL_MAGICAL_GAZE";
-	ESpell_name_by_value[ESpell::SPELL_ALL_SEEING_EYE] = "SPELL_ALL_SEEING_EYE";
-	ESpell_name_by_value[ESpell::SPELL_EYE_OF_GODS] = "SPELL_EYE_OF_GODS";
-	ESpell_name_by_value[ESpell::SPELL_BREATHING_AT_DEPTH] = "SPELL_BREATHING_AT_DEPTH";
-	ESpell_name_by_value[ESpell::SPELL_GENERAL_RECOVERY] = "SPELL_GENERAL_RECOVERY";
-	ESpell_name_by_value[ESpell::SPELL_COMMON_MEAL] = "SPELL_COMMON_MEAL";
-	ESpell_name_by_value[ESpell::SPELL_STONE_WALL] = "SPELL_STONE_WALL";
-	ESpell_name_by_value[ESpell::SPELL_SNAKE_EYES] = "SPELL_SNAKE_EYES";
-	ESpell_name_by_value[ESpell::SPELL_EARTH_AURA] = "SPELL_EARTH_AURA";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_PROT_FROM_EVIL] = "SPELL_GROUP_PROT_FROM_EVIL";
-	ESpell_name_by_value[ESpell::SPELL_ARROWS_FIRE] = "SPELL_ARROWS_FIRE";
-	ESpell_name_by_value[ESpell::SPELL_ARROWS_WATER] = "SPELL_ARROWS_WATER";
-	ESpell_name_by_value[ESpell::SPELL_ARROWS_EARTH] = "SPELL_ARROWS_EARTH";
-	ESpell_name_by_value[ESpell::SPELL_ARROWS_AIR] = "SPELL_ARROWS_AIR";
-	ESpell_name_by_value[ESpell::SPELL_ARROWS_DEATH] = "SPELL_ARROWS_DEATH";
-	ESpell_name_by_value[ESpell::SPELL_PALADINE_INSPIRATION] = "SPELL_PALADINE_INSPIRATION";
-	ESpell_name_by_value[ESpell::SPELL_DEXTERITY] = "SPELL_DEXTERITY";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_BLINK] = "SPELL_GROUP_BLINK";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_CLOUDLY] = "SPELL_GROUP_CLOUDLY";
-	ESpell_name_by_value[ESpell::SPELL_GROUP_AWARNESS] = "SPELL_GROUP_AWARNESS";
-	ESpell_name_by_value[ESpell::SPELL_MASS_FAILURE] = "SPELL_MASS_FAILURE";
-	ESpell_name_by_value[ESpell::SPELL_MASS_NOFLEE] = "SPELL_MASS_NOFLEE";
+  ESpell_name_by_value[ESpell::SPELL_NO_SPELL] = "SPELL_NO_SPELL";
+  ESpell_name_by_value[ESpell::SPELL_ARMOR] = "SPELL_ARMOR";
+  ESpell_name_by_value[ESpell::SPELL_TELEPORT] = "SPELL_TELEPORT";
+  ESpell_name_by_value[ESpell::SPELL_BLESS] = "SPELL_BLESS";
+  ESpell_name_by_value[ESpell::SPELL_BLINDNESS] = "SPELL_BLINDNESS";
+  ESpell_name_by_value[ESpell::SPELL_BURNING_HANDS] = "SPELL_BURNING_HANDS";
+  ESpell_name_by_value[ESpell::SPELL_CALL_LIGHTNING] = "SPELL_CALL_LIGHTNING";
+  ESpell_name_by_value[ESpell::SPELL_CHARM] = "SPELL_CHARM";
+  ESpell_name_by_value[ESpell::SPELL_CHILL_TOUCH] = "SPELL_CHILL_TOUCH";
+  ESpell_name_by_value[ESpell::SPELL_CLONE] = "SPELL_CLONE";
+  ESpell_name_by_value[ESpell::SPELL_COLOR_SPRAY] = "SPELL_COLOR_SPRAY";
+  ESpell_name_by_value[ESpell::SPELL_CONTROL_WEATHER] = "SPELL_CONTROL_WEATHER";
+  ESpell_name_by_value[ESpell::SPELL_CREATE_FOOD] = "SPELL_CREATE_FOOD";
+  ESpell_name_by_value[ESpell::SPELL_CREATE_WATER] = "SPELL_CREATE_WATER";
+  ESpell_name_by_value[ESpell::SPELL_CURE_BLIND] = "SPELL_CURE_BLIND";
+  ESpell_name_by_value[ESpell::SPELL_CURE_CRITIC] = "SPELL_CURE_CRITIC";
+  ESpell_name_by_value[ESpell::SPELL_CURE_LIGHT] = "SPELL_CURE_LIGHT";
+  ESpell_name_by_value[ESpell::SPELL_CURSE] = "SPELL_CURSE";
+  ESpell_name_by_value[ESpell::SPELL_DETECT_ALIGN] = "SPELL_DETECT_ALIGN";
+  ESpell_name_by_value[ESpell::SPELL_DETECT_INVIS] = "SPELL_DETECT_INVIS";
+  ESpell_name_by_value[ESpell::SPELL_DETECT_MAGIC] = "SPELL_DETECT_MAGIC";
+  ESpell_name_by_value[ESpell::SPELL_DETECT_POISON] = "SPELL_DETECT_POISON";
+  ESpell_name_by_value[ESpell::SPELL_DISPEL_EVIL] = "SPELL_DISPEL_EVIL";
+  ESpell_name_by_value[ESpell::SPELL_EARTHQUAKE] = "SPELL_EARTHQUAKE";
+  ESpell_name_by_value[ESpell::SPELL_ENCHANT_WEAPON] = "SPELL_ENCHANT_WEAPON";
+  ESpell_name_by_value[ESpell::SPELL_ENERGY_DRAIN] = "SPELL_ENERGY_DRAIN";
+  ESpell_name_by_value[ESpell::SPELL_FIREBALL] = "SPELL_FIREBALL";
+  ESpell_name_by_value[ESpell::SPELL_HARM] = "SPELL_HARM";
+  ESpell_name_by_value[ESpell::SPELL_HEAL] = "SPELL_HEAL";
+  ESpell_name_by_value[ESpell::SPELL_INVISIBLE] = "SPELL_INVISIBLE";
+  ESpell_name_by_value[ESpell::SPELL_LIGHTNING_BOLT] = "SPELL_LIGHTNING_BOLT";
+  ESpell_name_by_value[ESpell::SPELL_LOCATE_OBJECT] = "SPELL_LOCATE_OBJECT";
+  ESpell_name_by_value[ESpell::SPELL_MAGIC_MISSILE] = "SPELL_MAGIC_MISSILE";
+  ESpell_name_by_value[ESpell::SPELL_POISON] = "SPELL_POISON";
+  ESpell_name_by_value[ESpell::SPELL_PROT_FROM_EVIL] = "SPELL_PROT_FROM_EVIL";
+  ESpell_name_by_value[ESpell::SPELL_REMOVE_CURSE] = "SPELL_REMOVE_CURSE";
+  ESpell_name_by_value[ESpell::SPELL_SANCTUARY] = "SPELL_SANCTUARY";
+  ESpell_name_by_value[ESpell::SPELL_SHOCKING_GRASP] = "SPELL_SHOCKING_GRASP";
+  ESpell_name_by_value[ESpell::SPELL_SLEEP] = "SPELL_SLEEP";
+  ESpell_name_by_value[ESpell::SPELL_STRENGTH] = "SPELL_STRENGTH";
+  ESpell_name_by_value[ESpell::SPELL_SUMMON] = "SPELL_SUMMON";
+  ESpell_name_by_value[ESpell::SPELL_PATRONAGE] = "SPELL_PATRONAGE";
+  ESpell_name_by_value[ESpell::SPELL_WORD_OF_RECALL] = "SPELL_WORD_OF_RECALL";
+  ESpell_name_by_value[ESpell::SPELL_REMOVE_POISON] = "SPELL_REMOVE_POISON";
+  ESpell_name_by_value[ESpell::SPELL_SENSE_LIFE] = "SPELL_SENSE_LIFE";
+  ESpell_name_by_value[ESpell::SPELL_ANIMATE_DEAD] = "SPELL_ANIMATE_DEAD";
+  ESpell_name_by_value[ESpell::SPELL_DISPEL_GOOD] = "SPELL_DISPEL_GOOD";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_ARMOR] = "SPELL_GROUP_ARMOR";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_HEAL] = "SPELL_GROUP_HEAL";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_RECALL] = "SPELL_GROUP_RECALL";
+  ESpell_name_by_value[ESpell::SPELL_INFRAVISION] = "SPELL_INFRAVISION";
+  ESpell_name_by_value[ESpell::SPELL_WATERWALK] = "SPELL_WATERWALK";
+  ESpell_name_by_value[ESpell::SPELL_CURE_SERIOUS] = "SPELL_CURE_SERIOUS";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_STRENGTH] = "SPELL_GROUP_STRENGTH";
+  ESpell_name_by_value[ESpell::SPELL_HOLD] = "SPELL_HOLD";
+  ESpell_name_by_value[ESpell::SPELL_POWER_HOLD] = "SPELL_POWER_HOLD";
+  ESpell_name_by_value[ESpell::SPELL_MASS_HOLD] = "SPELL_MASS_HOLD";
+  ESpell_name_by_value[ESpell::SPELL_FLY] = "SPELL_FLY";
+  ESpell_name_by_value[ESpell::SPELL_BROKEN_CHAINS] = "SPELL_BROKEN_CHAINS";
+  ESpell_name_by_value[ESpell::SPELL_NOFLEE] = "SPELL_NOFLEE";
+  ESpell_name_by_value[ESpell::SPELL_CREATE_LIGHT] = "SPELL_CREATE_LIGHT";
+  ESpell_name_by_value[ESpell::SPELL_DARKNESS] = "SPELL_DARKNESS";
+  ESpell_name_by_value[ESpell::SPELL_STONESKIN] = "SPELL_STONESKIN";
+  ESpell_name_by_value[ESpell::SPELL_CLOUDLY] = "SPELL_CLOUDLY";
+  ESpell_name_by_value[ESpell::SPELL_SILENCE] = "SPELL_SILENCE";
+  ESpell_name_by_value[ESpell::SPELL_LIGHT] = "SPELL_LIGHT";
+  ESpell_name_by_value[ESpell::SPELL_CHAIN_LIGHTNING] = "SPELL_CHAIN_LIGHTNING";
+  ESpell_name_by_value[ESpell::SPELL_FIREBLAST] = "SPELL_FIREBLAST";
+  ESpell_name_by_value[ESpell::SPELL_IMPLOSION] = "SPELL_IMPLOSION";
+  ESpell_name_by_value[ESpell::SPELL_WEAKNESS] = "SPELL_WEAKNESS";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_INVISIBLE] = "SPELL_GROUP_INVISIBLE";
+  ESpell_name_by_value[ESpell::SPELL_SHADOW_CLOAK] = "SPELL_SHADOW_CLOAK";
+  ESpell_name_by_value[ESpell::SPELL_ACID] = "SPELL_ACID";
+  ESpell_name_by_value[ESpell::SPELL_REPAIR] = "SPELL_REPAIR";
+  ESpell_name_by_value[ESpell::SPELL_ENLARGE] = "SPELL_ENLARGE";
+  ESpell_name_by_value[ESpell::SPELL_FEAR] = "SPELL_FEAR";
+  ESpell_name_by_value[ESpell::SPELL_SACRIFICE] = "SPELL_SACRIFICE";
+  ESpell_name_by_value[ESpell::SPELL_WEB] = "SPELL_WEB";
+  ESpell_name_by_value[ESpell::SPELL_BLINK] = "SPELL_BLINK";
+  ESpell_name_by_value[ESpell::SPELL_REMOVE_HOLD] = "SPELL_REMOVE_HOLD";
+  ESpell_name_by_value[ESpell::SPELL_CAMOUFLAGE] = "SPELL_CAMOUFLAGE";
+  ESpell_name_by_value[ESpell::SPELL_POWER_BLINDNESS] = "SPELL_POWER_BLINDNESS";
+  ESpell_name_by_value[ESpell::SPELL_MASS_BLINDNESS] = "SPELL_MASS_BLINDNESS";
+  ESpell_name_by_value[ESpell::SPELL_POWER_SILENCE] = "SPELL_POWER_SILENCE";
+  ESpell_name_by_value[ESpell::SPELL_EXTRA_HITS] = "SPELL_EXTRA_HITS";
+  ESpell_name_by_value[ESpell::SPELL_RESSURECTION] = "SPELL_RESSURECTION";
+  ESpell_name_by_value[ESpell::SPELL_MAGICSHIELD] = "SPELL_MAGICSHIELD";
+  ESpell_name_by_value[ESpell::SPELL_FORBIDDEN] = "SPELL_FORBIDDEN";
+  ESpell_name_by_value[ESpell::SPELL_MASS_SILENCE] = "SPELL_MASS_SILENCE";
+  ESpell_name_by_value[ESpell::SPELL_REMOVE_SILENCE] = "SPELL_REMOVE_SILENCE";
+  ESpell_name_by_value[ESpell::SPELL_DAMAGE_LIGHT] = "SPELL_DAMAGE_LIGHT";
+  ESpell_name_by_value[ESpell::SPELL_DAMAGE_SERIOUS] = "SPELL_DAMAGE_SERIOUS";
+  ESpell_name_by_value[ESpell::SPELL_DAMAGE_CRITIC] = "SPELL_DAMAGE_CRITIC";
+  ESpell_name_by_value[ESpell::SPELL_MASS_CURSE] = "SPELL_MASS_CURSE";
+  ESpell_name_by_value[ESpell::SPELL_ARMAGEDDON] = "SPELL_ARMAGEDDON";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_FLY] = "SPELL_GROUP_FLY";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_BLESS] = "SPELL_GROUP_BLESS";
+  ESpell_name_by_value[ESpell::SPELL_REFRESH] = "SPELL_REFRESH";
+  ESpell_name_by_value[ESpell::SPELL_STUNNING] = "SPELL_STUNNING";
+  ESpell_name_by_value[ESpell::SPELL_HIDE] = "SPELL_HIDE";
+  ESpell_name_by_value[ESpell::SPELL_SNEAK] = "SPELL_SNEAK";
+  ESpell_name_by_value[ESpell::SPELL_DRUNKED] = "SPELL_DRUNKED";
+  ESpell_name_by_value[ESpell::SPELL_ABSTINENT] = "SPELL_ABSTINENT";
+  ESpell_name_by_value[ESpell::SPELL_FULL] = "SPELL_FULL";
+  ESpell_name_by_value[ESpell::SPELL_CONE_OF_COLD] = "SPELL_CONE_OF_COLD";
+  ESpell_name_by_value[ESpell::SPELL_BATTLE] = "SPELL_BATTLE";
+  ESpell_name_by_value[ESpell::SPELL_HAEMORRAGIA] = "SPELL_HAEMORRAGIA";
+  ESpell_name_by_value[ESpell::SPELL_COURAGE] = "SPELL_COURAGE";
+  ESpell_name_by_value[ESpell::SPELL_WATERBREATH] = "SPELL_WATERBREATH";
+  ESpell_name_by_value[ESpell::SPELL_SLOW] = "SPELL_SLOW";
+  ESpell_name_by_value[ESpell::SPELL_HASTE] = "SPELL_HASTE";
+  ESpell_name_by_value[ESpell::SPELL_MASS_SLOW] = "SPELL_MASS_SLOW";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_HASTE] = "SPELL_GROUP_HASTE";
+  ESpell_name_by_value[ESpell::SPELL_SHIELD] = "SPELL_SHIELD";
+  ESpell_name_by_value[ESpell::SPELL_PLAQUE] = "SPELL_PLAQUE";
+  ESpell_name_by_value[ESpell::SPELL_CURE_PLAQUE] = "SPELL_CURE_PLAQUE";
+  ESpell_name_by_value[ESpell::SPELL_AWARNESS] = "SPELL_AWARNESS";
+  ESpell_name_by_value[ESpell::SPELL_RELIGION] = "SPELL_RELIGION";
+  ESpell_name_by_value[ESpell::SPELL_AIR_SHIELD] = "SPELL_AIR_SHIELD";
+  ESpell_name_by_value[ESpell::SPELL_PORTAL] = "SPELL_PORTAL";
+  ESpell_name_by_value[ESpell::SPELL_DISPELL_MAGIC] = "SPELL_DISPELL_MAGIC";
+  ESpell_name_by_value[ESpell::SPELL_SUMMON_KEEPER] = "SPELL_SUMMON_KEEPER";
+  ESpell_name_by_value[ESpell::SPELL_FAST_REGENERATION] = "SPELL_FAST_REGENERATION";
+  ESpell_name_by_value[ESpell::SPELL_CREATE_WEAPON] = "SPELL_CREATE_WEAPON";
+  ESpell_name_by_value[ESpell::SPELL_FIRE_SHIELD] = "SPELL_FIRE_SHIELD";
+  ESpell_name_by_value[ESpell::SPELL_RELOCATE] = "SPELL_RELOCATE";
+  ESpell_name_by_value[ESpell::SPELL_SUMMON_FIREKEEPER] = "SPELL_SUMMON_FIREKEEPER";
+  ESpell_name_by_value[ESpell::SPELL_ICE_SHIELD] = "SPELL_ICE_SHIELD";
+  ESpell_name_by_value[ESpell::SPELL_ICESTORM] = "SPELL_ICESTORM";
+  ESpell_name_by_value[ESpell::SPELL_ENLESS] = "SPELL_ENLESS";
+  ESpell_name_by_value[ESpell::SPELL_SHINEFLASH] = "SPELL_SHINEFLASH";
+  ESpell_name_by_value[ESpell::SPELL_MADNESS] = "SPELL_MADNESS";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_MAGICGLASS] = "SPELL_GROUP_MAGICGLASS";
+  ESpell_name_by_value[ESpell::SPELL_CLOUD_OF_ARROWS] = "SPELL_CLOUD_OF_ARROWS";
+  ESpell_name_by_value[ESpell::SPELL_VACUUM] = "SPELL_VACUUM";
+  ESpell_name_by_value[ESpell::SPELL_METEORSTORM] = "SPELL_METEORSTORM";
+  ESpell_name_by_value[ESpell::SPELL_STONEHAND] = "SPELL_STONEHAND";
+  ESpell_name_by_value[ESpell::SPELL_MINDLESS] = "SPELL_MINDLESS";
+  ESpell_name_by_value[ESpell::SPELL_PRISMATICAURA] = "SPELL_PRISMATICAURA";
+  ESpell_name_by_value[ESpell::SPELL_EVILESS] = "SPELL_EVILESS";
+  ESpell_name_by_value[ESpell::SPELL_AIR_AURA] = "SPELL_AIR_AURA";
+  ESpell_name_by_value[ESpell::SPELL_FIRE_AURA] = "SPELL_FIRE_AURA";
+  ESpell_name_by_value[ESpell::SPELL_ICE_AURA] = "SPELL_ICE_AURA";
+  ESpell_name_by_value[ESpell::SPELL_SHOCK] = "SPELL_SHOCK";
+  ESpell_name_by_value[ESpell::SPELL_MAGICGLASS] = "SPELL_MAGICGLASS";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_SANCTUARY] = "SPELL_GROUP_SANCTUARY";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_PRISMATICAURA] = "SPELL_GROUP_PRISMATICAURA";
+  ESpell_name_by_value[ESpell::SPELL_DEAFNESS] = "SPELL_DEAFNESS";
+  ESpell_name_by_value[ESpell::SPELL_POWER_DEAFNESS] = "SPELL_POWER_DEAFNESS";
+  ESpell_name_by_value[ESpell::SPELL_REMOVE_DEAFNESS] = "SPELL_REMOVE_DEAFNESS";
+  ESpell_name_by_value[ESpell::SPELL_MASS_DEAFNESS] = "SPELL_MASS_DEAFNESS";
+  ESpell_name_by_value[ESpell::SPELL_DUSTSTORM] = "SPELL_DUSTSTORM";
+  ESpell_name_by_value[ESpell::SPELL_EARTHFALL] = "SPELL_EARTHFALL";
+  ESpell_name_by_value[ESpell::SPELL_SONICWAVE] = "SPELL_SONICWAVE";
+  ESpell_name_by_value[ESpell::SPELL_HOLYSTRIKE] = "SPELL_HOLYSTRIKE";
+  ESpell_name_by_value[ESpell::SPELL_ANGEL] = "SPELL_ANGEL";
+  ESpell_name_by_value[ESpell::SPELL_MASS_FEAR] = "SPELL_MASS_FEAR";
+  ESpell_name_by_value[ESpell::SPELL_FASCINATION] = "SPELL_FASCINATION";
+  ESpell_name_by_value[ESpell::SPELL_CRYING] = "SPELL_CRYING";
+  ESpell_name_by_value[ESpell::SPELL_OBLIVION] = "SPELL_OBLIVION";
+  ESpell_name_by_value[ESpell::SPELL_BURDEN_OF_TIME] = "SPELL_BURDEN_OF_TIME";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_REFRESH] = "SPELL_GROUP_REFRESH";
+  ESpell_name_by_value[ESpell::SPELL_PEACEFUL] = "SPELL_PEACEFUL";
+  ESpell_name_by_value[ESpell::SPELL_MAGICBATTLE] = "SPELL_MAGICBATTLE";
+  ESpell_name_by_value[ESpell::SPELL_BERSERK] = "SPELL_BERSERK";
+  ESpell_name_by_value[ESpell::SPELL_STONEBONES] = "SPELL_STONEBONES";
+  ESpell_name_by_value[ESpell::SPELL_ROOM_LIGHT] = "SPELL_ROOM_LIGHT";
+  ESpell_name_by_value[ESpell::SPELL_POISONED_FOG] = "SPELL_POISONED_FOG";
+  ESpell_name_by_value[ESpell::SPELL_THUNDERSTORM] = "SPELL_THUNDERSTORM";
+  ESpell_name_by_value[ESpell::SPELL_LIGHT_WALK] = "SPELL_LIGHT_WALK";
+  ESpell_name_by_value[ESpell::SPELL_FAILURE] = "SPELL_FAILURE";
+  ESpell_name_by_value[ESpell::SPELL_CLANPRAY] = "SPELL_CLANPRAY";
+  ESpell_name_by_value[ESpell::SPELL_GLITTERDUST] = "SPELL_GLITTERDUST";
+  ESpell_name_by_value[ESpell::SPELL_SCREAM] = "SPELL_SCREAM";
+  ESpell_name_by_value[ESpell::SPELL_CATS_GRACE] = "SPELL_CATS_GRACE";
+  ESpell_name_by_value[ESpell::SPELL_BULL_BODY] = "SPELL_BULL_BODY";
+  ESpell_name_by_value[ESpell::SPELL_SNAKE_WISDOM] = "SPELL_SNAKE_WISDOM";
+  ESpell_name_by_value[ESpell::SPELL_GIMMICKRY] = "SPELL_GIMMICKRY";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_CHALLENGE] = "SPELL_WC_OF_CHALLENGE";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_MENACE] = "SPELL_WC_OF_MENACE";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_RAGE] = "SPELL_WC_OF_RAGE";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_MADNESS] = "SPELL_WC_OF_MADNESS";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_THUNDER] = "SPELL_WC_OF_THUNDER";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_DEFENSE] = "SPELL_WC_OF_DEFENSE";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_BATTLE] = "SPELL_WC_OF_BATTLE";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_POWER] = "SPELL_WC_OF_POWER";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_BLESS] = "SPELL_WC_OF_BLESS";
+  ESpell_name_by_value[ESpell::SPELL_WC_OF_COURAGE] = "SPELL_WC_OF_COURAGE";
+  ESpell_name_by_value[ESpell::SPELL_RUNE_LABEL] = "SPELL_RUNE_LABEL";
+  ESpell_name_by_value[ESpell::SPELL_ACONITUM_POISON] = "SPELL_ACONITUM_POISON";
+  ESpell_name_by_value[ESpell::SPELL_SCOPOLIA_POISON] = "SPELL_SCOPOLIA_POISON";
+  ESpell_name_by_value[ESpell::SPELL_BELENA_POISON] = "SPELL_BELENA_POISON";
+  ESpell_name_by_value[ESpell::SPELL_DATURA_POISON] = "SPELL_DATURA_POISON";
+  ESpell_name_by_value[ESpell::SPELL_TIMER_REPAIR] = "SPELL_TIMER_REPAIR";
+  ESpell_name_by_value[ESpell::SPELL_LACKY] = "SPELL_LACKY";
+  ESpell_name_by_value[ESpell::SPELL_BANDAGE] = "SPELL_BANDAGE";
+  ESpell_name_by_value[ESpell::SPELL_NO_BANDAGE] = "SPELL_NO_BANDAGE";
+  ESpell_name_by_value[ESpell::SPELL_CAPABLE] = "SPELL_CAPABLE";
+  ESpell_name_by_value[ESpell::SPELL_STRANGLE] = "SPELL_STRANGLE";
+  ESpell_name_by_value[ESpell::SPELL_RECALL_SPELLS] = "SPELL_RECALL_SPELLS";
+  ESpell_name_by_value[ESpell::SPELL_HYPNOTIC_PATTERN] = "SPELL_HYPNOTIC_PATTERN";
+  ESpell_name_by_value[ESpell::SPELL_SOLOBONUS] = "SPELL_SOLOBONUS";
+  ESpell_name_by_value[ESpell::SPELL_VAMPIRE] = "SPELL_VAMPIRE";
+  ESpell_name_by_value[ESpell::SPELLS_RESTORATION] = "SPELLS_RESTORATION";
+  ESpell_name_by_value[ESpell::SPELL_AURA_DEATH] = "SPELL_AURA_DEATH";
+  ESpell_name_by_value[ESpell::SPELL_RECOVERY] = "SPELL_RECOVERY";
+  ESpell_name_by_value[ESpell::SPELL_MASS_RECOVERY] = "SPELL_MASS_RECOVERY";
+  ESpell_name_by_value[ESpell::SPELL_AURA_EVIL] = "SPELL_AURA_EVIL";
+  ESpell_name_by_value[ESpell::SPELL_MENTAL_SHADOW] = "SPELL_MENTAL_SHADOW";
+  ESpell_name_by_value[ESpell::SPELL_EVARDS_BLACK_TENTACLES] = "SPELL_EVARDS_BLACK_TENTACLES";
+  ESpell_name_by_value[ESpell::SPELL_WHIRLWIND] = "SPELL_WHIRLWIND";
+  ESpell_name_by_value[ESpell::SPELL_INDRIKS_TEETH] = "SPELL_INDRIKS_TEETH";
+  ESpell_name_by_value[ESpell::SPELL_MELFS_ACID_ARROW] = "SPELL_MELFS_ACID_ARROW";
+  ESpell_name_by_value[ESpell::SPELL_THUNDERSTONE] = "SPELL_THUNDERSTONE";
+  ESpell_name_by_value[ESpell::SPELL_CLOD] = "SPELL_CLOD";
+  ESpell_name_by_value[ESpell::SPELL_EXPEDIENT] = "SPELL_EXPEDIENT";
+  ESpell_name_by_value[ESpell::SPELL_SIGHT_OF_DARKNESS] = "SPELL_SIGHT_OF_DARKNESS";
+  ESpell_name_by_value[ESpell::SPELL_GENERAL_SINCERITY] = "SPELL_GENERAL_SINCERITY";
+  ESpell_name_by_value[ESpell::SPELL_MAGICAL_GAZE] = "SPELL_MAGICAL_GAZE";
+  ESpell_name_by_value[ESpell::SPELL_ALL_SEEING_EYE] = "SPELL_ALL_SEEING_EYE";
+  ESpell_name_by_value[ESpell::SPELL_EYE_OF_GODS] = "SPELL_EYE_OF_GODS";
+  ESpell_name_by_value[ESpell::SPELL_BREATHING_AT_DEPTH] = "SPELL_BREATHING_AT_DEPTH";
+  ESpell_name_by_value[ESpell::SPELL_GENERAL_RECOVERY] = "SPELL_GENERAL_RECOVERY";
+  ESpell_name_by_value[ESpell::SPELL_COMMON_MEAL] = "SPELL_COMMON_MEAL";
+  ESpell_name_by_value[ESpell::SPELL_STONE_WALL] = "SPELL_STONE_WALL";
+  ESpell_name_by_value[ESpell::SPELL_SNAKE_EYES] = "SPELL_SNAKE_EYES";
+  ESpell_name_by_value[ESpell::SPELL_EARTH_AURA] = "SPELL_EARTH_AURA";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_PROT_FROM_EVIL] = "SPELL_GROUP_PROT_FROM_EVIL";
+  ESpell_name_by_value[ESpell::SPELL_ARROWS_FIRE] = "SPELL_ARROWS_FIRE";
+  ESpell_name_by_value[ESpell::SPELL_ARROWS_WATER] = "SPELL_ARROWS_WATER";
+  ESpell_name_by_value[ESpell::SPELL_ARROWS_EARTH] = "SPELL_ARROWS_EARTH";
+  ESpell_name_by_value[ESpell::SPELL_ARROWS_AIR] = "SPELL_ARROWS_AIR";
+  ESpell_name_by_value[ESpell::SPELL_ARROWS_DEATH] = "SPELL_ARROWS_DEATH";
+  ESpell_name_by_value[ESpell::SPELL_PALADINE_INSPIRATION] = "SPELL_PALADINE_INSPIRATION";
+  ESpell_name_by_value[ESpell::SPELL_DEXTERITY] = "SPELL_DEXTERITY";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_BLINK] = "SPELL_GROUP_BLINK";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_CLOUDLY] = "SPELL_GROUP_CLOUDLY";
+  ESpell_name_by_value[ESpell::SPELL_GROUP_AWARNESS] = "SPELL_GROUP_AWARNESS";
+  ESpell_name_by_value[ESpell::SPELL_MASS_FAILURE] = "SPELL_MASS_FAILURE";
+  ESpell_name_by_value[ESpell::SPELL_MASS_NOFLEE] = "SPELL_MASS_NOFLEE";
 
-	for (const auto& i : ESpell_name_by_value)
-	{
-		ESpell_value_by_name[i.second] = i.first;
-	}
+  for (const auto &i : ESpell_name_by_value) {
+    ESpell_value_by_name[i.second] = i.first;
+  }
 }
 
-template <>
-const std::string& NAME_BY_ITEM<ESpell>(const ESpell item)
-{
-	if (ESpell_name_by_value.empty())
-	{
-		init_ESpell_ITEM_NAMES();
-	}
-	return ESpell_name_by_value.at(item);
+template<>
+const std::string &NAME_BY_ITEM<ESpell>(const ESpell item) {
+  if (ESpell_name_by_value.empty()) {
+    init_ESpell_ITEM_NAMES();
+  }
+  return ESpell_name_by_value.at(item);
 }
 
-template <>
-ESpell ITEM_BY_NAME(const std::string& name)
-{
-	if (ESpell_name_by_value.empty())
-	{
-		init_ESpell_ITEM_NAMES();
-	}
-	return ESpell_value_by_name.at(name);
+template<>
+ESpell ITEM_BY_NAME(const std::string &name) {
+  if (ESpell_name_by_value.empty()) {
+    init_ESpell_ITEM_NAMES();
+  }
+  return ESpell_value_by_name.at(name);
 }
 
 std::map<int /* vnum */, int /* count */> rune_list;
 
-void add_rune_stats(CHAR_DATA *ch, int vnum, int spelltype)
-{
-	if (IS_NPC(ch) || SPELL_RUNES != spelltype)
-	{
-		return;
-	}
-	std::map<int, int>::iterator i = rune_list.find(vnum);
-	if (rune_list.end() != i)
-	{
-		i->second += 1;
-	}
-	else
-	{
-		rune_list[vnum] = 1;
-	}
+void add_rune_stats(CHAR_DATA *ch, int vnum, int spelltype) {
+  if (IS_NPC(ch) || SPELL_RUNES != spelltype) {
+    return;
+  }
+  std::map<int, int>::iterator i = rune_list.find(vnum);
+  if (rune_list.end() != i) {
+    i->second += 1;
+  } else {
+    rune_list[vnum] = 1;
+  }
 }
 
-void extract_item(CHAR_DATA * ch, OBJ_DATA * obj, int spelltype)
-{
-	int extract = FALSE;
-	if (!obj)
-	{
-		return;
-	}
+void extract_item(CHAR_DATA *ch, OBJ_DATA *obj, int spelltype) {
+  int extract = FALSE;
+  if (!obj) {
+    return;
+  }
 
-	obj->set_val(3, time(nullptr));
+  obj->set_val(3, time(nullptr));
 
-	if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_USES))
-	{
-		obj->dec_val(2);
-		if (GET_OBJ_VAL(obj, 2) <= 0
-			&& IS_SET(GET_OBJ_SKILL(obj), ITEM_DECAY_EMPTY))
-		{
-			extract = TRUE;
-		}
-	}
-	else if (spelltype != SPELL_RUNES)
-	{
-		extract = TRUE;
-	}
+  if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_USES)) {
+    obj->dec_val(2);
+    if (GET_OBJ_VAL(obj, 2) <= 0
+        && IS_SET(GET_OBJ_SKILL(obj), ITEM_DECAY_EMPTY)) {
+      extract = TRUE;
+    }
+  } else if (spelltype != SPELL_RUNES) {
+    extract = TRUE;
+  }
 
-	if (extract)
-	{
-		if (spelltype == SPELL_RUNES)
-		{
-			snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U у вас в руках.",
-					 char_get_custom_label(obj, ch).c_str());
-			act(buf, FALSE, ch, obj, 0, TO_CHAR);
-		}
-		obj_from_char(obj);
-		extract_obj(obj);
-	}
+  if (extract) {
+    if (spelltype == SPELL_RUNES) {
+      snprintf(buf, MAX_STRING_LENGTH, "$o%s рассыпал$U у вас в руках.",
+               char_get_custom_label(obj, ch).c_str());
+      act(buf, FALSE, ch, obj, 0, TO_CHAR);
+    }
+    obj_from_char(obj);
+    extract_obj(obj);
+  }
 }
 
-int check_recipe_values(CHAR_DATA * ch, int spellnum, int spelltype, int showrecipe)
-{
-	int item0 = -1, item1 = -1, item2 = -1, obj_num = -1;
-	struct spell_create_item *items;
+int check_recipe_values(CHAR_DATA *ch, int spellnum, int spelltype, int showrecipe) {
+  int item0 = -1, item1 = -1, item2 = -1, obj_num = -1;
+  struct spell_create_item *items;
 
-	if (spellnum <= 0 || spellnum > MAX_SPELLS)
-		return (FALSE);
-	if (spelltype == SPELL_ITEMS)
-	{
-		items = &spell_create[spellnum].items;
-	}
-	else if (spelltype == SPELL_POTION)
-	{
-		items = &spell_create[spellnum].potion;
-	}
-	else if (spelltype == SPELL_WAND)
-	{
-		items = &spell_create[spellnum].wand;
-	}
-	else if (spelltype == SPELL_SCROLL)
-	{
-		items = &spell_create[spellnum].scroll;
-	}
-	else if (spelltype == SPELL_RUNES)
-	{
-		items = &spell_create[spellnum].runes;
-	}
-	else
-		return (FALSE);
+  if (spellnum <= 0 || spellnum > MAX_SPELLS)
+    return (FALSE);
+  if (spelltype == SPELL_ITEMS) {
+    items = &spell_create[spellnum].items;
+  } else if (spelltype == SPELL_POTION) {
+    items = &spell_create[spellnum].potion;
+  } else if (spelltype == SPELL_WAND) {
+    items = &spell_create[spellnum].wand;
+  } else if (spelltype == SPELL_SCROLL) {
+    items = &spell_create[spellnum].scroll;
+  } else if (spelltype == SPELL_RUNES) {
+    items = &spell_create[spellnum].runes;
+  } else
+    return (FALSE);
 
-	if (((obj_num = real_object(items->rnumber)) < 0 &&
-			spelltype != SPELL_ITEMS && spelltype != SPELL_RUNES) ||
-			((item0 = real_object(items->items[0])) +
-			 (item1 = real_object(items->items[1])) + (item2 = real_object(items->items[2])) < -2))
-	{
-		if (showrecipe)
-			send_to_char("Боги хранят в секрете этот рецепт.\n\r", ch);
-		return (FALSE);
-	}
+  if (((obj_num = real_object(items->rnumber)) < 0 &&
+      spelltype != SPELL_ITEMS && spelltype != SPELL_RUNES) ||
+      ((item0 = real_object(items->items[0])) +
+          (item1 = real_object(items->items[1])) + (item2 = real_object(items->items[2])) < -2)) {
+    if (showrecipe)
+      send_to_char("Боги хранят в секрете этот рецепт.\n\r", ch);
+    return (FALSE);
+  }
 
-	if (!showrecipe)
-		return (TRUE);
-	else
-	{
-		strcpy(buf, "Вам потребуется :\r\n");
-		if (item0 >= 0)
-		{
-			strcat(buf, CCIRED(ch, C_NRM));
-			strcat(buf, obj_proto[item0]->get_PName(0).c_str());
-			strcat(buf, "\r\n");
-		}
-		if (item1 >= 0)
-		{
-			strcat(buf, CCIYEL(ch, C_NRM));
-			strcat(buf, obj_proto[item1]->get_PName(0).c_str());
-			strcat(buf, "\r\n");
-		}
-		if (item2 >= 0)
-		{
-			strcat(buf, CCIGRN(ch, C_NRM));
-			strcat(buf, obj_proto[item2]->get_PName(0).c_str());
-			strcat(buf, "\r\n");
-		}
-		if (obj_num >= 0 && (spelltype == SPELL_ITEMS || spelltype == SPELL_RUNES))
-		{
-			strcat(buf, CCIBLU(ch, C_NRM));
-			strcat(buf, obj_proto[obj_num]->get_PName(0).c_str());
-			strcat(buf, "\r\n");
-		}
+  if (!showrecipe)
+    return (TRUE);
+  else {
+    strcpy(buf, "Вам потребуется :\r\n");
+    if (item0 >= 0) {
+      strcat(buf, CCIRED(ch, C_NRM));
+      strcat(buf, obj_proto[item0]->get_PName(0).c_str());
+      strcat(buf, "\r\n");
+    }
+    if (item1 >= 0) {
+      strcat(buf, CCIYEL(ch, C_NRM));
+      strcat(buf, obj_proto[item1]->get_PName(0).c_str());
+      strcat(buf, "\r\n");
+    }
+    if (item2 >= 0) {
+      strcat(buf, CCIGRN(ch, C_NRM));
+      strcat(buf, obj_proto[item2]->get_PName(0).c_str());
+      strcat(buf, "\r\n");
+    }
+    if (obj_num >= 0 && (spelltype == SPELL_ITEMS || spelltype == SPELL_RUNES)) {
+      strcat(buf, CCIBLU(ch, C_NRM));
+      strcat(buf, obj_proto[obj_num]->get_PName(0).c_str());
+      strcat(buf, "\r\n");
+    }
 
-		strcat(buf, CCNRM(ch, C_NRM));
-		if (spelltype == SPELL_ITEMS || spelltype == SPELL_RUNES)
-		{
-			strcat(buf, "для создания магии '");
-			strcat(buf, spell_name(spellnum));
-			strcat(buf, "'.");
-		}
-		else
-		{
-			strcat(buf, "для создания ");
-			strcat(buf, obj_proto[obj_num]->get_PName(1).c_str());
-		}
-		act(buf, FALSE, ch, 0, 0, TO_CHAR);
-	}
+    strcat(buf, CCNRM(ch, C_NRM));
+    if (spelltype == SPELL_ITEMS || spelltype == SPELL_RUNES) {
+      strcat(buf, "для создания магии '");
+      strcat(buf, spell_name(spellnum));
+      strcat(buf, "'.");
+    } else {
+      strcat(buf, "для создания ");
+      strcat(buf, obj_proto[obj_num]->get_PName(1).c_str());
+    }
+    act(buf, FALSE, ch, 0, 0, TO_CHAR);
+  }
 
-	return (TRUE);
+  return (TRUE);
 }
 
 /*
@@ -3175,337 +2940,280 @@ int check_recipe_values(CHAR_DATA * ch, int spellnum, int spelltype, int showrec
  * it to implement your own spells which require ingredients (i.e., some
  * heal spell which requires a rare herb or some such.)
  */
-bool mag_item_ok(CHAR_DATA * ch, OBJ_DATA * obj, int spelltype)
-{
-	int num = 0;
+bool mag_item_ok(CHAR_DATA *ch, OBJ_DATA *obj, int spelltype) {
+  int num = 0;
 
-	if (spelltype == SPELL_RUNES
-		&& GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_INGREDIENT)
-	{
-		return false;
-	}
+  if (spelltype == SPELL_RUNES
+      && GET_OBJ_TYPE(obj) != OBJ_DATA::ITEM_INGREDIENT) {
+    return false;
+  }
 
-	if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT)
-	{
-		if ((!IS_SET(GET_OBJ_SKILL(obj), ITEM_RUNES) && spelltype == SPELL_RUNES)
-			|| (IS_SET(GET_OBJ_SKILL(obj), ITEM_RUNES) && spelltype != SPELL_RUNES))
-		{
-			return false;
-		}
-	}
+  if (GET_OBJ_TYPE(obj) == OBJ_DATA::ITEM_INGREDIENT) {
+    if ((!IS_SET(GET_OBJ_SKILL(obj), ITEM_RUNES) && spelltype == SPELL_RUNES)
+        || (IS_SET(GET_OBJ_SKILL(obj), ITEM_RUNES) && spelltype != SPELL_RUNES)) {
+      return false;
+    }
+  }
 
-	if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_USES)
-		&& GET_OBJ_VAL(obj, 2) <= 0)
-	{
-		return false;
-	}
+  if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_USES)
+      && GET_OBJ_VAL(obj, 2) <= 0) {
+    return false;
+  }
 
-	if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_LAG))
-	{
-		num = 0;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG1s))
-			num += 1;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG2s))
-			num += 2;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG4s))
-			num += 4;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG8s))
-			num += 8;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG16s))
-			num += 16;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG32s))
-			num += 32;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG64s))
-			num += 64;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG128s))
-			num += 128;
-		if (GET_OBJ_VAL(obj, 3) + num - 5 * GET_REMORT(ch) >= time(nullptr))
-			return false;
-	}
+  if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_LAG)) {
+    num = 0;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG1s))
+      num += 1;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG2s))
+      num += 2;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG4s))
+      num += 4;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG8s))
+      num += 8;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG16s))
+      num += 16;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG32s))
+      num += 32;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG64s))
+      num += 64;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LAG128s))
+      num += 128;
+    if (GET_OBJ_VAL(obj, 3) + num - 5 * GET_REMORT(ch) >= time(nullptr))
+      return false;
+  }
 
-	if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_LEVEL))
-	{
-		num = 0;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL1))
-			num += 1;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL2))
-			num += 2;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL4))
-			num += 4;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL8))
-			num += 8;
-		if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL16))
-			num += 16;
-		if (GET_LEVEL(ch) + GET_REMORT(ch) < num)
-			return false;
-	}
+  if (IS_SET(GET_OBJ_SKILL(obj), ITEM_CHECK_LEVEL)) {
+    num = 0;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL1))
+      num += 1;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL2))
+      num += 2;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL4))
+      num += 4;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL8))
+      num += 8;
+    if (IS_SET(GET_OBJ_VAL(obj, 0), MI_LEVEL16))
+      num += 16;
+    if (GET_LEVEL(ch) + GET_REMORT(ch) < num)
+      return false;
+  }
 
-	return true;
+  return true;
 }
 
-int check_recipe_items(CHAR_DATA * ch, int spellnum, int spelltype, int extract, const CHAR_DATA * targ)
-{
-	OBJ_DATA *obj0 = nullptr, *obj1 = nullptr, *obj2 = nullptr, *obj3 = nullptr, *objo = nullptr;
-	int item0 = -1, item1 = -1, item2 = -1, item3 = -1;
-	int create = 0, obj_num = -1, percent = 0, num = 0;
-	ESkill skillnum = SKILL_INVALID;
-	struct spell_create_item *items;
+int check_recipe_items(CHAR_DATA *ch, int spellnum, int spelltype, int extract, const CHAR_DATA *targ) {
+  OBJ_DATA *obj0 = nullptr, *obj1 = nullptr, *obj2 = nullptr, *obj3 = nullptr, *objo = nullptr;
+  int item0 = -1, item1 = -1, item2 = -1, item3 = -1;
+  int create = 0, obj_num = -1, percent = 0, num = 0;
+  ESkill skillnum = SKILL_INVALID;
+  struct spell_create_item *items;
 
-	if (spellnum <= 0
-		|| spellnum > MAX_SPELLS)
-	{
-		return (FALSE);
-	}
-	if (spelltype == SPELL_ITEMS)
-	{
-		items = &spell_create[spellnum].items;
-	}
-	else if (spelltype == SPELL_POTION)
-	{
-		items = &spell_create[spellnum].potion;
-		skillnum = SKILL_CREATE_POTION;
-		create = 1;
-	}
-	else if (spelltype == SPELL_WAND)
-	{
-		items = &spell_create[spellnum].wand;
-		skillnum = SKILL_CREATE_WAND;
-		create = 1;
-	}
-	else if (spelltype == SPELL_SCROLL)
-	{
-		items = &spell_create[spellnum].scroll;
-		skillnum = SKILL_CREATE_SCROLL;
-		create = 1;
-	}
-	else if (spelltype == SPELL_RUNES)
-	{
-		items = &spell_create[spellnum].runes;
-	}
-	else
-	{
-		return (FALSE);
-	}
+  if (spellnum <= 0
+      || spellnum > MAX_SPELLS) {
+    return (FALSE);
+  }
+  if (spelltype == SPELL_ITEMS) {
+    items = &spell_create[spellnum].items;
+  } else if (spelltype == SPELL_POTION) {
+    items = &spell_create[spellnum].potion;
+    skillnum = SKILL_CREATE_POTION;
+    create = 1;
+  } else if (spelltype == SPELL_WAND) {
+    items = &spell_create[spellnum].wand;
+    skillnum = SKILL_CREATE_WAND;
+    create = 1;
+  } else if (spelltype == SPELL_SCROLL) {
+    items = &spell_create[spellnum].scroll;
+    skillnum = SKILL_CREATE_SCROLL;
+    create = 1;
+  } else if (spelltype == SPELL_RUNES) {
+    items = &spell_create[spellnum].runes;
+  } else {
+    return (FALSE);
+  }
 
-	if (((spelltype == SPELL_RUNES || spelltype == SPELL_ITEMS) &&
-			(item3 = items->rnumber) +
-			(item0 = items->items[0]) +
-			(item1 = items->items[1]) +
-			(item2 = items->items[2]) < -3)
-		|| ((spelltype == SPELL_SCROLL
-			|| spelltype == SPELL_WAND
-			|| spelltype == SPELL_POTION)
-				&& ((obj_num = items->rnumber) < 0
-					|| (item0 = items->items[0]) + (item1 = items->items[1])
-						+ (item2 = items->items[2]) < -2)))
-	{
-		return (FALSE);
-	}
+  if (((spelltype == SPELL_RUNES || spelltype == SPELL_ITEMS) &&
+      (item3 = items->rnumber) +
+          (item0 = items->items[0]) +
+          (item1 = items->items[1]) +
+          (item2 = items->items[2]) < -3)
+      || ((spelltype == SPELL_SCROLL
+          || spelltype == SPELL_WAND
+          || spelltype == SPELL_POTION)
+          && ((obj_num = items->rnumber) < 0
+              || (item0 = items->items[0]) + (item1 = items->items[1])
+                  + (item2 = items->items[2]) < -2))) {
+    return (FALSE);
+  }
 
-	const int item0_rnum = item0 >= 0 ? real_object(item0) : -1;
-	const int item1_rnum = item1 >= 0 ? real_object(item1) : -1;
-	const int item2_rnum = item2 >= 0 ? real_object(item2) : -1;
-	const int item3_rnum = item3 >= 0 ? real_object(item3) : -1;
+  const int item0_rnum = item0 >= 0 ? real_object(item0) : -1;
+  const int item1_rnum = item1 >= 0 ? real_object(item1) : -1;
+  const int item2_rnum = item2 >= 0 ? real_object(item2) : -1;
+  const int item3_rnum = item3 >= 0 ? real_object(item3) : -1;
 
-	for (auto obj = ch->carrying; obj; obj = obj->get_next_content())
-	{
-		if (item0 >= 0 && item0_rnum >= 0
-			&& GET_OBJ_VAL(obj, 1) == GET_OBJ_VAL(obj_proto[item0_rnum], 1)
-			&& mag_item_ok(ch, obj, spelltype))
-		{
-			obj0 = obj;
-			item0 = -2;
-			objo = obj0;
-			num++;
-		}
-		else if (item1 >= 0 && item1_rnum >= 0
-			&& GET_OBJ_VAL(obj, 1) == GET_OBJ_VAL(obj_proto[item1_rnum], 1)
-			&& mag_item_ok(ch, obj, spelltype))
-		{
-			obj1 = obj;
-			item1 = -2;
-			objo = obj1;
-			num++;
-		}
-		else if (item2 >= 0 && item2_rnum >= 0
-			&& GET_OBJ_VAL(obj, 1) == GET_OBJ_VAL(obj_proto[item2_rnum], 1)
-			&& mag_item_ok(ch, obj, spelltype))
-		{
-			obj2 = obj;
-			item2 = -2;
-			objo = obj2;
-			num++;
-		}
-		else if (item3 >= 0 && item3_rnum >= 0
-			&& GET_OBJ_VAL(obj, 1) == GET_OBJ_VAL(obj_proto[item3_rnum], 1)
-			&& mag_item_ok(ch, obj, spelltype))
-		{
-			obj3 = obj;
-			item3 = -2;
-			objo = obj3;
-			num++;
-		}
-	}
+  for (auto obj = ch->carrying; obj; obj = obj->get_next_content()) {
+    if (item0 >= 0 && item0_rnum >= 0
+        && GET_OBJ_VAL(obj, 1) == GET_OBJ_VAL(obj_proto[item0_rnum], 1)
+        && mag_item_ok(ch, obj, spelltype)) {
+      obj0 = obj;
+      item0 = -2;
+      objo = obj0;
+      num++;
+    } else if (item1 >= 0 && item1_rnum >= 0
+        && GET_OBJ_VAL(obj, 1) == GET_OBJ_VAL(obj_proto[item1_rnum], 1)
+        && mag_item_ok(ch, obj, spelltype)) {
+      obj1 = obj;
+      item1 = -2;
+      objo = obj1;
+      num++;
+    } else if (item2 >= 0 && item2_rnum >= 0
+        && GET_OBJ_VAL(obj, 1) == GET_OBJ_VAL(obj_proto[item2_rnum], 1)
+        && mag_item_ok(ch, obj, spelltype)) {
+      obj2 = obj;
+      item2 = -2;
+      objo = obj2;
+      num++;
+    } else if (item3 >= 0 && item3_rnum >= 0
+        && GET_OBJ_VAL(obj, 1) == GET_OBJ_VAL(obj_proto[item3_rnum], 1)
+        && mag_item_ok(ch, obj, spelltype)) {
+      obj3 = obj;
+      item3 = -2;
+      objo = obj3;
+      num++;
+    }
+  }
 
-	if (!objo ||
-			(items->items[0] >= 0 && item0 >= 0) ||
-			(items->items[1] >= 0 && item1 >= 0) ||
-			(items->items[2] >= 0 && item2 >= 0) || (items->rnumber >= 0 && item3 >= 0))
-	{
-		return (FALSE);
-	}
+  if (!objo ||
+      (items->items[0] >= 0 && item0 >= 0) ||
+      (items->items[1] >= 0 && item1 >= 0) ||
+      (items->items[2] >= 0 && item2 >= 0) || (items->rnumber >= 0 && item3 >= 0)) {
+    return (FALSE);
+  }
 
-	if (extract)
-	{
-		if (spelltype == SPELL_RUNES)
-		{
-			strcpy(buf, "Вы сложили ");
-		}
-		else
-		{
-			strcpy(buf, "Вы взяли ");
-		}
+  if (extract) {
+    if (spelltype == SPELL_RUNES) {
+      strcpy(buf, "Вы сложили ");
+    } else {
+      strcpy(buf, "Вы взяли ");
+    }
 
-		OBJ_DATA::shared_ptr obj;
-		if (create)
-		{
-			obj = world_objects.create_from_prototype_by_vnum(obj_num);
-			if (!obj)
-			{
-				return FALSE;
-			}
-			else
-			{
-				percent = number(1, 100);
-				if (skillnum > 0
-					&& percent > train_skill(ch, skillnum, percent, 0))
-				{
-					percent = -1;
-				}
-			}
-		}
+    OBJ_DATA::shared_ptr obj;
+    if (create) {
+      obj = world_objects.create_from_prototype_by_vnum(obj_num);
+      if (!obj) {
+        return FALSE;
+      } else {
+        percent = number(1, skill_info[skillnum].max_percent);
+        auto prob = calculate_skill(ch, skillnum, nullptr);
 
-		if (item0 == -2)
-		{
-			strcat(buf, CCWHT(ch, C_NRM));
-			strcat(buf, obj0->get_PName(3).c_str());
-			strcat(buf, ", ");
-			add_rune_stats(ch, GET_OBJ_VAL(obj0, 1), spelltype);
-		}
+        if (skillnum > 0
+            && percent > prob) {
+          percent = -1;
+        }
+      }
+    }
 
-		if (item1 == -2)
-		{
-			strcat(buf, CCWHT(ch, C_NRM));
-			strcat(buf, obj1->get_PName(3).c_str());
-			strcat(buf, ", ");
-			add_rune_stats(ch, GET_OBJ_VAL(obj1, 1), spelltype);
-		}
+    if (item0 == -2) {
+      strcat(buf, CCWHT(ch, C_NRM));
+      strcat(buf, obj0->get_PName(3).c_str());
+      strcat(buf, ", ");
+      add_rune_stats(ch, GET_OBJ_VAL(obj0, 1), spelltype);
+    }
 
-		if (item2 == -2)
-		{
-			strcat(buf, CCWHT(ch, C_NRM));
-			strcat(buf, obj2->get_PName(3).c_str());
-			strcat(buf, ", ");
-			add_rune_stats(ch, GET_OBJ_VAL(obj2, 1), spelltype);
-		}
+    if (item1 == -2) {
+      strcat(buf, CCWHT(ch, C_NRM));
+      strcat(buf, obj1->get_PName(3).c_str());
+      strcat(buf, ", ");
+      add_rune_stats(ch, GET_OBJ_VAL(obj1, 1), spelltype);
+    }
 
-		if (item3 == -2)
-		{
-			strcat(buf, CCWHT(ch, C_NRM));
-			strcat(buf, obj3->get_PName(3).c_str());
-			strcat(buf, ", ");
-			add_rune_stats(ch, GET_OBJ_VAL(obj3, 1), spelltype);
-		}
+    if (item2 == -2) {
+      strcat(buf, CCWHT(ch, C_NRM));
+      strcat(buf, obj2->get_PName(3).c_str());
+      strcat(buf, ", ");
+      add_rune_stats(ch, GET_OBJ_VAL(obj2, 1), spelltype);
+    }
 
-		strcat(buf, CCNRM(ch, C_NRM));
+    if (item3 == -2) {
+      strcat(buf, CCWHT(ch, C_NRM));
+      strcat(buf, obj3->get_PName(3).c_str());
+      strcat(buf, ", ");
+      add_rune_stats(ch, GET_OBJ_VAL(obj3, 1), spelltype);
+    }
 
-		if (create)
-		{
-			if (percent >= 0)
-			{
-				strcat(buf, " и создали $o3.");
-				act(buf, FALSE, ch, obj.get(), 0, TO_CHAR);
-				act("$n создал$g $o3.", FALSE, ch, obj.get(), 0, TO_ROOM | TO_ARENA_LISTEN);
-				obj_to_char(obj.get(), ch);
-			}
-			else
-			{
-				strcat(buf, " и попытались создать $o3.\r\n" "Ничего не вышло.");
-				act(buf, FALSE, ch, obj.get(), 0, TO_CHAR);
-				extract_obj(obj.get());
-			}
-		}
-		else
-		{
-			if (spelltype == SPELL_ITEMS)
-			{
-				strcat(buf, "и создали магическую смесь.\r\n");
-				act(buf, FALSE, ch, 0, 0, TO_CHAR);
-				act("$n смешал$g что-то в своей ноше.\r\n"
-					"Вы почувствовали резкий запах.", TRUE, ch, nullptr, nullptr, TO_ROOM | TO_ARENA_LISTEN);
-			}
-			else if (spelltype == SPELL_RUNES)
-			{
-				sprintf(buf + strlen(buf),
-					"котор%s вспыхнул%s ярким светом.%s",
-					num > 1 ? "ые" : GET_OBJ_SUF_3(objo), num > 1 ? "и" : GET_OBJ_SUF_1(objo),
-					PRF_FLAGGED(ch, PRF_COMPACT) ? "" : "\r\n");
-				act(buf, FALSE, ch, 0, 0, TO_CHAR);
-				act("$n сложил$g руны, которые вспыхнули ярким пламенем.",
-					TRUE, ch, nullptr, nullptr, TO_ROOM);
-				sprintf(buf, "$n сложил$g руны в заклинание '%s'%s%s.",
-					spell_name(spellnum),
-					(targ && targ != ch ? " на " : ""),
-					(targ && targ != ch ? GET_PAD(targ, 1) : ""));
-				act(buf, TRUE, ch, nullptr, nullptr, TO_ARENA_LISTEN);
-				auto skillnum = get_magic_skill_number_by_spell(spellnum);
-				if (skillnum > 0)
-				{
-					train_skill(ch, skillnum, skill_info[skillnum].max_percent, 0);
-				}
-			}
-		}
-		extract_item(ch, obj0, spelltype);
-		extract_item(ch, obj1, spelltype);
-		extract_item(ch, obj2, spelltype);
-		extract_item(ch, obj3, spelltype);
-	}
-	return (TRUE);
+    strcat(buf, CCNRM(ch, C_NRM));
+
+    if (create) {
+      if (percent >= 0) {
+        strcat(buf, " и создали $o3.");
+        act(buf, FALSE, ch, obj.get(), 0, TO_CHAR);
+        act("$n создал$g $o3.", FALSE, ch, obj.get(), 0, TO_ROOM | TO_ARENA_LISTEN);
+        obj_to_char(obj.get(), ch);
+      } else {
+        strcat(buf, " и попытались создать $o3.\r\n" "Ничего не вышло.");
+        act(buf, FALSE, ch, obj.get(), 0, TO_CHAR);
+        extract_obj(obj.get());
+      }
+    } else {
+      if (spelltype == SPELL_ITEMS) {
+        strcat(buf, "и создали магическую смесь.\r\n");
+        act(buf, FALSE, ch, 0, 0, TO_CHAR);
+        act("$n смешал$g что-то в своей ноше.\r\n"
+            "Вы почувствовали резкий запах.", TRUE, ch, nullptr, nullptr, TO_ROOM | TO_ARENA_LISTEN);
+      } else if (spelltype == SPELL_RUNES) {
+        sprintf(buf + strlen(buf),
+                "котор%s вспыхнул%s ярким светом.%s",
+                num > 1 ? "ые" : GET_OBJ_SUF_3(objo), num > 1 ? "и" : GET_OBJ_SUF_1(objo),
+                PRF_FLAGGED(ch, PRF_COMPACT) ? "" : "\r\n");
+        act(buf, FALSE, ch, 0, 0, TO_CHAR);
+        act("$n сложил$g руны, которые вспыхнули ярким пламенем.",
+            TRUE, ch, nullptr, nullptr, TO_ROOM);
+        sprintf(buf, "$n сложил$g руны в заклинание '%s'%s%s.",
+                spell_name(spellnum),
+                (targ && targ != ch ? " на " : ""),
+                (targ && targ != ch ? GET_PAD(targ, 1) : ""));
+        act(buf, TRUE, ch, nullptr, nullptr, TO_ARENA_LISTEN);
+        auto skillnum = get_magic_skill_number_by_spell(spellnum);
+        if (skillnum > 0) {
+          train_skill(ch, skillnum, true, nullptr);
+        }
+      }
+    }
+    extract_item(ch, obj0, spelltype);
+    extract_item(ch, obj1, spelltype);
+    extract_item(ch, obj2, spelltype);
+    extract_item(ch, obj3, spelltype);
+  }
+  return (TRUE);
 }
 
-void print_rune_stats(CHAR_DATA *ch)
-{
-	if (!IS_GRGOD(ch))
-	{
-		send_to_char(ch, "Только для иммов 33+.\r\n");
-		return;
-	}
+void print_rune_stats(CHAR_DATA *ch) {
+  if (!IS_GRGOD(ch)) {
+    send_to_char(ch, "Только для иммов 33+.\r\n");
+    return;
+  }
 
-	std::multimap<int, int> tmp_list;
-	for (std::map<int, int>::const_iterator i = rune_list.begin(),
-		iend = rune_list.end(); i != iend; ++i)
-	{
-		tmp_list.insert(std::make_pair(i->second, i->first));
-	}
-	std::string out(
-		"Rune stats:\r\n"
-		"vnum -> count\r\n"
-		"--------------\r\n");
-	for (std::multimap<int, int>::const_reverse_iterator i = tmp_list.rbegin(),
-		iend = tmp_list.rend(); i != iend; ++i)
-	{
-		out += boost::str(boost::format("%1% -> %2%\r\n") % i->second % i->first);
-	}
-	send_to_char(out, ch);
+  std::multimap<int, int> tmp_list;
+  for (std::map<int, int>::const_iterator i = rune_list.begin(),
+           iend = rune_list.end(); i != iend; ++i) {
+    tmp_list.insert(std::make_pair(i->second, i->first));
+  }
+  std::string out(
+      "Rune stats:\r\n"
+      "vnum -> count\r\n"
+      "--------------\r\n");
+  for (std::multimap<int, int>::const_reverse_iterator i = tmp_list.rbegin(),
+           iend = tmp_list.rend(); i != iend; ++i) {
+    out += boost::str(boost::format("%1% -> %2%\r\n") % i->second % i->first);
+  }
+  send_to_char(out, ch);
 }
 
-void print_rune_log()
-{
-	for (std::map<int, int>::const_iterator i = rune_list.begin(),
-		iend = rune_list.end(); i != iend; ++i)
-	{
-		log("RuneUsed: %d %d", i->first, i->second);
-	}
+void print_rune_log() {
+  for (std::map<int, int>::const_iterator i = rune_list.begin(),
+           iend = rune_list.end(); i != iend; ++i) {
+    log("RuneUsed: %d %d", i->first, i->second);
+  }
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
Вкратце. Ввел в skills_info поле cap, обозначющее собственно окочательный хардкап скилла. Убрал ограничения на прокачку до капа, естестенно с учетом уровня, ремортов и мудрости. Снял планку (в смысле - установил кап в 1000) с оружейных умений, магических и еще нескольких, где показалось, что серьезных последствий не будет. Баланс вроде бы нигде не поломал, но всяко может быть. Единственноч то некоторые скиллы у хаймортов просто тупо не будут фейлиться вообще, но это потом подкрутим. Чтобы снять капы с остальных скиллов - нужно пересматривать формулы. 