### PR TITLE
fix: memory leak - missing free for pgcurse and punreg punishment rea…

### DIFF
--- a/src/engine/entities/char_data.cpp
+++ b/src/engine/entities/char_data.cpp
@@ -461,6 +461,10 @@ void CharData::purge() {
 			free(FREEZE_REASON(this));
 		if (NAME_REASON(this))
 			free(NAME_REASON(this));
+		if (GCURSE_REASON(this))
+			free(GCURSE_REASON(this));
+		if (UNREG_REASON(this))
+			free(UNREG_REASON(this));
 // End reasons cleanup
 
 		if (KARMA(this))


### PR DESCRIPTION
…sons (#2978)

CharData::purge() freed 5 of 7 punishment reasons but missed pgcurse and punreg, leaking their reason strings on every Player destruction.