### PR TITLE
build: replace hardcoded gold linker with LINKER cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -939,8 +939,9 @@ set(CMAKE_EXE_LINKER_FLAGS_RELEASE "")
 set(CMAKE_EXE_LINKER_FLAGS_TEST "")
 set(CMAKE_EXE_LINKER_FLAGS_FASTTEST "")
 
-if (UNIX AND NOT APPLE AND NOT CYGWIN)
-	add_link_options(-fuse-ld=gold)
+set(LINKER "" CACHE STRING "Linker to use: gold, mold, lld, bfd, or empty for system default")
+if (LINKER AND UNIX AND NOT APPLE AND NOT CYGWIN)
+	add_link_options(-fuse-ld=${LINKER})
 endif ()
 
 ## Look for required components


### PR DESCRIPTION
Closes #2949

## Изменение

Заменяет захардкоженный `gold` линкер на CMake-опцию `LINKER`:

```cmake
set(LINKER "" CACHE STRING "Linker to use: gold, mold, lld, bfd, or empty for system default")
if (LINKER AND UNIX AND NOT APPLE AND NOT CYGWIN)
    add_link_options(-fuse-ld=${LINKER})
endif ()
```

## Использование

```bash
cmake -DLINKER=gold ..   # gold (прежнее поведение)
cmake -DLINKER=mold ..   # mold
cmake -DLINKER=lld  ..   # lld
cmake ..                 # системный линкер по умолчанию
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)