### PR TITLE
fix: admin API skips zone with vnum=1 and undercounts zones in stats

### DIFF
--- a/src/engine/network/admin_api/crud_handlers.cpp
+++ b/src/engine/network/admin_api/crud_handlers.cpp
@@ -172,7 +172,7 @@ void HandleListZones(DescriptorData* d)
 	response["status"] = "ok";
 	response["zones"] = json::array();
 
-	for (ZoneRnum zrn = 1; zrn < static_cast<ZoneRnum>(zone_table.size()); ++zrn)
+	for (ZoneRnum zrn = 0; zrn < static_cast<ZoneRnum>(zone_table.size()); ++zrn)
 	{
 		const ZoneData &zone = zone_table[zrn];
 		json zone_obj;
@@ -845,8 +845,8 @@ void HandleGetStats(DescriptorData* d)
 	json response;
 	response["status"] = "ok";
 
-	// Count zones (skip zone_table[0])
-	response["zones"] = zone_table.size() - 1;
+	// Count zones
+	response["zones"] = zone_table.size();
 
 	// Count mobs
 	response["mobs"] = top_of_mobt + 1;


### PR DESCRIPTION
Closes #2951

## Изменение

Исправлены два места в `crud_handlers.cpp`, унаследовавшие предположение о зарезервированном `zone_table[0]`.

**`HandleListZones`** — итерация начиналась с `zrn = 1`:
```cpp
// было:
for (ZoneRnum zrn = 1; ...)
// стало:
for (ZoneRnum zrn = 0; ...)
```

**`HandleGetStats`** — возвращало `size - 1`:
```cpp
// было:
response["zones"] = zone_table.size() - 1;
// стало:
response["zones"] = zone_table.size();
```

## Проверка

Проверено на большом YAML-мире (`~/repos/world.yaml/`): зона vnum=1 теперь отображается в списке, счётчик зон корректен.

🤖 Generated with [Claude Code](https://claude.com/claude-code)