### PR TITLE
правки в заклах колдуна

### DIFF
--- a/lib/cfg/spells.xml
+++ b/lib/cfg/spells.xml
@@ -733,7 +733,7 @@ base_stat id - (например "kWis") какой берем параметр,
             <action>
                 <damage saving="kWill">
                     <dices ndice="25" sdice="30" adice="180"/>
-                    <base_skill id="kFireMagic" low_skill_bonus="2.75" hi_skill_bonus="3"/>
+                    <base_skill id="kFireMagic" low_skill_bonus="2.5" hi_skill_bonus="2.75"/>
                     <base_stat id="kWis" threshold="22" weight="3.5"/>
                 </damage>
             </action>
@@ -2207,14 +2207,14 @@ base_stat id - (например "kWis") какой берем параметр,
     <spell id="kWhirlwind" element="kAir" mode="kEnabled">
         <name rus="вихрь" eng="whirlwind"/>
         <misc pos="kFight" violent="Y" danger="2"/>
-        <mana max="100" min="70" change="1"/>
+        <mana max="100" min="80" change="1"/>
         <targets val="kTarCharRoom|kTarFightVict"/>
         <flags val="kMagDamage|kNpcDamagePc|kNpcDamagePcMinhp"/>
         <talent_actions>
             <action>
                 <damage saving="kStability">
-                    <dices ndice="18" sdice="20" adice="65"/>
-                    <base_skill id="kAirMagic" low_skill_bonus="3" hi_skill_bonus="1.25"/>
+                    <dices ndice="18" sdice="18" adice="50"/>
+                    <base_skill id="kAirMagic" low_skill_bonus="3" hi_skill_bonus="1.75"/>
                     <base_stat id="kWis" threshold="32" weight="3.5"/>
                 </damage>
             </action>
@@ -2239,14 +2239,14 @@ base_stat id - (например "kWis") какой берем параметр,
     <spell id="kAcidArrow" element="kWater" mode="kEnabled">
         <name rus="кислотная стрела" eng="acid arrow"/>
         <misc pos="kFight" violent="Y" danger="2"/>
-        <mana max="120" min="100" change="1"/>
+        <mana max="130" min="100" change="1"/>
         <targets val="kTarCharRoom|kTarFightVict"/>
         <flags val="kMagDamage|kMagAffects|kNpcDamagePc|kNpcDamagePcMinhp"/>
         <talent_actions>
             <action>
                 <damage saving="kReflex">
-                    <dices ndice="20" sdice="25" adice="90"/>
-                    <base_skill id="kWaterMagic" low_skill_bonus="2" hi_skill_bonus="1.5"/>
+                    <dices ndice="20" sdice="25" adice="75"/>
+                    <base_skill id="kWaterMagic" low_skill_bonus="2" hi_skill_bonus="1.75"/>
                     <base_stat id="kWis" threshold="22" weight="1.5"/>
                 </damage>
             </action>
@@ -2281,7 +2281,7 @@ base_stat id - (например "kWis") какой берем параметр,
         <talent_actions>
             <action>
                 <damage saving="kReflex">
-                    <dices ndice="22" sdice="20" adice="90"/>
+                    <dices ndice="22" sdice="20" adice="60"/>
                     <base_skill id="kEarthMagic" low_skill_bonus="3" hi_skill_bonus="2"/>
                     <base_stat id="kWis" threshold="22" weight="2.5"/>
                 </damage>

--- a/lib/cfg/spells.xml
+++ b/lib/cfg/spells.xml
@@ -364,7 +364,7 @@ base_stat id - (например "kWis") какой берем параметр,
         <talent_actions>
             <action>
                 <damage saving="kReflex">
-                    <dices ndice="4" sdice="18" adice="0"/>
+                    <dices ndice="4" sdice="18" adice="5"/>
                     <base_skill id="kAirMagic" low_skill_bonus="3" hi_skill_bonus="1.25"/>
                     <base_stat id="kWis" threshold="22" weight="0.5"/>
                 </damage>
@@ -726,14 +726,14 @@ base_stat id - (например "kWis") какой берем параметр,
     <spell id="kGodsWrath" element="kFire" mode="kEnabled">
         <name rus="гнев богов" eng="gods wrath"/>
         <misc pos="kFight" violent="Y" danger="15"/>
