### PR TITLE
fix: краш при сбросе зоны в команде F (issue #2958)

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -2465,7 +2465,15 @@ void ZoneReset::ResetZoneEssential() {
 						}
 
 						if (leader) {
-							for (const auto ch : world[reset_cmd.arg1]->people) {
+							// Snapshot people list to avoid iterator invalidation:
+							// stop_follower/add_follower trigger act() -> act_mtrigger -> DG scripts
+							// which may extract characters and remove them from the people list.
+							std::vector<CharData *> people_snapshot(world[reset_cmd.arg1]->people.begin(),
+								world[reset_cmd.arg1]->people.end());
+							for (const auto ch : people_snapshot) {
+								if (ch->purged() || ch->in_room == kNowhere) {
+									continue;
+								}
 								if (ch->IsNpc()
 									&& GET_MOB_RNUM(ch) == reset_cmd.arg3
 									&& leader != ch
@@ -2473,7 +2481,9 @@ void ZoneReset::ResetZoneEssential() {
 									if (ch->has_master()) {
 										stop_follower(ch, kSfEmpty);
 									}
-
+									if (ch->purged() || ch->in_room == kNowhere) {
+										continue;
+									}
 									leader->add_follower(ch);
 
 									curr_state = 1;


### PR DESCRIPTION
## Причина краша

В `ZoneReset::ResetZoneEssential`, команда `'F'` (Follow mobiles), итерировала `world[room]->people` (`std::list<CharData*>`). Внутри цикла вызывались `stop_follower()` и `add_follower()`, которые через `act()` → `act_mtrigger` могли запускать DG-скрипты. Эти скрипты могли экстрактить персонажа, удаляя его из `people`. Это инвалидировало итератор текущего элемента — на следующей итерации `++__begin` читал мусор из освобождённого узла списка (`0x20` → краш в `IsNpc()`).

Цепочка из лога:
1. 'Q'-команды экстрактят старых мобов зоны 804
2. 'F'-команда запускает цикл по `people`
3. `stop_follower(ch, kSfEmpty)` → `act()` → `act_mtrigger` → DG-скрипт экстрактит `ch`
4. `add_follower(ch)` → `act()` видит `ch->in_room == kNowhere` → `"No valid target to act('$n начал$g следовать за $N4.')"`
5. Цикл читает `next` из освобождённого узла → `this=0x20` в `IsNpc()` → краш

## Фикс

- Снепшот `people` в `std::vector` до начала итерации
- Проверка `ch->purged() || ch->in_room == kNowhere` перед началом обработки и после `stop_follower`

Closes #2958