### PR TITLE
поправил сборку clang

### DIFF
--- a/src/engine/core/iosystem.cpp
+++ b/src/engine/core/iosystem.cpp
@@ -1078,37 +1078,37 @@ std::string MakePrompt(DescriptorData *d) {
 	auto out = fmt::memory_buffer();
 	out.reserve(kMaxPromptLength);
 	if (d->showstr_count) {
-		format_to(std::back_inserter(out),
+		fmt::format_to(std::back_inserter(out),
 				  "\rЛистать : <RETURN>, Q<К>онец, R<П>овтор, B<Н>азад, или номер страницы ({}/{}).",
 				  d->showstr_page, d->showstr_count);
 	} else if (d->writer) {
-		format_to(std::back_inserter(out), "] ");
+		fmt::format_to(std::back_inserter(out), "] ");
 	} else if (d->connected == CON_PLAYING && !ch->IsNpc()) {
 		if (GET_INVIS_LEV(ch)) {
-			format_to(std::back_inserter(out), "i{} ", GET_INVIS_LEV(ch));
+			fmt::format_to(std::back_inserter(out), "i{} ", GET_INVIS_LEV(ch));
 		}
 
 		if (ch->IsFlagged(EPrf::kDispHp)) {
-			format_to(std::back_inserter(out), "{}{}H{} ",
+			fmt::format_to(std::back_inserter(out), "{}{}H{} ",
 					  GetWarmValueColor(GET_HIT(ch), GET_REAL_MAX_HIT(ch)), GET_HIT(ch), kColorNrm);
 		}
 
 		if (ch->IsFlagged(EPrf::kDispMove)) {
-			format_to(std::back_inserter(out), "{}{}M{} ",
+			fmt::format_to(std::back_inserter(out), "{}{}M{} ",
 					  GetWarmValueColor(GET_MOVE(ch), GET_REAL_MAX_MOVE(ch)), GET_MOVE(ch), kColorNrm);
 		}
 
 		if (ch->IsFlagged(EPrf::kDispMana) && IS_MANA_CASTER(ch)) {
 			int current_mana = 100 * ch->mem_queue.stored;
-			format_to(std::back_inserter(out), "{}э{}{} ",
+			fmt::format_to(std::back_inserter(out), "{}э{}{} ",
 					  GetColdValueColor(current_mana, GET_MAX_MANA((ch).get())), ch->mem_queue.stored, kColorNrm);
 		}
 
 		if (ch->IsFlagged(EPrf::kDispExp)) {
 			if (IS_IMMORTAL(ch)) {
-				format_to(std::back_inserter(out), "??? ");
+				fmt::format_to(std::back_inserter(out), "??? ");
 			} else {
-				format_to(std::back_inserter(out), "{}o ",
+				fmt::format_to(std::back_inserter(out), "{}o ",
 						  GetExpUntilNextLvl(ch.get(), GetRealLevel(ch) + 1) - GET_EXP(ch));
 			}
 		}
@@ -1121,17 +1121,17 @@ std::string MakePrompt(DescriptorData *d) {
 					sec_hp = sec_hp*60/mana_gain;
 					int ch_hp = sec_hp/60;
 					sec_hp %= 60;
-					format_to(std::back_inserter(out), "Зауч:{}:{:02} ", ch_hp, sec_hp);
+					fmt::format_to(std::back_inserter(out), "Зауч:{}:{:02} ", ch_hp, sec_hp);
 				} else {
-					format_to(std::back_inserter(out), "Зауч:- ");
+					fmt::format_to(std::back_inserter(out), "Зауч:- ");
 				}
 			} else {
-				format_to(std::back_inserter(out), "Зауч:0 ");
+				fmt::format_to(std::back_inserter(out), "Зауч:0 ");
 			}
 		}
 
 		if (ch->IsFlagged(EPrf::kDispCooldowns)) {
-			format_to(std::back_inserter(out), "{}:{} ",
+			fmt::format_to(std::back_inserter(out), "{}:{} ",
 					  MUD::Skill(ESkill::kGlobalCooldown).GetAbbr(),
 					  ch->getSkillCooldownInPulses(ESkill::kGlobalCooldown));
 
@@ -1139,7 +1139,7 @@ std::string MakePrompt(DescriptorData *d) {
 				if (skill.IsAvailable()) {
 					int cooldown = ch->getSkillCooldownInPulses(skill.GetId());
 					if (cooldown > 0) {
-						format_to(std::back_inserter(out), "{}:{} ", skill.GetAbbr(), cooldown);
+						fmt::format_to(std::back_inserter(out), "{}:{} ", skill.GetAbbr(), cooldown);
 					}
 				}
 			}
@@ -1148,19 +1148,19 @@ std::string MakePrompt(DescriptorData *d) {
 		if (ch->IsFlagged(EPrf::kDispTimed)) {
 			for (auto timed = ch->timed; timed; timed = timed->next) {
 				if (timed->skill != ESkill::kWarcry && timed->skill != ESkill::kTurnUndead) {
-					format_to(std::back_inserter(out), "{}:{} ",
+					fmt::format_to(std::back_inserter(out), "{}:{} ",
 							  MUD::Skill(timed->skill).GetAbbr(), +timed->time);
 				}
 			}
 			if (ch->GetSkill(ESkill::kWarcry)) {
 				int wc_count = (kHoursPerDay - IsTimedBySkill(ch.get(), ESkill::kWarcry)) / kHoursPerWarcry;
-				format_to(std::back_inserter(out), "{}:{} ",
+				fmt::format_to(std::back_inserter(out), "{}:{} ",
 						  MUD::Skill(ESkill::kWarcry).GetAbbr(), wc_count);
 			}
 			if (ch->GetSkill(ESkill::kTurnUndead)) {
 				auto bonus =
 					std::max(1, kHoursPerTurnUndead + (CanUseFeat(ch.get(), EFeat::kExorcist) ? -2 : 0));
-				format_to(std::back_inserter(out), "{}:{} ",
+				fmt::format_to(std::back_inserter(out), "{}:{} ",
 						  MUD::Skill(ESkill::kTurnUndead).GetAbbr(),
 						  (kHoursPerDay - IsTimedBySkill(ch.get(), ESkill::kTurnUndead)) / bonus);
 			}
@@ -1168,41 +1168,41 @@ std::string MakePrompt(DescriptorData *d) {
 
 		if (!ch->GetEnemy() || ch->in_room != ch->GetEnemy()->in_room) {
 			if (ch->IsFlagged(EPrf::kDispLvl)) {
-				format_to(std::back_inserter(out), "{}L ", GetRealLevel(ch));
+				fmt::format_to(std::back_inserter(out), "{}L ", GetRealLevel(ch));
 			}
 
 			if (ch->IsFlagged(EPrf::kDispMoney)) {
-				format_to(std::back_inserter(out), "{}G ", ch->get_gold());
+				fmt::format_to(std::back_inserter(out), "{}G ", ch->get_gold());
 			}
 
 			if (ch->IsFlagged(EPrf::kDispExits)) {
 				static const char *dirs[] = {"С", "В", "Ю", "З", "^", "v"};
-				format_to(std::back_inserter(out), "Вых:");
+				fmt::format_to(std::back_inserter(out), "Вых:");
 				if (!AFF_FLAGGED(ch, EAffect::kBlind)) {
 					for (auto dir = 0; dir < EDirection::kMaxDirNum; ++dir) {
 						if (EXIT(ch, dir) && EXIT(ch, dir)->to_room() != kNowhere &&
 							!EXIT_FLAGGED(EXIT(ch, dir), EExitFlag::kHidden)) {
 							if (EXIT_FLAGGED(EXIT(ch, dir), EExitFlag::kClosed))
-								format_to(std::back_inserter(out), "({})", dirs[dir]);
+								fmt::format_to(std::back_inserter(out), "({})", dirs[dir]);
 							else
-								format_to(std::back_inserter(out), "{}", dirs[dir]);
+								fmt::format_to(std::back_inserter(out), "{}", dirs[dir]);
 						}
 					}
 				}
 			}
 		} else {
 			if (ch->IsFlagged(EPrf::kDispFight)) {
-				format_to(std::back_inserter(out), "{}", show_state(ch.get(), ch.get()));
+				fmt::format_to(std::back_inserter(out), "{}", show_state(ch.get(), ch.get()));
 			}
 			if (ch->GetEnemy()->GetEnemy() && ch->GetEnemy()->GetEnemy() != ch.get()) {
-				format_to(std::back_inserter(out), "{}",
+				fmt::format_to(std::back_inserter(out), "{}",
 						  show_state(ch.get(), ch->GetEnemy()->GetEnemy()));
 			}
-			format_to(std::back_inserter(out), "{}", show_state(ch.get(), ch->GetEnemy()));
+			fmt::format_to(std::back_inserter(out), "{}", show_state(ch.get(), ch->GetEnemy()));
 		};
-		format_to(std::back_inserter(out), "> ");
+		fmt::format_to(std::back_inserter(out), "> ");
 	} else if (d->connected == CON_PLAYING && ch->IsNpc()) {
-		format_to(std::back_inserter(out), "{{}}-> ", ch->get_name());
+		fmt::format_to(std::back_inserter(out), "{{}}-> ", ch->get_name());
 	}
 
 	return to_string(out);

--- a/src/engine/ui/cmd_god/do_liblist.cpp
+++ b/src/engine/ui/cmd_god/do_liblist.cpp
@@ -241,14 +241,14 @@ std::string PrintFlag(CharData *mob, const std::string &options) {
 
 	for (const auto & i : option_list) {
 		if (isname(i, "race")) {
-			format_to(std::back_inserter(out), " [раса: {}{}{} ]",
+			fmt::format_to(std::back_inserter(out), " [раса: {}{}{} ]",
 					  kColorCyn, PrintRace(mob), kColorNrm);
 		}
 		if (isname(i, "role")) {
-			format_to(std::back_inserter(out), " [роли: {}{}{} ]",
+			fmt::format_to(std::back_inserter(out), " [роли: {}{}{} ]",
 					  kColorCyn, PrintRole(mob), kColorNrm);
 		}
-		format_to(std::back_inserter(out), " [спец-проц: {}{}{} ]",
+		fmt::format_to(std::back_inserter(out), " [спец-проц: {}{}{} ]",
 				  kColorCyn, print_special(mob), kColorNrm);
 	}
 	return to_string(out);
@@ -257,23 +257,23 @@ std::string PrintFlag(CharData *mob, const std::string &options) {
 void Print(CharData *ch, int first, int last, const std::string &options) {
 	auto out = fmt::memory_buffer();
 
-	format_to(std::back_inserter(out), "Список мобов от {} до {}\r\n", first, last);
+	fmt::format_to(std::back_inserter(out), "Список мобов от {} до {}\r\n", first, last);
 	int cnt = 0;
 	for (int i = 0; i <= top_of_mobt; ++i) {
 		if (mob_index[i].vnum >= first && mob_index[i].vnum <= last) {
-			format_to(std::back_inserter(out), "{:5}. {:<45} [{:<6}] [{:<2}]{}",
+			fmt::format_to(std::back_inserter(out), "{:5}. {:<45} [{:<6}] [{:<2}]{}",
 					  ++cnt, mob_proto[i].get_name_str().substr(0, 45),
 					  mob_index[i].vnum, mob_proto[i].GetLevel(),
 					  PrintFlag(mob_proto + i, options));
 			if (!mob_proto[i].proto_script->empty()) {
-				format_to(std::back_inserter(out), " - есть скрипты -");
+				fmt::format_to(std::back_inserter(out), " - есть скрипты -");
 				for (const auto trigger_vnum : *mob_proto[i].proto_script) {
-					format_to(std::back_inserter(out), " {}", trigger_vnum);
+					fmt::format_to(std::back_inserter(out), " {}", trigger_vnum);
 				}
 			} else {
-				format_to(std::back_inserter(out), " - нет скриптов -");
+				fmt::format_to(std::back_inserter(out), " - нет скриптов -");
 			}
-			format_to(std::back_inserter(out), " Загружено в мир: {}, максимально: {}.\r\n", mob_index[i].total_online, mob_index[i].total_online);
+			fmt::format_to(std::back_inserter(out), " Загружено в мир: {}, максимально: {}.\r\n", mob_index[i].total_online, mob_index[i].total_online);
 		}
 	}
 	if (cnt == 0) {

--- a/src/gameplay/mechanics/guilds.cpp
+++ b/src/gameplay/mechanics/guilds.cpp
@@ -386,12 +386,12 @@ std::string GuildInfo::IGuildTalent::GetClassesList() const {
 		auto out = fmt::memory_buffer();
 		for (const auto class_id: trained_classes_) {
 			if (out.size()) {
-				format_to(std::back_inserter(out), ", {}", NAME_BY_ITEM(class_id));
+				fmt::format_to(std::back_inserter(out), ", {}", NAME_BY_ITEM(class_id));
 			} else {
-				format_to(std::back_inserter(out), "{}", NAME_BY_ITEM(class_id));
+				fmt::format_to(std::back_inserter(out), "{}", NAME_BY_ITEM(class_id));
 			}
 		}
-		format_to(std::back_inserter(out), ".");
+		fmt::format_to(std::back_inserter(out), ".");
 		return to_string(out);
 	} else {
 		return "all";

--- a/src/utils/grammar/cases.h
+++ b/src/utils/grammar/cases.h
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <array>
+#include <string>
 
 // \TODO Перенести список падажей в неймспейс grammar
 enum ECase {

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -919,20 +919,20 @@ std::string PrintNumberByDigits(long long num, const char separator) {
 	}
 
 	if (digits_num >= buffer.size()) {
-		format_to(std::back_inserter(out), "{}", buffer);
+		fmt::format_to(std::back_inserter(out), "{}", buffer);
 	} else {
 		auto modulo = buffer.size() % digits_num;
 		if (modulo != 0) {
-			format_to(std::back_inserter(out), "{}{}", buffer.substr(0, modulo), separator);
+			fmt::format_to(std::back_inserter(out), "{}{}", buffer.substr(0, modulo), separator);
 		}
 
 		unsigned pos = modulo;
 		while (pos < buffer.size() - digits_num) {
-			format_to(std::back_inserter(out), "{}{}", buffer.substr(pos, digits_num), separator);
+			fmt::format_to(std::back_inserter(out), "{}{}", buffer.substr(pos, digits_num), separator);
 			pos += digits_num;
 		}
 
-		format_to(std::back_inserter(out), "{}", buffer.substr(pos, digits_num));
+		fmt::format_to(std::back_inserter(out), "{}", buffer.substr(pos, digits_num));
 	}
 
 	return to_string(out);


### PR DESCRIPTION
- Убрал неоднозначность в fmt::format_to.
- Включил некоторые неявно включаемые заголовочные файлы.
- Сделал для clang в логгере альтернативную реализацию определения текущего времени с использованием ctime, так как chron::time_zone пока в llvm не поддерживается.