### PR TITLE
fix: heap buffer overflow in MobDgCast (#3025)

### DIFF
--- a/src/engine/scripting/dg_mobcmd.cpp
+++ b/src/engine/scripting/dg_mobcmd.cpp
@@ -1444,10 +1444,8 @@ void do_mzoneecho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/, Tri
 }
 // для команды mat
 void MobDgCast(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/, Trigger *trig) {
-	char *dg_arg = str_dup("DgCast ");
-	strcat(dg_arg, argument);
-	do_dg_cast(ch, trig, MOB_TRIGGER, dg_arg);
-	free(dg_arg);
+	std::string dg_arg = std::string("DgCast ") + argument;
+	do_dg_cast(ch, trig, MOB_TRIGGER, dg_arg.data());
 }
 
 const struct mob_command_info mob_cmd_info[] =


### PR DESCRIPTION
str_dup("DgCast ") allocated exactly 8 bytes, then strcat appended the spell argument beyond the buffer boundary, corrupting the heap. free() then crashed with "invalid next size (fast)".

Replace with std::string concatenation.