-        <mana max="110" min="100" change="1"/>
+        <mana max="140" min="120" change="1"/>
         <targets val="kTarCharRoom|kTarFightVict"/>
         <flags val="kMagDamage|kNpcDamagePc|kNpcDamagePcMinhp"/>
         <talent_actions>
             <action>
                 <damage saving="kWill">
                     <dices ndice="25" sdice="30" adice="180"/>
-                    <base_skill id="kFireMagic" low_skill_bonus="3" hi_skill_bonus="4"/>
+                    <base_skill id="kFireMagic" low_skill_bonus="2.75" hi_skill_bonus="3"/>
                     <base_stat id="kWis" threshold="22" weight="3.5"/>
                 </damage>
             </action>
@@ -1108,11 +1108,11 @@ base_stat id - (например "kWis") какой берем параметр,
         <misc pos="kFight" violent="Y" danger="15"/>
         <mana max="100" min="90" change="1"/>
         <targets val="kTarCharRoom|kTarFightVict"/>
-        <flags val="kMagAffects|kMagDamage|kNpcDamagePc|kNpcDamagePcMinhp"/>
+        <flags val="kMagAreas|kMagDamage|kMagAffects|kNpcDamagePc|kNpcDamagePcMinhp"/>
         <talent_actions>
             <action>
                 <damage saving="kStability">
-                    <dices ndice="11" sdice="5" adice="55"/>
+                    <dices ndice="11" sdice="7" adice="55"/>
                     <base_skill id="kAirMagic" low_skill_bonus="2.25" hi_skill_bonus="1.5"/>
                     <base_stat id="kWis" threshold="22" weight="0.5"/>
                 </damage>
@@ -1310,7 +1310,7 @@ base_stat id - (например "kWis") какой берем параметр,
     <spell id="kIceStorm" element="kWater" mode="kEnabled">
         <name rus="ледяной шторм" eng="ice storm"/>
         <misc pos="kFight" violent="Y" danger="5"/>
-        <mana max="125" min="90" change="3"/>
+        <mana max="135" min="100" change="3"/>
         <targets val="kTarIgnore"/>
         <flags val="kMagMasses|kMagDamage|kMagAffects|kNpcDamagePc"/>
         <talent_actions>
@@ -1318,7 +1318,7 @@ base_stat id - (например "kWis") какой берем параметр,
                 <damage saving="kStability">
                     <dices ndice="20" sdice="5" adice="50"/>
                     <base_skill id="kWaterMagic" low_skill_bonus="0.75" hi_skill_bonus="1.25"/>
-                    <base_stat id="kWis" threshold="22" weight="0.5"/>
+                    <base_stat id="kWis" threshold="22" weight="1"/>
                 </damage>
                 <area>
                     <decay cast="0.05" level="4" free_targets="3"/>
@@ -1613,7 +1613,7 @@ base_stat id - (например "kWis") какой берем параметр,
         <talent_actions>
             <action>
                 <damage saving="kStability">
-                    <dices ndice="10" sdice="12" adice="90"/>
+                    <dices ndice="12" sdice="12" adice="90"/>
                     <base_skill id="kEarthMagic" low_skill_bonus="0.75" hi_skill_bonus="1.5"/>
                     <base_stat id="kWis" threshold="50" weight="7"/>
                 </damage>
@@ -1770,14 +1770,14 @@ base_stat id - (например "kWis") какой берем параметр,
     </spell>
     <spell id="kPoosinedFog" element="kLife" mode="kEnabled">
         <name rus="ядовитый туман" eng="poisoned fog"/>
-        <misc pos="kStand" violent="N" danger="0"/>
+        <misc pos="kFight" violent="Y" danger="2"/>
         <mana max="10" min="10" change="1"/>
         <targets val="kTarRoomThis"/>
         <flags val="kMagRoom|kMagCasterInroom"/>
     </spell>
     <spell id="kThunderstorm" element="kAir" mode="kEnabled">
         <name rus="буря отмщения" eng="storm of vengeance"/>
-        <misc pos="kStand" violent="N" danger="0"/>
+        <misc pos="kFight" violent="Y" danger="7"/>
         <mana max="10" min="10" change="1"/>
         <targets val="kTarRoomThis"/>
         <flags val="kMagNeedControl|kMagRoom|kMagCasterInroom"/>
