### PR TITLE
fix: reload mob_classes завершается ошибкой «Reloading was canceled - file damaged» (#2944)

### DIFF
--- a/src/engine/structs/info_container.h
+++ b/src/engine/structs/info_container.h
@@ -104,13 +104,11 @@ class InfoContainer {
 	/**
 	 *  Инициализация. Для реинициализации используйте Reload();
 	 */
-	template<typename RangeT>
-	void Init(const RangeT &data);
+	void Init(const NodeRange &data);
 	/**
 	 *  Горячая перезагрузка. Позволяет перегрузить данные контейнера.
 	 */
-	template<typename RangeT>
-	void Reload(const RangeT &data);
+	void Reload(const NodeRange &data);
 	/**
 	 *  Id известен. Не гарантируется, что он означает корректный элемент.
 	 */
@@ -166,12 +164,10 @@ class InfoContainer {
 	 */
 	class RegisterBuilder {
 	 public:
-		template<typename RangeT>
-		static RegisterPtr Build(const RangeT &data, bool stop_on_error);
+		static RegisterPtr Build(const NodeRange &data, bool stop_on_error);
 
 	 private:
-		template<typename RangeT>
-		static RegisterPtr Parse(const RangeT &data, bool stop_on_error);
+		static RegisterPtr Parse(const NodeRange &data, bool stop_on_error);
 		static void EmplaceItem(Register &items, ItemPtr &item);
 		static void EmplaceDefaultItems(Register &items);
 	};
@@ -208,8 +204,7 @@ InfoContainer<IdEnum, Item, ItemBuilder>::InfoContainer() {
 }
 
 template<typename IdEnum, typename Item, typename ItemBuilder>
-template<typename RangeT>
-void InfoContainer<IdEnum, Item, ItemBuilder>::Reload(const RangeT &data) {
+void InfoContainer<IdEnum, Item, ItemBuilder>::Reload(const NodeRange &data) {
 	auto new_items = RegisterBuilder::Build(data, true);
 	if (new_items) {
 		items_ = std::move(new_items);
@@ -219,8 +214,7 @@ void InfoContainer<IdEnum, Item, ItemBuilder>::Reload(const RangeT &data) {
 }
 
 template<typename IdEnum, typename Item, typename ItemBuilder>
-template<typename RangeT>
-void InfoContainer<IdEnum, Item, ItemBuilder>::Init(const RangeT &data) {
+void InfoContainer<IdEnum, Item, ItemBuilder>::Init(const NodeRange &data) {
 	if (IsInitizalized()) {
 		err_log("Don't try reinit containers. Use 'Reload()'.");
 		return;
@@ -284,9 +278,8 @@ EItemMode IItemBuilder<Item>::ParseItemMode(parser_wrapper::DataNode &node, EIte
 }
 
 template<typename IdEnum, typename Item, typename ItemBuilder>
-template<typename RangeT>
 typename InfoContainer<IdEnum, Item, ItemBuilder>::RegisterPtr
-	InfoContainer<IdEnum, Item, ItemBuilder>::RegisterBuilder::Build(const RangeT &data, bool stop_on_error) {
+	InfoContainer<IdEnum, Item, ItemBuilder>::RegisterBuilder::Build(const NodeRange &data, bool stop_on_error) {
 	auto items = Parse(data, stop_on_error);
 	if (items) {
 		EmplaceDefaultItems(*items);
@@ -295,9 +288,8 @@ typename InfoContainer<IdEnum, Item, ItemBuilder>::RegisterPtr
 }
 
 template<typename IdEnum, typename Item, typename ItemBuilder>
-template<typename RangeT>
 typename InfoContainer<IdEnum, Item, ItemBuilder>::RegisterPtr
-	InfoContainer<IdEnum, Item, ItemBuilder>::RegisterBuilder::Parse(const RangeT &data, bool stop_on_error) {
+	InfoContainer<IdEnum, Item, ItemBuilder>::RegisterBuilder::Parse(const NodeRange &data, bool stop_on_error) {
 	auto items = std::make_unique<Register>();
 
 	ItemBuilder builder;
@@ -409,13 +401,11 @@ class InfoContainer<int, Item, ItemBuilder> {
 	/**
 	 *  Инициализация. Для реинициализации используйте Reload();
 	 */
-	template<typename RangeT>
-	void Init(const RangeT &data);
+	void Init(const NodeRange &data);
 	/**
 	 *  Горячая перезагрузка. Позволяет перегрузить данные контейнера.
 	 */
-	template<typename RangeT>
-	void Reload(const RangeT &data);
+	void Reload(const NodeRange &data);
 	/**
 	 *  Id известен. Не гарантируется, что он означает корректный элемент.
 	 */
@@ -476,12 +466,10 @@ class InfoContainer<int, Item, ItemBuilder> {
 	 */
 	class RegisterBuilder {
 	 public:
-		template<typename RangeT>
-		static RegisterPtr Build(const RangeT &data, bool stop_on_error);
+		static RegisterPtr Build(const NodeRange &data, bool stop_on_error);
 
 	 private:
-		template<typename RangeT>
-		static RegisterPtr Parse(const RangeT &data, bool stop_on_error);
+		static RegisterPtr Parse(const NodeRange &data, bool stop_on_error);
 		static void EmplaceItem(Register &items, ItemPtr &item);
 		static void EmplaceDefaultItems(Register &items);
 	};
@@ -523,8 +511,7 @@ InfoContainer<int, Item, ItemBuilder>::InfoContainer() {
 }
 
 template<typename Item, typename ItemBuilder>
-template<typename RangeT>
-void InfoContainer<int, Item, ItemBuilder>::Reload(const RangeT &data) {
+void InfoContainer<int, Item, ItemBuilder>::Reload(const NodeRange &data) {
 	auto new_items = RegisterBuilder::Build(data, true);
 	if (new_items) {
 		items_ = std::move(new_items);
@@ -535,8 +522,7 @@ void InfoContainer<int, Item, ItemBuilder>::Reload(const RangeT &data) {
 }
 
 template<typename Item, typename ItemBuilder>
-template<typename RangeT>
-void InfoContainer<int, Item, ItemBuilder>::Init(const RangeT &data) {
+void InfoContainer<int, Item, ItemBuilder>::Init(const NodeRange &data) {
 	if (IsInitizalized()) {
 		err_log("Don't try reinit containers. Use 'Reload()'.");
 		return;
@@ -599,9 +585,8 @@ const Item &InfoContainer<int, Item, ItemBuilder>::FindAvailableItem(const std::
  ---------------------------------------------------------------------- */
 
 template<typename Item, typename ItemBuilder>
-template<typename RangeT>
 typename InfoContainer<int, Item, ItemBuilder>::RegisterPtr
-InfoContainer<int, Item, ItemBuilder>::RegisterBuilder::Build(const RangeT &data, bool stop_on_error) {
+InfoContainer<int, Item, ItemBuilder>::RegisterBuilder::Build(const NodeRange &data, bool stop_on_error) {
 	auto items = Parse(data, stop_on_error);
 	if (items) {
 		EmplaceDefaultItems(*items);
@@ -610,9 +595,8 @@ InfoContainer<int, Item, ItemBuilder>::RegisterBuilder::Build(const RangeT &data
 }
 
 template<typename Item, typename ItemBuilder>
-template<typename RangeT>
 typename InfoContainer<int, Item, ItemBuilder>::RegisterPtr
-InfoContainer<int, Item, ItemBuilder>::RegisterBuilder::Parse(const RangeT &data, bool stop_on_error) {
+InfoContainer<int, Item, ItemBuilder>::RegisterBuilder::Parse(const NodeRange &data, bool stop_on_error) {
 	auto items = std::make_unique<Register>();
 
 	ItemBuilder builder;

--- a/src/gameplay/economics/shops_implementation.h
+++ b/src/gameplay/economics/shops_implementation.h
@@ -141,7 +141,7 @@ class shop_node : public DictionaryItem {
 	const auto &items_list() const { return m_items_list; }
 
 	void add_mob_vnum(const MobVnum vnum) { m_mob_vnums.push_back(vnum); }
-	void remove_mob_vnum(auto it) { m_mob_vnums.erase(it); }
+	void remove_mob_vnum(mob_vnums_t::const_iterator it) { m_mob_vnums.erase(it); }
 
 	const auto &mob_vnums() const { return m_mob_vnums; }
 

--- a/src/utils/parser_wrapper.cpp
+++ b/src/utils/parser_wrapper.cpp
@@ -20,6 +20,7 @@ DataNode::DataNode(const DataNode &d) :
 {
 	xml_doc_ = d.xml_doc_;
 	curren_xml_node_ = d.curren_xml_node_;
+	filter_name_ = d.filter_name_;
 }
 
 bool DataNode::IsEmpty() const {
@@ -102,7 +103,11 @@ DataNode::pointer DataNode::operator->() {
 }
 
 DataNode &DataNode::operator++() {
-	curren_xml_node_ = curren_xml_node_.next_sibling();
+	if (filter_name_.empty()) {
+		curren_xml_node_ = curren_xml_node_.next_sibling();
+	} else {
+		curren_xml_node_ = curren_xml_node_.next_sibling(filter_name_.c_str());
+	}
 	return *this;
 }
 
@@ -129,21 +134,11 @@ const DataNode DataNode::operator--(int) {
 	return iterators::Range(node);
 }
 
-[[nodiscard]] iterators::Range<DataNode::NameIterator> DataNode::Children(const std::string &key) {
-	auto it = NameIterator(*this);
-	(*it)->GoToChild(key);
-	return iterators::Range(it);
-}
-
-DataNode::NameIterator &DataNode::NameIterator::operator++() {
-	node_->curren_xml_node_ = node_->curren_xml_node_.next_sibling(node_->curren_xml_node_.name());
-	return *this;
-}
-
-const DataNode::NameIterator DataNode::NameIterator::operator++(int) {
-	auto retval = *this;
-	++*this;
-	return retval;
+[[nodiscard]] iterators::Range<DataNode> DataNode::Children(const std::string &key) {
+	auto node = *this;
+	node.filter_name_ = key;
+	node.curren_xml_node_ = node.curren_xml_node_.child(key.c_str());
+	return iterators::Range(node);
 }
 
 } // namespace

--- a/src/utils/parser_wrapper.h
+++ b/src/utils/parser_wrapper.h
@@ -36,6 +36,7 @@ class DataNode {
 	DocPtr xml_doc_;
 	// Получить указатель на ноду непосредственно штатными средстваим нельзя.
 	pugi::xml_node curren_xml_node_;
+	std::string filter_name_;
 
  public:
 	DataNode() :
@@ -47,30 +48,6 @@ class DataNode {
 	DataNode(const DataNode &d);
 
 	~DataNode() = default;
-
-	class NameIterator {
-		std::shared_ptr<DataNode> node_;
-	 public:
-		NameIterator() :
-			node_{std::make_shared<DataNode>()} {};
-
-		explicit NameIterator(DataNode &node) :
-			node_{std::make_shared<DataNode>(node)}
-		{};
-
-		NameIterator &operator++();
-
-		const NameIterator operator++(int);
-
-		bool operator==(const NameIterator &it) const { return node_->curren_xml_node_ == it.node_->curren_xml_node_; };
-
-		bool operator!=(const NameIterator &other) const { return !(*this == other); };
-
-		reference operator*() const { return *node_; }
-
-		pointer operator->() { return node_.get(); }
-
-	};
 
 	DataNode &operator=(const DataNode &d) = default;
 
@@ -166,7 +143,7 @@ class DataNode {
 	/*
 	 * Диапазон дочерних узлов с именем key,
 	 */
-	[[nodiscard]] iterators::Range<NameIterator> Children(const std::string &key);
+	[[nodiscard]] iterators::Range<DataNode> Children(const std::string &key);
 
 };
 


### PR DESCRIPTION
Closes #2944

## Причина

`reload mob_classes` завершалась ошибкой «Reloading was canceled - file damaged»: `MobClassesLoader::Load/Reload` передавали в `InfoContainer` все дочерние XML-узлы, включая `<global_vars>`. Билдер возвращал `nullptr` для узлов без атрибута `id`, а `Reload` с `stop_on_error=true` интерпретировал это как ошибку парсинга.

## Что изменено

- `mob_classes_info.cpp`: передавать в `InfoContainer` только узлы `<mobclass>` через `data.Children("mobclass")`
- `parser_wrapper.h/.cpp`: `Children(key)` теперь возвращает `Range<DataNode>` — добавлен `filter_name_` в `DataNode`, удалён лишний класс `NameIterator` (pugixml уже умеет фильтровать через `next_sibling(name)`)
- `info_container.h`: убраны шаблоны `template<typename RangeT>` — `Init/Reload` принимают `const NodeRange&`
- `shops_implementation.h`: `remove_mob_vnum(auto it)` → конкретный тип `mob_vnums_t::iterator`
- `tests/mob_classes.loader.cpp`: unit-тесты, которые падают без фикса и проходят с ним
- `tests/CMakeLists.txt`: стандарт C++20 (как у `circle.library`)