### PR TITLE
refactor: replace macros batch 3 (#3046)

### DIFF
--- a/src/engine/core/char_movement.cpp
+++ b/src/engine/core/char_movement.cpp
@@ -769,9 +769,9 @@ void FleeToRoom(CharData *ch, RoomRnum room) {
 
 	ch->in_room = room;
 	CheckLight(ch, kLightNo, kLightNo, kLightNo, kLightNo, 1);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILHIDE);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILSNEAK);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILCAMOUFLAGE);
+	ch->Temporary.unset(EXTRA_FAILHIDE);
+	ch->Temporary.unset(EXTRA_FAILSNEAK);
+	ch->Temporary.unset(EXTRA_FAILCAMOUFLAGE);
 	if (ch->IsFlagged(EPrf::kCoderinfo)) {
 		sprintf(buf,
 				"%sКомната=%s%d %sСвет=%s%d %sОсвещ=%s%d %sКостер=%s%d %sЛед=%s%d "

--- a/src/engine/core/handler.cpp
+++ b/src/engine/core/handler.cpp
@@ -237,9 +237,9 @@ void PlaceCharToRoom(CharData *ch, RoomRnum room) {
 
 	ch->in_room = room;
 	CheckLight(ch, kLightNo, kLightNo, kLightNo, kLightNo, 1);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILHIDE);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILSNEAK);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILCAMOUFLAGE);
