### PR TITLE
refactor: rewrite proxy check logic, fix proxy limit bypass (#2808)

### DIFF
--- a/src/administration/proxy.cpp
+++ b/src/administration/proxy.cpp
@@ -76,34 +76,42 @@ void RegisterSystem::LoadProxyList() {
 	SaveProxyList();
 }
 
-// проверка на присутствие в списке зарегистрированных ip и кол-ва соединений
-// 0 - нету, 1 - в маде уже макс. число коннектов с данного ip, 2 - все ок
-int CheckProxy(DescriptorData *ch) {
-	//сначала ищем в списке, зачем зря коннекты считать
-	ProxyListType::const_iterator it;
-	// мысль простая - есть второй ип, знач смотрим диапазон, нету - знач сверяем на равенство ип
-	for (it = proxy_list.begin(); it != proxy_list.end(); ++it) {
-		if (!it->second->ip2) {
-			if (it->first == ch->ip)
-				break;
-		} else if ((it->first <= ch->ip) && (ch->ip <= it->second->ip2))
-			break;
+const ProxyIpPtr FindProxyEntry(unsigned long ip) {
+	for (const auto &it : proxy_list) {
+		if (!it.second->ip2) {
+			if (it.first == ip) {
+				return it.second;
+			}
+		} else if (it.first <= ip && ip <= it.second->ip2) {
+			return it.second;
+		}
 	}
-	if (it == proxy_list.end())
-		return 0;
+	return nullptr;
+}
 
-	// терь можно и посчитать
-	DescriptorData *i;
-	int num_ip = 0;
-	for (i = descriptor_list; i; i = i->next)
-		if (i != ch && i->character && !IS_IMMORTAL(i->character) && (i->ip == ch->ip))
-			num_ip++;
+int CountPlayersFromIp(DescriptorData *d) {
+	int count = 0;
+	for (auto *i = descriptor_list; i; i = i->next) {
+		if (i != d
+			&& i->character
+			&& !IS_IMMORTAL(i->character)
+			&& i->ip == d->ip
+			&& (i->state == EConState::kPlaying || i->state == EConState::kMenu)) {
+			count++;
+		}
+	}
+	return count;
+}
 
-	// проверяем на кол-во коннектов
-	if (it->second->num <= num_ip)
-		return 1;
-
-	return 2;
+EProxyCheck CheckProxy(DescriptorData *d) {
+	auto proxy = FindProxyEntry(d->ip);
+	if (!proxy) {
+		return EProxyCheck::kNotInList;
+	}
+	if (CountPlayersFromIp(d) >= proxy->num) {
+		return EProxyCheck::kLimitReached;
+	}
+	return EProxyCheck::kAllowed;
 }
 
 // Тут все, что связано с регистрацией клубов и т.п.

--- a/src/administration/proxy.h
+++ b/src/administration/proxy.h
@@ -32,17 +32,29 @@ void SaveProxyList();
 unsigned long TxtToIp(std::string &text);
 
 struct ProxyIp {
-  unsigned long ip2{0L};   // конечный ип в случае диапазона
-  int num{0};             // кол-во максимальных коннектов
-  std::string text;    // комментарий
-  std::string textIp;  // ип в виде строки
-  std::string textIp2; // конечный ип в виде строки
+  unsigned long ip2{0L};
+  int num{0};
+  std::string text;
+  std::string textIp;
+  std::string textIp2;
 };
 
 using ProxyIpPtr = std::shared_ptr<ProxyIp>;
 using ProxyListType = std::map<unsigned long, ProxyIpPtr>;
 extern ProxyListType proxy_list;
 extern const int kMaxProxyConnect;
+
+struct DescriptorData;
+
+enum class EProxyCheck {
+	kNotInList,
+	kLimitReached,
+	kAllowed
+};
+
+const ProxyIpPtr FindProxyEntry(unsigned long ip);
+int CountPlayersFromIp(DescriptorData *d);
+EProxyCheck CheckProxy(DescriptorData *d);
 
 #endif //BYLINS_SRC_ADMINISTRATION_PROXY_H_
 

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -328,7 +328,6 @@ void redit_parse(DescriptorData *d, char *arg);
 void zedit_parse(DescriptorData *d, char *arg);
 void medit_parse(DescriptorData *d, char *arg);
 void trigedit_parse(DescriptorData *d, char *arg);
-extern int CheckProxy(DescriptorData *ch);
 extern void check_max_hp(CharData *ch);
 // local functions
 int perform_dupe_check(DescriptorData *d);
@@ -1769,66 +1768,75 @@ int pre_help(CharData *ch, char *argument) {
 	return (0);
 }
 
-// вобщем флажок для зареганных ип, потому что при очередной автопроверке, если превышен
-// лимит коннектов с ип - сядут все сместе, что выглядит имхо странно, может там комп новый воткнули
-// и просто еще до иммов не достучались лимит поднять... вобщем сидит тот, кто не успел Ж)
+// Проверяет допустимость подключения с данного IP.
+// Возвращает 1 если подключение разрешено, 0 если нет.
+// Порядок проверок:
+//   1. Бессмертные - всегда OK
+//   2. Нет дубликатов IP - OK
+//   3. Есть proxy запись - проверяем лимит (даже для зарегистрированных)
+//   4. Нет proxy записи - проверяем регистрацию персонажа/email
+//   5. Не зарегистрирован - в комнату незарегов
 int check_dupes_host(DescriptorData *d, bool autocheck = false) {
-	if (!d->character || IS_IMMORTAL(d->character) || d->character->desc->original)
+	if (!d->character || IS_IMMORTAL(d->character) || d->character->desc->original) {
 		return 1;
+	}
 
-	// в случае авточекалки нужная проверка уже выполнена до входа в функцию
+	if (CountPlayersFromIp(d) == 0) {
+		return 1;
+	}
+
+	auto proxy_result = CheckProxy(d);
+
+	switch (proxy_result) {
+		case EProxyCheck::kLimitReached:
+			if (autocheck) {
+				return 1;
+			}
+			SendMsgToChar("&RС вашего IP адреса находится максимально допустимое количество игроков.\r\n"
+						  "Обратитесь к Богам для увеличения лимита игроков с вашего адреса.&n",
+						  d->character.get());
+			return 0;
+
+		case EProxyCheck::kAllowed:
+			return 1;
+
+		case EProxyCheck::kNotInList:
+			break;
+	}
+
 	if (!autocheck) {
 		if (RegisterSystem::IsRegistered(d->character.get())) {
 			return 1;
 		}
-
 		if (RegisterSystem::IsRegisteredEmail(GET_EMAIL(d->character))) {
 			d->registered_email = true;
 			return 1;
 		}
 	}
 
-	for (DescriptorData *i = descriptor_list; i; i = i->next) {
-		if (i != d
-			&& i->ip == d->ip
-			&& i->character
-			&& !IS_IMMORTAL(i->character)
-			&&  (i->state == EConState::kPlaying
-				||  i->state == EConState::kMenu)) {
-			switch (CheckProxy(d)) {
-				case 0:
-					// если уже сидим в проксе, то смысла спамить никакого
-					if (d->character->in_room == r_unreg_start_room
-						|| d->character->get_was_in_room() == r_unreg_start_room) {
-						return 0;
-					}
-					SendMsgToChar(d->character.get(),
-								  "&RВы вошли с игроком %s с одного IP(%s)!\r\n"
-								  "Вам необходимо обратиться к Богам для регистрации.\r\n"
-								  "Пока вы будете помещены в комнату для незарегистрированных игроков.&n\r\n",
-								  GET_PAD(i->character, 4), i->host);
-					sprintf(buf,
-							"! ВХОД С ОДНОГО IP ! незарегистрированного игрока.\r\n"
-							"Вошел - %s, в игре - %s, IP - %s.\r\n"
-							"Игрок помещен в комнату незарегистрированных игроков.",
-							GET_NAME(d->character), GET_NAME(i->character), d->host);
-					mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
-					return 0;
+	if (d->character->in_room == r_unreg_start_room
+		|| d->character->get_was_in_room() == r_unreg_start_room) {
+		return 0;
+	}
 
-				case 1:
-					if (autocheck) {
-						return 1;
-					}
-					SendMsgToChar("&RС вашего IP адреса находится максимально допустимое количество игроков.\r\n"
-								  "Обратитесь к Богам для увеличения лимита игроков с вашего адреса.&n",
-								  d->character.get());
-					return 0;
-
-				default: return 1;
-			}
+	for (auto *i = descriptor_list; i; i = i->next) {
+		if (i != d && i->ip == d->ip && i->character && !IS_IMMORTAL(i->character)
+			&& (i->state == EConState::kPlaying || i->state == EConState::kMenu)) {
+			SendMsgToChar(d->character.get(),
+						  "&RВы вошли с игроком %s с одного IP(%s)!\r\n"
+						  "Вам необходимо обратиться к Богам для регистрации.\r\n"
+						  "Пока вы будете помещены в комнату для незарегистрированных игроков.&n\r\n",
+						  GET_PAD(i->character, 4), i->host);
+			sprintf(buf,
+					"! ВХОД С ОДНОГО IP ! незарегистрированного игрока.\r\n"
+					"Вошел - %s, в игре - %s, IP - %s.\r\n"
+					"Игрок помещен в комнату незарегистрированных игроков.",
+					GET_NAME(d->character), GET_NAME(i->character), d->host);
+			mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+			break;
 		}
 	}
-	return 1;
+	return 0;
 }
 
 int check_dupes_email(DescriptorData *d) {

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -53,7 +53,6 @@ extern int check_dupes_host(DescriptorData *d, bool autocheck = false);
 extern int idle_rent_time;
 extern int idle_max_level;
 extern int idle_void;
-extern int CheckProxy(DescriptorData *ch);
 void decrease_level(CharData *ch);
 int max_exp_gain_pc(CharData *ch);
 int max_exp_loss_pc(CharData *ch);


### PR DESCRIPTION
proxy add N was bypassed for registered players because check_dupes_host returned early on IsRegistered before checking proxy limits.

Rewrite:
- Split CheckProxy into FindProxyEntry + CountPlayersFromIp + CheckProxy
- Use EProxyCheck enum instead of magic int 0/1/2
- check_dupes_host now checks proxy limit FIRST (applies to everyone), registration only checked if IP is not in proxy_list
- Remove redundant loop in check_dupes_host (CountPlayersFromIp already counts all players from same IP)