### PR TITLE
refactor: simplify die_follower, remove kSfFollowerdie hack (#2985)

### DIFF
--- a/src/engine/core/handler.cpp
+++ b/src/engine/core/handler.cpp
@@ -1719,10 +1719,8 @@ void ExtractCharFromWorld(CharData *ch, int clear_objs, bool zone_reset) {
 	}
 
 //	log("[Extract char] Die followers");
-	if ((!ch->followers.empty() || ch->has_master())
-		&& die_follower(ch)) {
-		// TODO: странно все это с пуржем в stop_follower
-		//закостылил чтоб экстракт тут не делался для ch->has_master()
+	if (!ch->followers.empty() || ch->has_master()) {
+		die_follower(ch);
 	}
 //	log("[Extract char] Stop all fight for opponee");
 	change_fighting(ch, true);

--- a/src/engine/ui/cmd/do_follow.cpp
+++ b/src/engine/ui/cmd/do_follow.cpp
@@ -72,9 +72,7 @@ bool stop_follower(CharData *ch, int mode) {
 				GET_LASTROOM(ch) = ch->in_room;
 				PerformDropGold(ch, ch->get_gold());
 				ch->set_gold(0);
-				if (!IS_SET(mode, kSfFollowerdie)) {
 					ExtractCharFromWorld(ch, false);
-				}
 				return (true);
 			} else if (AFF_FLAGGED(ch, EAffect::kHelper)) {
 				AFF_FLAGS(ch).unset(EAffect::kHelper);
@@ -115,11 +113,20 @@ bool stop_follower(CharData *ch, int mode) {
 	return (false);
 }
 
-// * Called when a character that follows/is followed dies
-bool die_follower(CharData *ch) {
-	if (ch->has_master() && stop_follower(ch, kSfFollowerdie)) {
-		//  чармиса спуржили в stop_follower
-		return true;
+// Called when a character that follows/is followed dies.
+// Detaches ch from its master (if any) and dismisses all of ch's followers.
+void die_follower(CharData *ch) {
+	if (ch->has_master()) {
+		if (ch->get_master()->get_horse() == ch && ch->get_master()->IsOnHorse()) {
+			ch->DropFromHorse();
+		}
+
+		ch->get_master()->followers.remove(ch);
+		if (ch->get_master()->followers.empty() && !ch->get_master()->has_master()) {
+			ch->get_master()->removeGroupFlags();
+		}
+		ch->set_master(nullptr);
+		ch->removeGroupFlags();
 	}
 
 	if (ch->IsOnHorse()) {
@@ -129,7 +136,6 @@ bool die_follower(CharData *ch) {
 	while (!ch->followers.empty()) {
 		stop_follower(ch->followers.front(), kSfMasterdie);
 	}
-	return false;
 }
 
 // Check if making CH follow VICTIM will create an illegal //

--- a/src/engine/ui/cmd/do_follow.h
+++ b/src/engine/ui/cmd/do_follow.h
@@ -5,7 +5,7 @@ class CharData;
 
 void do_follow(CharData *ch, char *argument, int cmd, int subcmd);
 bool stop_follower(CharData *ch, int mode);
-bool die_follower(CharData *ch);
+void die_follower(CharData *ch);
 bool circle_follow(CharData *ch, CharData *victim);
 
 #endif //BYLINS_FOLLOW_H

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -155,7 +155,6 @@ extern const char *ACTNULL;
 #endif
 
 constexpr int kSfEmpty = 1 << 0;
-constexpr int kSfFollowerdie = 1 << 1;
 constexpr int kSfMasterdie = 1 << 2;
 constexpr int kSfCharmlost = 1 << 3;
 constexpr int kSfSilence = 1 << 4;


### PR DESCRIPTION
die_follower() used stop_follower(ch, kSfFollowerdie) to detach a dying character from its master. The kSfFollowerdie flag existed solely to prevent recursive ExtractCharFromWorld calls. This was confusing: kCorpse mobs were not extracted inside stop_follower but relied on the caller to finish the job.

Replace with direct detach from master's followers list in die_follower(). stop_follower() now always extracts kCorpse mobs.

- Remove kSfFollowerdie flag from utils.h
- die_follower() returns void instead of bool
- handler.cpp: remove empty if-body and TODO comment