### PR TITLE
fix: dangling string_view in inspect after mail/last_ip to std::strin…

### DIFF
--- a/src/engine/ui/cmd_god/do_inspect.cpp
+++ b/src/engine/ui/cmd_god/do_inspect.cpp
@@ -81,8 +81,8 @@ class ExtractedCharacterInfo {
   std::string clan_abbrev_;
   std::string class_name_;
   std::string name_;
-  std::string_view mail_;
-  std::string_view last_ip_;
+  std::string mail_;
+  std::string last_ip_;
   std::ostringstream punishments_;
   std::ostringstream extra_info_;
 
@@ -433,8 +433,8 @@ class InspectRequestChar : public InspectRequest {
   explicit InspectRequestChar(const CharData *author, const std::vector<std::string> &args);
 
  private:
-  std::string_view mail_;
-  std::string_view last_ip_;
+  std::string mail_;
+  std::string last_ip_;
 
   void NoteVictimInfo(const PlayerIndexElement &index);
   bool IsIndexMatched(const PlayerIndexElement &index) final;


### PR DESCRIPTION
…g change (#2979)

ExtractedCharacterInfo and InspectRequestChar stored mail_ and last_ip_ as std::string_view pointing into PlayerIndexElement::mail/last_ip. After converting those fields from char* to std::string, the string_view could become dangling if player_table resized during async inspect.

Replace std::string_view with std::string to make proper copies.