### PR TITLE
fix: alias =1..=9 parameter substitution broken (#3044)

### DIFF
--- a/src/engine/ui/alias.cpp
+++ b/src/engine/ui/alias.cpp
@@ -123,11 +123,11 @@ void FreeAlias(struct alias_data *a) {
  * is "$*", which stands for the entire original line after the alias.
  * ";" is used to delimit commands.
  */
-constexpr int kNumTokens{0};
+constexpr int kNumTokens{9};
 
 void perform_complex_alias(struct iosystem::TextBlocksQueue *input_q, char *orig, struct alias_data *a) {
 	struct iosystem::TextBlocksQueue temp_queue;
-	char *tokens[1], *temp, *write_point;
+	char *tokens[kNumTokens], *temp, *write_point;
 	int num_of_tokens = 0, num;
 
 	// First, parse the original string


### PR DESCRIPTION
## Summary
- `kNumTokens` было `0` вместо `9` — опечатка при рефакторинге `#define NUM_TOKENS 9` → `constexpr int kNumTokens{0}` (коммит c4e39bee8)
- `tokens[1]` исправлен на `tokens[kNumTokens]`
- Из-за `kNumTokens=0` цикл парсинга `while (num_of_tokens < kNumTokens)` никогда не выполнялся
- `=*` работал, т.к. обрабатывается отдельной веткой

Closes #3044

## Test plan
- [ ] `синон тест эм =1` → `тест вававава` → должно выполнить `эмоция вававава`
- [ ] `синон тест2 эм =1+эм =2` → `тест2 а б` → две эмоции
- [ ] `синон тест3 эм =*` → `тест3 а б` → `эмоция а б` (регрессия)

🤖 Generated with [Claude Code](https://claude.com/claude-code)