### PR TITLE
fix: build fails with -DHAVE_TG=OFF (missing sys/socket.h)

### DIFF
--- a/src/engine/core/iosystem.cpp
+++ b/src/engine/core/iosystem.cpp
@@ -8,7 +8,6 @@
 
 #include "engine/core/iosystem.h"
 
-#include <sys/socket.h>
 #include "engine/entities/char_data.h"
 #include "engine/core/handler.h"
 #include "engine/network/descriptor_data.h"
@@ -893,8 +892,8 @@ ssize_t perform_socket_write(socket_t desc, const char *txt, size_t length)
 #define write	socketwrite
 #endif
 
-#if defined(__APPLE__) || defined(__MACH__) || defined(__CYGWIN__)
 #include <sys/socket.h>
+#if defined(__APPLE__) || defined(__MACH__) || defined(__CYGWIN__)
 # ifndef MSG_NOSIGNAL
 #   define MSG_NOSIGNAL SO_NOSIGPIPE
 # endif


### PR DESCRIPTION
## Summary
- `iosystem.cpp` использует `send()` и `MSG_NOSIGNAL`, но не включал `<sys/socket.h>`
- Работало только при `HAVE_TG=ON`, когда хедер приходил транзитивно через OpenSSL/CURL
- `sysdep.h` включает `<sys/socket.h>` только при `__COMM_C__` (определён только в `comm.cpp`)

## Test plan
- [ ] Собрать с `-DHAVE_TG=OFF`
- [ ] Собрать с `-DHAVE_TG=ON` (регрессия)

🤖 Generated with [Claude Code](https://claude.com/claude-code)