### PR TITLE
fix: heap buffer overflow in ObjDgCast, also fix wrong argument (#3025)

### DIFF
--- a/src/engine/scripting/dg_objcmd.cpp
+++ b/src/engine/scripting/dg_objcmd.cpp
@@ -1023,10 +1023,8 @@ void do_ozoneecho(ObjData *obj, char *argument, int/* cmd*/, int/* subcmd*/, Tri
 }
 // для команды oat
 void ObjDgCast(ObjData *obj, char *argument, int/* cmd*/, int/* subcmd*/, Trigger *trig) {
-	char *dg_arg = str_dup("DgCast ");
-	strcat(dg_arg, argument);
-	do_dg_cast(obj, trig, OBJ_TRIGGER, argument);
-	free(dg_arg);
+	std::string dg_arg = std::string("DgCast ") + argument;
+	do_dg_cast(obj, trig, OBJ_TRIGGER, dg_arg.data());
 }
 
 const struct obj_command_info obj_cmd_info[] =


### PR DESCRIPTION
Same str_dup+strcat overflow as MobDgCast. Additionally, ObjDgCast passed raw 'argument' to do_dg_cast instead of the constructed 'dg_arg' with "DgCast " prefix.