### PR TITLE
fix: skip charmice mobs in F-command during zone reset (#2958)

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -2470,6 +2470,9 @@ void ZoneReset::ResetZoneEssential() {
 									&& GET_MOB_RNUM(ch) == reset_cmd.arg3
 									&& leader != ch
 									&& !ch->makes_loop(leader)) {
+									if (IS_CHARMICE(ch)) {
+										continue;
+									}
 									if (ch->has_master()) {
 										stop_follower(ch, kSfEmpty);
 									}


### PR DESCRIPTION
F-command iterates room->people to set up mob following. When it finds a charmice (e.g. player-raised undead) by VNUM, stop_follower() extracts it via ExtractCharFromWorld, which removes the mob from room->people during iteration — invalidating the iterator and causing a crash (this=0x20 in IsNpc()).

Skip charmice mobs in F-command to prevent the crash.