### PR TITLE
fix: filter warcries from spell list (#2390)

### DIFF
--- a/src/engine/ui/cmd/do_spells.cpp
+++ b/src/engine/ui/cmd/do_spells.cpp
@@ -58,6 +58,8 @@ void DisplaySpells(CharData *ch, CharData *vict, bool all) {
 			continue;
 		if (MUD::Spell(spell_id).IsInvalid())
 			continue;
+		if (MUD::Spell(spell_id).IsFlagged(kMagWarcry))
+			continue;
 		if (IS_MANA_CASTER(ch) && !spell_create.contains(spell_id))
 			continue;
 		if (!IS_MANA_CASTER(ch) && !IS_GOD(ch) && ROOM_FLAGGED(ch->in_room, ERoomFlag::kDominationArena)) {


### PR DESCRIPTION
Warcries (kMagWarcry) were displayed in the "закл все" spell list for hunter class, appearing as "Круг 13" entries. They are not regular spells and should not appear in the spell list.