### PR TITLE
Фикс для автолута с инфрой

### DIFF
--- a/src/game_fight/fight_stuff.cpp
+++ b/src/game_fight/fight_stuff.cpp
@@ -493,7 +493,7 @@ void auto_loot(CharData *ch, CharData *killer, ObjData *corpse, int local_gold) 
 	char obj[256];
 
 	if (is_dark(IN_ROOM(killer))
-		&& !CanUseFeat(killer, EFeat::kDarkReading)
+		&& !(CAN_SEE_IN_DARK(killer) || CanUseFeat(killer, EFeat::kDarkReading))
 		&& !(killer->IsNpc()
 			&& AFF_FLAGGED(killer, EAffect::kCharmed)
 			&& killer->has_master()


### PR DESCRIPTION
При автограбеже во тьме должен учитываться аффект "инфра"

