### PR TITLE
fix: top_of_trigt off-by-one errors (#2167)

### DIFF
--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -2548,7 +2548,7 @@ bool SqliteWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int n
 	}
 
 	int saved_count = 0;
-	for (TrgRnum trig_rnum = first_trig; trig_rnum <= last_trig && trig_rnum <= top_of_trigt; ++trig_rnum)
+	for (TrgRnum trig_rnum = first_trig; trig_rnum <= last_trig && trig_rnum < top_of_trigt; ++trig_rnum)
 	{
 		if (!trig_index[trig_rnum])
 		{

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -205,7 +205,7 @@ public:
 // Get trigger name by vnum (for trigger comments)
 std::string GetTriggerNameComment(int trigger_vnum) {
 	int rnum = GetTriggerRnum(trigger_vnum);
-	if (rnum >= 0 && rnum <= top_of_trigt) {
+	if (rnum >= 0 && rnum < top_of_trigt) {
 		return trig_index[rnum]->proto->get_name();
 	}
 	return "";
@@ -2762,7 +2762,7 @@ bool YamlWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int not
 
 	int saved_count = 0;
 	log("SaveTriggers: Iterating triggers from %d to %d, specific_vnum=%d", first_trig, last_trig, specific_vnum);
-	for (TrgRnum trig_rnum = first_trig; trig_rnum <= last_trig && trig_rnum <= top_of_trigt; ++trig_rnum)
+	for (TrgRnum trig_rnum = first_trig; trig_rnum <= last_trig && trig_rnum < top_of_trigt; ++trig_rnum)
 	{
 		if (!trig_index[trig_rnum])
 		{

--- a/src/engine/network/admin_api/crud_handlers.cpp
+++ b/src/engine/network/admin_api/crud_handlers.cpp
@@ -858,7 +858,7 @@ void HandleGetStats(DescriptorData* d)
 	response["rooms"] = world.size();
 
 	// Count triggers
-	response["triggers"] = top_of_trigt + 1;
+	response["triggers"] = top_of_trigt;
 
 	SendJsonResponse(d, response);
 }


### PR DESCRIPTION
top_of_trigt is a count (next free index), not the last valid index (unlike top_of_mobt/top_of_world). Several places incorrectly used <= instead of <, accessing one element past the end.

- yaml_world_data_source.cpp: rnum <= top_of_trigt → <
- yaml_world_data_source.cpp: trig_rnum <= top_of_trigt → <
- sqlite_world_data_source.cpp: trig_rnum <= top_of_trigt → <
- crud_handlers.cpp: top_of_trigt + 1 → top_of_trigt (already count)