### PR TITLE
fix: add_trig_to_owner missing for T-command during zone reset (#2886)

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -2756,20 +2756,26 @@ void ZoneReset::ResetZoneEssential() {
 					// 'T' <flag> <trigger_type> <trigger_vnum> <RoomVnum, для WLD_TRIGGER>
 					if (reset_cmd.arg1 == MOB_TRIGGER && tmob) {
 						auto trig = read_trigger(reset_cmd.arg2);
-						if (!add_trigger(SCRIPT(tmob).get(), trig, -1)) {
+						if (add_trigger(SCRIPT(tmob).get(), trig, -1)) {
+							add_trig_to_owner(-1, trig_index[reset_cmd.arg2]->vnum, GET_MOB_VNUM(tmob));
+						} else {
 							ExtractTrigger(trig);
 						}
 						curr_state = 1;
 					} else if (reset_cmd.arg1 == OBJ_TRIGGER && tobj) {
 						auto trig = read_trigger(reset_cmd.arg2);
-						if (!add_trigger(tobj->get_script().get(), trig, -1)) {
+						if (add_trigger(tobj->get_script().get(), trig, -1)) {
+							add_trig_to_owner(-1, trig_index[reset_cmd.arg2]->vnum, GET_OBJ_VNUM(tobj));
+						} else {
 							ExtractTrigger(trig);
 						}
 						curr_state = 1;
 					} else if (reset_cmd.arg1 == WLD_TRIGGER) {
 						if (reset_cmd.arg3 > kNowhere) {
 							auto trig = read_trigger(reset_cmd.arg2);
-							if (!add_trigger(world[reset_cmd.arg3]->script.get(), trig, -1)) {
+							if (add_trigger(world[reset_cmd.arg3]->script.get(), trig, -1)) {
+								add_trig_to_owner(-1, trig_index[reset_cmd.arg2]->vnum, world[reset_cmd.arg3]->vnum);
+							} else {
 								ExtractTrigger(trig);
 							}
 							curr_state = 1;


### PR DESCRIPTION
The T-command handler in ResetZoneEssential called add_trigger() but did not call add_trig_to_owner() on success. This meant triggers attached via zone file T-commands were not tracked in the owner_trig map, unlike triggers attached during boot or via DG attach command.