### PR TITLE
fix: lowercase skipped indented trigger commands (#3029)

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -331,10 +331,9 @@ void TriggersFile::parse_trigger(int vnum) {
 			(*ptr)->line_num = num++;
 
 			// lowercase the command (first word) for faster comparison at runtime
-			for (auto &c : (*ptr)->cmd) {
-				if (c == ' ') break;
-				c = LOWER(c);
-			}
+				auto it = (*ptr)->cmd.begin();
+				while (it != (*ptr)->cmd.end() && (*it == ' ' || *it == '\t')) ++it;
+				while (it != (*ptr)->cmd.end() && *it != ' ') { *it = LOWER(*it); ++it; }
 			ptr = &(*ptr)->next;
 
 			std::smatch match;

--- a/src/engine/db/world_data_source_base.cpp
+++ b/src/engine/db/world_data_source_base.cpp
@@ -51,10 +51,9 @@ void WorldDataSourceBase::ParseTriggerScript(Trigger *trig, const std::string &s
 			cmd->next = nullptr;
 
 			// lowercase the command (first word) for faster comparison at runtime
-			for (auto &c : cmd->cmd) {
-				if (c == ' ') break;
-				c = LOWER(c);
-			}
+			auto it = cmd->cmd.begin();
+			while (it != cmd->cmd.end() && (*it == ' ' || *it == '\t')) ++it;
+			while (it != cmd->cmd.end() && *it != ' ') { *it = LOWER(*it); ++it; }
 
 			if (!head)
 			{

--- a/src/engine/scripting/dg_olc.cpp
+++ b/src/engine/scripting/dg_olc.cpp
@@ -375,10 +375,9 @@ void trigedit_save(DescriptorData *d) {
 	const auto cmd_token = strtok(s, "\n\r");
 	// lowercase the command (first word) for faster comparison at runtime
 	auto lowercase_first_word = [](std::string &str) {
-		for (auto &c : str) {
-			if (c == ' ') break;
-			c = LOWER(c);
-		}
+		auto it = str.begin();
+		while (it != str.end() && (*it == ' ' || *it == '\t')) ++it;
+		while (it != str.end() && *it != ' ') { *it = LOWER(*it); ++it; }
 	};
 
 	if (cmd_token) { //тут штатная ошибка циркуля, если strok не нашел подстроку то он возвращает не nullptr а строку полностью т.е. надо str_cmp(cmd_token, s)


### PR DESCRIPTION
Trigger script lines are often indented with spaces/tabs:
    DgAffect %owner% ...

The previous code broke at the first space, so indented lines were never lowercased. Now skip leading whitespace before lowercasing the first word.

Fixed in all 3 loaders: world_data_source_base, boot_data_files, dg_olc.