### PR TITLE
Fix CharData copy assignment dangling morph pointer

### DIFF
--- a/src/engine/entities/char_data.cpp
+++ b/src/engine/entities/char_data.cpp
@@ -83,6 +83,69 @@ CharData::CharData() :
 CharData::~CharData() {
 	this->purge();
 }
+
+
+CharData::CharData(const CharData &rhv) : ProtectedCharData(rhv) {
+	set_normal_morph();
+	*this = rhv;
+}
+CharData &CharData::operator=(const CharData &rhv) {
+	if (this != &rhv) {
+		// Copy base class
+		ProtectedCharData::operator=(rhv);
+
+		// Copy members
+		name_ = rhv.name_;
+		short_descr_ = rhv.short_descr_;
+		chclass_ = rhv.chclass_;
+		is_npc_ = rhv.is_npc_;
+		level_ = rhv.level_;
+		level_add_ = rhv.level_add_;
+		uid_ = rhv.uid_;
+		exp_ = rhv.exp_;
+		remorts_ = rhv.remorts_;
+		remorts_add_ = rhv.remorts_add_;
+		last_logon_ = rhv.last_logon_;
+		last_exchange_ = rhv.last_exchange_;
+		gold_ = rhv.gold_;
+		bank_gold_ = rhv.bank_gold_;
+		ruble = rhv.ruble;
+		str_ = rhv.str_;
+		str_add_ = rhv.str_add_;
+		dex_ = rhv.dex_;
+		dex_add_ = rhv.dex_add_;
+		con_ = rhv.con_;
+		con_add_ = rhv.con_add_;
+		wis_ = rhv.wis_;
+		wis_add_ = rhv.wis_add_;
+		int_ = rhv.int_;
+		int_add_ = rhv.int_add_;
+		cha_ = rhv.cha_;
+		cha_add_ = rhv.cha_add_;
+		morphs_ = rhv.morphs_;
+		role_ = rhv.role_;
+		restore_timer_ = rhv.restore_timer_;
+		count_score = rhv.count_score;
+		souls = rhv.souls;
+		skill_bonus_ = rhv.skill_bonus_;
+		type_charmice_ = rhv.type_charmice_;
+		skills = rhv.skills;
+		skills_add_ = rhv.skills_add_;
+		attackers_ = rhv.attackers_;
+		obj_bonus_ = rhv.obj_bonus_;
+		in_room = rhv.in_room;
+		player_data = rhv.player_data;
+		add_abils = rhv.add_abils;
+		real_abils = rhv.real_abils;
+		points = rhv.points;
+		char_specials = rhv.char_specials;
+		mob_specials = rhv.mob_specials;
+
+		// Fix the morph pointer: create new NormalMorph pointing to this object
+		set_normal_morph();
+	}
+	return *this;
+}
 void CharData::set_type_charmice(int type) {
 	this->type_charmice_ = type;
 }

