### PR TITLE
fix: missing .c_str() for std::string in log() format (#2979)

### DIFF
--- a/src/engine/db/player_index.cpp
+++ b/src/engine/db/player_index.cpp
@@ -267,7 +267,7 @@ void ActualizePlayersIndex(char *name) {
 				}
 
 #ifdef TEST_BUILD
-				log("entry: char:%s level:%d mail:%s ip:%s", element.name().c_str(), element.level, element.mail, element.last_ip);
+				log("entry: char:%s level:%d mail:%s ip:%s", element.name().c_str(), element.level, element.mail.c_str(), element.last_ip.c_str());
 #endif
 
 				top_idnum = std::max(top_idnum, short_ch->get_uid());


### PR DESCRIPTION
After changing mail/last_ip to std::string, the TEST_BUILD log call passed std::string directly to printf-style %s format. Add .c_str().