### PR TITLE
fix: memory leaks in str_dup usage (#2979)

### DIFF
--- a/src/engine/ui/cmd_god/do_set_all.cpp
+++ b/src/engine/ui/cmd_god/do_set_all.cpp
@@ -205,15 +205,6 @@ void setall_inspect() {
 	}
 	if (it->second->mail && it->second->pwd)
 		Password::send_password(it->second->mail, it->second->pwd);
-	// освобождение памяти
-	if (it->second->pwd)
-		free(it->second->pwd);
-	if (it->second->reason)
-		free(it->second->reason);
-	if (it->second->newmail)
-		free(it->second->newmail);
-	if (it->second->mail)
-		free(it->second->mail);
 	gettimeofday(&stop, nullptr);
 	timediff(&result, &stop, &it->second->start);
 	sprintf(buf1, "Всего найдено: %d.\r\n", it->second->found);

--- a/src/engine/ui/cmd_god/do_set_all.h
+++ b/src/engine/ui/cmd_god/do_set_all.h
@@ -34,6 +34,13 @@ struct setall_inspect_request {
   int pos; // позиция в таблице
   struct timeval start;        //время когда запустили запрос для отладки
   std::string out;        //буфер в который накапливается вывод
+
+  ~setall_inspect_request() {
+	free(mail);
+	free(pwd);
+	free(newmail);
+	free(reason);
+  }
 };
 
 class CharData;

--- a/src/gameplay/crafting/item_creation.cpp
+++ b/src/gameplay/crafting/item_creation.cpp
@@ -504,8 +504,7 @@ void mredit_disp_menu(DescriptorData *d) {
 }
 
 void do_list_make(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
-	std::string tmpstr, skill_name;
-	char *obj_name;
+	std::string tmpstr, skill_name, obj_name;
 	char tmpbuf[kMaxInputLength];
 	MakeRecept *trec;
 	if (make_recepts.size() == 0) {
@@ -519,12 +518,11 @@ void do_list_make(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/
 	for (size_t i = 0; i < make_recepts.size(); i++) {
 		int j = 0;
 		skill_name = "Нет";
-		obj_name = str_dup("Нет");
+		obj_name = "Нет";
 		trec = make_recepts[i];
 		auto obj = GetObjectPrototype(trec->obj_proto);
 		if (obj) {
-			obj_name = str_dup(obj->get_PName(ECase::kNom).substr(0, 39).c_str());
-			utils::RemoveColors(obj_name);
+			obj_name = utils::RemoveColors(obj->get_PName(ECase::kNom).substr(0, 39));
 		}
 		while (make_skills[j].num != ESkill::kUndefined) {
 			if (make_skills[j].num == trec->skill) {
@@ -534,18 +532,17 @@ void do_list_make(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/
 			j++;
 		}
 		sprintf(tmpbuf, "%3zd  %-1s  %-6s  %-40s(%5d) :",
-				i + 1, (trec->locked ? "*" : " "), skill_name.c_str(), obj_name, trec->obj_proto);
+				i + 1, (trec->locked ? "*" : " "), skill_name.c_str(), obj_name.c_str(), trec->obj_proto);
 		tmpstr += string(tmpbuf);
 		for (int j = 0; j < MAX_PARTS; j++) {
 			if (trec->parts[j].proto != 0) {
 				obj = GetObjectPrototype(trec->parts[j].proto);
 				if (obj) {
-					obj_name = str_dup(obj->get_PName(ECase::kNom).substr(0, 34).c_str());
-					utils::RemoveColors(obj_name);
+					obj_name = utils::RemoveColors(obj->get_PName(ECase::kNom).substr(0, 34));
 				} else {
-					obj_name = str_dup("Нет");
+					obj_name = "Нет";
 				}
-				sprintf(tmpbuf, " %-35s(%5d)", obj_name, trec->parts[j].proto);
+				sprintf(tmpbuf, " %-35s(%5d)", obj_name.c_str(), trec->parts[j].proto);
 				if (j > 0) {
 					if (j % 2 == 0) {
 						// разбиваем строчки если ингров больше 2;


### PR DESCRIPTION
1. item_creation.cpp: replace char* obj_name with std::string to prevent leaks from repeated str_dup in loop without free

2. do_set_all.h: add destructor to setall_inspect_request to free mail, pwd, newmail, reason fields on destruction. Remove manual free() calls from do_set_all.cpp (now handled by destructor).