### PR TITLE
fix: replace no-op set_wait(0) with zero_wait() (#2618)

### DIFF
--- a/src/gameplay/fight/fight_stuff.cpp
+++ b/src/gameplay/fight/fight_stuff.cpp
@@ -556,7 +556,7 @@ void raw_kill(CharData *ch, CharData *killer) {
 		if (hitter.deleted)
 			continue;
 		if (hitter.ch->GetEnemy() == ch) {
-			SetWaitState(hitter.ch, 0);
+			hitter.ch->zero_wait();
 		}
 	}
 	if (!ch || ch->purged()) {

--- a/src/gameplay/skills/bash.cpp
+++ b/src/gameplay/skills/bash.cpp
@@ -267,7 +267,7 @@ void go_bash(CharData *ch, CharData *vict) {
 
 	//разные типы лагов в зависимости от того, есть ли "удар щитом", а так же при фейле/успехе и т.д.
 	switch (lag) {
-		case 0: SetWait(ch, 0, true);
+		case 0: ch->zero_wait();
 			break;
 		case 1: SetSkillCooldownInFight(ch, ESkill::kBash, 1);
 			break;

--- a/src/gameplay/skills/firstaid.cpp
+++ b/src/gameplay/skills/firstaid.cpp
@@ -94,8 +94,7 @@ void DoFirstaid(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				else 
 					sprintf(buf, "%s оказала вам первую помощь.\r\n", ch->get_name().c_str());
 				SendMsgToChar(buf, vict);
-				if (vict->get_wait() > 0)
-					vict->set_wait(0);
+				vict->zero_wait();
 				update_pos(vict);
 			} else {
 				act("Вы безрезультатно попытались оказать первую помощь $N2.",

--- a/src/gameplay/skills/slay.cpp
+++ b/src/gameplay/skills/slay.cpp
@@ -75,7 +75,7 @@ void go_slay(CharData *ch, CharData *vict) {
 		}
 	}
 	switch (lag) {
-		case 0: SetWait(ch, 0, true);
+		case 0: ch->zero_wait();
 			break;
 		case 1: SetSkillCooldownInFight(ch, ESkill::kGlobalCooldown, 1);
 			break;


### PR DESCRIPTION
set_wait(0) was silently ignored (guard: if (_ > 0)). These calls intended to clear wait state but did nothing. Replace with zero_wait() which properly resets m_wait to 0.

- fight_stuff.cpp: clear attacker wait when target dies
- bash.cpp: no lag on bash case 0
- slay.cpp: no lag on slay case 0
- firstaid.cpp: clear victim wait on successful first aid (was a bug: first aid never actually cleared the victim's lag)