### PR TITLE
Рефакторинг аккаутов

### DIFF
--- a/src/administration/accounts.cpp
+++ b/src/administration/accounts.cpp
@@ -20,6 +20,9 @@ std::shared_ptr<Account> Account::get_account(const std::string &email) {
 	}
 	return nullptr;
 }
+
+// TODO логика никак не относится к аккаунту
+// убрать процессинг к валютам, когда они будут готовы
 int Account::zero_hryvn(CharData *ch, int val) {
 	const int zone_lvl = zone_table[world[ch->in_room]->zone_rn].mob_level;
 	for (auto &plr : this->players_list) {
@@ -146,10 +149,6 @@ void Account::read_from_file() {
 		}
 		in.close();
 	}
-}
-
-std::string Account::get_email() {
-	return this->email;
 }
 
 time_t Account::get_last_login() const {

--- a/src/administration/accounts.cpp
+++ b/src/administration/accounts.cpp
@@ -249,3 +249,8 @@ bool Account::quest_is_available(int id) {
 	}
 	return true;
 }
+
+std::string Account::email() const
+{
+	return email_;
+}

--- a/src/administration/accounts.cpp
+++ b/src/administration/accounts.cpp
@@ -14,11 +14,50 @@ std::unordered_map<std::string, std::shared_ptr<Account>> accounts;
 #define CRYPT(a, b) ((char *) crypt((a),(b)))
 #endif
 
+DQuest::DQuest()
+	: id(0)
+	, count(0)
+	, time(0)
+{
+}
+
+
+DQuest::DQuest(int id, int count, time_t time)
+	: id(id)
+	, count(count)
+	, time(time)
+{
+}
+
+LoginIndex::LoginIndex()
+	: count(0)
+	, last_login(time(0))
+{
+}
+
+LoginIndex::LoginIndex(int count, time_t last_login)
+	: count(count)
+	, last_login(last_login)
+{
+}
+
 std::shared_ptr<Account> Account::get_account(const std::string &email) {
 	if (accounts.contains(email)) {
 		return accounts[email];
 	}
 	return nullptr;
+}
+
+const std::string Account::config_parameter_daily_quest_ = "DaiQ: ";
+const std::string Account::config_parameter_password_ = "Pwd: ";
+const std::string Account::config_parameter_last_login_ = "ll: ";
+const std::string Account::config_parameter_history_login_ = "hl: ";
+
+Account::Account(const std::string &email)
+	: email_(email)
+	, last_login_(0)
+{
+	read_from_file();
 }
 
 // TODO логика никак не относится к аккаунту
