### PR TITLE
fix: replace char* mail/last_ip with std::string in PlayerIndexElemen…

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -469,7 +469,7 @@ ObjData::shared_ptr read_one_object_new(char **data, int *error) {
 				if (object->get_custom_label()->author > 0) {
 					for (std::size_t i = 0; i < player_table.size(); i++) {
 						if (player_table[i].uid() == object->get_custom_label()->author) {
-							object->get_custom_label()->author_mail = str_dup(player_table[i].mail);
+							object->get_custom_label()->author_mail = str_dup(player_table[i].mail.c_str());
 							break;
 						}
 					}

--- a/src/engine/db/player_index.cpp
+++ b/src/engine/db/player_index.cpp
@@ -248,11 +248,10 @@ void ActualizePlayersIndex(char *name) {
 
 				PlayerIndexElement element(GET_NAME(short_ch));
 
-				CREATE(element.mail, strlen(GET_EMAIL(short_ch)) + 1);
-				for (int i = 0; (element.mail[i] = LOWER(GET_EMAIL(short_ch)[i])); i++);
+				element.mail = GET_EMAIL(short_ch);
+				for (auto &c : element.mail) c = LOWER(c);
 
-				CREATE(element.last_ip, strlen(GET_LASTIP(short_ch)) + 1);
-				for (int i = 0; (element.last_ip[i] = GET_LASTIP(short_ch)[i]); i++);
+				element.last_ip = GET_LASTIP(short_ch);
 
 				element.set_uid(short_ch->get_uid());
 				element.level = GetRealLevel(short_ch);

--- a/src/engine/db/player_index.h
+++ b/src/engine/db/player_index.h
@@ -20,8 +20,8 @@ class PlayerIndexElement {
  public:
   explicit PlayerIndexElement(std::string_view name);
 
-  char *mail{nullptr};
-  char *last_ip{nullptr};
+  std::string mail;
+  std::string last_ip;
   int level{0};
   int remorts{0};
   ECharClass plr_class{ECharClass::kUndefined};

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -456,14 +456,10 @@ void Player::save_char() {
 	fprintf(saved, "Clas: %d\n", to_underlying(this->GetClass()));
 	fprintf(saved, "LstL: %ld\n", static_cast<long int>(LAST_LOGON(this)));
 	// сохраняем last_ip, который должен содержать айпишник с последнего удачного входа
-	if (player_table[this->get_pfilepos()].last_ip) {
-		strcpy(buf, player_table[this->get_pfilepos()].last_ip);
-	} else {
-		strcpy(buf, "Unknown");
+	if (player_table[this->get_pfilepos()].last_ip.empty()) {
+		player_table[this->get_pfilepos()].last_ip = "Unknown";
 	}
-	fprintf(saved, "Host: %s\n", buf);
-	free(player_table[this->get_pfilepos()].last_ip);
-	player_table[this->get_pfilepos()].last_ip = str_dup(buf);
+	fprintf(saved, "Host: %s\n", player_table[this->get_pfilepos()].last_ip.c_str());
 	fprintf(saved, "Id  : %ld\n", this->get_uid());
 	fprintf(saved, "Exp : %ld\n", this->get_exp());
 	fprintf(saved, "Rmrt: %d\n", this->get_remort());
@@ -929,10 +925,7 @@ void Player::save_char() {
 		player_table[i].last_logon = LAST_LOGON(this);
 		player_table[i].level = GetRealLevel(this);
 		player_table[i].remorts = GetRealRemort(this);
-		if (player_table[i].mail) {
-			free(player_table[i].mail);
-		}
-		player_table[i].mail = str_dup(GET_EMAIL(this));
+		player_table[i].mail = GET_EMAIL(this);
 		player_table[i].set_uid(this->get_uid());
 		player_table[i].plr_class = GetClass();
 		//end by WorM

--- a/src/engine/network/logon.cpp
+++ b/src/engine/network/logon.cpp
@@ -33,9 +33,7 @@ void add_logon_record(DescriptorData *d) {
 
 	int pos = d->character->get_pfilepos();
 	if (pos >= 0) {
-		if (player_table[pos].last_ip)
-			free(player_table[pos].last_ip);
-		player_table[pos].last_ip = str_dup(d->host);
+		player_table[pos].last_ip = d->host;
 		player_table[pos].last_logon = LAST_LOGON(d->character);
 	}
 }

--- a/src/engine/ui/cmd_god/do_inspect.cpp
+++ b/src/engine/ui/cmd_god/do_inspect.cpp
@@ -98,8 +98,8 @@ class ExtractedCharacterInfo {
 void ExtractedCharacterInfo::ExtractDataFromIndex(const PlayerIndexElement &index) {
 	online_ = (DescriptorByUid(index.uid()) != nullptr);
 	name_ = (index.name().empty() ? kUndefined : index.name());
-	mail_ = (index.mail ? index.mail : kUndefined);
-	last_ip_ = (index.last_ip ? index.last_ip : kUndefined);
+	mail_ = (index.mail.empty() ? kUndefined : index.mail);
+	last_ip_ = (index.last_ip.empty() ? kUndefined : index.last_ip);
 	class_name_ = MUD::Class(index.plr_class).GetName();
 	level_ = index.level;
 	remort_ = index.remorts;
@@ -401,7 +401,7 @@ InspectRequestIp::InspectRequestIp(const CharData *author, const std::vector<std
 }
 
 bool InspectRequestIp::IsIndexMatched(const PlayerIndexElement &index) {
-	return (index.last_ip && strstr(index.last_ip, GetRequestText().data()));
+	return (!index.last_ip.empty() && index.last_ip.find(GetRequestText()) != std::string::npos);
 }
 
 // =======================================  INSPECT MAIL  ============================================
@@ -423,7 +423,7 @@ InspectRequestMail::InspectRequestMail(const CharData *author, const std::vector
 }
 
 bool InspectRequestMail::IsIndexMatched(const PlayerIndexElement &index) {
-	return (index.mail && strstr(index.mail, GetRequestText().data()));
+	return (!index.mail.empty() && index.mail.find(GetRequestText()) != std::string::npos);
 }
 
 // =======================================  INSPECT CHAR  ============================================
@@ -452,8 +452,8 @@ InspectRequestChar::InspectRequestChar(const CharData *author, const std::vector
 }
 
 void InspectRequestChar::NoteVictimInfo(const PlayerIndexElement &index) {
-	mail_ = (index.mail ? index.mail : kUndefined);
-	last_ip_ = (index.last_ip ? index.last_ip : kUndefined);
+	mail_ = (index.mail.empty() ? kUndefined : index.mail);
+	last_ip_ = (index.last_ip.empty() ? kUndefined : index.last_ip);
 	report_generator_.SetReportHeader(fmt::format(
 		"Incpecting character (e-mail or last IP): {}{}{}. E-mail: {} Last IP: {}\r\n",
 		kColorWht,
@@ -464,7 +464,7 @@ void InspectRequestChar::NoteVictimInfo(const PlayerIndexElement &index) {
 }
 
 bool InspectRequestChar::IsIndexMatched(const PlayerIndexElement &index) {
-	return ((index.mail && (mail_ == index.mail)) || (index.last_ip && (last_ip_ == index.last_ip)));
+	return ((!index.mail.empty() && (mail_ == index.mail)) || (!index.last_ip.empty() && (last_ip_ == index.last_ip)));
 }
 
 // =======================================  INSPECT ALL  ============================================

--- a/src/engine/ui/cmd_god/do_set_all.cpp
+++ b/src/engine/ui/cmd_god/do_set_all.cpp
@@ -57,8 +57,8 @@ void setall_inspect() {
 		d_vict = DescriptorByUid(player_table[it->second->pos].uid());
 		if (d_vict)
 			is_online = 1;
-		if (player_table[it->second->pos].mail)
-			if (strstr(player_table[it->second->pos].mail, it->second->mail)) {
+		if (!player_table[it->second->pos].mail.empty())
+			if (player_table[it->second->pos].mail.find(it->second->mail) != std::string::npos) {
 				it->second->found++;
 				if (it->second->type_req == kSetallFreeze) {
 					if (is_online) {
@@ -103,7 +103,7 @@ void setall_inspect() {
 						sprintf(buf2,
 								"Смена e-mail адреса персонажа %s с %s на %s.\r\n",
 								player_table[it->second->pos].name().c_str(),
-								player_table[it->second->pos].mail,
+								player_table[it->second->pos].mail.c_str(),
 								it->second->newmail);
 						AddKarma(d_vict->character.get(), buf2, GET_NAME(imm_d->character));
 						it->second->out += buf2;
@@ -125,7 +125,7 @@ void setall_inspect() {
 							sprintf(buf2,
 									"Смена e-mail адреса персонажа %s с %s на %s.\r\n",
 									player_table[it->second->pos].name().c_str(),
-									player_table[it->second->pos].mail,
+									player_table[it->second->pos].mail.c_str(),
 									it->second->newmail);
 							it->second->out += buf2;
 							AddKarma(vict, buf2, GET_NAME(imm_d->character));

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -2340,8 +2340,8 @@ void init_char(CharData *ch, PlayerIndexElement &element) {
 	element.level = 0;
 	element.remorts = 0;
 	element.last_logon = -1;
-	element.mail = nullptr;//added by WorM mail
-	element.last_ip = nullptr;//added by WorM последний айпи
+	element.mail.clear();
+	element.last_ip.clear();
 
 	if (GetRealLevel(ch) > kLvlGod) {
 		SetGodSkills(ch);
@@ -3891,12 +3891,8 @@ void DeletePcByHimself(const char *name) {
 		player_table[id].remorts = -1;
 		player_table[id].last_logon = -1;
 		player_table[id].activity = -1;
-		if (player_table[id].mail)
-			free(player_table[id].mail);
-		player_table[id].mail = nullptr;
-		if (player_table[id].last_ip)
-			free(player_table[id].last_ip);
-		player_table[id].last_ip = nullptr;
+		player_table[id].mail.clear();
+		player_table[id].last_ip.clear();
 	}
 }
 

--- a/src/gameplay/fight/pk.cpp
+++ b/src/gameplay/fight/pk.cpp
@@ -84,7 +84,7 @@ int pk_player_count(CharData *ch) {
 		bool flag = true;
 		for (pkg = pk->next; pkg && flag; pkg = pkg->next) {
 			long j = GetPtableByUnique(pkg->unique);
-			flag = strcmp(player_table[i].mail, player_table[j].mail) != 0;
+			flag = player_table[i].mail != player_table[j].mail;
 		}
 		if (flag) ++count;
 	}
@@ -102,7 +102,7 @@ int pk_calc_spamm(CharData *ch) {
 				long j = GetPtableByUnique(pkg->unique);
 				// Cчитаем убийства со временем больше TIME_PK_GROUP (5 секунд) и чаров с разных мыл
 				spamPK = !(MAX(pk->kill_at, pkg->kill_at) - MIN(pk->kill_at, pkg->kill_at) <= TIME_PK_GROUP
-					|| strcmp(player_table[i].mail, player_table[j].mail) == 0);
+					|| player_table[i].mail == player_table[j].mail);
 			}
 			if (spamPK) {
 				++count;
@@ -1098,7 +1098,7 @@ bool bloody::handle_transfer(CharData *ch, CharData *victim, ObjData *obj, ObjDa
 				|| (CLAN(victim)
 					&& (CLAN(victim)->is_clan_member(it->second.owner_unique)
 						|| CLAN(victim)->is_alli_member(it->second.owner_unique)))
-				|| strcmp(player_table[GetPtableByUnique(it->second.owner_unique)].mail, GET_EMAIL(victim)) == 0)) {
+				|| player_table[GetPtableByUnique(it->second.owner_unique)].mail == GET_EMAIL(victim))) {
 			remove_obj(obj); //снимаем флаг
 			result = true;
 		} else if (!ch && victim && (!IS_GOD(victim))) //лут не владельцем

--- a/src/gameplay/mechanics/named_stuff.cpp
+++ b/src/gameplay/mechanics/named_stuff.cpp
@@ -204,7 +204,7 @@ bool parse_nedit_menu(CharData *ch, char *arg) {
 				return false;
 			}
 			ch->desc->named_obj->uid = num;
-			ch->desc->named_obj->mail = str_dup(player_table[GetPtableByUnique(num)].mail);
+			ch->desc->named_obj->mail = player_table[GetPtableByUnique(num)].mail;
 			break;
 
 		case '3':
@@ -343,7 +343,7 @@ void do_named(CharData *ch, char *argument, int cmd, int subcmd) {
 			uid = GetUniqueByName(buf);
 			//*buf = '\0';
 			if (uid > 0) {
-				strcpy(buf, player_table[GetPtableByUnique(uid)].mail);
+				strcpy(buf, player_table[GetPtableByUnique(uid)].mail.c_str());
 			}
 		}
 	}


### PR DESCRIPTION
…t (#2979)

PlayerIndexElement::mail and last_ip were char* allocated with str_dup/CREATE but never freed (empty destructor). Replace with std::string for automatic memory management via RAII.

Updated all 10 files that access these fields: removed manual free/str_dup pairs, replaced strcmp with ==, added .c_str() for C API calls (sprintf, inet_addr, strcpy).