### PR TITLE
refactor: remove not_null macro, inline replacements in OLC editors (…

### DIFF
--- a/src/engine/olc/medit.cpp
+++ b/src/engine/olc/medit.cpp
@@ -560,13 +560,13 @@ void medit_save_to_disk(ZoneRnum zone_num) {
 		strcpy(buf2, mob->player_data.description.c_str());
 		strip_string(buf2);
 		fprintf(mob_file, "%s~\n" "%s~\n" "%s~\n" "%s~\n" "%s~\n" "%s~\n" "%s~\n" "%s~\n" "%s~\n",
-				not_null(GET_ALIAS(mob), "неопределен"),
-				not_null(GET_PAD(mob, 0), "кто"),
-				not_null(GET_PAD(mob, 1), "кого"),
-				not_null(GET_PAD(mob, 2), "кому"),
-				not_null(GET_PAD(mob, 3), "кого"),
-				not_null(GET_PAD(mob, 4), "кем"),
-				not_null(GET_PAD(mob, 5), "о ком"), buf1, buf2);
+				(GET_ALIAS(mob) && *GET_ALIAS(mob)) ? GET_ALIAS(mob) : "неопределен",
+				not_empty(mob->player_data.PNames[ECase::kNom], "кто"),
+				not_empty(mob->player_data.PNames[ECase::kGen], "кого"),
+				not_empty(mob->player_data.PNames[ECase::kDat], "кому"),
+				not_empty(mob->player_data.PNames[ECase::kAcc], "кого"),
+				not_empty(mob->player_data.PNames[ECase::kIns], "кем"),
+				not_empty(mob->player_data.PNames[ECase::kPre], "о ком"), buf1, buf2);
 		if (mob->mob_specials.Questor)
 			strcpy(buf1, mob->mob_specials.Questor);
 		else
@@ -1767,26 +1767,26 @@ void medit_parse(DescriptorData *d, char *arg) {
 			medit_disp_saves(d);
 			return;
 		}
-		case MEDIT_ALIAS: OLC_MOB(d)->SetCharAliases(not_null(arg, "неопределен"));
+		case MEDIT_ALIAS: OLC_MOB(d)->SetCharAliases((arg && *arg) ? arg : "неопределен");
 			break;
 
-		case MEDIT_PAD0: OLC_MOB(d)->player_data.PNames[ECase::kNom] = std::string(not_null(arg, "кто-то"));
-			OLC_MOB(d)->set_npc_name(not_null(arg, "кто-то"));
+		case MEDIT_PAD0: OLC_MOB(d)->player_data.PNames[ECase::kNom] = std::string((arg && *arg) ? arg : "кто-то");
+			OLC_MOB(d)->set_npc_name((arg && *arg) ? arg : "кто-то");
 			break;
 
-		case MEDIT_PAD1: OLC_MOB(d)->player_data.PNames[ECase::kGen] = std::string(not_null(arg, "кого-то"));
+		case MEDIT_PAD1: OLC_MOB(d)->player_data.PNames[ECase::kGen] = std::string((arg && *arg) ? arg : "кого-то");
 			break;
 
-		case MEDIT_PAD2: OLC_MOB(d)->player_data.PNames[ECase::kDat] = std::string(not_null(arg, "кому-то"));
+		case MEDIT_PAD2: OLC_MOB(d)->player_data.PNames[ECase::kDat] = std::string((arg && *arg) ? arg : "кому-то");
 			break;
 
-		case MEDIT_PAD3: OLC_MOB(d)->player_data.PNames[ECase::kAcc] = std::string(not_null(arg, "кого-то"));
+		case MEDIT_PAD3: OLC_MOB(d)->player_data.PNames[ECase::kAcc] = std::string((arg && *arg) ? arg : "кого-то");
 			break;
 
-		case MEDIT_PAD4: OLC_MOB(d)->player_data.PNames[ECase::kIns] = std::string(not_null(arg, "кем-то"));
+		case MEDIT_PAD4: OLC_MOB(d)->player_data.PNames[ECase::kIns] = std::string((arg && *arg) ? arg : "кем-то");
 			break;
 
-		case MEDIT_PAD5: OLC_MOB(d)->player_data.PNames[ECase::kPre] = std::string(not_null(arg, "о ком-то"));
+		case MEDIT_PAD5: OLC_MOB(d)->player_data.PNames[ECase::kPre] = std::string((arg && *arg) ? arg : "о ком-то");
 			break;
 			//-------------------------------------------------------------------
 		case MEDIT_L_DESC:

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -450,8 +450,8 @@ void oedit_disp_extradesc_menu(DescriptorData *d) {
 			 "%s3%s) Следующий дескриптор: %s\r\n"
 			 "%s0%s) Выход\r\n"
 			 "Ваш выбор : ",
-			 grn, nrm, yel, not_null(extra_desc->keyword, "<NONE>"),
-			 grn, nrm, yel, not_null(extra_desc->description, "<NONE>"),
+			 grn, nrm, yel, (extra_desc->keyword && *extra_desc->keyword) ? extra_desc->keyword : "<NONE>",
+			 grn, nrm, yel, (extra_desc->description && *extra_desc->description) ? extra_desc->description : "<NONE>",
 			 grn, nrm, buf1, grn, nrm);
 	SendMsgToChar(buf, d->character.get());
 	OLC_MODE(d) = OEDIT_EXTRADESC_MENU;
@@ -1576,29 +1576,29 @@ void oedit_parse(DescriptorData *d, char *arg) {
 			}
 			break;
 
-		case OEDIT_EDIT_NAMELIST: OLC_OBJ(d)->set_aliases(not_null(arg, nullptr));
+		case OEDIT_EDIT_NAMELIST: OLC_OBJ(d)->set_aliases((arg && *arg) ? arg : "undefined");
 			break;
 
-		case OEDIT_PAD0: OLC_OBJ(d)->set_short_description(not_null(arg, "что-то"));
-			OLC_OBJ(d)->set_PName(ECase::kNom, not_null(arg, "что-то"));
+		case OEDIT_PAD0: OLC_OBJ(d)->set_short_description((arg && *arg) ? arg : "что-то");
+			OLC_OBJ(d)->set_PName(ECase::kNom, (arg && *arg) ? arg : "что-то");
 			break;
 
-		case OEDIT_PAD1: OLC_OBJ(d)->set_PName(ECase::kGen, not_null(arg, "-чего-то"));
+		case OEDIT_PAD1: OLC_OBJ(d)->set_PName(ECase::kGen, (arg && *arg) ? arg : "-чего-то");
 			break;
 
-		case OEDIT_PAD2: OLC_OBJ(d)->set_PName(ECase::kDat, not_null(arg, "-чему-то"));
+		case OEDIT_PAD2: OLC_OBJ(d)->set_PName(ECase::kDat, (arg && *arg) ? arg : "-чему-то");
 			break;
 
-		case OEDIT_PAD3: OLC_OBJ(d)->set_PName(ECase::kAcc, not_null(arg, "-что-то"));
+		case OEDIT_PAD3: OLC_OBJ(d)->set_PName(ECase::kAcc, (arg && *arg) ? arg : "-что-то");
 			break;
 
-		case OEDIT_PAD4: OLC_OBJ(d)->set_PName(ECase::kIns, not_null(arg, "-чем-то"));
+		case OEDIT_PAD4: OLC_OBJ(d)->set_PName(ECase::kIns, (arg && *arg) ? arg : "-чем-то");
 			break;
 
-		case OEDIT_PAD5: OLC_OBJ(d)->set_PName(ECase::kPre, not_null(arg, "-чем-то"));
+		case OEDIT_PAD5: OLC_OBJ(d)->set_PName(ECase::kPre, (arg && *arg) ? arg : "-чем-то");
 			break;
 
-		case OEDIT_LONGDESC: OLC_OBJ(d)->set_description(not_null(arg, "неопределено"));
+		case OEDIT_LONGDESC: OLC_OBJ(d)->set_description((arg && *arg) ? arg : "неопределено");
 			break;
 
 		case OEDIT_TYPE: number = atoi(arg);
@@ -1998,7 +1998,7 @@ void oedit_parse(DescriptorData *d, char *arg) {
 		case OEDIT_EXTRADESC_KEY:
 			if (OLC_DESC(d)->keyword)
 				free(OLC_DESC(d)->keyword);
-			OLC_DESC(d)->keyword = str_dup(not_null(arg, nullptr));
+			OLC_DESC(d)->keyword = str_dup((arg && *arg) ? arg : "undefined");
 			oedit_disp_extradesc_menu(d);
 			return;
 

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -79,9 +79,6 @@ struct DescriptorData;
 //	false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false
 //};
 
-inline const char *not_null(const char *ptr, const char *str) {
-	return (ptr && *ptr) ? ptr : (str ? str : "undefined");
-}
 
 inline const char *not_empty(const std::string &s) {
 	return s.empty() ? "undefined" : s.c_str();


### PR DESCRIPTION
…#3046)

Макрос not_null удалён. В oedit.cpp и medit.cpp заменён на прямые проверки (arg && *arg) и not_empty() для std::string полей.