### PR TITLE
issue.2005

### DIFF
--- a/src/game_fight/fight_constants.h
+++ b/src/game_fight/fight_constants.h
@@ -57,6 +57,7 @@ enum {
 	kDrawBriefAirShield,	// было отражение от воздушного щита в кратком режиме
 	kDrawBriefIceShield,	// было отражение от ледяного щита в кратком режиме
 	kDrawBriefMagMirror,	// была обратка от маг. зеркала
+	kIgnoreBlink,			// игнор мигания
 
 	kHitFlagsNum			// кол-во флагов
 };


### PR DESCRIPTION
Все стабы вора игнорируют санку и мигание.
Игнор призмы убрал.
Для игнорирования мигания введен новый флаг fight::kIgnoreBlink. в damage.process выдернул проверки на отсутствие стаба с воровским ударом, теперь там проверяются только флаги. Перенес установку флагов в hit.
Стаб наемника в сердце насмерть доступен теперь по игрокам. Для проверки успеха критстаба теперь применяется бросок на здоровье вместо бброска на реакцию. Вместо ловкости туда передается skill rate умения "заколоть". Для всех, кроме обладателей воровского удара, шанс критстаба теперь зависит только от ловки. Кажется, починил обнуление флага fight::kCritHit в одном месте. Правки по мелочи MIN/MAX на std::min и std::max.
Бонус к урону стаба от скрытого удара в hit теперь работает и по игрокам.