@@ -2207,15 +2207,15 @@ base_stat id - (например "kWis") какой берем параметр,
     <spell id="kWhirlwind" element="kAir" mode="kEnabled">
         <name rus="вихрь" eng="whirlwind"/>
         <misc pos="kFight" violent="Y" danger="2"/>
-        <mana max="70" min="50" change="1"/>
+        <mana max="100" min="70" change="1"/>
         <targets val="kTarCharRoom|kTarFightVict"/>
         <flags val="kMagDamage|kNpcDamagePc|kNpcDamagePcMinhp"/>
         <talent_actions>
             <action>
                 <damage saving="kStability">
-                    <dices ndice="18" sdice="25" adice="75"/>
-                    <base_skill id="kAirMagic" low_skill_bonus="3" hi_skill_bonus="0.25"/>
-                    <base_stat id="kWis" threshold="32" weight="5"/>
+                    <dices ndice="18" sdice="20" adice="65"/>
+                    <base_skill id="kAirMagic" low_skill_bonus="3" hi_skill_bonus="1.25"/>
+                    <base_stat id="kWis" threshold="32" weight="3.5"/>
                 </damage>
             </action>
         </talent_actions>
@@ -2239,15 +2239,15 @@ base_stat id - (например "kWis") какой берем параметр,
     <spell id="kAcidArrow" element="kWater" mode="kEnabled">
         <name rus="кислотная стрела" eng="acid arrow"/>
         <misc pos="kFight" violent="Y" danger="2"/>
-        <mana max="110" min="100" change="1"/>
+        <mana max="120" min="100" change="1"/>
         <targets val="kTarCharRoom|kTarFightVict"/>
-        <flags val="kMagDamage|kNpcDamagePc|kNpcDamagePcMinhp"/>
+        <flags val="kMagDamage|kMagAffects|kNpcDamagePc|kNpcDamagePcMinhp"/>
         <talent_actions>
             <action>
                 <damage saving="kReflex">
                     <dices ndice="20" sdice="25" adice="90"/>
                     <base_skill id="kWaterMagic" low_skill_bonus="2" hi_skill_bonus="1.5"/>
-                    <base_stat id="kWis" threshold="22" weight="0.5"/>
+                    <base_stat id="kWis" threshold="22" weight="1.5"/>
                 </damage>
             </action>
         </talent_actions>
@@ -2275,13 +2275,13 @@ base_stat id - (например "kWis") какой берем параметр,
     <spell id="kClod" element="kEarth" mode="kEnabled">
         <name rus="глыба" eng="clod"/>
         <misc pos="kFight" violent="Y" danger="2"/>
-        <mana max="110" min="100" change="1"/>
+        <mana max="130" min="110" change="1"/>
         <targets val="kTarCharRoom|kTarFightVict"/>
-        <flags val="kMagDamage|kNpcDamagePc|kNpcDamagePcMinhp"/>
+        <flags val="kMagDamage|kNpcAffectPc|kMagAffects|kNpcDamagePc|kNpcDamagePcMinhp"/>
         <talent_actions>
             <action>
                 <damage saving="kReflex">
-                    <dices ndice="22" sdice="25" adice="180"/>
+                    <dices ndice="22" sdice="20" adice="90"/>
                     <base_skill id="kEarthMagic" low_skill_bonus="3" hi_skill_bonus="2"/>
                     <base_stat id="kWis" threshold="22" weight="2.5"/>
                 </damage>

--- a/src/game_magic/magic.cpp
+++ b/src/game_magic/magic.cpp
@@ -300,6 +300,18 @@ float CalcModCoef(ESpell spell_id, int percent) {
 			}
 			return 1;
 			break;
+		case ESpell::kWhirlwind:
+			if (percent > 60) {
+				return (percent) / 60; // 120 -2 вихря, 180 вихря и т.д.
+			}
+			return 1;
+			break;
+		case ESpell::kLightingBolt:
+			if (percent > 100) {
+				return (percent - 80) / 20; // 
+			}
+			return 1;
+			break;
 		default: return 1;
 	}
 	return 0;
@@ -492,6 +504,17 @@ int CastDamage(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 				count = (level + 9) / 10;
 			break;
 		}