--- a/src/engine/entities/char_data.h
+++ b/src/engine/entities/char_data.h
@@ -330,7 +330,9 @@ class CharData : public ProtectedCharData {
 	using followers_list_t = std::list<CharData *>;
 
 	CharData();
+	CharData(const CharData &rhv);
 	~CharData() override;
+    CharData &operator=(const CharData &rhv);
 
 	friend void do_mtransform(CharData *ch, char *argument, int cmd, int subcmd);
 	friend void medit_mobile_copy(CharData *dst, CharData *src);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TESTS
 		msdp.builder.cpp
 		char.affects.cpp
 		char.leaders.cpp
+		char.morph.copy.cpp
 		obj.copy.cpp
 		act.makefood.cpp
 		utils.editor.cpp

--- a/tests/char.morph.copy.cpp
+++ b/tests/char.morph.copy.cpp
@@ -1,0 +1,91 @@
+#include "engine/entities/char_data.h"
+
+#include <gtest/gtest.h>
+
+// п╒п╣я│я┌ п╫п╟ п╠п╟пЁ: п©п╬я│п╩п╣ п╨п╬п©п╦я─п╬п╡п╟п╫п╦я▐ CharData я┤п╣я─п╣п╥ operator=,
+// current_morph_->ch_ я┐п╨п╟п╥я▀п╡п╟п╣я┌ п╫п╟ я│я┌п╟я─я▀п╧ (п╡п╬п╥п╪п╬п╤п╫п╬ я┐п╢п╟п╩я▒п╫п╫я▀п╧) п╬п╠я┼п╣п╨я┌.
+// get_wis() п╡я▀п╥я▀п╡п╟п╣я┌ current_morph_->GetWis() -> ch_->GetInbornWis(),
+// я┤я┌п╬ п©я─п╦п╡п╬п╢п╦я┌ п╨ segfault п╣я│п╩п╦ п╬я─п╦пЁп╦п╫п╟п╩ я┐п╢п╟п╩я▒п╫.
+
+TEST(CHAR_MorphCopy, AssignmentOperator_MorphPointerValid)
+{
+	// п║п╬п╥п╢п╟я▒п╪ п╬я─п╦пЁп╦п╫п╟п╩я▄п╫я▀п╧ п©п╣я─я│п╬п╫п╟п╤
+	CharData original;
+	original.player_specials = std::make_shared<player_special_data>();
+	original.set_wis(15);
+
+	// п║п╬п╥п╢п╟я▒п╪ п╫п╬п╡я▀п╧ п©п╣я─я│п╬п╫п╟п╤ п╦ п╨п╬п©п╦я─я┐п╣п╪ п╡ п╫п╣пЁп╬ я┤п╣я─п╣п╥ operator=
+	CharData copy;
+	copy.player_specials = std::make_shared<player_special_data>();
+	copy = original;
+
+	// п÷п╬я│п╩п╣ п╨п╬п©п╦я─п╬п╡п╟п╫п╦я▐ get_wis() п╢п╬п╩п╤п╣п╫ я─п╟п╠п╬я┌п╟я┌я▄ п╨п╬я─я─п╣п╨я┌п╫п╬
+	// п╦ п╡п╬п╥п╡я─п╟я┴п╟я┌я▄ я│п╨п╬п©п╦я─п╬п╡п╟п╫п╫п╬п╣ п╥п╫п╟я┤п╣п╫п╦п╣
+	EXPECT_EQ(15, copy.get_wis());
+}
+
+TEST(CHAR_MorphCopy, AssignmentOperator_OriginalDeleted_CopyStillWorks)
+{
+	CharData copy;
+	copy.player_specials = std::make_shared<player_special_data>();
+
+	{
+		// п║п╬п╥п╢п╟я▒п╪ п╬я─п╦пЁп╦п╫п╟п╩ п╡ п╬я┌п╢п╣п╩я▄п╫п╬п╪ я│п╨п╬я┐п©п╣
+		CharData original;
+		original.player_specials = std::make_shared<player_special_data>();
+		original.set_wis(20);
+
+		// п п╬п©п╦я─я┐п╣п╪
+		copy = original;
+
+		// original п╠я┐п╢п╣я┌ я┐п╫п╦я┤я┌п╬п╤п╣п╫ п©я─п╦ п╡я▀я┘п╬п╢п╣ п╦п╥ я│п╨п╬я┐п©п╟
+	}
+
+	// п÷п╬я│п╩п╣ я┐п╫п╦я┤я┌п╬п╤п╣п╫п╦я▐ п╬я─п╦пЁп╦п╫п╟п╩п╟ copy.get_wis() п²п∙ п╢п╬п╩п╤п╣п╫ п©п╟п╢п╟я┌я▄
+	// п╜я┌п╬ пЁп╩п╟п╡п╫я▀п╧ я┌п╣я│я┌ п╫п╟ п╠п╟пЁ - current_morph_->ch_ п╢п╬п╩п╤п╣п╫ я┐п╨п╟п╥я▀п╡п╟я┌я▄ п╫п╟ copy, п╟ п╫п╣ п╫п╟ original
+	EXPECT_EQ(20, copy.get_wis());
+}
+
+TEST(CHAR_MorphCopy, ArrayReallocation_SimulatesMobProtoResize)
+{
+	// п║п╦п╪я┐п╩я▐я├п╦я▐ я┌п╬пЁп╬, я┤я┌п╬ п©я─п╬п╦я│я┘п╬п╢п╦я┌ п╡ medit.cpp п©я─п╦ п╢п╬п╠п╟п╡п╩п╣п╫п╦п╦ п╫п╬п╡п╬пЁп╬ п╪п╬п╠п╟:
+	// 1. п║п╬п╥п╢п╟я▒я┌я│я▐ п╫п╬п╡я▀п╧ п╪п╟я│я│п╦п╡
+	// 2. п п╬п©п╦я─я┐я▌я┌я│я▐ я█п╩п╣п╪п╣п╫я┌я▀ п╦п╥ я│я┌п╟я─п╬пЁп╬
+	// 3. п║я┌п╟я─я▀п╧ п╪п╟я│я│п╦п╡ я┐п╢п╟п╩я▐п╣я┌я│я▐
+	// 4. п·п╠я─п╟я┴п╣п╫п╦п╣ п╨ я█п╩п╣п╪п╣п╫я┌п╟п╪ п╫п╬п╡п╬пЁп╬ п╪п╟я│я│п╦п╡п╟
+
+	const int OLD_SIZE = 3;
+	const int NEW_SIZE = 4;
+
+	// "п║я┌п╟я─я▀п╧" п╪п╟я│я│п╦п╡ (я│п╦п╪я┐п╩я▐я├п╦я▐ mob_proto)
+	CharData* old_array = new CharData[OLD_SIZE];
+	for (int i = 0; i < OLD_SIZE; ++i) {
+		old_array[i].player_specials = std::make_shared<player_special_data>();
+		old_array[i].set_wis(10 + i);
+	}
+
+	// "п²п╬п╡я▀п╧" п╪п╟я│я│п╦п╡
+	CharData* new_array = new CharData[NEW_SIZE];
+	for (int i = 0; i < NEW_SIZE; ++i) {
+		new_array[i].player_specials = std::make_shared<player_special_data>();
+	}
+
+	// п п╬п©п╦я─я┐п╣п╪ я█п╩п╣п╪п╣п╫я┌я▀ (п╨п╟п╨ п╡ medit.cpp я│я┌я─п╬п╨п╦ 413, 418)
+	for (int i = 0; i < OLD_SIZE; ++i) {
+		new_array[i] = old_array[i];
+	}
+
+	// пёп╢п╟п╩я▐п╣п╪ я│я┌п╟я─я▀п╧ п╪п╟я│я│п╦п╡ (п╨п╟п╨ п╡ medit.cpp я│я┌я─п╬п╨п╟ 437)
+	delete[] old_array;
+	old_array = nullptr;
+
+	// п╒п╣п©п╣я─я▄ п╬п╠я─п╟я┴п╟п╣п╪я│я▐ п╨ get_wis() п╫п╟ я█п╩п╣п╪п╣п╫я┌п╟я┘ п╫п╬п╡п╬пЁп╬ п╪п╟я│я│п╦п╡п╟
+	// п╜я┌п╬ п╢п╬п╩п╤п╫п╬ я─п╟п╠п╬я┌п╟я┌я▄, п╟ п╫п╣ п©п╟п╢п╟я┌я▄ я│ segfault
+	for (int i = 0; i < OLD_SIZE; ++i) {
+		EXPECT_EQ(10 + i, new_array[i].get_wis());
+	}
+
+	delete[] new_array;
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
When CharData was copied via operator=, the NormalMorph::ch_ pointer was not updated to point to the new object, causing segfault when accessing methods like get_wis() after the original was deleted.

Added explicit copy constructor and operator= that properly reinitialize the morph pointer via set_normal_morph() after copying data.

Added test char.morph.copy.cpp to verify the fix.