### PR TITLE
Removed microseconds from timestamp is syslog

### DIFF
--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -60,7 +60,7 @@ std::size_t vlog_buffer(char *buffer, const std::size_t buffer_size, const char 
 		return result;
 	}
 
-	const auto utc_now = std::chrono::system_clock::now();
+	const auto utc_now = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
 	const auto now = std::chrono::zoned_time{time_zone, utc_now};
 
 	const auto str = std::format("{:%Y-%m-%d %T}", now);


### PR DESCRIPTION
Пример лога:
```
2025-04-01 20:48:51.613 :: Code version Apr  1 2025 20:48:08, revision: 6a41adddf (Test)
2025-04-01 20:48:51.613 :: Finding player limit.
2025-04-01 20:48:51.613 :: Opening mother connection.
```