### PR TITLE
fix: ExtractFirstArgument aliasing bug when s and remains are same ob…

### DIFF
--- a/src/utils/utils_string.cpp
+++ b/src/utils/utils_string.cpp
@@ -207,6 +207,7 @@ std::string FirstWordOnString(std::string s, std::string mask) {
 
 // аналог one_argument для string
 // пропускает ведущие пробелы, возвращает первое слово, в remains остаток после пробела
+// безопасно вызывать как ExtractFirstArgument(str, str) - нет проблем с алиасингом
 std::string ExtractFirstArgument(const std::string &s, std::string &remains) {
 	auto start = s.find_first_not_of(' ');
 	if (start == std::string::npos) {
@@ -215,11 +216,13 @@ std::string ExtractFirstArgument(const std::string &s, std::string &remains) {
 	}
 	auto space_pos = s.find(' ', start);
 	if (space_pos != std::string::npos) {
+		std::string word = s.substr(start, space_pos - start);
 		remains = s.substr(space_pos + 1);
-		return s.substr(start, space_pos - start);
+		return word;
 	}
+	std::string word = s.substr(start);
 	remains.clear();
-	return s.substr(start);
+	return word;
 }
 
 std::string SubstToLow(std::string s) {

--- a/tests/utils.string.cpp
+++ b/tests/utils.string.cpp
@@ -452,6 +452,14 @@ TEST(Utils_String, ExtractFirstArgument_MultipleWords)
 	EXPECT_EQ("two three", remains);
 }
 
+TEST(Utils_String, ExtractFirstArgument_Aliasing)
+{
+	std::string s = "one two three";
+	std::string word = utils::ExtractFirstArgument(s, s);
+	EXPECT_EQ("one", word);
+	EXPECT_EQ("two three", s);
+}
+
 // ===== FirstWordOnString =====
 
 TEST(Utils_String, FirstWordOnString_ExtractsFirstWord)


### PR DESCRIPTION
…ject (#3037)

Когда вызывали ExtractFirstArgument(str, str), присвоение remains = s.substr(space_pos + 1) портило s до извлечения слова. Результат: dgaffect парсил аргументы неправильно.

Фикс: извлекаем слово в локальную переменную до модификации remains.