### PR TITLE
refactor: replace MAX_FIRSTAID_REMOVE with ERemovableSpell enum (#3006)

### DIFF
--- a/src/engine/entities/char_data.h
+++ b/src/engine/entities/char_data.h
@@ -831,17 +831,39 @@ class CharData : public ProtectedCharData {
 	bool IsLeader();
 };
 
-# define MAX_FIRSTAID_REMOVE 17
+enum ERemovableSpell {
+	kRemAbstinent = 0,
+	kRemPoison,
+	kRemMadness,
+	kRemWeakness,
+	kRemSlowdown,
+	kRemMindless,
+	kRemColdWind,
+	kRemFever,
+	kRemCurse,
+	kRemDeafness,
+	kRemSilence,
+	kRemBlindness,
+	kRemSleep,
+	kRemHold,
+	kRemVacuum,
+	kRemHaemorrhage,
+	kRemBattle,
+	kMaxFirstaidRemove
+};
+
 inline ESpell GetRemovableSpellId(int num) {
-	static const ESpell spell[MAX_FIRSTAID_REMOVE] = {ESpell::kAbstinent, ESpell::kPoison, ESpell::kMadness,
+	static const ESpell spell[kMaxFirstaidRemove] = {
+		ESpell::kAbstinent, ESpell::kPoison, ESpell::kMadness,
 		ESpell::kWeaknes, ESpell::kSlowdown, ESpell::kMindless, ESpell::kColdWind,
 		ESpell::kFever, ESpell::kCurse, ESpell::kDeafness, ESpell::kSilence,
-		ESpell::kBlindness, ESpell::kSleep, ESpell::kHold, ESpell::kVacuum, ESpell::kHaemorrhage, ESpell::kBattle};
-	if (num < MAX_FIRSTAID_REMOVE) {
+		ESpell::kBlindness, ESpell::kSleep, ESpell::kHold, ESpell::kVacuum,
+		ESpell::kHaemorrhage, ESpell::kBattle
+	};
+	if (num < kMaxFirstaidRemove) {
 		return spell[num];
-	} else {
-		return ESpell::kUndefined;
 	}
+	return ESpell::kUndefined;
 }
 inline const player_special_data::ignores_t &CharData::get_ignores() const {
 	const auto &ps = get_player_specials();

--- a/src/gameplay/affects/affect_data.cpp
+++ b/src/gameplay/affects/affect_data.cpp
@@ -284,7 +284,7 @@ void player_affect_update() {
 //					sprintf(buf, "ЧАР: Спелл %s висит на %s длительносить %d\r\n", MUD::Spell(affect->type).GetCName(), GET_PAD(i, 5), affect->duration);
 //					mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
 					if (ROOM_FLAGGED(i->in_room, ERoomFlag::kDominationArena)) {
-						for (int count = MAX_FIRSTAID_REMOVE - 1; count >= 0; count--) {
+						for (int count = kMaxFirstaidRemove - 1; count >= 0; count--) {
 							if (affect->type == GetRemovableSpellId(count)) {
 								affect->duration -= 15;
 								break;

--- a/src/gameplay/fight/fight_stuff.cpp
+++ b/src/gameplay/fight/fight_stuff.cpp
@@ -365,7 +365,7 @@ void arena_kill(CharData *ch, CharData *killer) {
 			PlaceCharToRoom(f, to_room);
 		}
 	}
-	for (int i=0; i < MAX_FIRSTAID_REMOVE; i++) {
+	for (int i=0; i < kMaxFirstaidRemove; i++) {
 		RemoveAffectFromChar(ch, GetRemovableSpellId(i));
 	}
 	// наемовские яды

--- a/src/gameplay/skills/firstaid.cpp
+++ b/src/gameplay/skills/firstaid.cpp
@@ -59,7 +59,7 @@ void DoFirstaid(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 	}
 	auto spell_id{ESpell::kUndefined};
-	for (int count = MAX_FIRSTAID_REMOVE - 1; count >= 0; count--) {
+	for (int count = kMaxFirstaidRemove - 1; count >= 0; count--) {
 		spell_id = GetRemovableSpellId(count);
 		if (IsAffectedBySpell(vict, spell_id)) {
 			need = true;


### PR DESCRIPTION
Replace the #define MAX_FIRSTAID_REMOVE 17 with an enum that gives meaningful names to each removable spell index:
  kRemAbstinent=0, kRemPoison=1, ..., kRemBattle=16, kMaxFirstaidRemove=17

This makes the difficulty threshold in firstaid (prob/10 > count) readable: you can see which spell corresponds to which skill level.