+	ch->Temporary.unset(EXTRA_FAILHIDE);
+	ch->Temporary.unset(EXTRA_FAILSNEAK);
+	ch->Temporary.unset(EXTRA_FAILCAMOUFLAGE);
 	if (ch->IsFlagged(EPrf::kCoderinfo)) {
 		sprintf(buf,
 				"%sКомната=%s%d %sСвет=%s%d %sОсвещ=%s%d %sКостер=%s%d %sЛед=%s%d "

--- a/src/engine/db/player_index.cpp
+++ b/src/engine/db/player_index.cpp
@@ -251,7 +251,7 @@ void ActualizePlayersIndex(char *name) {
 				element.mail = GET_EMAIL(short_ch);
 				for (auto &c : element.mail) c = LOWER(c);
 
-				element.last_ip = GET_LASTIP(short_ch);
+				element.last_ip = short_ch->player_specials->saved.LastIP;
 
 				element.set_uid(short_ch->get_uid());
 				element.level = GetRealLevel(short_ch);

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -985,7 +985,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 	set_last_logon(time(nullptr));
 	set_exp(0);
 	set_remort(0);
-	GET_LASTIP(this)[0] = 0;
+	this->player_specials->saved.LastIP[0] = 0;
 	GET_EMAIL(this)[0] = 0;
 	char_specials.saved.act.from_string("");    // suspicious line: we should clear flags. Loading from "" does not clear flags.
 
@@ -1031,7 +1031,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 				break;
 			case 'H':
 				if (!strcmp(tag, "Host")) {
-					strcpy(GET_LASTIP(this), line);
+					strcpy(this->player_specials->saved.LastIP, line);
 				}
 				break;
 			case 'I':
@@ -1063,7 +1063,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 	} while (!skip_file);
 
 	bool reboot = (load_flags & ELoadCharFlags::kReboot);
-	while ((reboot) && (!*GET_EMAIL(this) || !*GET_LASTIP(this))) {
+	while ((reboot) && (!*GET_EMAIL(this) || !*this->player_specials->saved.LastIP)) {
 		if (!fbgetline(fl, line)) {
 			log("SYSERROR: Wrong file ascii %d %s", id, filename);
 			return (-1);
@@ -1074,7 +1074,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 		if (!strcmp(tag, "EMal"))
 			strcpy(GET_EMAIL(this), line);
 		else if (!strcmp(tag, "Host"))
-			strcpy(GET_LASTIP(this), line);
+			strcpy(this->player_specials->saved.LastIP, line);
 	}
 
 	// если с загруженными выше полями что-то хочется делать после лоада - делайте это здесь
@@ -1470,7 +1470,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 						num = cap_hryvn;
 					this->set_hryvn(num);
 				} else if (!strcmp(tag, "Host"))
-					strcpy(GET_LASTIP(this), line);
+					strcpy(this->player_specials->saved.LastIP, line);
 				break;
 
 			case 'I':

--- a/src/engine/olc/medit.cpp
+++ b/src/engine/olc/medit.cpp
@@ -649,7 +649,7 @@ void medit_save_to_disk(ZoneRnum zone_num) {
 		if (GET_WEIGHT(mob))
 			fprintf(mob_file, "Weight: %d\n", GET_WEIGHT(mob));
 		strcpy(buf1, "Special_Bitvector: ");
-		NPC_FLAGS(mob).tascii(FlagData::kPlanesNumber, buf1);
+		mob->mob_specials.npc_flags.tascii(FlagData::kPlanesNumber, buf1);
 		fprintf(mob_file, "%s\n", buf1);
 		for (const auto &feat : MUD::Feats()) {
 			if (mob->HaveFeat(feat.GetId())) {

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -1876,7 +1876,7 @@ void find_replacement(void *go,
 				if ((num = atoi(subfield)) > 0)
 					num = GetRoomRnum(num);
 				if (num != kNowhere)
-					sprintf(str, "%d", GET_ROOM_SKY(num));
+					sprintf(str, "%d", (world[num]->weather.duration > 0 ? world[num]->weather.sky : weather_info.sky));
 				else
 					sprintf(str, "%d", weather_info.sky);
 			} else if (!str_cmp(field, "type")) {

--- a/src/engine/ui/cmd/do_camouflage.cpp
+++ b/src/engine/ui/cmd/do_camouflage.cpp
@@ -45,7 +45,7 @@ void do_camouflage(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*
 	}
 
 	SendMsgToChar("Вы начали усиленно маскироваться.\r\n", ch);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILCAMOUFLAGE);
+	ch->Temporary.unset(EXTRA_FAILCAMOUFLAGE);
 	percent = number(1, MUD::Skill(ESkill::kDisguise).difficulty);
 	prob = CalcCurrentSkill(ch, ESkill::kDisguise, nullptr);
 

--- a/src/engine/ui/cmd/do_hide.cpp
+++ b/src/engine/ui/cmd/do_hide.cpp
@@ -42,7 +42,7 @@ void do_hide(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	}
 
 	SendMsgToChar("Хорошо, вы попытаетесь спрятаться.\r\n", ch);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILHIDE);
+	ch->Temporary.unset(EXTRA_FAILHIDE);
 	percent = number(1, MUD::Skill(ESkill::kHide).difficulty);
 	prob = CalcCurrentSkill(ch, ESkill::kHide, nullptr);
 

--- a/src/engine/ui/cmd/do_remort.cpp
+++ b/src/engine/ui/cmd/do_remort.cpp
@@ -73,7 +73,7 @@ void DoRemort(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	ch->remort();
 	act(remort_msg2, false, ch, nullptr, nullptr, kToRoom);
 	ch->set_remort(ch->get_remort() + 1);
-	CLR_GOD_FLAG(ch, EGf::kRemort);
+	REMOVE_BIT(ch->player_specials->saved.GodsLike, EGf::kRemort);
 	ch->inc_str(1);
 	ch->inc_dex(1);
 	ch->inc_con(1);

--- a/src/engine/ui/cmd/do_sneak.cpp
+++ b/src/engine/ui/cmd/do_sneak.cpp
@@ -26,7 +26,7 @@ void do_sneak(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	}
 	RemoveAffectFromChar(ch, ESpell::kSneak);
 	SendMsgToChar("Хорошо, вы попытаетесь двигаться бесшумно.\r\n", ch);
-	EXTRA_FLAGS(ch).unset(EXTRA_FAILSNEAK);
+	ch->Temporary.unset(EXTRA_FAILSNEAK);
 	percent = number(1, MUD::Skill(ESkill::kSneak).difficulty);
 	prob = CalcCurrentSkill(ch, ESkill::kSneak, nullptr);
 

--- a/src/engine/ui/cmd_god/do_last.cpp
+++ b/src/engine/ui/cmd_god/do_last.cpp
@@ -30,7 +30,7 @@ void DoPageLastLogins(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/)
 		sprintf(buf, "[%5ld] [%2d %s] %-12s : %-18s : %-20s\r\n",
 				chdata->get_uid(), GetRealLevel(chdata),
 				MUD::Class(chdata->GetClass()).GetAbbr().c_str(), GET_NAME(chdata),
-				GET_LASTIP(chdata)[0] ? GET_LASTIP(chdata) : "Unknown", ctime(&tmp_time));
+				chdata->player_specials->saved.LastIP[0] ? chdata->player_specials->saved.LastIP : "Unknown", ctime(&tmp_time));
 		SendMsgToChar(buf, ch);
 	}
 }

--- a/src/engine/ui/cmd_god/do_set.cpp
+++ b/src/engine/ui/cmd_god/do_set.cpp
@@ -482,9 +482,9 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 				return 0;
 			}
 			if (on_off_mode) {
-				SET_GOD_FLAG(vict, EGf::kDemigod);
+				SET_BIT(vict->player_specials->saved.GodsLike, EGf::kDemigod);
 			} else {
-				CLR_GOD_FLAG(vict, EGf::kDemigod);
+				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kDemigod);
 			}
 			break;
 		case 33:
@@ -567,7 +567,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 
 		case 42:
 			if (on_off_mode) {
-				SET_GOD_FLAG(vict, EGf::kGodsLike);
+				SET_BIT(vict->player_specials->saved.GodsLike, EGf::kGodsLike);
 				if (sscanf(val_arg, "%s %d", npad[0], &i) != 0)
 					GCURSE_DURATION(vict) = (i > 0) ? time(nullptr) + i * 60 * 60 : MAX_TIME;
 				else
@@ -576,19 +576,19 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 				mudlog(buf, BRF, kLvlImplementator, SYSLOG, 0);
 
 			} else {
-				CLR_GOD_FLAG(vict, EGf::kGodsLike);
+				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kGodsLike);
 			}
 			break;
 		case 43:
 			if (on_off_mode) {
-				SET_GOD_FLAG(vict, EGf::kGodscurse);
+				SET_BIT(vict->player_specials->saved.GodsLike, EGf::kGodscurse);
 				if (sscanf(val_arg, "%s %d", npad[0], &i) != 0) {
 					GCURSE_DURATION(vict) = (i > 0) ? time(nullptr) + i * 60 * 60 : MAX_TIME;
 				} else {
 					GCURSE_DURATION(vict) = 0;
 				}
 			} else {
-				CLR_GOD_FLAG(vict, EGf::kGodscurse);
+				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kGodscurse);
 			}
 			break;
 		case 44:
