### PR TITLE
refactor: create mud_string.cpp with MUD argument parsing functions (…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ set(SOURCES
 		src/gameplay/mechanics/weather.cpp
 		src/engine/olc/zedit.cpp
 		src/utils/utils_string.cpp
+		src/utils/mud_string.cpp
 		src/engine/db/world_objects.cpp
 		src/engine/db/obj_prototypes.cpp
 		src/engine/db/world_checksum.cpp
@@ -534,6 +535,7 @@ set(HEADERS
 		src/engine/db/world_objects.h
 		src/engine/db/world_checksum.h
 		src/utils/utils_string.h
+		src/utils/mud_string.h
 		src/gameplay/affects/affect_handler.h
 		src/gameplay/economics/auction.h
 		src/utils/backtrace.h

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -1061,26 +1061,7 @@ cpp_extern const struct command_info cmd_info[] =
 		{"\n", EPosition::kDead, nullptr, 0, 0, 0}
 	};
 
-const char *dir_fill[] = {"in",
-						  "from",
-						  "with",
-						  "the",
-						  "on",
-						  "at",
-						  "to",
-						  "\n"
-};
-
-const char *reserved[] = {"a",
-						  "an",
-						  "self",
-						  "me",
-						  "all",
-						  "room",
-						  "someone",
-						  "something",
-						  "\n"
-};
+// dir_fill, reserved moved to mud_string.cpp
 
 void check_hiding_cmd(CharData *ch, int percent) {
 	int remove_hide = false;
@@ -1381,97 +1362,7 @@ char *delete_doubledollar(char *string) {
 	return (string);
 }
 
-int fill_word(const char *argument) {
-	return (search_block(argument, dir_fill, true) >= 0);
-}
-
-int reserved_word(const char *argument) {
-	return (search_block(argument, reserved, true) >= 0);
-}
-
-template<typename T>
-T one_argument_template(T argument, char *first_arg) {
-	char *begin = first_arg;
-
-	if (!argument) {
-		log("SYSERR: one_argument received a NULL pointer!");
-		*first_arg = '\0';
-		return (nullptr);
-	}
-	do {
-		skip_spaces(&argument);
-		first_arg = begin;
-		while (*argument && !a_isspace(*argument)) {
-			*(first_arg++) = a_lcc(*argument);
-			argument++;
-		}
-		*first_arg = '\0';
-	} while (fill_word(begin));
-	skip_spaces(&argument);
-	return (argument);
-}
-
-template<typename T>
-T any_one_arg_template(T argument, char *first_arg) {
-	if (!argument) {
-		log("SYSERR: any_one_arg() passed a NULL pointer.");
-		return 0;
-	}
-	skip_spaces(&argument);
-
-	int num = 0;
-//	int len = strlen(argument);
-	while (*argument && !a_isspace(*argument) && num < kMaxStringLength - 1) {
-		*first_arg = a_lcc(*argument);
-		++first_arg;
-		++argument;
-		++num;
-	}
-	*first_arg = '\0';
-	skip_spaces(&argument);
-	return argument;
-}
-
-char *one_argument(char *argument, char *first_arg) { return one_argument_template(argument, first_arg); }
-const char *one_argument(const char *argument, char *first_arg) { return one_argument_template(argument, first_arg); }
-char *any_one_arg(char *argument, char *first_arg) { return any_one_arg_template(argument, first_arg); }
-const char *any_one_arg(const char *argument, char *first_arg) { return any_one_arg_template(argument, first_arg); }
-
-void SplitArgument(const char *arguments, std::vector<std::string> &out) {
-	char local_buf[kMaxTrglineLength];
-	const char *current_arg = arguments;
-	out.clear();
-	do {
-		current_arg = one_argument(current_arg, local_buf);
-		if (!*local_buf) {
-			break;
-		}
-		out.emplace_back(local_buf);
-	} while (*current_arg);
-}
-
-void SplitArgument(const char *arguments, std::vector<short> &out) {
-	std::vector<std::string> tmp;
-	SplitArgument(arguments, tmp);
-	for (const auto &value : tmp) {
-		out.push_back(atoi(value.c_str()));
-	}
-}
-
-void SplitArgument(const char *arguments, std::vector<int> &out) {
-	std::vector<std::string> tmp;
-	SplitArgument(arguments, tmp);
-	for (const auto &value : tmp) {
-		out.push_back(atoi(value.c_str()));
-	}
-}
-
-// return first space-delimited token in arg1; remainder of string in arg2 //
-void half_chop(const char *string, char *arg1, char *arg2) {
-	const char *temp = any_one_arg_template(string, arg1);
-	skip_spaces(&temp);
-	strl_cpy(arg2, temp, kMaxStringLength);
-}
+// fill_word, reserved_word, one_argument, any_one_arg, SplitArgument, half_chop moved to mud_string.cpp
 
 // Used in specprocs, mostly.  (Exactly) matches "command" to cmd number //
 int find_command(const char *command) {

--- a/src/engine/ui/interpreter.h
+++ b/src/engine/ui/interpreter.h
@@ -30,8 +30,7 @@ void DoMove(CharData *ch, char *, int, int subcmd);
 void command_interpreter(CharData *ch, char *argument);
 int search_block(const char *target_string, const char **list, int exact);
 int search_block(const std::string &block, const char **list, int exact);
-int fill_word(const char *argument);
-void half_chop(char const *string, char *arg1, char *arg2);
+// fill_word, half_chop moved to mud_string.h
 void nanny(DescriptorData *d, char *argument);
 
 int is_number(const char *str);
@@ -121,38 +120,7 @@ struct SortStruct {
 extern SortStruct *cmd_sort_info;
 extern int num_of_cmds;
 
-/**
-* copy the first non-fill-word, space-delimited argument of 'argument'
-* to 'first_arg'; return a pointer to the remainder of the string.
-*/
-char *one_argument(char *argument, char *first_arg);
-const char *one_argument(const char *argument, char *first_arg);
-
-///
-/// same as one_argument except that it doesn't ignore fill words
-/// как бы декларируем, что first_arg должен быть не менее kMaxInputLength
-///
-char *any_one_arg(char *argument, char *first_arg);
-const char *any_one_arg(const char *argument, char *first_arg);
-
-/**
-* Same as one_argument except that it takes two args and returns the rest;
-* ignores fill words
-*/
-template<typename T>
-T two_arguments(T argument, char *first_arg, char *second_arg) {
-	return (one_argument(one_argument(argument, first_arg), second_arg));
-}
-
-template<typename T>
-T three_arguments(T argument, char *first_arg, char *second_arg, char *third_arg) {
-	return (one_argument(one_argument(one_argument(argument, first_arg), second_arg), third_arg));
-}
-
-// читает все аргументы из arguments в out
-void SplitArgument(const char *arguments, std::vector<std::string> &out);
-void SplitArgument(const char *arguments, std::vector<short> &out);
-void SplitArgument(const char *arguments, std::vector<int> &out);
+// one_argument, any_one_arg, two_arguments, three_arguments, SplitArgument moved to mud_string.h
 
 void SortCommands();
 

--- a/src/utils/mud_string.cpp
+++ b/src/utils/mud_string.cpp
@@ -1,0 +1,118 @@
+#include "mud_string.h"
+
+#include "utils.h"
+
+int search_block(const char *target_string, const char **list, int exact);
+
+static const char *dir_fill[] = {"in",
+	"from",
+	"with",
+	"the",
+	"on",
+	"at",
+	"to",
+	"\n"
+};
+
+static const char *reserved[] = {"a",
+	"an",
+	"self",
+	"me",
+	"all",
+	"room",
+	"someone",
+	"something",
+	"\n"
+};
+
+int fill_word(const char *argument) {
+	return (search_block(argument, dir_fill, true) >= 0);
+}
+
+int reserved_word(const char *argument) {
+	return (search_block(argument, reserved, true) >= 0);
+}
+
+template<typename T>
+T one_argument_template(T argument, char *first_arg) {
+	char *begin = first_arg;
+
+	if (!argument) {
+		log("SYSERR: one_argument received a NULL pointer!");
+		*first_arg = '\0';
+		return (nullptr);
+	}
+	do {
+		skip_spaces(&argument);
+		first_arg = begin;
+		while (*argument && !a_isspace(*argument)) {
+			*(first_arg++) = a_lcc(*argument);
+			argument++;
+		}
+		*first_arg = '\0';
+	} while (fill_word(begin));
+	skip_spaces(&argument);
+	return (argument);
+}
+
+template<typename T>
+T any_one_arg_template(T argument, char *first_arg) {
+	if (!argument) {
+		log("SYSERR: any_one_arg() passed a NULL pointer.");
+		return 0;
+	}
+	skip_spaces(&argument);
+
+	int num = 0;
+	while (*argument && !a_isspace(*argument) && num < kMaxStringLength - 1) {
+		*first_arg = a_lcc(*argument);
+		++first_arg;
+		++argument;
+		++num;
+	}
+	*first_arg = '\0';
+	skip_spaces(&argument);
+	return argument;
+}
+
+char *one_argument(char *argument, char *first_arg) { return one_argument_template(argument, first_arg); }
+const char *one_argument(const char *argument, char *first_arg) { return one_argument_template(argument, first_arg); }
+char *any_one_arg(char *argument, char *first_arg) { return any_one_arg_template(argument, first_arg); }
+const char *any_one_arg(const char *argument, char *first_arg) { return any_one_arg_template(argument, first_arg); }
+
+void SplitArgument(const char *arguments, std::vector<std::string> &out) {
+	char local_buf[kMaxTrglineLength];
+	const char *current_arg = arguments;
+	out.clear();
+	do {
+		current_arg = one_argument(current_arg, local_buf);
+		if (!*local_buf) {
+			break;
+		}
+		out.emplace_back(local_buf);
+	} while (*current_arg);
+}
+
+void SplitArgument(const char *arguments, std::vector<short> &out) {
+	std::vector<std::string> tmp;
+	SplitArgument(arguments, tmp);
+	for (const auto &value : tmp) {
+		out.push_back(atoi(value.c_str()));
+	}
+}
+
+void SplitArgument(const char *arguments, std::vector<int> &out) {
+	std::vector<std::string> tmp;
+	SplitArgument(arguments, tmp);
+	for (const auto &value : tmp) {
+		out.push_back(atoi(value.c_str()));
+	}
+}
+
+void half_chop(const char *string, char *arg1, char *arg2) {
+	const char *temp = any_one_arg_template(string, arg1);
+	skip_spaces(&temp);
+	strl_cpy(arg2, temp, kMaxStringLength);
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/utils/mud_string.h
+++ b/src/utils/mud_string.h
@@ -1,0 +1,45 @@
+#ifndef BYLINS_SRC_UTILS_MUD_STRING_H_
+#define BYLINS_SRC_UTILS_MUD_STRING_H_
+
+#include <string>
+#include <vector>
+
+/// Проверить является ли слово служебным (in, from, with, the, on, at, to).
+int fill_word(const char *argument);
+
+/// Проверить является ли слово зарезервированным (a, an, self, me, all, room, ...).
+int reserved_word(const char *argument);
+
+/// Извлечь первый аргумент из строки, пропуская служебные слова.
+/// Приводит к нижнему регистру.
+char *one_argument(char *argument, char *first_arg);
+const char *one_argument(const char *argument, char *first_arg);
+
+/// Извлечь первый аргумент из строки БЕЗ пропуска служебных слов.
+/// Приводит к нижнему регистру.
+char *any_one_arg(char *argument, char *first_arg);
+const char *any_one_arg(const char *argument, char *first_arg);
+
+/// Разбор строки на два аргумента через one_argument.
+template<typename T>
+T two_arguments(T argument, char *first_arg, char *second_arg) {
+	return (one_argument(one_argument(argument, first_arg), second_arg));
+}
+
+/// Разбор строки на три аргумента через one_argument.
+template<typename T>
+T three_arguments(T argument, char *first_arg, char *second_arg, char *third_arg) {
+	return (one_argument(one_argument(one_argument(argument, first_arg), second_arg), third_arg));
+}
+
+/// Разделить строку на первое слово (arg1) и остаток (arg2).
+void half_chop(const char *string, char *arg1, char *arg2);
+
+/// Разбить строку на отдельные аргументы.
+void SplitArgument(const char *arguments, std::vector<std::string> &out);
+void SplitArgument(const char *arguments, std::vector<short> &out);
+void SplitArgument(const char *arguments, std::vector<int> &out);
+
+#endif //BYLINS_SRC_UTILS_MUD_STRING_H_
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -26,6 +26,7 @@
 #include "engine/core/config.h"
 #include "utils/id_converter.h"
 #include "utils_string.h"
+#include "mud_string.h"
 #include "logger.h"
 #include "utils/backtrace.h"
 


### PR DESCRIPTION
…#3007)

Move MUD-specific argument parsing from interpreter.cpp to new src/utils/mud_string.cpp:
- dir_fill/reserved arrays
- fill_word, reserved_word
- one_argument (2 overloads + template)
- any_one_arg (2 overloads + template)
- two_arguments, three_arguments (templates in .h)
- SplitArgument (3 overloads)
- half_chop

All declarations in mud_string.h with Russian comments. utils.h includes mud_string.h for backward compatibility.