### PR TITLE
fix: print stack trace to syslog on SIGSEGV/SIGBUS crash

### DIFF
--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -57,6 +57,7 @@
 #include "utils_char_obj.inl"
 #include "utils/id_converter.h"
 #include "utils/logger.h"
+#include "utils/backtrace.h"
 #include "engine/network/msdp/msdp.h"
 #include "engine/network/msdp/msdp_constants.h"
 #include "engine/entities/zone.h"
@@ -1988,6 +1989,7 @@ RETSIGTYPE reap(int/* sig*/) {
 
 RETSIGTYPE crash_handle(int/* sig*/) {
 	log("Crash detected !");
+	debug::backtrace(runtime_config.logs(SYSLOG).handle());
 	// Сливаем файловые буферы.
 	fflush(stdout);
 	fflush(stderr);


### PR DESCRIPTION
## Summary

- `debug::backtrace()` уже используется в 26 местах кода, но не вызывалась из `crash_handle()`
- Добавлен вызов сразу после `log("Crash detected !")`, до сброса буферов
- Трейс пишется в syslog через `runtime_config.logs(SYSLOG).handle()`

## Как это работает

При получении SIGSEGV/SIGBUS сигнал-хендлер запускается поверх стека места краша. Поэтому `backtrace()` внутри хендлера захватывает полный стек, включая фрейм с упавшим кодом.

## Release build

Работает в продакшн-сборке:
- `-O0` — нет инлайнинга, все фреймы присутствуют
- `-rdynamic` — имена функций видны без `addr2line`

## Изменения

`src/engine/core/comm.cpp`:
- `#include "utils/backtrace.h"` 
- `debug::backtrace(runtime_config.logs(SYSLOG).handle())` в `crash_handle()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)