### PR TITLE
fix: timed_feat stored time_t in ubyte causing immediate timer expiry…

### DIFF
--- a/src/engine/entities/char_data.h
+++ b/src/engine/entities/char_data.h
@@ -776,7 +776,7 @@ class CharData : public ProtectedCharData {
 
 	char_affects_list_t affected;    // affected by what spells
 	std::unordered_map<ESkill, time_t> timed_skill;    // use which timed skill/spells
-	std::unordered_map<EFeat, ubyte> timed_feat;    // use which timed feats
+	std::unordered_map<EFeat, time_t> timed_feat;    // use which timed feats
 	ObjData *equipment[EEquipPos::kNumEquipPos];    // Equipment array
 
 	ObjData *carrying;    // Head of list


### PR DESCRIPTION
… (#2988)

timed_feat map used ubyte (0-255) as value type while ImposeTimedFeat stored absolute timestamps (time_t ~1.7 billion). The value was silently truncated to 1 byte, making IsTimedByFeat always see an expired timer and immediately erase it. This made feat timers (relocate, shadow throw, berserker, etc.) non-functional.

Change ubyte to time_t to match timed_skill.