### PR TITLE
refactor: replace MIN/MAX with std::min/std::max (#3015)

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -647,7 +647,7 @@ void ObjectFile::parse_object(const int nr) {
 	tobj->set_spec_param(sparam);
 
 	tobj->set_maximum_durability(t[1]);
-	tobj->set_current_durability(MIN(t[1], t[2]));
+	tobj->set_current_durability(std::min(t[1], t[2]));
 	tobj->set_material(static_cast<EObjMaterial>(t[3]));
 
 	if (tobj->get_current_durability() > tobj->get_maximum_durability()) {
@@ -1810,7 +1810,7 @@ bool HelpFile::load_help() {
 		if ((*line == '#') && (*(line + 1) != 0)) {
 			min_level = atoi((line + 1));
 		}
-		min_level = MAX(0, MIN(min_level, kLvlImplementator));
+		min_level = std::max(0, std::min(min_level, kLvlImplementator));
 		// now, add the entry to the index with each keyword on the keyword line
 		std::string entry_str(entry);
 		scan = one_word(key, next_key);

--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -1141,7 +1141,7 @@ void Crash_reload_timer(int index) {
 
 	if (!ReadCrashTimerFile(index, false)) {
 		sprintf(buf, "SYSERR: Unable to read timer file for %s.", player_table[index].name().c_str());
-		mudlog(buf, BRF, MAX(kLvlImmortal, kLvlGod), SYSLOG, true);
+		mudlog(buf, BRF, std::max(kLvlImmortal, kLvlGod), SYSLOG, true);
 	}
 }
 
@@ -1247,7 +1247,7 @@ void Crash_timer_obj(const std::size_t index, long time) {
 	if (idelete) {
 		if (!Crash_write_timer(index)) {
 			sprintf(buf, "SYSERR: [TO] Error writing timer file for %s.", name.c_str());
-			mudlog(buf, CMP, MAX(kLvlImmortal, kLvlGod), SYSLOG, true);
+			mudlog(buf, CMP, std::max(kLvlImmortal, kLvlGod), SYSLOG, true);
 		}
 	}
 }
@@ -1288,7 +1288,7 @@ void Crash_list_objects(CharData *ch, int index) {
 			int tmr = data.timer;
 			auto obj = obj_proto[rnum];
 			if (!(stable_objs::IsTimerUnlimited(obj.get()) || obj->has_flag(EObjFlag::kNoRentTimer))) {
-				tmr = MAX(-1, data.timer - timer_dec);
+				tmr = std::max(-1, data.timer - timer_dec);
 			}
 			ss << fmt::format(" [{:>7}] ({:>5}au) <{:>6}> {:<20}\r\n",
 					data.vnum, obj->get_rent_off(), tmr, obj->get_short_description().c_str());
@@ -1355,7 +1355,7 @@ int Crash_load(CharData *ch) {
 
 	if (!SAVEINFO(index)) {
 		sprintf(buf, "%s entering game with no equipment.", GET_NAME(ch));
-		mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		return (1);
 	}
 
@@ -1371,7 +1371,7 @@ int Crash_load(CharData *ch) {
 		case RENT_TIMEDOUT: sprintf(buf, "%s retrieving auto-saved items and entering game.", GET_NAME(ch));
 			break;
 		default: sprintf(buf, "SYSERR: %s entering game with undefined rent code %d.", GET_NAME(ch), RENTCODE(index));
-			mudlog(buf, BRF, MAX(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
+			mudlog(buf, BRF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 			SendMsgToChar("\r\n** Неизвестный код ренты **\r\n"
 						  "Проблемы с восстановлением ваших вещей из файла.\r\n"
 						  "Обращайтесь за помощью к Богам.\r\n", ch);
@@ -1379,14 +1379,14 @@ int Crash_load(CharData *ch) {
 			return (1);
 			break;
 	}
-	mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+	mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 
 	//Деньги за постой
 	num_of_days = (float) (time(0) - SAVEINFO(index)->rent.time) / kSecsPerRealDay;
 	sprintf(buf, "%s was %1.2f days in rent.", GET_NAME(ch), num_of_days);
-	mudlog(buf, LGH, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+	mudlog(buf, LGH, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 	cost = (int) (SAVEINFO(index)->rent.net_cost_per_diem * num_of_days);
-	cost = MAX(0, cost);
+	cost = std::max(0, cost);
 	// added by WorM (Видолюб) 2010.06.04 сумма потраченная на найм(возвращается при креше)
 	if (RENTCODE(index) == RENT_CRASH) {
 		if (!ch->IsImmortal() && CanUseFeat(ch, EFeat::kEmployer) && ch->player_specials->saved.HiredCost != 0) {
@@ -1404,7 +1404,7 @@ int Crash_load(CharData *ch) {
 		sprintf(buf, "%s** На сей раз постой был бесплатным **%s\r\n", kColorWht, kColorNrm);
 		SendMsgToChar(buf, ch);
 		sprintf(buf, "%s entering game, free crashrent.", GET_NAME(ch));
-		mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(buf, NRM, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 	} else if (cost > ch->get_gold() + ch->get_bank()) {
 		sprintf(buf, "%sВы находились на постое %1.2f дней.\n\r"
 					 "%s"
@@ -1422,7 +1422,7 @@ int Crash_load(CharData *ch) {
 				GetDeclensionInNumber(ch->get_gold() + ch->get_bank(), EWhat::kMoneyA), kColorNrm);
 		SendMsgToChar(buf, ch);
 		sprintf(buf, "%s: rented equipment lost (no $).", GET_NAME(ch));
-		mudlog(buf, LGH, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(buf, LGH, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		ch->set_bank(0);
 		ch->set_gold(0);
 		ClearCrashSavedObjects(index);
@@ -1747,7 +1747,7 @@ int Crash_calculate_rent(ObjData *obj) {
 	int cost = 0;
 	for (; obj; obj = obj->get_next_content()) {
 		cost += Crash_calculate_rent(obj->get_contains());
-		cost += MAX(0, obj->get_rent_off());
+		cost += std::max(0, obj->get_rent_off());
 	}
 	return (cost);
 }
@@ -1756,7 +1756,7 @@ int Crash_calculate_rent_eq(ObjData *obj) {
 	int cost = 0;
 	for (; obj; obj = obj->get_next_content()) {
 		cost += Crash_calculate_rent(obj->get_contains());
-		cost += MAX(0, obj->get_rent_on());
+		cost += std::max(0, obj->get_rent_on());
 	}
 	return (cost);
 }
@@ -1807,7 +1807,7 @@ void Crash_save(std::stringstream &write_buffer, int iplayer, ObjData *obj, int 
 		if (obj->get_in_obj()) {
 			obj->get_in_obj()->sub_weight(obj->get_weight());
 		}
-		Crash_save(write_buffer, iplayer, obj->get_contains(), MIN(0, location) - 1, savetype);
+		Crash_save(write_buffer, iplayer, obj->get_contains(), std::min(0, location) - 1, savetype);
 		if (iplayer >= 0) {
 			write_one_object(write_buffer, obj, location);
 			SaveTimeInfo tmp_node;
@@ -1892,7 +1892,7 @@ int save_char_objects(CharData *ch, int savetype, int rentcost) {
 
 	// чаевые
 	if (min_rent_cost(ch) > 0) {
-		cost += MAX(0, min_rent_cost(ch));
+		cost += std::max(0, min_rent_cost(ch));
 	} else {
 		cost /= 2;
 	}
@@ -2117,7 +2117,7 @@ void Crash_report_rent(CharData *ch, CharData *recep, ObjData *obj, int *cost,
 	if (obj) {
 		if (!Crash_is_unrentable(ch, obj)) {
 			/*(*nitems)++;
-			*cost += MAX(0, ((equip ? obj->get_rent_on() : obj->get_rent_off()) * factor));
+			*cost += std::max(0, ((equip ? obj->get_rent_on() : obj->get_rent_off()) * factor));
 			if (rentshow)
 			{
 				if (*nitems == 1)
@@ -2151,7 +2151,7 @@ void Crash_report_rent(CharData *ch, CharData *recep, ObjData *obj, int *cost,
 			// - 2700 кун (900 если надеть) за красный пузырек [9]
 			for (i = obj; i; i = i->get_next_content()) {
 				(*nitems)++;
-				*cost += MAX(0, ((equip ? i->get_rent_on() : i->get_rent_off()) * factor));
+				*cost += std::max(0, ((equip ? i->get_rent_on() : i->get_rent_off()) * factor));
 				if (rentshow) {
 					if (*nitems == 1) {
 						if (!recursive) {
@@ -2278,12 +2278,12 @@ int Crash_offer_rent(CharData *ch, CharData *receptionist, int rentshow, int fac
 				(factor == RENT_FACTOR ? "в день " : ""));
 		act(buf, false, receptionist, 0, ch, kToVict);
 
-		if (MAX(0, *totalcost / divide) > ch->get_gold() + ch->get_bank()) {
+		if (std::max(0, *totalcost / divide) > ch->get_gold() + ch->get_bank()) {
 			act("\"...которых у тебя отродясь не было.\"", false, receptionist, 0, ch, kToVict);
 			return (false);
 		}
 
-		*totalcost = MAX(0, *totalcost / divide);
+		*totalcost = std::max(0, *totalcost / divide);
 		if (divide == 2) {
 			act("$n сказал$g вам : \"Так уж и быть, я скощу тебе половину.\"",
 				false, receptionist, 0, ch, kToVict);
@@ -2293,7 +2293,7 @@ int Crash_offer_rent(CharData *ch, CharData *receptionist, int rentshow, int fac
 			Crash_rent_deadline(ch, receptionist, *totalcost);
 		}
 	} else {
-		*totalcost = MAX(0, *totalcost / divide);
+		*totalcost = std::max(0, *totalcost / divide);
 	}
 	return (true);
 }
@@ -2389,7 +2389,7 @@ int gen_receptionist(CharData *ch, CharData *recep, int cmd, char * /*arg*/, int
 			ch->SetFlag(EPlrFlag::kCryo);
 		}
 
-		mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 
 		if ((save_room == r_helled_start_room)
 			|| (save_room == r_named_start_room)
@@ -2424,7 +2424,7 @@ int gen_receptionist(CharData *ch, CharData *recep, int cmd, char * /*arg*/, int
 					GET_LOADROOM(ch),
 					GET_ROOM_VNUM(save_room));
 			GET_LOADROOM(ch) = GET_ROOM_VNUM(save_room);
-			mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+			mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 			SetWaitState(ch, 1 * kBattleRound);
 			ch->save_char();
 		}

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -1936,7 +1936,7 @@ void SqliteWorldDataSource::LoadObjects()
 		int max_dur = sqlite3_column_int(stmt, 21);
 		int cur_dur = sqlite3_column_int(stmt, 22);
 		obj->set_maximum_durability(max_dur);
-		obj->set_current_durability(std::min(max_dur, cur_dur));  // Match Legacy: MIN(max, cur)
+		obj->set_current_durability(std::min(max_dur, cur_dur));  // Match Legacy: std::min(max, cur)
 		int timer = sqlite3_column_int(stmt, 23);
 		if (timer <= 0) {
 			timer = ObjData::SEVEN_DAYS;  // Match Legacy: default timer is 7 days

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -818,7 +818,7 @@ void Player::save_char() {
 	fprintf(saved, "Expt: %llu\n", GetStatistic(CharStat::PkRemortExpLost));
 
 	// не забываем рестить ману и при сейве
-	this->set_who_mana(MIN(kWhoManaMax,
+	this->set_who_mana(std::min(kWhoManaMax,
 						   this->get_who_mana() + (time(0) - this->get_who_last()) * kWhoManaRestPerSecond));
 	fprintf(saved, "Wman: %u\n", this->get_who_mana());
 
@@ -2045,7 +2045,7 @@ void Player::add_ice_currency(int value) {
 }
 
 void Player::sub_ice_currency(int value) {
-	this->ice_currency = MAX(0, ice_currency - value);
+	this->ice_currency = std::max(0, ice_currency - value);
 }
 
 bool Player::is_arena_player() {
@@ -2211,7 +2211,7 @@ unsigned long int Player::getTelegramId() {
 }
 
 void Player::setGloryRespecTime(time_t param) {
-	this->player_specials->saved.lastGloryRespecTime = MAX(1, param);
+	this->player_specials->saved.lastGloryRespecTime = std::max(1, param);
 }
 
 time_t Player::getGloryRespecTime() {

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -1677,7 +1677,7 @@ void oedit_parse(DescriptorData *d, char *arg) {
 		case OEDIT_MAXVALUE: OLC_OBJ(d)->set_maximum_durability(atoi(arg));
 			break;
 
-		case OEDIT_CURVALUE: OLC_OBJ(d)->set_current_durability(MIN(OLC_OBJ(d)->get_maximum_durability(), atoi(arg)));
+		case OEDIT_CURVALUE: OLC_OBJ(d)->set_current_durability(std::min(OLC_OBJ(d)->get_maximum_durability(), atoi(arg)));
 			break;
 
 		case OEDIT_SEXVALUE:
@@ -1908,7 +1908,7 @@ void oedit_parse(DescriptorData *d, char *arg) {
 			}
 			if (need_break)
 				break;
-			OLC_OBJ(d)->set_val(2, MAX(min_val, MIN(number, max_val)));
+			OLC_OBJ(d)->set_val(2, std::max(min_val, std::min(number, max_val)));
 			OLC_VAL(d) = 1;
 			oedit_disp_val4_menu(d);
 			return;
@@ -1946,7 +1946,7 @@ void oedit_parse(DescriptorData *d, char *arg) {
 				default:
 					break;
 			}
-			OLC_OBJ(d)->set_val(3, MAX(min_val, MIN(number, max_val)));
+			OLC_OBJ(d)->set_val(3, std::max(min_val, std::min(number, max_val)));
 			break;
 
 		case OEDIT_AFFECTS: number = planebit(arg, &plane, &bit);

--- a/src/engine/olc/zedit.cpp
+++ b/src/engine/olc/zedit.cpp
@@ -1379,7 +1379,7 @@ void zedit_parse(DescriptorData *d, char *arg) {
 					zedit_save_internally(d);
 					sprintf(buf, "OLC: %s edits zone info for room %d.", GET_NAME(d->character), OLC_NUM(d));
 					olc_log("%s edit zone %d", GET_NAME(d->character), OLC_NUM(d));
-					mudlog(buf, NRM, MAX(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
+					mudlog(buf, NRM, std::max(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
 					// FALL THROUGH
 				case 'n':
 				case 'N':
@@ -2026,9 +2026,9 @@ void zedit_parse(DescriptorData *d, char *arg) {
 		case ZEDIT_ZONE_TOP:
 			// * Parse and add new top room in zone and return to main menu.
 			if (OLC_ZNUM(d) == static_cast<ZoneRnum>(zone_table.size()) - 1) {
-				OLC_ZONE(d)->top = MAX(OLC_ZNUM(d) * 100, MIN(99900, atoi(arg)));
+				OLC_ZONE(d)->top = std::max(OLC_ZNUM(d) * 100, std::min(99900, atoi(arg)));
 			} else {
-				OLC_ZONE(d)->top = MAX(OLC_ZNUM(d) * 100, MIN(zone_table[OLC_ZNUM(d) + 1].vnum * 100, atoi(arg)));
+				OLC_ZONE(d)->top = std::max(OLC_ZNUM(d) * 100, std::min(zone_table[OLC_ZNUM(d) + 1].vnum * 100, atoi(arg)));
 			}
 
 			OLC_ZONE(d)->top = (OLC_ZONE(d)->top / 100) * 100 + 99;

--- a/src/engine/scripting/dg_db_scripts.cpp
+++ b/src/engine/scripting/dg_db_scripts.cpp
@@ -379,7 +379,7 @@ void trg_spellturntemp(CharData *ch, ESpell spell_id, int spelldiff, int vnum) {
 
 void trg_spelladd(CharData *ch, ESpell spell_id, int spelldiff, int vnum) {
 	int spell = GET_SPELL_MEM(ch, spell_id);
-	GET_SPELL_MEM(ch, spell_id) = std::max(0, MIN(spell + spelldiff, 50));
+	GET_SPELL_MEM(ch, spell_id) = std::max(0, std::min(spell + spelldiff, 50));
 
 	if (spell > GET_SPELL_MEM(ch, spell_id)) {
 		if (GET_SPELL_MEM(ch, spell_id)) {

--- a/src/engine/scripting/dg_olc.cpp
+++ b/src/engine/scripting/dg_olc.cpp
@@ -234,7 +234,7 @@ void trigedit_parse(DescriptorData *d, char *arg) {
 				case 'y': trigedit_save(d);
 					sprintf(buf, "OLC: %s edits trigger %d", GET_NAME(d->character), OLC_NUM(d));
 					olc_log("%s end trig %d", GET_NAME(d->character), OLC_NUM(d));
-					mudlog(buf, NRM, MAX(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
+					mudlog(buf, NRM, std::max(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
 					// fall through
 
 				case 'n': cleanup_olc(d, CLEANUP_ALL);
@@ -494,7 +494,7 @@ void trigedit_save(DescriptorData *d) {
 	// Save trigger to disk using data source abstraction (YAML/SQLite/Legacy)
 	TriggerDistribution(d);
 	zone = zone_table[OLC_ZNUM(d)].vnum;
-	int notify_level = MAX(kLvlBuilder, GET_INVIS_LEV(d->character));
+	int notify_level = std::max(kLvlBuilder, GET_INVIS_LEV(d->character));
 
 	auto* data_source = world_loader::WorldDataSourceManager::Instance().GetDataSource();
 	if (!data_source->SaveTriggers(OLC_ZNUM(d), OLC_NUM(d), notify_level)) {

--- a/src/engine/ui/cmd/do_drink.cpp
+++ b/src/engine/ui/cmd/do_drink.cpp
@@ -180,7 +180,7 @@ int CalcDrinkAmount(CharData *ch, ObjData *jar, int subcmd) {
 	} else {
 		V = 999.0;
 	}
-	amount = MIN(amount, round(V + 0.49999));
+	amount = std::min(amount, round(V + 0.49999));
 
 	if (subcmd != kScmdDrink) // пьем прямо, не глотаем, не пробуем
 	{

--- a/src/engine/ui/cmd/do_drunkoff.cpp
+++ b/src/engine/ui/cmd/do_drunkoff.cpp
@@ -106,8 +106,8 @@ void do_drunkoff(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	percent = number(1, MUD::Skill(ESkill::kHangovering).difficulty);
 	prob = CalcCurrentSkill(ch, ESkill::kHangovering, nullptr);
 	TrainSkill(ch, ESkill::kHangovering, percent <= prob, nullptr);
-	amount = MIN(amount, GET_OBJ_VAL(obj, 1));
-	weight = MIN(amount, obj->get_weight());
+	amount = std::min(amount, GET_OBJ_VAL(obj, 1));
+	weight = std::min(amount, obj->get_weight());
 	weight_change_object(obj, -weight);    // Subtract amount //
 	obj->sub_val(1, amount);
 	if (!GET_OBJ_VAL(obj, 1))    // The last bit //

--- a/src/engine/ui/cmd/do_hire.cpp
+++ b/src/engine/ui/cmd/do_hire.cpp
@@ -126,9 +126,9 @@ long CalcHirePrice(CharData *ch, CharData *victim) {
 	hirePoints += rem_hirePoints + int_hirePoints + cha_hirePoints;
 	hirePoints = hirePoints * 5 * GetRealLevel(ch);
 
-	int min_price = MAX((m_dr / 300 * GetRealLevel(victim)), (GetRealLevel(victim) * 5));
-	min_price = MAX(min_price, mob_proto[victim->get_rnum()].get_gold());
-	long finalPrice = MAX(min_price, (int) ceil(price - hirePoints));
+	int min_price = std::max((m_dr / 300 * GetRealLevel(victim)), (GetRealLevel(victim) * 5));
+	min_price = std::max(min_price, mob_proto[GET_MOB_RNUM(victim)].get_gold());
+	long finalPrice = std::max(min_price, (int) ceil(price - hirePoints));
 
 	ch->send_to_TC(true, true, true,
 				   "Параметры персонажа: RMRT: %.4lf, CHA: %.4lf, INT: %.4lf, TOTAL: %.4lf. Цена чармиса:  %.4lf. Итоговая цена: %d \r\n",
@@ -285,7 +285,7 @@ void DoFindhelpee(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				}
 			}
 			if (aff != hired->affected.end()) {
-				long oldcost = MAX(0, (int) (((*aff)->duration - 1) / 2) * (int) abs(hired->mob_specials.hire_price));
+				long oldcost = std::max(0, (int) (((*aff)->duration - 1) / 2) * (int) abs(hired->mob_specials.hire_price));
 				if (oldcost > 0) {
 					if (hired->mob_specials.hire_price < 0) {
 						ch->add_bank(oldcost);
@@ -391,7 +391,7 @@ void DoFreehelpee(CharData *ch, char * /* argument*/, int/* cmd*/, int/* subcmd*
 	if (!ch->IsImmortal()) {
 		for (const auto &aff : hired->affected) {
 			if (aff->type == ESpell::kCharm) {
-				long cost = MAX(0, (int) ((aff->duration - 1) / 2) * (int) abs(hired->mob_specials.hire_price));
+				long cost = std::max(0, (int) ((aff->duration - 1) / 2) * (int) abs(hired->mob_specials.hire_price));
 				if (cost > 0) {
 					if (hired->mob_specials.hire_price < 0) {
 						ch->add_bank(cost);

--- a/src/engine/ui/cmd/do_learn.cpp
+++ b/src/engine/ui/cmd/do_learn.cpp
@@ -152,7 +152,7 @@ void LearnReceiptBook(CharData *ch, ObjData *obj) {
 	if (receipt_skill) {
 		throw AlreadyKnown(receipt_name);
 	}
-	if (MAX(GET_OBJ_VAL(obj, 2), imrecipes[receipt_id].level) <= GetRealLevel(ch) &&
+	if (std::max(GET_OBJ_VAL(obj, 2), imrecipes[receipt_id].level) <= GetRealLevel(ch) &&
 		imrecipes[receipt_id].remort <= GetRealRemort(ch)) {
 		if (imrecipes[receipt_id].level == -1 || imrecipes[receipt_id].remort == -1) {
 			SendMsgToChar("Некорректная запись рецепта для вашего класса - сообщите Богам.\r\n", ch);

--- a/src/engine/ui/cmd/do_score.cpp
+++ b/src/engine/ui/cmd/do_score.cpp
@@ -156,14 +156,14 @@ void PrintScoreList(CharData *ch) {
 				  ch->add_abils.percent_physdam_add,
 				  ch->add_abils.percent_exp_add);
 	SendMsgToChar(ch, "Сопротивление: огню: %d, воздуху: %d, воде: %d, земле: %d, тьме: %d, живучесть: %d, разум: %d, иммунитет: %d.\r\n",
-				  MIN(GET_RESIST(ch, EResist::kFire), 75),
-				  MIN(GET_RESIST(ch, EResist::kAir), 75),
-				  MIN(GET_RESIST(ch, EResist::kWater), 75),
-				  MIN(GET_RESIST(ch, EResist::kEarth), 75),
-				  MIN(GET_RESIST(ch, EResist::kDark), 75),
-				  MIN(GET_RESIST(ch, EResist::kVitality), 75),
-				  MIN(GET_RESIST(ch, EResist::kMind), 75),
-				  MIN(GET_RESIST(ch, EResist::kImmunity), 75));
+				  std::min(GET_RESIST(ch, EResist::kFire), 75),
+				  std::min(GET_RESIST(ch, EResist::kAir), 75),
+				  std::min(GET_RESIST(ch, EResist::kWater), 75),
+				  std::min(GET_RESIST(ch, EResist::kEarth), 75),
+				  std::min(GET_RESIST(ch, EResist::kDark), 75),
+				  std::min(GET_RESIST(ch, EResist::kVitality), 75),
+				  std::min(GET_RESIST(ch, EResist::kMind), 75),
+				  std::min(GET_RESIST(ch, EResist::kImmunity), 75));
 	SendMsgToChar(ch, "Спас броски: воля: %d, здоровье: %d, стойкость: %d, реакция: %d, маг.резист: %d, физ.резист %d, отчар.резист: %d.\r\n",
 			-CalcSaving(ch, ch, ESaving::kWill, false),
 			-CalcSaving(ch, ch, ESaving::kCritical, false),

--- a/src/engine/ui/cmd/do_spells.cpp
+++ b/src/engine/ui/cmd/do_spells.cpp
@@ -100,7 +100,7 @@ void DisplaySpells(CharData *ch, CharData *vict, bool all) {
 			time_str.clear();
 			if (IS_SET(GET_SPELL_TYPE(ch, spell_id), ESpellType::kTemp)) {
 				time_str.append("[");
-				time_str.append(std::to_string(MAX(1,
+				time_str.append(std::to_string(std::max(1,
 						static_cast<int>(std::ceil(static_cast<double>(temporary_spells::GetSpellLeftTime(ch, spell_id))
 						/ kSecsPerMudHour)))));
 				time_str.append("]");

--- a/src/engine/ui/cmd/do_steal.cpp
+++ b/src/engine/ui/cmd/do_steal.cpp
@@ -43,7 +43,7 @@ void go_steal(CharData *ch, CharData *vict, char *obj_name) {
 		success = 1;    // ALWAYS SUCCESS, unless heavy object.
 
 	if (!AWAKE(vict))    // Easier to steal from sleeping people.
-		percent = MAX(percent - 50, 0);
+		percent = std::max(percent - 50, 0);
 
 	// NO, NO With Imp's and Shopkeepers, and if player thieving is not allowed
 	if ((vict->IsImmortal() || GET_GOD_FLAG(vict, EGf::kGodsLike) || GET_MOB_SPEC(vict) == shop_ext)

--- a/src/engine/ui/cmd/do_who.cpp
+++ b/src/engine/ui/cmd/do_who.cpp
@@ -330,7 +330,7 @@ bool PerformWhoSpamcontrol(CharData *ch, unsigned short int mode) {
 
 	// рестим ману, в БД скорость реста маны удваивается
 	time_t ctime = time(nullptr);
-	who_cost_mana = MIN(kWhoManaMax,
+	who_cost_mana = std::min(kWhoManaMax,
 						who_cost_mana + (ctime - last) * kWhoManaRestPerSecond
 							+ (ctime - last) * kWhoManaRestPerSecond * (NORENTABLE(ch) ? 1 : 0));
 	ch->set_who_mana(who_cost_mana);

--- a/src/engine/ui/cmd_god/do_invisible.cpp
+++ b/src/engine/ui/cmd_god/do_invisible.cpp
@@ -30,7 +30,7 @@ void do_invis(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				perform_immort_invis(ch, GetRealLevel(ch));
 		}
 	} else {
-		level = MIN(atoi(arg), kLvlImplementator);
+		level = std::min(atoi(arg), kLvlImplementator);
 		if (level > GetRealLevel(ch) && !ch->IsFlagged(EPrf::kCoderinfo))
 			SendMsgToChar("Вы не можете достичь невидимости выше вашего уровня.\r\n", ch);
 		else if (GetRealLevel(ch) < kLvlImplementator && level > kLvlImmortal && !ch->IsFlagged(EPrf::kCoderinfo))

--- a/src/engine/ui/cmd_god/do_wizutil.cpp
+++ b/src/engine/ui/cmd_god/do_wizutil.cpp
@@ -53,7 +53,7 @@ void DoWizutil(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 													: vict->SetFlag(EPlrFlag::kNoTitle);
 				result = vict->IsFlagged(EPlrFlag::kNoTitle);
 				sprintf(buf, "(GC) Notitle %s for %s by %s.", (result ? "ON" : "OFF"), GET_NAME(vict), GET_NAME(ch));
-				mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+				mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 				imm_log("Notitle %s for %s by %s.", (result ? "ON" : "OFF"), GET_NAME(vict), GET_NAME(ch));
 				strcat(buf, "\r\n");
 				SendMsgToChar(buf, ch);

--- a/src/engine/ui/cmd_god/do_zclear.cpp
+++ b/src/engine/ui/cmd_god/do_zclear.cpp
@@ -43,7 +43,7 @@ void DoClearZone(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 		DecayObjectsOnRepop(zone_repop_list);
 		ResetZone(zrn);
 		sprintf(buf, "(GC) %s clear and reset zone %d (%s), delta %f", GET_NAME(ch), zrn, zone_table[zrn].name.c_str(), timer.delta().count());
-		mudlog(buf, NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(buf, NRM, std::max(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s clear and reset zone %d (%s)", GET_NAME(ch), zrn, zone_table[zrn].name.c_str());
 	} else {
 		SendMsgToChar("Нет такой зоны.\r\n", ch);

--- a/src/engine/ui/cmd_god/do_zreset.cpp
+++ b/src/engine/ui/cmd_god/do_zreset.cpp
@@ -40,7 +40,7 @@ void DoZreset(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 		}
 		SendMsgToChar("Перезагружаю мир.\r\n", ch);
 		sprintf(buf, "(GC) %s reset entire world.", GET_NAME(ch));
-		mudlog(buf, NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(buf, NRM, std::max(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s reset entire world.", GET_NAME(ch));
 		return;
 	} else if (*arg == '.') {
@@ -57,7 +57,7 @@ void DoZreset(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 		DecayObjectsOnRepop(zone_repop_list);
 		ResetZone(i);
 		sprintf(buf, "(GC) %s reset zone %d (%s), delta %f", GET_NAME(ch), i, zone_table[i].name.c_str(), timer.delta().count());
-		mudlog(buf, NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(buf, NRM, std::max(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s reset zone %d (%s)", GET_NAME(ch), i, zone_table[i].name.c_str());
 	} else {
 		SendMsgToChar("Нет такой зоны.\r\n", ch);

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -1480,7 +1480,7 @@ int perform_dupe_check(DescriptorData *d) {
 			if (str_cmp(d->host, k->host)) {
 				sprintf(buf, "ПОВТОРНЫЙ ВХОД! Id = %ld Персонаж = %s Хост = %s(был %s)",
 						d->character->get_uid(), GET_NAME(d->character), k->host, d->host);
-				mudlog(buf, BRF, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+				mudlog(buf, BRF, std::max(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 				//send_to_gods(buf);
 			}
 
@@ -1502,7 +1502,7 @@ int perform_dupe_check(DescriptorData *d) {
 			if (str_cmp(d->host, k->host)) {
 				sprintf(buf, "ПОВТОРНЫЙ ВХОД! Id = %ld Name = %s Host = %s(был %s)",
 						d->character->get_uid(), GET_NAME(d->character), k->host, d->host);
-				mudlog(buf, BRF, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+				mudlog(buf, BRF, std::max(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 				//send_to_gods(buf);
 			}
 
@@ -1582,7 +1582,7 @@ int perform_dupe_check(DescriptorData *d) {
 			act("$n восстановил$g связь.",
 				true, d->character.get(), nullptr, nullptr, kToRoom);
 			sprintf(buf, "%s [%s] has reconnected.", GET_NAME(d->character), d->host);
-			mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+			mudlog(buf, NRM, std::max(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			login_change_invoice(d->character.get());
 			break;
 
@@ -1591,12 +1591,12 @@ int perform_dupe_check(DescriptorData *d) {
 				"Тело $s было захвачено новым духом!",
 				true, d->character.get(), nullptr, nullptr, kToRoom);
 			sprintf(buf, "%s has re-logged in ... disconnecting old socket.", GET_NAME(d->character));
-			mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+			mudlog(buf, NRM, std::max(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			break;
 
 		case UNSWITCH: iosystem::write_to_output("Пересоединяемся для перевключения игрока.", d);
 			sprintf(buf, "%s [%s] has reconnected (UNSWITCH).", GET_NAME(d->character), d->host);
-			mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+			mudlog(buf, NRM, std::max(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			break;
 
 		default:
@@ -1686,7 +1686,7 @@ int check_dupes_host(DescriptorData *d, bool autocheck = false) {
 					"Вошел - %s, в игре - %s, IP - %s.\r\n"
 					"Игрок помещен в комнату незарегистрированных игроков.",
 					GET_NAME(d->character), GET_NAME(i->character), d->host);
-			mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+			mudlog(buf, NRM, std::max(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			break;
 		}
 	}

--- a/src/engine/ui/modify.cpp
+++ b/src/engine/ui/modify.cpp
@@ -1242,17 +1242,17 @@ void show_string(DescriptorData *d, char *input) {
 		// R is for refresh, so back up one page internally so we can display
 		// it again.
 	else if (LOWER(*buf) == 'r' || LOWER(*buf) == 'п') {
-		d->showstr_page = MAX(0, d->showstr_page - 1);
+		d->showstr_page = std::max(0, d->showstr_page - 1);
 	}
 		// B is for back, so back up two pages internally so we can display the
 		// correct page here.
 	else if (LOWER(*buf) == 'b' || LOWER(*buf) == 'н') {
-		d->showstr_page = MAX(0, d->showstr_page - 2);
+		d->showstr_page = std::max(0, d->showstr_page - 2);
 	}
 		// Feature to 'goto' a page.  Just type the number of the page and you
 		// are there!
 	else if (a_isdigit(*buf)) {
-		d->showstr_page = MAX(0, MIN(atoi(buf) - 1, d->showstr_count - 1));
+		d->showstr_page = std::max(0, std::min(atoi(buf) - 1, d->showstr_count - 1));
 	} else if (*buf) {
 		SendMsgToChar("Листать : <RETURN>, Q<К>онец, R<П>овтор, B<Н>азад, или номер страницы.\r\n", d->character.get());
 		return;

--- a/src/gameplay/affects/affect_data.cpp
+++ b/src/gameplay/affects/affect_data.cpp
@@ -107,8 +107,8 @@ int apply_armour(CharData *ch, int eq_pos) {
 		factor *= kMobArmourMult;
 
 	// чтобы не плюсовать левую броню на стафе с текущей прочностью выше максимальной
-	int cur_dur = MIN(obj->get_maximum_durability(), obj->get_current_durability());
-	return (factor * GET_OBJ_VAL(obj, 1) * cur_dur / MAX(1, obj->get_maximum_durability()));
+	int cur_dur = std::min(obj->get_maximum_durability(), obj->get_current_durability());
+	return (factor * GET_OBJ_VAL(obj, 1) * cur_dur / std::max(1, obj->get_maximum_durability()));
 }
 
 ///
@@ -330,13 +330,13 @@ void player_affect_update() {
 							}
 						}
 						if (IS_SET(affect->battleflag, kAfPulsedec))
-							affect->duration -= MIN(affect->duration, kSecsPerPlayerAffect * kPassesPerSec);
+							affect->duration -= std::min(affect->duration, kSecsPerPlayerAffect * kPassesPerSec);
 						else
 							affect->duration--;
 						profile.sections[static_cast<std::size_t>(Section::kDominationAdjust)] += domination_timer.delta().count();
 					} else {
 						if (IS_SET(affect->battleflag, kAfPulsedec))
-							affect->duration -= MIN(affect->duration, kSecsPerPlayerAffect * kPassesPerSec);
+							affect->duration -= std::min(affect->duration, kSecsPerPlayerAffect * kPassesPerSec);
 						else
 							affect->duration--;
 					}

--- a/src/gameplay/ai/graph.cpp
+++ b/src/gameplay/ai/graph.cpp
@@ -169,9 +169,9 @@ int go_sense(CharData *ch, CharData *victim) {
 	int percent, dir, skill = CalcCurrentSkill(ch, ESkill::kSense, victim);
 
 	skill = skill
-		- MAX(1, (GetRealRemort(victim) - GetRealRemort(ch)) * 5); // разница в ремортах *5 вычитается из текущего умения
-	skill = skill - MAX(1, (GetRealLevel(victim) - GetRealLevel(ch)) * 5);
-	skill = MAX(0, skill);
+		- std::max(1, (GetRealRemort(victim) - GetRealRemort(ch)) * 5); // разница в ремортах *5 вычитается из текущего умения
+	skill = skill - std::max(1, (GetRealLevel(victim) - GetRealLevel(ch)) * 5);
+	skill = std::max(0, skill);
 	percent = number(0, MUD::Skill(ESkill::kSense).difficulty);
 	if (percent > skill) {
 		int tries = 10;

--- a/src/gameplay/ai/spec_procs.cpp
+++ b/src/gameplay/ai/spec_procs.cpp
@@ -1001,7 +1001,7 @@ int dump(CharData *ch, void * /*me*/, int cmd, char *argument) {
 	while (!world[ch->in_room]->contents.empty()) {
 		auto k = world[ch->in_room]->contents.front();
 		act("$p рассыпал$U в прах!", false, 0, k, 0, kToRoom);
-		value += MAX(1, MIN(1, k->get_cost() / 10));
+		value += std::max(1, std::min(1, k->get_cost() / 10));
 		ExtractObjFromWorld(k);
 	}
 

--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -3760,7 +3760,7 @@ int Clan::ChestTax() {
 		}
 	}
 	this->chest_objcount = count;
-	this->chest_discount = MAX(50, 75 - 5 * (this->clan_level));
+	this->chest_discount = std::max(50, 75 - 5 * (this->clan_level));
 	return cost * this->chest_discount / 100;
 }
 
@@ -4038,8 +4038,8 @@ int Clan::print_spell_locate_object(CharData *ch, int count, std::string name) {
 		for (auto chest : world[GetRoomRnum((*clan)->chest_room)]->contents) {
 			if (Clan::is_clan_chest(chest)) {
 				for (temp = chest->get_contains(); temp; temp = temp->get_next_content()) {
-					if (!ch->IsGod()) {
-						if (number(1, 100) > (40 + MAX((GetRealInt(ch) - 25) * 2, 0))) {
+					if (!IS_GOD(ch)) {
+						if (number(1, 100) > (40 + std::max((GetRealInt(ch) - 25) * 2, 0))) {
 							continue;
 						}
 						if (temp->has_flag(EObjFlag::kNolocate)) {
@@ -4474,7 +4474,7 @@ void Clan::disable_ingr_chest(CharData *ch) {
 }
 
 int Clan::ingr_chest_max_objects() {
-	return 600 * MAX(1, this->clan_level) + this->last_exp.get_exp() / 10000000;
+	return 600 * std::max(1, this->clan_level) + this->last_exp.get_exp() / 10000000;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/gameplay/classes/classes_spell_slots.cpp
+++ b/src/gameplay/classes/classes_spell_slots.cpp
@@ -1186,7 +1186,7 @@ int CalcCircleSlotsAmount(CharData *ch, int circle) {
 			break;
 		case ECharClass::kSorcerer:
 			if (GetRealLevel(ch) >= MIN_CL_LEVEL && circle < MAX_CL_SLOT && GetRealWis(ch) >= MIN_CL_WIS) {
-				wis_block = MIN(MAX_CL_WIS, GetRealWis(ch)) - MIN_CL_WIS;
+				wis_block = std::min(MAX_CL_WIS, GetRealWis(ch)) - MIN_CL_WIS;
 				wis_block = wis_block / CL_WIS_DIV;
 				wis_block = wis_block * (MAX_CL_LEVEL - MIN_CL_LEVEL + 1);
 				wis_line = GetRealLevel(ch) - MIN_CL_LEVEL;
@@ -1195,7 +1195,7 @@ int CalcCircleSlotsAmount(CharData *ch, int circle) {
 			break;
 		case ECharClass::kPaladine:
 			if (GetRealLevel(ch) >= MIN_PA_LEVEL && circle < MAX_PA_SLOT && GetRealWis(ch) >= MIN_PA_WIS) {
-				wis_block = MIN(MAX_PA_WIS, GetRealWis(ch)) - MIN_PA_WIS;
+				wis_block = std::min(MAX_PA_WIS, GetRealWis(ch)) - MIN_PA_WIS;
 				wis_block = wis_block / PA_WIS_DIV;
 				wis_block = wis_block * (MAX_PA_LEVEL - MIN_PA_LEVEL + 1);
 				wis_line = GetRealLevel(ch) - MIN_PA_LEVEL;

--- a/src/gameplay/crafting/im.cpp
+++ b/src/gameplay/crafting/im.cpp
@@ -1168,7 +1168,7 @@ void im_improve_recipe(CharData *ch, im_rskill *rs, int success) {
 		else
 			prob += (10 * diff);
 		prob += number(1, rs->perc * 5);
-		if (number(1, MAX(1, prob)) <= GetRealInt(ch)) {
+		if (number(1, std::max(1, prob)) <= GetRealInt(ch)) {
 			if (success)
 				sprintf(buf,
 						"%sВы постигли тонкости приготовления рецепта \"%s\".%s\r\n",
@@ -1179,8 +1179,8 @@ void im_improve_recipe(CharData *ch, im_rskill *rs, int success) {
 						kColorBoldCyn, imrecipes[rs->rid].name, kColorNrm);
 			SendMsgToChar(buf, ch);
 			rs->perc += number(1, 2);
-			if (!ch->IsImmortal())
-				rs->perc = MIN(kZeroRemortSkillCap + GetRealRemort(ch) * 5, rs->perc);
+			if (!IS_IMMORTAL(ch))
+				rs->perc = std::min(kZeroRemortSkillCap + GetRealRemort(ch) * 5, rs->perc);
 		}
 	}
 }
@@ -1714,7 +1714,7 @@ void AddRecipe(CharData *ch, int rid, int recipediff) {
 		return;
 
 	skill = rs->perc;
-	rs->perc = MAX(1, MIN(skill + recipediff, kMaxRecipeLevel));
+	rs->perc = std::max(1, std::min(skill + recipediff, kMaxRecipeLevel));
 
 	if (skill > rs->perc)
 		sprintf(buf, "Ваше знание рецепта '%s' понизилось.\r\n", imrecipes[rid].name);

--- a/src/gameplay/crafting/item_creation.cpp
+++ b/src/gameplay/crafting/item_creation.cpp
@@ -654,7 +654,7 @@ void go_create_weapon(CharData *ch, ObjData *obj, int obj_type, ESkill skill) {
 		percent = number(1, MUD::Skill(skill).difficulty);
 		prob = CalcCurrentSkill(ch, skill, nullptr);
 		TrainSkill(ch, skill, true, nullptr);
-		weight = MIN(obj->get_weight() - 2, obj->get_weight() * prob / percent);
+		weight = std::min(obj->get_weight() - 2, obj->get_weight() * prob / percent);
 	}
 	if (weight < created_item[obj_type].min_weight) {
 		SendMsgToChar("У вас не хватило материала.\r\n", ch);
@@ -665,7 +665,7 @@ void go_create_weapon(CharData *ch, ObjData *obj, int obj_type, ESkill skill) {
 		if (!tobj) {
 			SendMsgToChar("Образец был невозвратимо утерян.\r\n", ch);
 		} else {
-			tobj->set_weight(MIN(weight, created_item[obj_type].max_weight));
+			tobj->set_weight(std::min(weight, created_item[obj_type].max_weight));
 			tobj->set_cost(2 * obj->get_cost() / 3);
 			tobj->set_owner(ch->get_uid());
 			tobj->set_extra_flag(EObjFlag::kTransformed);
@@ -677,9 +677,9 @@ void go_create_weapon(CharData *ch, ObjData *obj, int obj_type, ESkill skill) {
 			if (skill == ESkill::kReforging) {
 				if (ch->GetSkill(skill) >= 105 && number(1, 100) <= 2 + (ch->GetSkill(skill) - 105) / 10) {
 					tobj->set_extra_flag(EObjFlag::kHasThreeSlots);
-				} else if (number(1, 100) <= 5 + MAX((ch->GetSkill(skill) - 80), 0) / 5) {
+				} else if (number(1, 100) <= 5 + std::max((ch->GetSkill(skill) - 80), 0) / 5) {
 					tobj->set_extra_flag(EObjFlag::kHasTwoSlots);
-				} else if (number(1, 100) <= 20 + MAX((ch->GetSkill(skill) - 80), 0) / 5 * 4) {
+				} else if (number(1, 100) <= 20 + std::max((ch->GetSkill(skill) - 80), 0) / 5 * 4) {
 					tobj->set_extra_flag(EObjFlag::kHasOneSlot);
 				}
 			}
@@ -691,30 +691,30 @@ void go_create_weapon(CharData *ch, ObjData *obj, int obj_type, ESkill skill) {
 				case 4:
 				case 11: {
 					// Карачун. Таймер должен зависить от таймера прототипа.
-					// Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
+					// Формула std::max(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
 					// В минимуме один день реала, в максимуме таймер из прототипа
 					const int
 						timer_value =
 						tobj->get_timer() / 100 * ch->GetSkill(skill) - number(0, tobj->get_timer() / 100 * 25);
-					const int timer = MAX(ObjData::ONE_DAY, timer_value);
+					const int timer = std::max(ObjData::ONE_DAY, timer_value);
 					tobj->set_timer(timer);
 					sprintf(buf, "Ваше изделие продержится примерно %d дней\n", tobj->get_timer() / 24 / 60);
 					act(buf, false, ch, tobj.get(), 0, kToChar);
 					tobj->set_material(obj->get_material());
 					// Карачун. Так логичнее.
-					// было tobj->get_maximum_durability() = MAX(50, MIN(300, 300 * prob / percent));
-					// Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
+					// было tobj->get_maximum_durability() = std::max(50, std::min(300, 300 * prob / percent));
+					// Формула std::max(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
 					// при расчете числа умножены на 100, перед приравниванием делятся на 100. Для не потерять десятые.
 					tobj->set_maximum_durability(
-						MAX(20000, 35000 / 100 * ch->GetSkill(skill) - number(0, 35000 / 100 * 25)) / 100);
+						std::max(20000, 35000 / 100 * ch->GetSkill(skill) - number(0, 35000 / 100 * 25)) / 100);
 					tobj->set_current_durability(tobj->get_maximum_durability());
 					percent = number(1, MUD::Skill(skill).difficulty);
 					prob = CalcCurrentSkill(ch, skill, nullptr);
-					ndice = MAX(2, MIN(4, prob / percent));
+					ndice = std::max(2, std::min(4, prob / percent));
 					ndice += tobj->get_weight() / 10;
 					percent = number(1, MUD::Skill(skill).difficulty);
 					prob = CalcCurrentSkill(ch, skill, nullptr);
-					sdice = MAX(2, MIN(5, prob / percent));
+					sdice = std::max(2, std::min(5, prob / percent));
 					sdice += tobj->get_weight() / 10;
 					tobj->set_val(1, ndice);
 					tobj->set_val(2, sdice);
@@ -743,9 +743,9 @@ void go_create_weapon(CharData *ch, ObjData *obj, int obj_type, ESkill skill) {
 				case 6: tobj->set_timer(ObjData::ONE_DAY);
 					tobj->set_maximum_durability(50);
 					tobj->set_current_durability(50);
-					ndice = MAX(2, MIN(4, GetRealLevel(ch) / number(6, 8)));
+					ndice = std::max(2, std::min(4, GetRealLevel(ch) / number(6, 8)));
 					ndice += (tobj->get_weight() / 10);
-					sdice = MAX(2, MIN(5, GetRealLevel(ch) / number(4, 5)));
+					sdice = std::max(2, std::min(5, GetRealLevel(ch) / number(4, 5)));
 					sdice += (tobj->get_weight() / 10);
 					tobj->set_val(1, ndice);
 					tobj->set_val(2, sdice);
@@ -761,29 +761,29 @@ void go_create_weapon(CharData *ch, ObjData *obj, int obj_type, ESkill skill) {
 				case 9:
 				case 10: {
 					// Карачун. Таймер должен зависить от таймера прототипа.
-					// Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
+					// Формула std::max(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
 					// В минимуме один день реала, в максимуме таймер из прототипа
 					const int
 						timer_value =
 						tobj->get_timer() / 100 * ch->GetSkill(skill) - number(0, tobj->get_timer() / 100 * 25);
-					const int timer = MAX(ObjData::ONE_DAY, timer_value);
+					const int timer = std::max(ObjData::ONE_DAY, timer_value);
 					tobj->set_timer(timer);
 					sprintf(buf, "Ваше изделие продержится примерно %d дней\n", tobj->get_timer() / 24 / 60);
 					act(buf, false, ch, tobj.get(), 0, kToChar);
 					tobj->set_material(obj->get_material());
 					// Карачун. Так логичнее.
-					// было tobj->get_maximum_durability() = MAX(50, MIN(300, 300 * prob / percent));
-					// Формула MAX(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
+					// было tobj->get_maximum_durability() = std::max(50, std::min(300, 300 * prob / percent));
+					// Формула std::max(<минимум>, <максимум>/100*<процент скила>-<рандом от 0 до 25% максимума>)
 					// при расчете числа умножены на 100, перед приравниванием делятся на 100. Для не потерять десятые.
 					tobj->set_maximum_durability(
-						MAX(20000, 10000 / 100 * ch->GetSkill(skill) - number(0, 15000 / 100 * 25)) / 100);
+						std::max(20000, 10000 / 100 * ch->GetSkill(skill) - number(0, 15000 / 100 * 25)) / 100);
 					tobj->set_current_durability(tobj->get_maximum_durability());
 					percent = number(1, MUD::Skill(skill).difficulty);
 					prob = CalcCurrentSkill(ch, skill, nullptr);
-					ndice = MAX(2, MIN((105 - material_value[tobj->get_material()]) / 10, prob / percent));
+					ndice = std::max(2, std::min((105 - material_value[tobj->get_material()]) / 10, prob / percent));
 					percent = number(1, MUD::Skill(skill).difficulty);
 					prob = CalcCurrentSkill(ch, skill, nullptr);
-					sdice = MAX(1, MIN((105 - material_value[tobj->get_material()]) / 15, prob / percent));
+					sdice = std::max(1, std::min((105 - material_value[tobj->get_material()]) / 15, prob / percent));
 					tobj->set_val(0, ndice);
 					tobj->set_val(1, sdice);
 					tobj->set_wear_flags(created_item[obj_type].wear);
@@ -1787,7 +1787,7 @@ int MakeRecept::make(CharData *ch) {
 			make_fail = true;
 		}
 	};
-	created_lev = created_lev / MAX(1, (ingr_cnt - used_non_ingrs));
+	created_lev = created_lev / std::max(1, (ingr_cnt - used_non_ingrs));
 	int j;
 	int craft_move = MIN_MAKE_MOVE + (created_lev / 2) - 1;
 	// Снимаем мувы за умение

--- a/src/gameplay/crafting/mining.cpp
+++ b/src/gameplay/crafting/mining.cpp
@@ -254,7 +254,7 @@ void do_dig(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 	// возможность копать мощные камни зависит от навыка
-	random_stone = number(1, MIN(prob, 100));
+	random_stone = number(1, std::min(prob, 100));
 	if (random_stone >= dig_vars.stone9_skill)
 		stone_num = 9;
 	else if (random_stone >= dig_vars.stone8_skill)

--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -895,7 +895,7 @@ int shop_node::can_sell_count(const int item_index) const {
 
 		if (numToSell != -1) {
 			numToSell -=
-				MIN(numToSell, obj_proto.actual_count(rnum));    //считаем не только онлайн, но и то что в ренте
+				std::min(numToSell, obj_proto.actual_count(rnum));    //считаем не только онлайн, но и то что в ренте
 		}
 
 		return numToSell;
@@ -1060,7 +1060,7 @@ void shop_node::do_shop_cmd(CharData *ch, CharData *keeper, ObjData *obj, std::s
 			case EObjMaterial::kBronze:
 			case EObjMaterial::kCeramic:
 			case EObjMaterial::kBone:
-			case EObjMaterial::kOrganic: repair_price += MAX(1, repair_price / 2);
+			case EObjMaterial::kOrganic: repair_price += std::max(1, repair_price / 2);
 				break;
 
 			case EObjMaterial::kIron:

--- a/src/gameplay/fight/fight.cpp
+++ b/src/gameplay/fight/fight.cpp
@@ -1309,7 +1309,7 @@ int calc_initiative(CharData *ch, bool mode) {
 	initiative += GET_INITIATIVE(ch);
 
 	if (!ch->IsNpc()) {
-		switch (ch->GetCarryingWeight() * 10 / MAX(1, CAN_CARRY_W(ch))) {
+		switch (ch->GetCarryingWeight() * 10 / std::max(1, CAN_CARRY_W(ch))) {
 			case 10:
 			case 9:
 			case 8: initiative -= 20;
@@ -1595,7 +1595,7 @@ void using_mob_skills(CharData *ch) {
 				if (sk_num == ESkill::kBash) {
 //SendMsgToChar(caster, "Баш предфункция\r\n");
 //sprintf(buf, "%s башат предфункция\r\n",GET_NAME(caster));
-//mudlog(buf, LGH, MAX(kLevelImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
+//mudlog(buf, LGH, std::max(kLevelImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 					if (caster->GetPosition() >= EPosition::kFight
 						|| CalcCurrentSkill(ch, ESkill::kBash, caster) > number(50, 80)) {
 						sk_use = 0;
@@ -1604,7 +1604,7 @@ void using_mob_skills(CharData *ch) {
 				} else {
 //SendMsgToChar(caster, "Подножка предфункция\r\n");
 //sprintf(buf, "%s подсекают предфункция\r\n",GET_NAME(caster));
-//                mudlog(buf, LGH, MAX(kLevelImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
+//                mudlog(buf, LGH, std::max(kLevelImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 
 					if (caster->GetPosition() >= EPosition::kFight
 						|| CalcCurrentSkill(ch, ESkill::kChopoff, caster) > number(50, 80)) {
@@ -2064,14 +2064,14 @@ void perform_violence() {
 		initiative = std::clamp(initiative, -100, 100);
 		if (initiative == 0) {
 			it.ch->initiative = -100; //Если кубик выпал в 0 - бей последним шанс 1 из 201
-			min_init = MIN(min_init, -100);
+			min_init = std::min(min_init, -100);
 		} else {
 			it.ch->initiative = initiative;
 		}
 
 		it.ch->battle_affects.set(kEafFirst);
-		max_init = MAX(max_init, initiative);
-		min_init = MIN(min_init, initiative);
+		max_init = std::max(max_init, initiative);
+		min_init = std::min(min_init, initiative);
 	}
 	int size = 0;
 	//* обработка раунда по очередности инициативы

--- a/src/gameplay/fight/pk.cpp
+++ b/src/gameplay/fight/pk.cpp
@@ -101,7 +101,7 @@ int pk_calc_spamm(CharData *ch) {
 			for (pkg = pk->next; pkg && spamPK; pkg = pkg->next) {
 				long j = GetPtableByUnique(pkg->unique);
 				// Cчитаем убийства со временем больше TIME_PK_GROUP (5 секунд) и чаров с разных мыл
-				spamPK = !(MAX(pk->kill_at, pkg->kill_at) - MIN(pk->kill_at, pkg->kill_at) <= TIME_PK_GROUP
+				spamPK = !(std::max(pk->kill_at, pkg->kill_at) - std::min(pk->kill_at, pkg->kill_at) <= TIME_PK_GROUP
 					|| player_table[i].mail == player_table[j].mail);
 			}
 			if (spamPK) {
@@ -208,7 +208,7 @@ void pk_update_revenge(CharData *agressor, CharData *victim, int attime, int ren
 	}
 	pk->battle_exp = time(nullptr) + attime * 60;
 	if (!group::same_group(agressor, victim)) {
-		agressor->player_specials->may_rent = MAX(NORENTABLE(agressor), time(nullptr) + renttime * 60);
+		agressor->player_specials->may_rent = std::max(NORENTABLE(agressor), time(nullptr) + renttime * 60);
 	}
 	return;
 }
@@ -250,7 +250,7 @@ void pk_increment_kill(CharData *agressor, CharData *victim, int rent, bool flag
 		pk_check_spamm(agressor);
 	}
 
-	AGRO(agressor) = MAX(AGRO(agressor), time(nullptr) + KILLER_UNRENTABLE * 60);
+	AGRO(agressor) = std::max(AGRO(agressor), time(nullptr) + KILLER_UNRENTABLE * 60);
 	agressor->agrobd = true;
 	pk_update_revenge(agressor, victim, BATTLE_DURATION, rent ? KILLER_UNRENTABLE : 0);
 	pk_update_revenge(victim, agressor, BATTLE_DURATION, rent ? REVENGE_UNRENTABLE : 0);
@@ -491,7 +491,7 @@ void pk_thiefs_action(CharData *thief, CharData *victim) {
 			else
 				act("$N продлил$G право на ваш отстрел!", false, thief, 0, victim, kToChar);
 			pk->thief_exp = time(nullptr) + THIEF_UNRENTABLE * 60;
-			thief->player_specials->may_rent = MAX(NORENTABLE(thief), time(nullptr) + THIEF_UNRENTABLE * 60);
+			thief->player_specials->may_rent = std::max(NORENTABLE(thief), time(nullptr) + THIEF_UNRENTABLE * 60);
 			break;
 	}
 	return;
@@ -1025,8 +1025,8 @@ bool has_clan_members_in_group(CharData *ch) {
 }
 
 void pkPortal(CharData *ch) {
-	AGRO(ch) = MAX(AGRO(ch), time(nullptr) + PENTAGRAM_TIME * 60);
-	ch->player_specials->may_rent = MAX(NORENTABLE(ch), time(nullptr) + PENTAGRAM_TIME * 60);
+	AGRO(ch) = std::max(AGRO(ch), time(nullptr) + PENTAGRAM_TIME * 60);
+	ch->player_specials->may_rent = std::max(NORENTABLE(ch), time(nullptr) + PENTAGRAM_TIME * 60);
 }
 
 BloodyInfoMap &bloody_map = GlobalObjects::bloody_map();
@@ -1105,8 +1105,8 @@ bool bloody::handle_transfer(CharData *ch, CharData *victim, ObjData *obj, ObjDa
 			{
 				return false;
 			}
-			AGRO(victim) = MAX(AGRO(victim), KILLER_UNRENTABLE * 60 + it->second.kill_at);
-			victim->player_specials->may_rent = MAX(NORENTABLE(victim), KILLER_UNRENTABLE * 60 + it->second.kill_at);
+			AGRO(victim) = std::max(AGRO(victim), KILLER_UNRENTABLE * 60 + it->second.kill_at);
+			victim->player_specials->may_rent = std::max(NORENTABLE(victim), KILLER_UNRENTABLE * 60 + it->second.kill_at);
 			result = true;
 		} else if (ch
 			&& container

--- a/src/gameplay/magic/magic_rooms.cpp
+++ b/src/gameplay/magic/magic_rooms.cpp
@@ -404,7 +404,7 @@ int CallMagicToRoom(int/* level*/, CharData *ch, RoomData *room, ESpell spell_id
 			if (IS_MANA_CASTER(ch)) {
 				af[0].modifier = 95;
 			} else {
-				af[0].modifier = MIN(100, GetRealInt(ch) + MAX((GetRealInt(ch) - 30) * 4, 0));
+				af[0].modifier = std::min(100, GetRealInt(ch) + std::max((GetRealInt(ch) - 30) * 4, 0));
 			}
 			if (af[0].modifier > 99) {
 				to_char = "Вы запечатали магией все входы.";

--- a/src/gameplay/magic/spells.cpp
+++ b/src/gameplay/magic/spells.cpp
@@ -170,7 +170,7 @@ void SpellCreateWater(int/* level*/, CharData *ch, CharData *victim, ObjData *ob
 	int water;
 	if (ch == nullptr || (obj == nullptr && victim == nullptr))
 		return;
-	// level = MAX(MIN(level, kLevelImplementator), 1);       - not used
+	// level = std::max(std::min(level, kLevelImplementator), 1);       - not used
 
 	if (obj
 		&& obj->get_type() == EObjType::kLiquidContainer) {
@@ -1920,9 +1920,9 @@ void mort_show_char_values(CharData *victim, CharData *ch, int fullness) {
 	sprintf(buf, "Уровень : %d, может выдержать повреждений : %d(%d), ", val0, val1, val2);
 	SendMsgToChar(buf, ch);
 	SendMsgToChar(ch, "Перевоплощений : %d\r\n", GetRealRemort(victim));
-	val0 = MIN(GET_AR(victim), 100);
-	val1 = MIN(GET_MR(victim), 100);
-	val2 = MIN(GET_PR(victim), 100);
+	val0 = std::min(GET_AR(victim), 100);
+	val1 = std::min(GET_MR(victim), 100);
+	val2 = std::min(GET_PR(victim), 100);
 	sprintf(buf,
 			"Защита от чар : %d, Защита от магических повреждений : %d, Защита от физических повреждений : %d\r\n",
 			val0,

--- a/src/gameplay/mechanics/glory.cpp
+++ b/src/gameplay/mechanics/glory.cpp
@@ -118,7 +118,7 @@ void GloryNode::copy_stat(const GloryTimePtr& k) {
 	if (spend_glory < MAX_STATS_BY_GLORY) {
 		GloryTimePtr tmp_node(new glory_time);
 		*tmp_node = *k;
-		tmp_node->glory = MIN(k->glory, MAX_STATS_BY_GLORY - spend_glory);
+		tmp_node->glory = std::min(k->glory, MAX_STATS_BY_GLORY - spend_glory);
 		spend_glory += tmp_node->glory;
 		timers.push_back(tmp_node);
 	}
@@ -702,7 +702,7 @@ void spend_glory_menu(CharData *ch) {
 		out << "    (" << (ch->desc->glory->olc_add_cha > 0 ? "+" : "") << ch->desc->glory->olc_add_cha << ")";
 	out << "\r\n\r\n"
 		<< "  Можно добавить: "
-		<< MIN((MAX_STATS_BY_GLORY - ch->desc->glory->olc_add_spend_glory),
+		<< std::min((MAX_STATS_BY_GLORY - ch->desc->glory->olc_add_spend_glory),
 			   ch->desc->glory->olc_node->free_glory / 1000)
 		<< "\r\n\r\n";
 

--- a/src/gameplay/mechanics/glory_const.cpp
+++ b/src/gameplay/mechanics/glory_const.cpp
@@ -807,7 +807,7 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 						  GET_PAD(vict, 2), amount, get_glory(vict->get_uid()));
 			// запись в карму, логи
 			sprintf(buf, "(GC) %s sets +%d const glory to %s.", GET_NAME(ch), amount, GET_NAME(vict));
-			mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+			mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 			imm_log("%s", buf);
 			sprintf(buf, "Change const glory +%d by %s", amount, GET_NAME(ch));
 			AddKarma(vict, buf, reason);
@@ -824,7 +824,7 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 						  GET_PAD(vict, 1), amount, get_glory(vict->get_uid()));
 			// запись в карму, логи
 			sprintf(buf, "(GC) %s sets -%d const glory to %s.", GET_NAME(ch), amount, GET_NAME(vict));
-			mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+			mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 			imm_log("%s", buf);
 			sprintf(buf, "Change const glory -%d by %s", amount, GET_NAME(ch));
 			AddKarma(vict, buf, reason);
@@ -836,7 +836,7 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				SendMsgToChar(ch, "%s - очищена запись постоянной славы.\r\n", vict->get_name().c_str());
 				// запись в карму, логи
 				sprintf(buf, "(GC) %s reset const glory to %s.", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+				mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 				imm_log("%s", buf);
 				sprintf(buf, "Reset stats and const glory by %s", GET_NAME(ch));
 				AddKarma(vict, buf, reason);

--- a/src/gameplay/mechanics/sets_drop.cpp
+++ b/src/gameplay/mechanics/sets_drop.cpp
@@ -641,7 +641,7 @@ int calc_drop_chance(std::list<MobNode>::iterator &mob, int obj_rnum) {
 	} else {
 		// 2.6% .. 3.4% / 38 ... 28
 /*		int mob_lvl = mob_proto[mob->rnum].get_level();
-		int lvl_mod = MIN(MAX(0, mob_lvl - MIN_SOLO_MOB_LVL), 6);
+		int lvl_mod = std::min(std::max(0, mob_lvl - MIN_SOLO_MOB_LVL), 6);
 		drop_chance = (26 + lvl_mod * 1.45) / mob->miw;
 */
 		chance = DEFAULT_SOLO_CHANCE;

--- a/src/gameplay/mechanics/sight.cpp
+++ b/src/gameplay/mechanics/sight.cpp
@@ -200,7 +200,7 @@ void look_at_room(CharData *ch, int ignore_brief, bool msdp_mode) {
 
 	// now list characters & objects
 	if (world[ch->in_room]->fires) {
-		sprintf(buf, "%sВ центре %s.%s\r\n", kColorRed, Fires[MIN(world[ch->in_room]->fires, MAX_FIRES - 1)], kColorNrm);
+		sprintf(buf, "%sВ центре %s.%s\r\n", kColorRed, Fires[std::min(world[ch->in_room]->fires, MAX_FIRES - 1)], kColorNrm);
 		SendMsgToChar(buf, ch);
 	}
 	if (room_spells::IsRoomAffected(world[ch->in_room], ESpell::kPortalTimer)) {

--- a/src/gameplay/mechanics/weather.cpp
+++ b/src/gameplay/mechanics/weather.cpp
@@ -342,11 +342,11 @@ void weather_change() {
 		}
 	}
 
-	weather_info.icelevel = MAX(0, MIN(100, weather_info.icelevel + icelevel));
+	weather_info.icelevel = std::max(0, std::min(100, weather_info.icelevel + icelevel));
 	if (gsnowlevel < -1 && weather_info.rainlevel < 20)
 		weather_info.rainlevel -= (gsnowlevel / 2);
-	weather_info.snowlevel = MAX(0, MIN(120, weather_info.snowlevel + gsnowlevel));
-	weather_info.rainlevel = MAX(0, MIN(80, weather_info.rainlevel + grainlevel));
+	weather_info.snowlevel = std::max(0, std::min(120, weather_info.snowlevel + gsnowlevel));
+	weather_info.rainlevel = std::max(0, std::min(80, weather_info.rainlevel + grainlevel));
 
 	profiler.next_step("Change some values for world");
 
@@ -367,11 +367,11 @@ void weather_change() {
 		else
 			world[i]->weather.duration--;
 
-		world[i]->weather.icelevel = MAX(0, MIN(100, world[i]->weather.icelevel + icelevel));
+		world[i]->weather.icelevel = std::max(0, std::min(100, world[i]->weather.icelevel + icelevel));
 		if (snowcast < -1 && world[i]->weather.rainlevel < 20)
 			world[i]->weather.rainlevel -= (snowcast / 2);
-		world[i]->weather.snowlevel = MAX(0, MIN(120, world[i]->weather.snowlevel + snowcast));
-		world[i]->weather.rainlevel = MAX(0, MIN(80, world[i]->weather.rainlevel + raincast));
+		world[i]->weather.snowlevel = std::max(0, std::min(120, world[i]->weather.snowlevel + snowcast));
+		world[i]->weather.rainlevel = std::max(0, std::min(80, world[i]->weather.rainlevel + raincast));
 	}
 	profiler.next_step("weather");
 	switch (time_info.month) {
@@ -421,13 +421,13 @@ void weather_change() {
 
 	weather_info.change += (RollDices(1, 4) * diff + RollDices(2, 6) - RollDices(2, 6));
 
-	weather_info.change = MIN(weather_info.change, 12);
-	weather_info.change = MAX(weather_info.change, -12);
+	weather_info.change = std::min(weather_info.change, 12);
+	weather_info.change = std::max(weather_info.change, -12);
 
 	weather_info.pressure += weather_info.change;
 
-	weather_info.pressure = MIN(weather_info.pressure, 1040);
-	weather_info.pressure = MAX(weather_info.pressure, 960);
+	weather_info.pressure = std::min(weather_info.pressure, 1040);
+	weather_info.pressure = std::max(weather_info.pressure, 960);
 
 	if (time_info.month == EMonth::kMay)
 		weather_info.season = ESeason::kSpring;
@@ -579,7 +579,7 @@ void weather_change() {
 		strcat(buf, "Резкое потепление.\r\n");
 		SET_BIT(cweather_type, kWeatherQuickhot);
 	}
-	weather_info.temperature = MIN(year_temp[time_info.month].max, MAX(year_temp[time_info.month].min, temp));
+	weather_info.temperature = std::min(year_temp[time_info.month].max, std::max(year_temp[time_info.month].min, temp));
 
 	if (weather_info.change >= 10 || weather_info.change <= -10) {
 		strcat(buf, "Сильный ветер.\r\n");
@@ -846,8 +846,8 @@ int CalcDaySpellMod(CharData *ch, ESpell /* spell_id */, int type, int value) {
 			break;
 		case GAPPLY_SPELL_EFFECT: break;
 	}
-	if (ch->IsImmortal() || GET_GOD_FLAG(ch, EGf::kGodsLike))
-		modi = MAX(modi, value);
+	if (IS_IMMORTAL(ch) || GET_GOD_FLAG(ch, EGf::kGodsLike))
+		modi = std::max(modi, value);
 	return (modi);
 }
 
@@ -1027,8 +1027,8 @@ int weather_skill_modifier(CharData *ch, ESkill skillnum, int type, int value) {
 			}
 			break;
 	}
-	if (ch->IsImmortal())
-		modi = MAX(modi, value);
+	if (IS_IMMORTAL(ch))
+		modi = std::max(modi, value);
 	return (modi);
 }
 

--- a/src/gameplay/skills/relocate.cpp
+++ b/src/gameplay/skills/relocate.cpp
@@ -104,7 +104,7 @@ void do_relocate(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		SendMsgToChar(ch, "%sВаш поступок был расценен как потенциально агрессивный.%s\r\n",
 					  kColorBoldRed, kColorBoldBlk);
 		pkPortal(ch);
-		timed.time = 18 - MIN(GetRealRemort(ch), 15);
+		timed.time = 18 - std::min(GetRealRemort(ch), 15);
 		SetWaitState(ch, 3 * kBattleRound);
 		Affect<EApply> af;
 		af.duration = CalcDuration(ch, 3, 0, 0, 0, 0);

--- a/src/gameplay/skills/townportal.cpp
+++ b/src/gameplay/skills/townportal.cpp
@@ -122,7 +122,7 @@ void SetSkillTownportalTimer(CharData *ch) {
 		timed.skill = ESkill::kTownportal;
 		// timed.time - это unsigned char, поэтому при уходе в минус будет вынос на 255 и ниже
 		int modif = ch->GetSkill(ESkill::kTownportal) / 7 + number(1, 5);
-		timed.time = MAX(1, 25 - modif);
+		timed.time = std::max(1, 25 - modif);
 		ImposeTimedSkill(ch, &timed);
 //	}
 }

--- a/src/gameplay/skills/track.cpp
+++ b/src/gameplay/skills/track.cpp
@@ -56,7 +56,7 @@ int go_track(CharData *ch, CharData *victim, const ESkill skill_no) {
 	//current_skillpercent = GET_SKILL(ch, ESkill::kSense);
 	if ((!victim->IsNpc()) && (!ch->IsGod()) && (!ch->IsNpc())) //Если цель чар и ищет не бог
 	{
-		percent = MIN(99, number(0, GetRealRemort(victim)) + percent);
+		percent = std::min(99, number(0, GetRealRemort(victim)) + percent);
 	}
 	if (percent > CalcCurrentSkill(ch, skill_no, victim)) {
 		int tries = 10;
@@ -248,11 +248,11 @@ void do_hidetrack(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/
 		for (i = 0; i <= EDirection::kMaxDirNum; i++)
 			if (track[i]) {
 				if (i < EDirection::kMaxDirNum)
-					track[i]->time_outgone[Reverse[i]] <<= MIN(31, prob);
+					track[i]->time_outgone[Reverse[i]] <<= std::min(31, prob);
 				else
 					for (rdir = 0; rdir < EDirection::kMaxDirNum; rdir++) {
-						track[i]->time_income[rdir] <<= MIN(31, prob);
-						track[i]->time_outgone[rdir] <<= MIN(31, prob);
+						track[i]->time_income[rdir] <<= std::min(31, prob);
+						track[i]->time_outgone[rdir] <<= std::min(31, prob);
 					}
 				//sprintf(buf,"Заметены следы %d\r\n",i);
 				//SendMsgToChar(buf,ch);

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -91,7 +91,7 @@ int GaussIntNumber(double mean, double sigma, int min_val, int max_val) {
 	//округляем
 	iresult = ((dresult < mean) ? ceil(dresult) : floor(dresult));
 	//возвращаем с обрезанием по диапазону
-	return MAX(MIN(iresult, max_val), min_val);
+	return std::max(std::min(iresult, max_val), min_val);
 }
 
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -59,13 +59,7 @@ char AltToLat[] = {
 
 const char *ACTNULL = "<NULL>";
 
-int MIN(int a, int b) {
-	return (a < b ? a : b);
-}
-
-int MAX(int a, int b) {
-	return (a > b ? a : b);
-}
+// MIN/MAX removed - use std::min/std::max
 
 // Create and append to dynamic length string - Alez
 char *str_add(char *dst, const char *src) {

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -136,21 +136,10 @@ extern const char *ACTNULL;
 #define MIN_TITLE_LEV   25
 
 // undefine MAX and MIN so that our functions are used instead
-#ifdef MAX
-#undef MAX
-#endif
-
-#ifdef MIN
-#undef MIN
-#endif
-
 constexpr int kSfEmpty = 1 << 0;
 constexpr int kSfMasterdie = 1 << 2;
 constexpr int kSfCharmlost = 1 << 3;
 constexpr int kSfSilence = 1 << 4;
-
-int MAX(int a, int b);
-int MIN(int a, int b);
 
 #define KtoW(c) ((ubyte)(c) < 128 ? (c) : KoiToWin[(ubyte)(c)-128])
 #define KtoW2(c) ((ubyte)(c) < 128 ? (c) : KoiToWin2[(ubyte)(c)-128])
@@ -345,7 +334,7 @@ inline void TOGGLE_BIT(T &var, const Bitvector bit) {
 #define GET_REAL_AGE(ch) (CalcCharAge((ch))->year + GET_AGE_ADD(ch))
 #define GET_PC_NAME(ch) ((ch)->GetCharAliases().c_str())
 #define GET_NAME(ch)    ((ch)->get_name().c_str())
-#define GET_MAX_MANA(ch)      (mana[MIN(50, GetRealWis(ch))])
+#define GET_MAX_MANA(ch)      (mana[std::min(50, GetRealWis(ch))])
 #define GET_MEM_CURRENT(ch)   ((ch)->mem_queue.Empty() ? 0 : CalcSpellManacost(ch, (ch)->mem_queue.queue->spell_id))
 
 #define GET_EMAIL(ch)          ((ch)->player_specials->saved.EMail)


### PR DESCRIPTION
Remove custom MIN/MAX functions from utils.cpp/utils.h and replace all 160 usages across 46 files with std::min/std::max.