### PR TITLE
A trigger type 'fighting round' was added to otrigger types. 

### DIFF
--- a/src/dg_script/dg_scripts.h
+++ b/src/dg_script/dg_scripts.h
@@ -59,6 +59,7 @@ extern const char *attach_name[];
 #define OTRIG_RANDOM           (1 << 1)    // checked randomly           //
 #define OTRIG_COMMAND          (1 << 2)    // character types a command  //
 #define OTRIG_PURGE           (1 << 3)    // object purge  //
+#define OTRIG_FIGHT           (1 << 4)    // every fight round  //
 #define OTRIG_TIMER            (1 << 5)    // item's timer expires       //
 #define OTRIG_GET              (1 << 6)    // item is picked up          //
 #define OTRIG_DROP             (1 << 7)    // character trys to drop obj //
@@ -349,6 +350,7 @@ void hitprcnt_mtrigger(CHAR_DATA *ch);
 int damage_mtrigger(CHAR_DATA *damager, CHAR_DATA *victim);
 void random_mtrigger(CHAR_DATA *ch);
 void random_otrigger(OBJ_DATA *obj);
+void fight_otrigger(CHAR_DATA *actor);
 void random_wtrigger(ROOM_DATA *room, int num, void *s, int types, const TriggersList &list);
 void reset_wtrigger(ROOM_DATA *ch);
 void load_mtrigger(CHAR_DATA *ch);

--- a/src/dg_script/dg_triggers.cpp
+++ b/src/dg_script/dg_triggers.cpp
@@ -90,7 +90,7 @@ const char *otrig_types[] = {"Global",
 							 "Random",
 							 "Command",
 							 "Разрушился",
-							 "UNUSED",
+							 "Fighting round",
 							 "Timer",
 							 "Get",
 							 "Drop",
@@ -842,6 +842,30 @@ void random_otrigger(OBJ_DATA *obj) {
 	}
 }
 
+void run_fight_otrigger(CHAR_DATA *actor, OBJ_DATA *obj, int mode) {
+	char buf[MAX_INPUT_LENGTH];
+	if (!SCRIPT_CHECK(obj, OTRIG_FIGHT) || GET_INVIS_LEV(actor)) {
+		return;
+	}
+	for (auto t : obj->get_script()->trig_list) {
+		if (TRIGGER_CHECK(t, OTRIG_FIGHT) && IS_SET(GET_TRIG_NARG(t), mode)) {
+			ADD_UID_CHAR_VAR(buf, t, actor, "actor", 0);
+			script_driver(obj, t, OBJ_TRIGGER, TRIG_NEW);
+		}
+	}
+}
+
+void fight_otrigger(CHAR_DATA *actor) {
+	for (auto item: (actor)->equipment) {
+		if (item) {
+			run_fight_otrigger(actor, item, OCMD_EQUIP);
+		}
+	}
+	for (auto item = actor->carrying; item; item = item->get_next_content()) {
+		run_fight_otrigger(actor, item, OCMD_INVEN);
+	}
+}
+
 void timer_otrigger(OBJ_DATA *obj) {
 	if (!SCRIPT_CHECK(obj, OTRIG_TIMER)) {
 		return;
@@ -852,8 +876,6 @@ void timer_otrigger(OBJ_DATA *obj) {
 			script_driver(obj, t, OBJ_TRIGGER, TRIG_NEW);
 		}
 	}
-
-	return;
 }
 
 int get_otrigger(OBJ_DATA *obj, CHAR_DATA *actor) {
@@ -911,7 +933,7 @@ int cmd_otrig(OBJ_DATA *obj, CHAR_DATA *actor, char *cmd, const char *argument, 
 
 			if (IS_SET(GET_TRIG_NARG(t), type)
 				&& (t->arglist[0] == '*'
-					|| 0 == strn_cmp(t->arglist.c_str(), cmd, t->arglist.size()))) {
+				|| 0 == strn_cmp(t->arglist.c_str(), cmd, t->arglist.size()))) {
 				if (!IS_NPC(actor)
 					&& (GET_POS(actor) == POS_SLEEPING))   // command триггер не будет срабатывать если игрок спит
 				{

--- a/src/fightsystem/fight.cpp
+++ b/src/fightsystem/fight.cpp
@@ -1850,11 +1850,13 @@ void process_player_attack(CHAR_DATA *ch, int min_init) {
 	if (GET_POS(ch) > POS_STUNNED
 		&& GET_POS(ch) < POS_FIGHTING
 		&& GET_AF_BATTLE(ch, EAF_STAND)) {
-		sprintf(buf, "%sВам лучше встать на ноги!%s\r\n",
-				CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
+		sprintf(buf, "%sВам лучше встать на ноги!%s\r\n", CCWHT(ch, C_NRM), CCNRM(ch, C_NRM));
 		send_to_char(buf, ch);
 		CLR_AF_BATTLE(ch, EAF_STAND);
 	}
+
+	// Срабатывание батл-триггеров амуниции
+	fight_otrigger(ch);
 
 	//* каст заклинания
 	if (ch->get_cast_spell() && GET_WAIT(ch) <= 0) {

--- a/src/fightsystem/fight.cpp
+++ b/src/fightsystem/fight.cpp
@@ -1855,9 +1855,6 @@ void process_player_attack(CHAR_DATA *ch, int min_init) {
 		CLR_AF_BATTLE(ch, EAF_STAND);
 	}
 
-	// Срабатывание батл-триггеров амуниции
-	fight_otrigger(ch);
-
 	//* каст заклинания
 	if (ch->get_cast_spell() && GET_WAIT(ch) <= 0) {
 		if (AFF_FLAGGED(ch, EAffectFlag::AFF_SILENCE) || AFF_FLAGGED(ch, EAffectFlag::AFF_STRANGLED)) {
@@ -2087,24 +2084,22 @@ void perform_violence() {
 				|| !AWAKE(ch)) {
 				continue;
 			}
-
 			// If mob cast 'fear', 'teleport', 'recall', etc when initiative setted
-			if (!ch->get_fighting()
-				|| ch->in_room != IN_ROOM(ch->get_fighting())) {
+			if (!ch->get_fighting() || ch->in_room != IN_ROOM(ch->get_fighting())) {
 				continue;
 			}
-
-			if (initiative == 0) //везде в стоп-файтах ставится инициатива равная 0, убираем двойную атаку
-			{
+			//везде в стоп-файтах ставится инициатива равная 0, убираем двойную атаку
+			if (initiative == 0) {
 				continue;
 			}
-
 			//* выполнение атак в раунде
 			if (IS_NPC(ch)) {
 				process_npc_attack(ch);
 			} else {
 				process_player_attack(ch, min_init);
 			}
+			// Срабатывание батл-триггеров амуниции
+			fight_otrigger(ch);
 		}
 	}
 


### PR DESCRIPTION
Добавил тип триггера для объектов "раунд боя". Числовой аргумент работает как для командного триггера: 1 - предмет должен быть экипирован, 2 - в инвентаре, 3 - все равно где. На полу не работает, т.к. у комнат нет события "в комнате происходит раунд боя" и на пол можно накидать кучу предметов, да и похоже невохможно вычленить раунд для конкретной комнаты: все сражающиеся в мире персонажи, похоже, обрабатываются одним списком.  Обойти это можно, но уже сложнее.