@@ -769,9 +769,9 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 		case 52:
 			// Отдельный лог команд персонажа
 			if (on_off_mode) {
-				SET_GOD_FLAG(vict, EGf::kPerslog);
+				SET_BIT(vict->player_specials->saved.GodsLike, EGf::kPerslog);
 			} else {
-				CLR_GOD_FLAG(vict, EGf::kPerslog);
+				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kPerslog);
 			}
 			break;
 
@@ -873,12 +873,12 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			break;
 		case 60: // флаг тестера
 			if (!str_cmp(val_arg, "off") || !str_cmp(val_arg, "выкл")) {
-				CLR_GOD_FLAG(vict, EGf::kAllowTesterMode);
+				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kAllowTesterMode);
 				vict->UnsetFlag(EPrf::kTester); // обнулим реж тестер
 				sprintf(buf, "%s убрал флаг тестера для игрока %s", GET_NAME(ch), GET_NAME(vict));
 				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
 			} else {
-				SET_GOD_FLAG(vict, EGf::kAllowTesterMode);
+				SET_BIT(vict->player_specials->saved.GodsLike, EGf::kAllowTesterMode);
 				sprintf(buf, "%s установил флаг тестера для игрока %s", GET_NAME(ch), GET_NAME(vict));
 				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
 				//			send_to_gods(buf);
@@ -947,11 +947,11 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 		}
 		case 69: // флаг скилл тестера
 			if (!str_cmp(val_arg, "off") || !str_cmp(val_arg, "выкл")) {
-				CLR_GOD_FLAG(vict, EGf::kSkillTester);
+				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kSkillTester);
 				sprintf(buf, "%s убрал флаг &Rскилл тестера&n для игрока %s", GET_NAME(ch), GET_NAME(vict));
 				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
 			} else {
-				SET_GOD_FLAG(vict, EGf::kSkillTester);
+				SET_BIT(vict->player_specials->saved.GodsLike, EGf::kSkillTester);
 				sprintf(buf, "%s установил флаг &Rскилл тестера&n для игрока %s", GET_NAME(ch), GET_NAME(vict));
 				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
 			}

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -1351,8 +1351,8 @@ int special(CharData *ch, int cmd, char *argument, int fnum) {
 	int j;
 
 	// special in room? //
-	if ((VALID_RNUM(ch->in_room) ? world[ch->in_room]->func : nullptr) != nullptr) {
-		if ((VALID_RNUM(ch->in_room) ? world[ch->in_room]->func : nullptr)(ch, world[ch->in_room], cmd, argument)) {
+	if ((ValidRnum(ch->in_room) ? world[ch->in_room]->func : nullptr) != nullptr) {
+		if ((ValidRnum(ch->in_room) ? world[ch->in_room]->func : nullptr)(ch, world[ch->in_room], cmd, argument)) {
 			check_hiding_cmd(ch, -1);
 			return (1);
 		}
@@ -1992,11 +1992,11 @@ void do_entergame(DescriptorData *d) {
 	// На входе в игру вешаем флаг (странно, что он до этого нигде не вешался
 	if (privilege::IsContainedInGodsList(GET_NAME(d->character), d->character->get_uid())
 		&& (GetRealLevel(d->character) < kLvlGod)) {
-		SET_GOD_FLAG(d->character, EGf::kDemigod);
+		SET_BIT(d->character->player_specials->saved.GodsLike, EGf::kDemigod);
 	}
 	// Насильственно забираем этот флаг у иммов (если он, конечно же, есть
 	if ((GET_GOD_FLAG(d->character, EGf::kDemigod) && GetRealLevel(d->character) >= kLvlGod)) {
-		CLR_GOD_FLAG(d->character, EGf::kDemigod);
+		REMOVE_BIT(d->character->player_specials->saved.GodsLike, EGf::kDemigod);
 	}
 
 	switch (d->character->get_sex()) {
@@ -2142,7 +2142,7 @@ void DoAfterPassword(DescriptorData *d) {
 	}
 	time_t tmp_time = d->character->get_last_logon();
 	sprintf(buf, "\r\nПоследний раз вы заходили к нам в %s с адреса (%s).\r\n",
-			rustime(localtime(&tmp_time)), GET_LASTIP(d->character));
+			rustime(localtime(&tmp_time)), d->character->player_specials->saved.LastIP);
 	iosystem::write_to_output(buf, d);
 
 	//if (!GloryMisc::check_stats(d->character))
@@ -2238,7 +2238,7 @@ void init_char(CharData *ch, PlayerIndexElement &element) {
 	for (i = 0; i < 3; i++) {
 		GET_COND(ch, i) = (GetRealLevel(ch) == kLvlImplementator ? -1 : i == DRUNK ? 0 : 24);
 	}
-	GET_LASTIP(ch)[0] = 0;
+	ch->player_specials->saved.LastIP[0] = 0;
 	//	GET_LOADROOM(ch) = start_room;
 	ch->SetFlag(EPrf::kDispHp);
 	ch->SetFlag(EPrf::kDispMana);

--- a/src/gameplay/ai/spec_assign.cpp
+++ b/src/gameplay/ai/spec_assign.cpp
@@ -197,7 +197,7 @@ void clear_mob_charm(CharData *mob) {
 		mob->UnsetFlag(EMobFlag::kMounting);
 		mob->SetFlag(EMobFlag::kNoCharm);
 		mob->SetFlag(EMobFlag::kNoResurrection);
-		NPC_FLAGS(mob).unset(ENpcFlag::kHelped);
+		mob->mob_specials.npc_flags.unset(ENpcFlag::kHelped);
 	} else {
 		log("SYSERROR: mob = %s (%s:%d)",
 			mob ? (mob->purged() ? "purged" : "true") : "false",

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -522,14 +522,14 @@ void beat_punish(const CharData::shared_ptr &i) {
 	if (GET_GOD_FLAG(i, EGf::kGodsLike)
 		&& GCURSE_DURATION(i) != 0
 		&& GCURSE_DURATION(i) <= time(nullptr)) {
-		CLR_GOD_FLAG(i, EGf::kGodsLike);
+		REMOVE_BIT(i->player_specials->saved.GodsLike, EGf::kGodsLike);
 		SendMsgToChar("Вы более не под защитой Богов.\r\n", i.get());
 	}
 
 	if (GET_GOD_FLAG(i, EGf::kGodscurse)
 		&& GCURSE_DURATION(i) != 0
 		&& GCURSE_DURATION(i) <= time(nullptr)) {
-		CLR_GOD_FLAG(i, EGf::kGodscurse);
+		REMOVE_BIT(i->player_specials->saved.GodsLike, EGf::kGodscurse);
 		SendMsgToChar("Боги более не в обиде на вас.\r\n", i.get());
 	}
 
@@ -860,7 +860,7 @@ void EndowExpToChar(CharData *ch, int gain) {
 								  "%sПоздравляем, вы набрали максимальное количество опыта!\r\n"
 								  "%s%s\r\n", kColorBoldGrn, Remort::WHERE_TO_REMORT_STR.c_str(), kColorNrm);
 				}
-				SET_GOD_FLAG(ch, EGf::kRemort);
+				SET_BIT(ch->player_specials->saved.GodsLike, EGf::kRemort);
 			}
 		}
 		ch->set_exp(std::min(ch->get_exp(), GetExpUntilNextLvl(ch, kLvlImmortal) - 1));
@@ -905,7 +905,7 @@ void EndowExpToChar(CharData *ch, int gain) {
 			SendMsgToChar(ch, "%sВы потеряли право на перевоплощение!%s\r\n",
 						  kColorBoldRed, kColorNrm);
 		}
-		CLR_GOD_FLAG(ch, EGf::kRemort);
+		REMOVE_BIT(ch->player_specials->saved.GodsLike, EGf::kRemort);
 	}
 
 	char_stat::AddClassExp(ch->GetClass(), gain);

--- a/src/gameplay/fight/fight_stuff.cpp
+++ b/src/gameplay/fight/fight_stuff.cpp
@@ -803,7 +803,7 @@ void perform_group_gain(CharData *ch, CharData *victim, int members, int koef) {
 				&& !IS_CHARMICE(victim)
 				&& !ROOM_FLAGGED(victim->in_room, ERoomFlag::kArena)) {
 				mob_stat::AddMob(victim, members);
-				EXTRA_FLAGS(victim).set(EXTRA_GRP_KILL_COUNT);
+				victim->Temporary.set(EXTRA_GRP_KILL_COUNT);
 		} else if (ch->IsNpc() && !victim->IsNpc()
 			&& !ROOM_FLAGGED(victim->in_room, ERoomFlag::kArena)) {
 			mob_stat::AddMob(ch, 0);

--- a/src/gameplay/fight/pk.cpp
+++ b/src/gameplay/fight/pk.cpp
@@ -114,7 +114,7 @@ int pk_calc_spamm(CharData *ch) {
 
 void pk_check_spamm(CharData *ch) {
 	if (pk_calc_spamm(ch) > MAX_PKILL_FOR_PERIOD) {
-		SET_GOD_FLAG(ch, EGf::kGodscurse);
+		SET_BIT(ch->player_specials->saved.GodsLike, EGf::kGodscurse);
 		GCURSE_DURATION(ch) = time(0) + TIME_GODS_CURSE * 60 * 60;
 		act("Боги прокляли тот день, когда ты появился на свет!", false, ch, 0, 0, kToChar);
 	}

--- a/src/gameplay/magic/spells.cpp
+++ b/src/gameplay/magic/spells.cpp
@@ -756,7 +756,7 @@ void SpellLocateObject(int level, CharData *ch, CharData* /*victim*/, ObjData *o
 				return false;
 			}
 
-			if (!VALID_RNUM(carried_by->in_room)) {
+			if (!ValidRnum(carried_by->in_room)) {
 				sprintf(buf,
 						"SYSERR: Illegal room %d, char %s. Создана кора для исследований",
 						carried_by->in_room,

--- a/src/gameplay/mechanics/hide.cpp
+++ b/src/gameplay/mechanics/hide.cpp
@@ -22,7 +22,7 @@ int SkipHiding(CharData *ch, CharData *vict) {
 			SendMsgToChar("Вы попытались спрятаться, но ваша экипировка выдала вас.\r\n", ch);
 			RemoveAffectFromChar(ch, ESpell::kHide);
 			MakeVisible(ch, EAffect::kHide);
-			EXTRA_FLAGS(ch).set(EXTRA_FAILHIDE);
+			ch->Temporary.set(EXTRA_FAILHIDE);
 		} else if (IsAffectedBySpell(ch, ESpell::kHide)) {
 			if (AFF_FLAGGED(vict, EAffect::kDetectLife)) {
 				act("$N почувствовал$G ваше присутствие.", false, ch, nullptr, vict, kToChar);
@@ -52,7 +52,7 @@ int SkipCamouflage(CharData *ch, CharData *vict) {
 			SendMsgToChar("Вы попытались замаскироваться, но ваша экипировка выдала вас.\r\n", ch);
 			RemoveAffectFromChar(ch, ESpell::kCamouflage);
 			MakeVisible(ch, EAffect::kDisguise);
-			EXTRA_FLAGS(ch).set(EXTRA_FAILCAMOUFLAGE);
+			ch->Temporary.set(EXTRA_FAILCAMOUFLAGE);
 		} else if (IsAffectedBySpell(ch, ESpell::kCamouflage)) {
 			if (AFF_FLAGGED(vict, EAffect::kDetectLife)) {
 				act("$N почувствовал$G ваше присутствие.", false, ch, nullptr, vict, kToChar);

--- a/src/gameplay/mechanics/illumination.cpp
+++ b/src/gameplay/mechanics/illumination.cpp
@@ -24,7 +24,7 @@ bool is_dark(RoomRnum room) {
 		coef += 2.0;
 	// если светит луна и комната !помещение и !город
 	if ((SECT(room) != ESector::kInside) && (SECT(room) != ESector::kCity)
-		&& (GET_ROOM_SKY(room) == kSkyLightning
+		&& ((world[room]->weather.duration > 0 ? world[room]->weather.sky : weather_info.sky) == kSkyLightning
 			&& weather_info.moon_day >= kFullMoonStart
 			&& weather_info.moon_day <= kFullMoonStop))
 		coef += 1.0;

--- a/src/gameplay/mechanics/weather.cpp
+++ b/src/gameplay/mechanics/weather.cpp
@@ -865,7 +865,7 @@ int CalcWeatherSpellMod(CharData *ch, ESpell spell_id, int type, int value) {
 		return (modi);
 		}
 
-	sky = GET_ROOM_SKY(ch->in_room);
+	sky = (world[ch->in_room]->weather.duration > 0 ? world[ch->in_room]->weather.sky : weather_info.sky);
 	auto element = MUD::Spell(spell_id).GetElement();
 	switch (type) {
 		case GAPPLY_SPELL_SUCCESS:
@@ -999,7 +999,7 @@ int weather_skill_modifier(CharData *ch, ESkill skillnum, int type, int value) {
 		ROOM_FLAGGED(ch->in_room, ERoomFlag::kIndoors) || ROOM_FLAGGED(ch->in_room, ERoomFlag::kNoWeather))
 		return (modi);
 
-	sky = GET_ROOM_SKY(ch->in_room);
+	sky = (world[ch->in_room]->weather.duration > 0 ? world[ch->in_room]->weather.sky : weather_info.sky);
 
 	switch (type) {
 		case GAPPLY_SKILL_SUCCESS:
@@ -1040,7 +1040,7 @@ int GetComplexSkillMod(CharData *ch, ESkill skillnum, int type, int value) {
 }
 
 int get_room_sky(int rnum) {
-	return GET_ROOM_SKY(rnum);
+	return (world[rnum]->weather.duration > 0 ? world[rnum]->weather.sky : weather_info.sky);
 }
 
 // Calculate the MUD time passed over the last time_to-time_from centuries (secs) //

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -322,22 +322,17 @@ inline void TOGGLE_BIT(T &var, const Bitvector bit) {
 }
 
 
-#define NPC_FLAGS(ch)  ((ch)->mob_specials.npc_flags)
-#define EXTRA_FLAGS(ch) ((ch)->Temporary)
-
-
-#define NPC_FLAGGED(ch, flag)   (NPC_FLAGS(ch).get(flag))
-#define EXTRA_FLAGGED(ch, flag) (EXTRA_FLAGS(ch).get(flag))
+#define NPC_FLAGGED(ch, flag)   ((ch)->mob_specials.npc_flags.get(flag))
+#define EXTRA_FLAGGED(ch, flag) ((ch)->Temporary.get(flag))
 #define ROOM_FLAGGED(loc, flag) (world[(loc)]->get_flag(flag))
 #define EXIT_FLAGGED(exit, flag)     (IS_SET((exit)->exit_info, (flag)))
 #define OBJVAL_FLAGGED(obj, flag)    (IS_SET(GET_OBJ_VAL((obj), 1), (flag)))
 
 // room utils ***********************************************************
 #define SECT(room)   (world[(room)]->sector_type)
-#define GET_ROOM_SKY(room) (world[room]->weather.duration > 0 ? world[room]->weather.sky : weather_info.sky)
-
-#define VALID_RNUM(rnum)   ((rnum) > 0 && (rnum) <= top_of_world)
-#define GET_ROOM_VNUM(rnum) ((RoomVnum)(VALID_RNUM(rnum) ? world[(rnum)]->vnum : kNowhere))
+extern int top_of_world;
+inline bool ValidRnum(int rnum) { return rnum > 0 && rnum <= top_of_world; }
+#define GET_ROOM_VNUM(rnum) ((RoomVnum)(ValidRnum(rnum) ? world[(rnum)]->vnum : kNowhere))
 
 // char utils ***********************************************************
 #define IS_MANA_CASTER(ch) ((ch)->GetClass() == ECharClass::kMagus)
@@ -346,10 +341,7 @@ inline void TOGGLE_BIT(T &var, const Bitvector bit) {
 #define GET_MAX_MANA(ch)      (mana[MIN(50, GetRealWis(ch))])
 
 #define GET_EMAIL(ch)          ((ch)->player_specials->saved.EMail)
-#define GET_LASTIP(ch)         ((ch)->player_specials->saved.LastIP)
 #define GET_GOD_FLAG(ch, flag)  (IS_SET((ch)->player_specials->saved.GodsLike, flag))
-#define SET_GOD_FLAG(ch, flag)  (SET_BIT((ch)->player_specials->saved.GodsLike, flag))
-#define CLR_GOD_FLAG(ch, flag)  (REMOVE_BIT((ch)->player_specials->saved.GodsLike, flag))
 #define NAME_GOD(ch)  ((ch)->player_specials->saved.NameGod)
 #define NAME_ID_GOD(ch)  ((ch)->player_specials->saved.NameIDGod)
 


### PR DESCRIPTION
## Summary
Третья партия — 7 макросов удалены (22 файла, ~60 замен):

- `NPC_FLAGS` → встроен в `NPC_FLAGGED` + 2 прямых использования
- `EXTRA_FLAGS` → встроен в `EXTRA_FLAGGED` + 10 использований
- `GET_LASTIP` → прямой доступ к полю
- `SET_GOD_FLAG` / `CLR_GOD_FLAG` → прямой `SET_BIT`/`REMOVE_BIT`
- `GET_ROOM_SKY` → прямое выражение
- `VALID_RNUM` → `inline ValidRnum()`

## Test plan
- [x] Сборка без ошибок
- [ ] Проверить стабильность на мастере

🤖 Generated with [Claude Code](https://claude.com/claude-code)