@@ -47,7 +86,7 @@ int Account::zero_hryvn(CharData *ch, int val) {
 }
 
 void Account::complete_quest(int id) {
-	for (auto &x : this->dquests) {
+	for (auto &x : dquests_) {
 		if (x.id == id) {
 			x.count += 1;
 			x.time = time(nullptr);
@@ -58,7 +97,7 @@ void Account::complete_quest(int id) {
 	dq_tmp.id = id;
 	dq_tmp.count = 1;
 	dq_tmp.time = time(nullptr);
-	this->dquests.push_back(dq_tmp);
+	dquests_.push_back(dq_tmp);
 }
 
 std::vector<PlayerIndexElement> Account::all_chars_in_account() const
@@ -72,7 +111,7 @@ std::vector<PlayerIndexElement> Account::all_chars_in_account() const
 			return false;
 		}
 
-		return email.compare(pie.mail) == 0;
+		return email_.compare(pie.mail) == 0;
 	});
 
 	return result_list;
@@ -82,7 +121,7 @@ void Account::show_players(CharData *ch) {
 	int count = 1;
 	std::stringstream ss;
 	const auto &chars_in_account = all_chars_in_account();
-	ss << "Данные аккаунта: " << this->email << "\r\n";
+	ss << "Данные аккаунта: " << email_ << "\r\n";
 	for (auto &x : chars_in_account) {
 		if (!x.name()) {
 			continue;
@@ -99,7 +138,7 @@ void Account::list_players(DescriptorData *d) {
 	int count = 1;
 	std::stringstream ss;
 	const auto &chars_in_account = all_chars_in_account();
-	ss << "Данные аккаунта: " << this->email << "\r\n";
+	ss << "Данные аккаунта: " << email_ << "\r\n";
 	iosystem::write_to_output(ss.str().c_str(), d);
 	for (auto &x : chars_in_account) {
 		if (!x.name()) {
@@ -117,34 +156,41 @@ void Account::list_players(DescriptorData *d) {
 
 void Account::save_to_file() {
 	std::ofstream out;
-	out.open(LIB_ACCOUNTS + this->email);
+	out.open(LIB_ACCOUNTS + email_);
 	if (out.is_open()) {
-		for (const auto &x : this->dquests) {
-			out << "DaiQ: " << x.id << " " << x.count << " " << x.time << "\n";
+		for (const auto &x : dquests_) {
+			out << config_parameter_daily_quest_ << x.id << " " << x.count << " " << x.time << "\n";
 		}
-		for (const auto &x : this->history_logins) {
-			out << "hl: " << x.first << " " << x.second.count << " " << x.second.last_login << "\n";
+		for (const auto &x : history_logins_) {
+			out << config_parameter_history_login_ << x.first << " " << x.second.count << " " << x.second.last_login << "\n";
 		}
-		out << "Pwd: " << this->hash_password << "\n";
-		out << "ll: " << this->last_login << "\n";
+		if (hash_password_.has_value()) {
+			// пароля на аккаунте может и не быть, поэтому проверяем перед сохранением
+			out << config_parameter_password_ << hash_password_.value() << "\n";
+		}
+		out << config_parameter_last_login_ << last_login_ << "\n";
 	}
 	out.close();
 }
 
 void Account::read_from_file() {
 	std::string line;
-	std::ifstream in(LIB_ACCOUNTS + this->email);
+	std::ifstream in(LIB_ACCOUNTS + email_);
 	std::vector<std::string> tmp;
 
 	if (in.is_open()) {
 		while (getline(in, line)) {
-			tmp = utils::Split(line);
-			if (line.starts_with("DaiQ: ")) {
-				DQuest tmp_quest{};
-				tmp_quest.id = atoi(tmp[1].c_str());
-				tmp_quest.count = atoi(tmp[2].c_str());
-				tmp_quest.time = atoi(tmp[3].c_str());
-				this->dquests.push_back(tmp_quest);
+			const std::vector<std::string> splitted_line = utils::Split(line);
+			if (line.starts_with(config_parameter_daily_quest_)) {
+				const auto &read_id = atoi(tmp[1].c_str());
+				const auto &read_count = atoi(tmp[2].c_str());
+				const auto &read_time = atoi(tmp[3].c_str());
+				dquests_.emplace_back(read_id, read_count, read_time);
+			} else if (line.starts_with(config_parameter_password_)) {
+				hash_password_ = line.substr(config_parameter_password_.length());
+				if (hash_password_->empty()) {
+					hash_password_ = std::nullopt;
+				}
 			}
 		}
 		in.close();
@@ -152,35 +198,30 @@ void Account::read_from_file() {
 }
 
 time_t Account::get_last_login() const {
-	return this->last_login;
+	return last_login_;
 }
 
 void Account::set_last_login() {
-	this->last_login = time(nullptr);
-}
-
-Account::Account(const std::string &email) {
-	this->email = email;
-	this->read_from_file();
-	this->hash_password = "";
-	this->last_login = 0;
+	last_login_ = time(nullptr);
 }
 
 void Account::add_login(const std::string &ip_addr) {
-	if (this->history_logins.count(ip_addr)) {
-		this->history_logins[ip_addr].last_login = time(nullptr);
-		this->history_logins[ip_addr].count += 1;
+	if (history_logins_.count(ip_addr)) {
+		history_logins_[ip_addr].last_login = time(nullptr);
+		history_logins_[ip_addr].count += 1;
 		return;
 	}
-	login_index tmp{};
-	tmp.last_login = time(nullptr);
-	tmp.count = 1;
-	this->history_logins.insert(std::pair<std::string, login_index>(ip_addr, tmp));
+
+	const auto current_last_login = time(nullptr);
+	const int current_count = 1;
+	const LoginIndex ll{current_count, current_last_login};
+	history_logins_.insert(std::pair<std::string, LoginIndex>(ip_addr, ll));
 }
+
 /* Показ хистори логинов */
 void Account::show_history_logins(CharData *ch) {
 	std::stringstream ss;
-	for (auto &x : this->history_logins) {
+	for (auto &x : history_logins_) {
 		ss << "IP: " << x.first
 				<< " count: " << x.second.count 
 				<< " time: " << rustime(localtime(&x.second.last_login)) 
@@ -190,15 +231,15 @@ void Account::show_history_logins(CharData *ch) {
 }
 
 void Account::set_password(const std::string &password) {
-	this->hash_password = Password::generate_md5_hash(password);
+	hash_password_ = Password::generate_md5_hash(password);
 }
 
 bool Account::compare_password(const std::string &password) {
-	return CompareParam(this->hash_password, CRYPT(password.c_str(), this->hash_password.c_str()), true);
+	return hash_password_.has_value() ? (hash_password_.value(), CRYPT(password.c_str(), hash_password_->c_str()), true) : false;
 }
 
 bool Account::quest_is_available(int id) {
-	for (const auto &x : this->dquests) {
+	for (const auto &x : dquests_) {
 		if (x.id == id) {
 			if (x.time != 0 && (time(0) - x.time) < 82800) {
 				return false;

--- a/src/administration/accounts.h
+++ b/src/administration/accounts.h
@@ -72,6 +72,7 @@ public:
 	bool compare_password(const std::string &password);
 	void show_history_logins(CharData *ch);
 	void add_login(const std::string &ip_addr);
+	std::string email() const;
 
 private:
 	std::vector<PlayerIndexElement> all_chars_in_account() const;

--- a/src/administration/accounts.h
+++ b/src/administration/accounts.h
@@ -17,13 +17,25 @@
 #include <memory>
 #include <unordered_map>
 
-struct DQuest {
+class DQuest {
+public:
+	DQuest();
+	DQuest(int id, int count, time_t time);
+	virtual ~DQuest() = default;
+
+public:
 	int id;
 	int count;
 	time_t time;
 };
 
-struct login_index {
+class LoginIndex {
+public:
+	LoginIndex();
+	LoginIndex(int count, time_t last_login);
+	virtual ~LoginIndex() = default;
+
+public:
 	// количество заходов
 	int count;
 	// дата последнего захода с данного ip
@@ -31,26 +43,27 @@ struct login_index {
 };
 
 class Account {
- private:
-	std::string email;
-	std::vector<std::string> characters;
-	std::vector<DQuest> dquests;
-	std::string karma;
+private:
+	const std::string email_;
+	std::vector<DQuest> dquests_;
 	// пароль (а точнее его хеш) аккаунта
-	std::string hash_password;
+	std::optional<std::string> hash_password_;
 	// дата последнего входа в аккаунт
-	time_t last_login;
+	time_t last_login_;
 	// История логинов, ключ - айпи, в структуре количество раз, с которых был произведен заход с данного айпи-адреса + дата, когда последний раз выходили с данного айпишника
-	std::unordered_map<std::string, login_index> history_logins;
+	std::unordered_map<std::string, LoginIndex> history_logins_;
 
- public:
-	Account(const std::string &name);
+public:
+	static std::shared_ptr<Account> get_account(const std::string &email);
+	Account(const std::string &email);
+	virtual ~Account() = default;
+
+public:
 	void save_to_file();
 	void read_from_file();
 	bool quest_is_available(int id);
 	int zero_hryvn(CharData *ch, int val);
 	void complete_quest(int id);
-	static std::shared_ptr<Account> get_account(const std::string &email);
 	void show_players(CharData *ch);
 	void list_players(DescriptorData *d);
 	time_t get_last_login() const;
@@ -62,6 +75,12 @@ class Account {
 
 private:
 	std::vector<PlayerIndexElement> all_chars_in_account() const;
+
+private:
+	static const std::string config_parameter_daily_quest_;
+	static const std::string config_parameter_password_;
+	static const std::string config_parameter_last_login_;
+	static const std::string config_parameter_history_login_;
 };
 
 extern std::unordered_map<std::string, std::shared_ptr<Account>> accounts;

--- a/src/administration/accounts.h
+++ b/src/administration/accounts.h
@@ -36,8 +36,6 @@ class Account {
 	std::vector<std::string> characters;
 	std::vector<DQuest> dquests;
 	std::string karma;
-	// список чаров на мыле (только уиды)
-	std::vector<long> players_list;
 	// пароль (а точнее его хеш) аккаунта
 	std::string hash_password;
 	// дата последнего входа в аккаунт

--- a/src/administration/accounts.h
+++ b/src/administration/accounts.h
@@ -9,6 +9,7 @@
 #include "engine/structs/structs.h"
 #include "engine/entities/char_data.h"
 #include "engine/network/descriptor_data.h"
+#include "engine/db/global_objects.h"
 
 #include <string>
 #include <vector>
@@ -45,7 +46,6 @@ class Account {
 	std::unordered_map<std::string, login_index> history_logins;
 
  public:
-	void purge_erased();
 	Account(const std::string &name);
 	void save_to_file();
 	void read_from_file();
@@ -56,14 +56,15 @@ class Account {
 	static std::shared_ptr<Account> get_account(const std::string &email);
 	void show_players(CharData *ch);
 	void list_players(DescriptorData *d);
-	void add_player(long uid);
-	void remove_player(long uid);
 	time_t get_last_login() const;
 	void set_last_login();
 	void set_password(const std::string &password);
 	bool compare_password(const std::string &password);
 	void show_history_logins(CharData *ch);
 	void add_login(const std::string &ip_addr);
+
+private:
+	std::vector<PlayerIndexElement> all_chars_in_account() const;
 };
 
 extern std::unordered_map<std::string, std::shared_ptr<Account>> accounts;

--- a/src/administration/accounts.h
+++ b/src/administration/accounts.h
@@ -49,7 +49,6 @@ class Account {
 	Account(const std::string &name);
 	void save_to_file();
 	void read_from_file();
-	std::string get_email();
 	bool quest_is_available(int id);
 	int zero_hryvn(CharData *ch, int val);
 	void complete_quest(int id);

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -3196,10 +3196,6 @@ void ActualizePlayersIndex(char *name) {
 
 				log("Adding new player %s", element.name());
 				player_table.Append(element);
-			} else {
-				log("Delete %s from account email: %s",
-					GET_NAME(short_ch),
-					short_ch->get_account()->get_email().c_str());
 			}
 		} else {
 			log("SYSERR: Failed to load player %s.", name);

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -3200,7 +3200,6 @@ void ActualizePlayersIndex(char *name) {
 				log("Delete %s from account email: %s",
 					GET_NAME(short_ch),
 					short_ch->get_account()->get_email().c_str());
-				short_ch->get_account()->remove_player(short_ch->get_uid());
 			}
 		} else {
 			log("SYSERR: Failed to load player %s.", name);

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -1096,7 +1096,6 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 		this->account = temp_account;
 	}
 //	log("Add account %s player id %d  name %s", GET_EMAIL(this), this->get_uid(), name);
-	this->account->add_player(this->get_uid());
 
 	if (load_flags & ELoadCharFlags::kReboot) {
 		fbclose(fl);

--- a/src/engine/network/descriptor_data.h
+++ b/src/engine/network/descriptor_data.h
@@ -33,6 +33,8 @@ namespace  obj_sets_olc {
 	class sedit;
 }
 
+class Account;
+
 struct DescriptorData {
 	DescriptorData();
 
@@ -78,6 +80,7 @@ struct DescriptorData {
 
 	std::shared_ptr<CharData> character;    // linked to char       //
 	std::shared_ptr<CharData> original;    // original char if switched     //
+	std::shared_ptr<Account> account;      // аккаунт (при входе в игру)
 
 	DescriptorData *snooping;    // Who is this char snooping  //
 	DescriptorData *snoop_by;    // And who is snooping this char //
@@ -174,6 +177,8 @@ const __uint8_t CON_SEDIT = 54;            // sedit - редактировани
 const __uint8_t CON_RESET_RELIGION = 55;    // сброс религии из меню сброса статов
 const __uint8_t CON_RANDOM_NUMBER = 56;    // Verification code entry: where player enter the game from new location
 const __uint8_t CON_INIT = 57;                // just connected
+const __uint8_t CON_ACC_PASSWORD = 58;     // ввод пароля для аккаунта
+const __uint8_t CON_ACC_MAIN = 59;         // главное меню аккаунта
 // не забываем отражать новые состояния в connected_types -- Krodo
 
 #endif //BYLINS_SRC_STRUCTS_DESCRIPTOR_DATA_H_

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -2594,7 +2594,6 @@ void DoAfterEmailConfirm(DescriptorData *d) {
 	}
 	d->character->save_char();
 	d->character->get_account()->set_last_login();
-	d->character->get_account()->add_player(d->character->get_uid());
 
 	// добавляем в список ждущих одобрения
 	if (!(int) NAME_FINE(d->character)) {
@@ -3592,7 +3591,6 @@ void nanny(DescriptorData *d, char *argument) {
 				iosystem::write_to_output(buffer, d);
 				sprintf(buffer, "%s (lev %d) has self-deleted.", GET_NAME(d->character), GetRealLevel(d->character));
 				mudlog(buffer, NRM, kLvlGod, SYSLOG, true);
-				d->character->get_account()->remove_player(d->character->get_uid());
 				STATE(d) = CON_CLOSE;
 				return;
 			} else {

--- a/src/gameplay/core/constants.cpp
+++ b/src/gameplay/core/constants.cpp
@@ -564,7 +564,7 @@ const char *connected_types[] =
 		"GloryConst OLC",
 		"NamedStuff OLC",
 		"Select new kin",
-		// 50-57
+		// 50-59
 		"Select new race",
 		"Interactive console",
 		"обмен гривен",
@@ -573,6 +573,8 @@ const char *connected_types[] =
 		"select new religion",
 		"Verification",
 		"Just connected",
+		"Account password",
+		"Account main menu",
 		"\n"
 	};
 


### PR DESCRIPTION
 - обновлен код аккаунтов на более современный вид
 - добавлена заготовка на вход в аккаунт через имейл. проблем быть не должно т.к. паролей на аккаунтах нет и установить (на данный момент) игровым способом их нельзя
 - удален список чаров из аккаунта. т.к. это создаёт только дополнительные связи с другими модулями (что повышает сложность кода и вероятность ошибки). список чаров на аккаунте можно получить на лету, перебрав всех персонажей (т.к. имейл грузится сразу в память и дополнительно читать ничего не надо). по поводу быстродействия переживать не стоит, т.к. это простая и нечастая операция.