### PR TITLE
правки в заклинаниях

### DIFF
--- a/src/cmd/score.cpp
+++ b/src/cmd/score.cpp
@@ -799,8 +799,7 @@ void PrintScoreBase(CharData *ch) {
 
 	int glory = Glory::get_glory(GET_UNIQUE(ch));
 	if (glory) {
-	//	sprintf(buf + strlen(buf), "Вы заслужили %d %s славы.\r\n",
-				glory, GetDeclensionInNumber(glory, EWhat::kPoint));
+	//	sprintf(buf + strlen(buf), "Вы заслужили %d %s славы.\r\n", glory, GetDeclensionInNumber(glory, EWhat::kPoint));
 	}
 	glory = GloryConst::get_glory(GET_UNIQUE(ch));
 	if (glory) {

--- a/src/cmd/score.cpp
+++ b/src/cmd/score.cpp
@@ -799,7 +799,7 @@ void PrintScoreBase(CharData *ch) {
 
 	int glory = Glory::get_glory(GET_UNIQUE(ch));
 	if (glory) {
-		sprintf(buf + strlen(buf), "Вы заслужили %d %s славы.\r\n",
+	//	sprintf(buf + strlen(buf), "Вы заслужили %d %s славы.\r\n",
 				glory, GetDeclensionInNumber(glory, EWhat::kPoint));
 	}
 	glory = GloryConst::get_glory(GET_UNIQUE(ch));

--- a/src/game_magic/magic.cpp
+++ b/src/game_magic/magic.cpp
@@ -1461,7 +1461,7 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 		case ESpell::kMassSlow:
 		case ESpell::kSlowdown: savetype = ESaving::kStability;
 			if (AFF_FLAGGED(victim, EAffect::kBrokenChains)
-				|| (ch != victim && CalcGeneralSaving(ch, victim, savetype, modi * number(1, koef_modifier / 2)))) {
+				|| (ch != victim && CalcGeneralSaving(ch, victim, savetype, modi))) {
 				SendMsgToChar(NOEFFECT, ch);
 				success = false;
 				break;
@@ -2015,7 +2015,12 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 				default: break;
 			}
 */
+			if (spell_id==ESpell::kEarthfall){
+				auto skill = ch->GetSkill(GetMagicSkillId(spell_id));
+				modi += skill/5;
+			}
 			if (IS_IMMORTAL(victim) || (!IS_IMMORTAL(ch) && CalcGeneralSaving(ch, victim, savetype, modi))) {
+				SendMsgToChar(NOEFFECT, ch);
 				success = false;
 				break;
 			}

--- a/src/game_magic/magic.cpp
+++ b/src/game_magic/magic.cpp
@@ -2016,8 +2016,7 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 			}
 */
 			if (spell_id==ESpell::kEarthfall){
-				auto skill = ch->GetSkill(GetMagicSkillId(spell_id));
-				modi += skill/5;
+				modi += ch->GetSkill(GetMagicSkillId(spell_id))/5;
 			}
 			if (IS_IMMORTAL(victim) || (!IS_IMMORTAL(ch) && CalcGeneralSaving(ch, victim, savetype, modi))) {
 				SendMsgToChar(NOEFFECT, ch);


### PR DESCRIPTION
1. убрали ошибочный добавочный каст при заклинании "замедление" / "массовое замедление"
2. добавили сообщение о фейле заклинания "ледяной шторм" / "камнепад" / "шок"
3. увеличили шанс прохождения заклинания "камнепад" в зависимости от школы магии земли