+		case ESpell::kLightingBolt: {
+				count = CalcModCoef(spell_id, ch->GetSkill(GetMagicSkillId(spell_id)));
+				count += number(1, 5)==1?1:0;
+				count = std::max(count, 4);
+			break;
+		}
+		case ESpell::kWhirlwind: {
+				count = CalcModCoef(spell_id, ch->GetSkill(GetMagicSkillId(spell_id)));
+				count += number(1, 5)==1?1:0;
+			break;
+		}
 		case ESpell::kAcid: {
 			obj = nullptr;
 			if (victim->IsNpc()) {
@@ -510,6 +533,51 @@ int CastDamage(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 				act("Кислота покрыла $o3.", false, victim, obj, nullptr, kToChar);
 				alterate_object(obj, number(level * 2, level * 4), 100);
 			}
+			break;
+		}
+		case ESpell::kClod: {
+				if (GET_POS(victim) > EPosition::kSit && !IS_IMMORTAL(victim) && (number(1, 100) > GET_AR(victim)) &&
+					(AFF_FLAGGED(victim, EAffect::kHold) || !CalcGeneralSaving(ch, victim, ESaving::kReflex, modi))) {
+				if (IS_HORSE(victim))
+					victim->drop_from_horse();
+				act("$n3 придавило глыбой камня.", false, victim, nullptr, nullptr, kToRoom | kToArenaListen);
+				act("Огромная глыба камня свалила вас на землю!", false, victim, nullptr, nullptr, kToChar);
+				GET_POS(victim) = EPosition::kSit;
+				update_pos(victim);
+				SetWaitState(victim, 2 * kBattleRound);
+			}
+			break;
+		}
+		case ESpell::kAcidArrow: {
+			int rnd = number(1, 5);
+			switch (rnd) {
+				case 1: // обожгло глотку - молча
+				act("Кислота плеснула на горло $n1", false, victim, nullptr, nullptr, kToRoom | kToArenaListen);
+				act("Жуткая кислота опалила ваше горло!", false, victim, nullptr, nullptr, kToChar);
+				CastAffect(level, ch, victim, ESpell::kSilence); 
+					break;
+				case 2: // телесный ожог - лихорадка
+				act("$n покрылся язвами по всему телу.", false, victim, nullptr, nullptr, kToRoom | kToArenaListen);
+				act("Кислота причинила вам жуткие ожоги кожи!", false, victim, nullptr, nullptr, kToChar);
+				CastAffect(level, ch, victim, ESpell::kFever); 
+					break;
+				case 3: // ядовитые испарения - яд
+				act("$n позеленел от действия кислотной стрелы.", false, victim, nullptr, nullptr, kToRoom | kToArenaListen);
+				act("Кислота обожгла вам все тело!", false, victim, nullptr, nullptr, kToChar);
+				CastAffect(level, ch, victim, ESpell::kPoison); 
+					break;
+				case 4: // обожгло глаза - слепота
+				act("Часть кислоты попала в глаза $n3.", false, victim, nullptr, nullptr, kToRoom | kToArenaListen);
+				act("Кислотные испарения выедают вам глаза!", false, victim, nullptr, nullptr, kToChar);
+				CastAffect(level, ch, victim, ESpell::kBlindness); 
+					break;
+				case 5: // обожгот экип - кислотой
+				act("Кислота покрыла доспехи $n3.", false, victim, nullptr, nullptr, kToRoom | kToArenaListen);
+				act("Кислота покрыла ваши доспехи.", false, victim, nullptr, nullptr, kToChar);
+				CastDamage(level, ch, victim, ESpell::kAcid); 
+					break;
+				default:break;
+			}	
 			break;
 		}
 		case ESpell::kEarthquake: {
@@ -1600,7 +1668,7 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 
 		case ESpell::kPoison: savetype = ESaving::kCritical;
 			if (ch != victim && (AFF_FLAGGED(victim, EAffect::kGodsShield) ||
-				CalcGeneralSaving(ch, victim, savetype, modi - GetRealCon(victim) / 2))) {
+				CalcGeneralSaving(ch, victim, savetype, modi))) {
 				if (ch->in_room
 					== IN_ROOM(victim)) // Добавлено чтобы яд нанесенный SPELL_POISONED_FOG не спамил чару постоянно
 					SendMsgToChar(NOEFFECT, ch);
@@ -2496,6 +2564,51 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 			//Додати обработчик
 			break;
 		}
+		// case ESpell::kAcidArrow: {
+		// 	int rnd = number(1, 5);
+		// 	switch (rnd) {
+		// 		case 1:
+		// 		CastAffect(level, ch, victim, ESpell::kSilence); // обожгло глотку - молча
+		// 		to_room = "Кислота плеснула на горло $n1";
+		// 		to_vict = "Жуткая кислота опалила ваше горло!";
+		// 			break;
+		// 		case 2:
+		// 		CastAffect(level, ch, victim, ESpell::kFever); // телесный ожог - лихорадка
+		// 		to_room = "$n покрылся язвами по всему телу.";
+		// 		to_vict = "Кислота причинила вам жуткие ожоги кожи!";
+		// 			break;
+		// 		case 3:
+		// 		CastAffect(level, ch, victim, ESpell::kPoison); // ядовитые испарения - яд
+		// 		to_room = "$n позеленел от действия кислотной стрелы.";
+		// 		to_vict = "Кислота обожгла вам все тело!";
+		// 			break;
+		// 		case 4:
+		// 		CastAffect(level, ch, victim, ESpell::kBlindness); // обожгло глаза - слепота
+		// 		to_room = "Часть кислоты попала в глаза $n3";
+		// 		to_vict = "Кислотные испарения выедают вам глаза!";
+		// 			break;
+		// 		case 5:
+		// 		CastAffect(level, ch, victim, ESpell::kAcid); // обожглот экип - кислотой
+		// 		to_room = "Кислота покрыла доспехи $n3.";
+		// 		to_vict = "Кислота покрыла ваши доспехи.";
+		// 			break;
+		// 		default:break;
+		// 	}	
+		// 	break;
+		// }
+		// case ESpell::kClod: {
+		// 		if (GET_POS(victim) > EPosition::kSit && !IS_IMMORTAL(victim) && (number(1, 100) > GET_AR(victim)) &&
+		// 			(AFF_FLAGGED(victim, EAffect::kHold) || !CalcGeneralSaving(ch, victim, ESaving::kReflex, modi))) {
+		// 		if (IS_HORSE(victim))
+		// 			victim->drop_from_horse();
+		// 		act("$n3 придавило глыбой камня.", false, victim, nullptr, nullptr, kToRoom | kToArenaListen);
+		// 		act("Огромная глыба камня свалила вас на землю.", false, victim, nullptr, nullptr, kToChar);
+		// 		GET_POS(victim) = EPosition::kSit;
+		// 		update_pos(victim);
+		// 		SetWaitState(victim, 2 * kBattleRound);
+		// 	}
+		// 	break;
+		// }
 		case ESpell::kPaladineInspiration:
 			/*
          * групповой спелл, развешивающий рандомные аффекты, к сожалению

--- a/src/game_magic/magic.cpp
+++ b/src/game_magic/magic.cpp
@@ -301,14 +301,14 @@ float CalcModCoef(ESpell spell_id, int percent) {
 			return 1;
 			break;
 		case ESpell::kWhirlwind:
-			if (percent > 60) {
-				return (percent) / 60; // 120 -2 вихря, 180 вихря и т.д.
+			if (percent > 80) {
+				return (percent) / 80; // 160 -2 вихря, 240 - 3 вихря и т.д.
 			}
 			return 1;
 			break;
 		case ESpell::kLightingBolt:
 			if (percent > 100) {
-				return (percent - 80) / 20; // 
+				return (percent - 70) / 30; // 130 - 2 молнии, 160 -3, 190 -4
 			}
 			return 1;
 			break;
@@ -507,12 +507,12 @@ int CastDamage(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 		case ESpell::kLightingBolt: {
 				count = CalcModCoef(spell_id, ch->GetSkill(GetMagicSkillId(spell_id)));
 				count += number(1, 5)==1?1:0;
-				count = std::max(count, 4);
+				count = std::min(count, 4);
 			break;
 		}
 		case ESpell::kWhirlwind: {
 				count = CalcModCoef(spell_id, ch->GetSkill(GetMagicSkillId(spell_id)));
-				count += number(1, 5)==1?1:0;
+				count += number(1, 7)==1?1:0;
 			break;
 		}
 		case ESpell::kAcid: {

--- a/src/game_magic/magic.cpp
+++ b/src/game_magic/magic.cpp
@@ -2564,51 +2564,7 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 			//Додати обработчик
 			break;
 		}
-		// case ESpell::kAcidArrow: {
-		// 	int rnd = number(1, 5);
-		// 	switch (rnd) {
-		// 		case 1:
-		// 		CastAffect(level, ch, victim, ESpell::kSilence); // обожгло глотку - молча
-		// 		to_room = "Кислота плеснула на горло $n1";
-		// 		to_vict = "Жуткая кислота опалила ваше горло!";
-		// 			break;
-		// 		case 2:
-		// 		CastAffect(level, ch, victim, ESpell::kFever); // телесный ожог - лихорадка
-		// 		to_room = "$n покрылся язвами по всему телу.";
-		// 		to_vict = "Кислота причинила вам жуткие ожоги кожи!";
-		// 			break;
-		// 		case 3:
-		// 		CastAffect(level, ch, victim, ESpell::kPoison); // ядовитые испарения - яд
-		// 		to_room = "$n позеленел от действия кислотной стрелы.";
-		// 		to_vict = "Кислота обожгла вам все тело!";
-		// 			break;
-		// 		case 4:
-		// 		CastAffect(level, ch, victim, ESpell::kBlindness); // обожгло глаза - слепота
-		// 		to_room = "Часть кислоты попала в глаза $n3";
-		// 		to_vict = "Кислотные испарения выедают вам глаза!";
-		// 			break;
-		// 		case 5:
-		// 		CastAffect(level, ch, victim, ESpell::kAcid); // обожглот экип - кислотой
-		// 		to_room = "Кислота покрыла доспехи $n3.";
-		// 		to_vict = "Кислота покрыла ваши доспехи.";
-		// 			break;
-		// 		default:break;
-		// 	}	
-		// 	break;
-		// }
-		// case ESpell::kClod: {
-		// 		if (GET_POS(victim) > EPosition::kSit && !IS_IMMORTAL(victim) && (number(1, 100) > GET_AR(victim)) &&
-		// 			(AFF_FLAGGED(victim, EAffect::kHold) || !CalcGeneralSaving(ch, victim, ESaving::kReflex, modi))) {
-		// 		if (IS_HORSE(victim))
-		// 			victim->drop_from_horse();
-		// 		act("$n3 придавило глыбой камня.", false, victim, nullptr, nullptr, kToRoom | kToArenaListen);
-		// 		act("Огромная глыба камня свалила вас на землю.", false, victim, nullptr, nullptr, kToChar);
-		// 		GET_POS(victim) = EPosition::kSit;
-		// 		update_pos(victim);
-		// 		SetWaitState(victim, 2 * kBattleRound);
-		// 	}
-		// 	break;
-		// }
+		
 		case ESpell::kPaladineInspiration:
 			/*
          * групповой спелл, развешивающий рандомные аффекты, к сожалению


### PR DESCRIPTION
правки в заклинаниях колдуна :
"гнев богов"
>  урезан прирост урона от школы магии 
>  увеличено время мема

"глыба"
> урезан базовый урон
> увеличено время мема
> добавлена возможность сбить цель с ног

"вихрь"
> урезан базовый урон
> увеличено время мема
> слегка увеличен прирост урона от школы магии
> при высоком уровне магии возможны дополнительные вихри

"кислотная стрела"
> увеличено время мема
> слегка увеличен прирост урона от школы магии
> добавлены аффекты при успехе проходения : слепота, молчание, лихорадка, яд, кислота

"молния"
> теперь должна работать коректно ( будут возникать несколько молний до 4)
> добавлено значение "adice"

"ледяной шторм" 
> слегка увеличен урон
> увеличено время мема

"камнепад"
 > слегка увеличен урон 

"ледяной ветер"
> слегка увеличен урон
> теперь заклинание действительно массовое, до 6 целей

"ядовитый туман", "буря отмщения"
> снят флаг невозможности приминения заклинания в бою.
> установлен флаг в violent="Y
> увеличено значение угрозы для ИИ нпс

"яд"
> шанс прохождения приведен к общей формуле