### PR TITLE
fix: memory leak in do_set_all - missing delete before continue (#2978)

### DIFF
--- a/src/engine/ui/cmd_god/do_set_all.cpp
+++ b/src/engine/ui/cmd_god/do_set_all.cpp
@@ -65,6 +65,7 @@ void setall_inspect() {
 						if (GetRealLevel(d_vict->character) >= kLvlGod) {
 							sprintf(buf1, "Персонаж %s бессмертный!\r\n", player_table[it->second->pos].name().c_str());
 							it->second->out += buf1;
+							delete vict;
 							continue;
 						}
 						punishments::SetFreeze(imm_d->character.get(),
@@ -82,6 +83,7 @@ void setall_inspect() {
 							if (GetRealLevel(vict) >= kLvlGod) {
 								sprintf(buf1, "Персонаж %s бессмертный!\r\n", player_table[it->second->pos].name().c_str());
 								it->second->out += buf1;
+								delete vict;
 								continue;
 							}
 							punishments::SetFreeze(imm_d->character.get(),
@@ -96,6 +98,7 @@ void setall_inspect() {
 						if (GetRealLevel(d_vict->character) >= kLvlGod) {
 							sprintf(buf1, "Персонаж %s бессмертный!\r\n", player_table[it->second->pos].name().c_str());
 							it->second->out += buf1;
+							delete vict;
 							continue;
 						}
 						strncpy(GET_EMAIL(d_vict->character), it->second->newmail, 127);
@@ -118,6 +121,7 @@ void setall_inspect() {
 						} else {
 							if (GetRealLevel(vict) >= kLvlGod) {
 								it->second->out += buf1;
+								delete vict;
 								continue;
 							}
 							strncpy(GET_EMAIL(vict), it->second->newmail, 127);
@@ -137,6 +141,7 @@ void setall_inspect() {
 						if (GetRealLevel(d_vict->character) >= kLvlGod) {
 							sprintf(buf1, "Персонаж %s бессмертный!\r\n", player_table[it->second->pos].name().c_str());
 							it->second->out += buf1;
+							delete vict;
 							continue;
 						}
 						Password::set_password(d_vict->character.get(), std::string(it->second->pwd));
@@ -156,6 +161,7 @@ void setall_inspect() {
 						if (GetRealLevel(vict) >= kLvlGod) {
 							sprintf(buf1, "Персонаж %s бессмертный!\r\n", player_table[it->second->pos].name().c_str());
 							it->second->out += buf1;
+							delete vict;
 							continue;
 						}
 						Password::set_password(vict, std::string(it->second->pwd));
@@ -173,6 +179,7 @@ void setall_inspect() {
 						if (GetRealLevel(d_vict->character) >= kLvlGod) {
 							sprintf(buf1, "Персонаж %s бессмертный!\r\n", player_table[it->second->pos].name().c_str());
 							it->second->out += buf1;
+							delete vict;
 							continue;
 						}
 						punishments::SetHell(imm_d->character.get(),
@@ -190,6 +197,7 @@ void setall_inspect() {
 							if (GetRealLevel(vict) >= kLvlGod) {
 								sprintf(buf1, "Персонаж %s бессмертный!\r\n", player_table[it->second->pos].name().c_str());
 								it->second->out += buf1;
+								delete vict;
 								continue;
 							}
 							punishments::SetHell(imm_d->character.get(),


### PR DESCRIPTION
Player objects allocated with new at the top of each loop iteration were not deleted when hitting continue paths (god-level checks). 8 continue statements skipped the delete at the end of the loop body.