### PR TITLE
fix: memory leak in Logon.ip - replace char* with std::string (#2978)

### DIFF
--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -1505,7 +1505,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 						fbgetline(fl, line);
 						sscanf(line, "%s %ld %ld", &buf[0], &lnum, &lnum2);
 						if (buf[0] != '~') {
-							const network::Logon cur_log = {str_dup(buf), lnum, lnum2, false};
+							const network::Logon cur_log = {buf, lnum, lnum2, false};
 							LOGON_LIST(this).push_back(cur_log);
 						} else break;
 					} while (true);

--- a/src/engine/network/logon.cpp
+++ b/src/engine/network/logon.cpp
@@ -20,11 +20,11 @@ void add_logon_record(DescriptorData *d) {
 
 	const auto logon = std::find_if(LOGON_LIST(d->character).begin(), LOGON_LIST(d->character).end(),
 									[&](const Logon &l) -> bool {
-									  return !strcmp(l.ip, d->host);
+									  return l.ip == d->host;
 									});
 
 	if (logon == LOGON_LIST(d->character).end()) {
-		const Logon cur_log = {str_dup(d->host), 1, time(nullptr), false};
+		const Logon cur_log = {d->host, 1, time(nullptr), false};
 		LOGON_LIST(d->character).push_back(cur_log);
 	} else {
 		++logon->count;

--- a/src/engine/network/logon.h
+++ b/src/engine/network/logon.h
@@ -9,6 +9,7 @@
 #define BYLINS_SRC_ENGINE_NETWORK_LOGON_H_
 
 #include <ctime>
+#include <string>
 #include <vector>
 
 struct DescriptorData;
@@ -16,7 +17,7 @@ struct DescriptorData;
 namespace network {
 
 struct Logon {
-  char *ip;
+  std::string ip;
   long count;
   time_t lasttime;
   bool is_first;

--- a/src/engine/ui/cmd_god/do_inspect.cpp
+++ b/src/engine/ui/cmd_god/do_inspect.cpp
@@ -479,7 +479,7 @@ class InspectRequestAll : public InspectRequest {
   std::ostringstream current_char_intercesting_logons_;
 
   void NoteVictimInfo(const CharData::shared_ptr &vict);
-  bool IsIpMatched(const char *ip);
+  bool IsIpMatched(const std::string &ip);
   bool IsLogonsIntersect(const CharData::shared_ptr &player);
   void NoteLogonInfo(const network::Logon &logon);
   void FlushLogonsBufferToReportGenerator();
@@ -514,7 +514,7 @@ void InspectRequestAll::NoteVictimInfo(const CharData::shared_ptr &vict) {
 												  kColorNrm));
 	vict_uid_ = vict->get_uid();
 	for (const auto &logon : LOGON_LIST(vict)) {
-		if (logon.ip && !kIgnoredIpChecklist.contains(logon.ip)) {
+		if (!logon.ip.empty() && !kIgnoredIpChecklist.contains(logon.ip)) {
 			victim_ip_log_.insert(logon.ip);
 		}
 	}
@@ -563,8 +563,8 @@ bool InspectRequestAll::IsLogonsIntersect(const CharData::shared_ptr &player) {
 	return result;
 }
 
-bool InspectRequestAll::IsIpMatched(const char *ip) {
-	return (ip && !kIgnoredIpChecklist.contains(ip) && victim_ip_log_.contains(ip));
+bool InspectRequestAll::IsIpMatched(const std::string &ip) {
+	return (!ip.empty() && !kIgnoredIpChecklist.contains(ip) && victim_ip_log_.contains(ip));
 }
 
 void InspectRequestAll::NoteLogonInfo(const network::Logon &logon) {

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -81,7 +81,7 @@ void do_statip(CharData *ch, CharData *k) {
 		for (const auto &logon : LOGON_LIST(k)) {
 			sprintf(buf1,
 					"%16s %5ld %20s%s\r\n",
-					logon.ip,
+					logon.ip.c_str(),
 					logon.count,
 					rustime(localtime(&logon.lasttime)),
 					logon.is_first ? " (создание)" : "");

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -2239,7 +2239,7 @@ void DoAfterPassword(DescriptorData *d) {
 
 	const uint32_t MASK = 16777215;
 	for (const auto &logon : LOGON_LIST(d->character)) {
-		uint32_t current_subnet = inet_addr(logon.ip) & MASK;
+		uint32_t current_subnet = inet_addr(logon.ip.c_str()) & MASK;
 		subnets.insert(current_subnet);
 	}
 


### PR DESCRIPTION
Logon.ip was allocated via str_dup() but never freed when the logon list was cleared in CharData::purge(). Every temporary Player load (e.g. inspect all) leaked all IP strings from the logon list.

Replace char* ip with std::string ip in network::Logon struct so memory is managed automatically via RAII.