### PR TITLE
refactor: replace macros batch 2 - inline + remove IS_MOB (#3046)

### DIFF
--- a/src/engine/db/player_index.cpp
+++ b/src/engine/db/player_index.cpp
@@ -262,7 +262,7 @@ void ActualizePlayersIndex(char *name) {
 					element.last_logon = -1;
 					element.activity = -1;
 				} else {
-					element.last_logon = LAST_LOGON(short_ch);
+					element.last_logon = short_ch->get_last_logon();
 					element.activity = number(0, kObjectSaveActivity - 1);
 				}
 
@@ -384,7 +384,7 @@ bool MustBeDeleted(CharData *short_ch) {
 	}
 	if (timeout >= 0) {
 		timeout *= kSecsPerRealDay;
-		if ((time(nullptr) - LAST_LOGON(short_ch)) > timeout) {
+		if ((time(nullptr) - short_ch->get_last_logon()) > timeout) {
 			return true;
 		}
 	}

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -454,7 +454,7 @@ void Player::save_char() {
 	}
 	fprintf(saved, "Levl: %d\n", this->GetLevel());
 	fprintf(saved, "Clas: %d\n", to_underlying(this->GetClass()));
-	fprintf(saved, "LstL: %ld\n", static_cast<long int>(LAST_LOGON(this)));
+	fprintf(saved, "LstL: %ld\n", static_cast<long int>(this->get_last_logon()));
 	// сохраняем last_ip, который должен содержать айпишник с последнего удачного входа
 	if (player_table[this->get_pfilepos()].last_ip.empty()) {
 		player_table[this->get_pfilepos()].last_ip = "Unknown";
@@ -642,7 +642,7 @@ void Player::save_char() {
 	fprintf(saved, "Room: %d\n", GET_LOADROOM(this));
 //	li = this->player_data.time.birth;
 //	fprintf(saved, "Brth: %ld %s\n", static_cast<long int>(li), ctime(&li));
-	fprintf(saved, "Lexc: %ld\n", static_cast<long>(LAST_EXCHANGE(this)));
+	fprintf(saved, "Lexc: %ld\n", static_cast<long>(this->get_last_exchange()));
 	fprintf(saved, "Badp: %d\n", GET_BAD_PWS(this));
 
 	for (unsigned i = 0; i < board_date_.size(); ++i) {
@@ -923,7 +923,7 @@ void Player::save_char() {
 
 	i = GetPlayerTablePosByName(GET_NAME(this));
 	if (i >= 0) {
-		player_table[i].last_logon = LAST_LOGON(this);
+		player_table[i].last_logon = this->get_last_logon();
 		player_table[i].level = GetRealLevel(this);
 		player_table[i].remorts = GetRealRemort(this);
 		player_table[i].mail = GET_EMAIL(this);
@@ -1915,7 +1915,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 	 * If you're not poisioned and you've been away for more than an hour of
 	 * real time, we'll set your HMV back to full
 	 */
-	if (!AFF_FLAGGED(this, EAffect::kPoisoned) && (((long) (time(0) - LAST_LOGON(this))) >= kSecsPerRealHour)) {
+	if (!AFF_FLAGGED(this, EAffect::kPoisoned) && (((long) (time(0) - this->get_last_logon())) >= kSecsPerRealHour)) {
 		this->set_hit(this->get_real_max_hit());
 		this->set_move(this->get_real_max_move());
 	} else

--- a/src/engine/network/logon.cpp
+++ b/src/engine/network/logon.cpp
@@ -34,7 +34,7 @@ void add_logon_record(DescriptorData *d) {
 	int pos = d->character->get_pfilepos();
 	if (pos >= 0) {
 		player_table[pos].last_ip = d->host;
-		player_table[pos].last_logon = LAST_LOGON(d->character);
+		player_table[pos].last_logon = d->character->get_last_logon();
 	}
 }
 

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -2407,7 +2407,7 @@ void find_replacement(void *go,
 				sprintf(str, "%d", GET_CAST_SUCCESS(mob));
 		} else if (!str_cmp(field, "age")) {
 			if (!mob->IsNpc())
-				sprintf(str, "%d", GET_REAL_AGE(mob));
+				sprintf(str, "%d", CalcCharAge(mob)->year + GET_AGE_ADD(mob));
 		} else if (!str_cmp(field, "hrbase")) {
 			sprintf(str, "%d", GET_HR(mob));
 		} else if (!str_cmp(field, "hradd")) {

--- a/src/engine/ui/cmd/do_hire.cpp
+++ b/src/engine/ui/cmd/do_hire.cpp
@@ -46,7 +46,7 @@ float CalcChaForHire(CharData *victim) {
 		if (cha_app[i].charms >= reformed_hp)
 			break;
 	}
-	i = POSI(i);
+	i = Posi(i);
 	needed_cha = i - 1 + (reformed_hp - cha_app[i - 1].charms) / (cha_app[i].charms - cha_app[i - 1].charms);
 	return VPOSI<float>(needed_cha, 1.0, 50.0);
 }

--- a/src/engine/ui/cmd/do_learn.cpp
+++ b/src/engine/ui/cmd/do_learn.cpp
@@ -24,7 +24,7 @@ bool IsLearningFailed(CharData *ch, ObjData *obj) {
 	addchance += (GET_OBJ_VAL(obj, 0) == EBook::kSpell) ? 0 : 10;
 
 	if (!obj->has_flag(EObjFlag::KNofail)
-		&& number(1, 100) > int_app[POSI(GetRealInt(ch))].spell_aknowlege + addchance) {
+		&& number(1, 100) > int_app[Posi(GetRealInt(ch))].spell_aknowlege + addchance) {
 		return true;
 	}
 	return false;

--- a/src/engine/ui/cmd/do_memorize.cpp
+++ b/src/engine/ui/cmd/do_memorize.cpp
@@ -106,7 +106,7 @@ void show_wizdom(CharData *ch, int bitset) {
 				int div, min, sec;
 				div = CalcManaGain(ch);
 				if (div > 0) {
-					sec = std::max(0, 1 + GET_MEM_CURRENT(ch) - ch->mem_queue.stored);    // sec/div -- время мема в мин
+					sec = std::max(0, 1 + (ch->mem_queue.Empty() ? 0 : CalcSpellManacost(ch, ch->mem_queue.queue->spell_id)) - ch->mem_queue.stored);    // sec/div -- время мема в мин
 					sec = sec * 60 / div;    // время мема в сек
 					min = sec / 60;
 					sec %= 60;

--- a/src/engine/ui/cmd_god/do_last.cpp
+++ b/src/engine/ui/cmd_god/do_last.cpp
@@ -26,7 +26,7 @@ void DoPageLastLogins(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/)
 	if (GetRealLevel(chdata) > GetRealLevel(ch) && !ch->IsImpl() && !ch->IsFlagged(EPrf::kCoderinfo)) {
 		SendMsgToChar("Вы не столь уж и божественны для этого.\r\n", ch);
 	} else {
-		time_t tmp_time = LAST_LOGON(chdata);
+		time_t tmp_time = chdata->get_last_logon();
 		sprintf(buf, "[%5ld] [%2d %s] %-12s : %-18s : %-20s\r\n",
 				chdata->get_uid(), GetRealLevel(chdata),
 				MUD::Class(chdata->GetClass()).GetAbbr().c_str(), GET_NAME(chdata),

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -1351,8 +1351,8 @@ int special(CharData *ch, int cmd, char *argument, int fnum) {
 	int j;
 
 	// special in room? //
-	if (GET_ROOM_SPEC(ch->in_room) != nullptr) {
-		if (GET_ROOM_SPEC(ch->in_room)(ch, world[ch->in_room], cmd, argument)) {
+	if ((VALID_RNUM(ch->in_room) ? world[ch->in_room]->func : nullptr) != nullptr) {
+		if ((VALID_RNUM(ch->in_room) ? world[ch->in_room]->func : nullptr)(ch, world[ch->in_room], cmd, argument)) {
 			check_hiding_cmd(ch, -1);
 			return (1);
 		}
@@ -1950,8 +1950,8 @@ void do_entergame(DescriptorData *d) {
 	chardata_by_uid[d->character->get_uid()] = d->character.get();
 	GET_ACTIVITY(d->character) = number(0, kPlayerSaveActivity - 1);
 	d->character->set_last_logon(time(nullptr));
-//	player_table[GetPtableByUnique(d->character->get_uid())].last_logon = LAST_LOGON(d->character);
-	player_table[d->character->get_pfilepos()].last_logon = LAST_LOGON(d->character);
+//	player_table[GetPtableByUnique(d->character->get_uid())].last_logon = d->character->get_last_logon();
+	player_table[d->character->get_pfilepos()].last_logon = d->character->get_last_logon();
 	network::add_logon_record(d);
 	// чтобы восстановление маны спам-контроля "кто" не шло, когда чар заходит после
 	// того, как повисел на менюшке; важно, чтобы этот вызов шел раньше save_char()
@@ -2140,7 +2140,7 @@ void DoAfterPassword(DescriptorData *d) {
 		iosystem::write_to_output(buf, d);
 		GET_BAD_PWS(d->character) = 0;
 	}
-	time_t tmp_time = LAST_LOGON(d->character);
+	time_t tmp_time = d->character->get_last_logon();
 	sprintf(buf, "\r\nПоследний раз вы заходили к нам в %s с адреса (%s).\r\n",
 			rustime(localtime(&tmp_time)), GET_LASTIP(d->character));
 	iosystem::write_to_output(buf, d);

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -762,7 +762,7 @@ void beat_points_update(int pulse) {
 				handle_recall_spells(d->character.get());
 			}
 
-			while (d->character->mem_queue.stored > GET_MEM_CURRENT(d->character.get()) && !d->character->mem_queue.Empty()) {
+			while (d->character->mem_queue.stored > (d->character->mem_queue.Empty() ? 0 : CalcSpellManacost(d->character.get(), d->character->mem_queue.queue->spell_id)) && !d->character->mem_queue.Empty()) {
 				auto spell_id = MemQ_learn(d->character.get());
 				++GET_SPELL_MEM(d->character, spell_id);
 				d->character->caster_level += MUD::Spell(spell_id).GetDanger();

--- a/src/gameplay/mechanics/mem_queue.cpp
+++ b/src/gameplay/mechanics/mem_queue.cpp
@@ -199,7 +199,7 @@ ESpell MemQ_learn(CharData *ch) {
 	if (ch->mem_queue.Empty()) {
 		return ESpell::kUndefined;
 	}
-	auto num = GET_MEM_CURRENT(ch);
+	auto num = ch->mem_queue.Empty() ? 0 : CalcSpellManacost(ch, ch->mem_queue.queue->spell_id);
 	ch->mem_queue.stored -= num;
 	ch->mem_queue.total -= num;
 	auto spell_id = ch->mem_queue.queue->spell_id;

--- a/src/gameplay/skills/armoring.cpp
+++ b/src/gameplay/skills/armoring.cpp
@@ -41,7 +41,7 @@ void DoArmoring(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			return;
 		}
 
-	if (!OBJWEAR_FLAGGED(obj, (to_underlying(EWearFlag::kBody)
+	if (!obj->get_wear_mask((to_underlying(EWearFlag::kBody)
 		| to_underlying(EWearFlag::kShoulders)
 		| to_underlying(EWearFlag::kHead)
 		| to_underlying(EWearFlag::kArms)

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -182,10 +182,10 @@ constexpr int kSecsPerRealDay = 24*kSecsPerRealHour;
 // IS_IMMORTAL/IS_GOD/IS_GRGOD/IS_IMPL заменены на методы CharData:
 // ch->IsImmortal(), ch->IsGod(), ch->IsGrGod(), ch->IsImpl()
 
-#define IS_SHOPKEEPER(ch) (IS_MOB(ch) && mob_index[(ch)->get_rnum()].func == shop_ext)
-#define IS_RENTKEEPER(ch) (IS_MOB(ch) && mob_index[(ch)->get_rnum()].func == receptionist)
-#define IS_POSTKEEPER(ch) (IS_MOB(ch) && mob_index[(ch)->get_rnum()].func == postmaster)
-#define IS_BANKKEEPER(ch) (IS_MOB(ch) && mob_index[(ch)->get_rnum()].func == bank)
+#define IS_SHOPKEEPER(ch) ((ch)->IsNpc() && mob_index[(ch)->get_rnum()].func == shop_ext)
+#define IS_RENTKEEPER(ch) ((ch)->IsNpc() && mob_index[(ch)->get_rnum()].func == receptionist)
+#define IS_POSTKEEPER(ch) ((ch)->IsNpc() && mob_index[(ch)->get_rnum()].func == postmaster)
+#define IS_BANKKEEPER(ch) ((ch)->IsNpc() && mob_index[(ch)->get_rnum()].func == bank)
 
 // string utils *********************************************************
 
@@ -325,14 +325,12 @@ inline void TOGGLE_BIT(T &var, const Bitvector bit) {
 #define NPC_FLAGS(ch)  ((ch)->mob_specials.npc_flags)
 #define EXTRA_FLAGS(ch) ((ch)->Temporary)
 
-#define IS_MOB(ch)          ((ch)->IsNpc() && (ch)->get_rnum() >= 0)
 
 #define NPC_FLAGGED(ch, flag)   (NPC_FLAGS(ch).get(flag))
 #define EXTRA_FLAGGED(ch, flag) (EXTRA_FLAGS(ch).get(flag))
 #define ROOM_FLAGGED(loc, flag) (world[(loc)]->get_flag(flag))
 #define EXIT_FLAGGED(exit, flag)     (IS_SET((exit)->exit_info, (flag)))
 #define OBJVAL_FLAGGED(obj, flag)    (IS_SET(GET_OBJ_VAL((obj), 1), (flag)))
-#define OBJWEAR_FLAGGED(obj, mask)   ((obj)->get_wear_mask(mask))
 
 // room utils ***********************************************************
 #define SECT(room)   (world[(room)]->sector_type)
@@ -340,23 +338,18 @@ inline void TOGGLE_BIT(T &var, const Bitvector bit) {
 
 #define VALID_RNUM(rnum)   ((rnum) > 0 && (rnum) <= top_of_world)
 #define GET_ROOM_VNUM(rnum) ((RoomVnum)(VALID_RNUM(rnum) ? world[(rnum)]->vnum : kNowhere))
-#define GET_ROOM_SPEC(room) (VALID_RNUM(room) ? world[(room)]->func : nullptr)
 
 // char utils ***********************************************************
 #define IS_MANA_CASTER(ch) ((ch)->GetClass() == ECharClass::kMagus)
-#define GET_REAL_AGE(ch) (CalcCharAge((ch))->year + GET_AGE_ADD(ch))
 #define GET_PC_NAME(ch) ((ch)->GetCharAliases().c_str())
 #define GET_NAME(ch)    ((ch)->get_name().c_str())
 #define GET_MAX_MANA(ch)      (mana[MIN(50, GetRealWis(ch))])
-#define GET_MEM_CURRENT(ch)   ((ch)->mem_queue.Empty() ? 0 : CalcSpellManacost(ch, (ch)->mem_queue.queue->spell_id))
 
 #define GET_EMAIL(ch)          ((ch)->player_specials->saved.EMail)
 #define GET_LASTIP(ch)         ((ch)->player_specials->saved.LastIP)
 #define GET_GOD_FLAG(ch, flag)  (IS_SET((ch)->player_specials->saved.GodsLike, flag))
 #define SET_GOD_FLAG(ch, flag)  (SET_BIT((ch)->player_specials->saved.GodsLike, flag))
 #define CLR_GOD_FLAG(ch, flag)  (REMOVE_BIT((ch)->player_specials->saved.GodsLike, flag))
-#define LAST_LOGON(ch)         ((ch)->get_last_logon())
-#define LAST_EXCHANGE(ch)         ((ch)->get_last_exchange())
 #define NAME_GOD(ch)  ((ch)->player_specials->saved.NameGod)
 #define NAME_ID_GOD(ch)  ((ch)->player_specials->saved.NameIDGod)
 
@@ -364,7 +357,7 @@ inline void TOGGLE_BIT(T &var, const Bitvector bit) {
 #define STRING_WIDTH(ch)  ((ch)->player_specials->saved.stringWidth)
 #define NOTIFY_EXCH_PRICE(ch)  ((ch)->player_specials->saved.ntfyExchangePrice)
 
-#define POSI(val)      (((val) < 50) ? (((val) > 0) ? (val) : 1) : 50)
+inline int Posi(int val) { return std::clamp(val, 1, 50); }
 
 template<typename T>
 inline T VPOSI(const T val, const T min, const T max) {
@@ -392,7 +385,7 @@ inline T VPOSI(const T val, const T min, const T max) {
 #define GET_SIZE(ch)    ((ch)->real_abils.size)
 #define GET_SIZE_ADD(ch)  ((ch)->add_abils.size_add)
 #define GET_REAL_SIZE(ch) (VPOSI(GET_SIZE(ch) + GET_SIZE_ADD(ch), 1, 100))
-#define GET_POS_SIZE(ch)  (POSI(GET_REAL_SIZE(ch) >> 1))
+#define GET_POS_SIZE(ch)  (Posi(GET_REAL_SIZE(ch) >> 1))
 #define GET_HR(ch)         ((ch)->real_abils.hitroll)
 #define GET_HR_ADD(ch)    ((ch)->add_abils.hr_add)
 #define GET_REAL_HR(ch)   (VPOSI(GET_HR(ch)+GET_HR_ADD(ch), -50, (IS_MORTIFIER(ch) ? 100 : 50)))
@@ -496,9 +489,9 @@ const int kNameLevel = 5;
 
 #define GET_EQ(ch, i)      ((ch)->equipment[i])
 
-#define GET_MOB_SPEC(ch)   (IS_MOB(ch) ? mob_index[(ch)->get_rnum()].func : nullptr)
+#define GET_MOB_SPEC(ch)   ((ch)->IsNpc() ? mob_index[(ch)->get_rnum()].func : nullptr)
 #define GET_MOB_RNUM(mob)  (mob)->get_rnum()
-#define GET_MOB_VNUM(mob)  (IS_MOB(mob) ? mob_index[(mob)->get_rnum()].vnum : -1)
+#define GET_MOB_VNUM(mob)  ((mob)->IsNpc() ? mob_index[(mob)->get_rnum()].vnum : -1)
 
 #define GET_DEFAULT_POS(ch)   ((ch)->mob_specials.default_pos)
 #define MEMORY(ch)          ((ch)->mob_specials.memory)


### PR DESCRIPTION
## Summary
Вторая партия замены макросов:

**Удалены (заменены на прямые вызовы):**
- `OBJWEAR_FLAGGED` → `obj->get_wear_mask()`
- `GET_REAL_AGE` → `CalcCharAge()->year + GET_AGE_ADD()`
- `LAST_EXCHANGE` → `->get_last_exchange()`
- `GET_MEM_CURRENT` → прямое выражение
- `GET_ROOM_SPEC` → прямое выражение
- `LAST_LOGON` → `->get_last_logon()`
- `POSI` → `inline Posi()` с `std::clamp`

**IS_MOB удалён:**
- `IS_MOB(ch)` = `IsNpc() && get_rnum() >= 0` — избыточная проверка rnum
- Заменён на `(ch)->IsNpc()` в IS_SHOPKEEPER, IS_RENTKEEPER, IS_POSTKEEPER, IS_BANKKEEPER, GET_MOB_SPEC, GET_MOB_VNUM

## Test plan
- [x] Сборка без ошибок
- [ ] Проверить стабильность на мастере

🤖 Generated with [Claude Code](https://claude.com/claude-code)