### PR TITLE
fix: clear clan owner on disband (#2656)

### DIFF
--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -2167,6 +2167,7 @@ void Clan::DestroyClan(Clan::shared_ptr clan, char *reason) {
 
 	}
 	clan->m_members.clear();                    // remove all members from clan
+	clan->owner.clear();
 
 }
 


### PR DESCRIPTION
## Summary
- При роспуске дружины (`DestroyClan`) не очищалось поле `owner`
- Воевода продолжал отображаться в `дрлист` после роспуска

Фикс: `clan->owner.clear()` после `clan->m_members.clear()`

Closes #2656

## Test plan
- [ ] Распустить дружину, проверить что воевода не отображается в дрлист

🤖 Generated with [Claude Code](https://claude.com/claude-code)