### PR TITLE
refactor: replace macros batch 4 (#3046)

### DIFF
--- a/src/administration/names.cpp
+++ b/src/administration/names.cpp
@@ -52,8 +52,8 @@ int was_agree_name(DescriptorData *d) {
 			}
 			d->character->set_sex(static_cast<EGender>(sex));
 			// Auto-Agree char ...
-			NAME_GOD(d->character) = immlev + 1000;
-			NAME_ID_GOD(d->character) = GetPlayerIdByName(immname);
+			(d->character)->player_specials->saved.NameGod = immlev + 1000;
+			(d->character)->player_specials->saved.NameIDGod = GetPlayerIdByName(immname);
 			sprintf(buf, "\r\nВаше имя одобрено!\r\n");
 			iosystem::write_to_output(buf, d);
 			sprintf(buf, "AUTOAGREE: %s was agreed by %s", GET_PC_NAME(d->character), immname);
@@ -363,7 +363,7 @@ static void go_name(CharData *ch, CharData *vict, int action) {
 	}
 
 	// одобряем или нет
-	int lev = NAME_GOD(vict);
+	int lev = (vict)->player_specials->saved.NameGod;
 	if (lev > 1000)
 		lev = lev - 1000;
 	if (lev > god_level) {
@@ -372,12 +372,12 @@ static void go_name(CharData *ch, CharData *vict, int action) {
 	}
 
 	if (lev == god_level)
-		if (NAME_ID_GOD(vict) != ch->get_uid())
+		if ((vict)->player_specials->saved.NameIDGod != ch->get_uid())
 			SendMsgToChar("Об этом имени уже позаботился другой бог вашего уровня.\r\n", ch);
 
 	if (action == NAME_AGREE) {
-		NAME_GOD(vict) = god_level + 1000;
-		NAME_ID_GOD(vict) = ch->get_uid();
+		(vict)->player_specials->saved.NameGod = god_level + 1000;
+		(vict)->player_specials->saved.NameIDGod = ch->get_uid();
 		//SendMsgToChar("Имя одобрено!\r\n", ch);
 		SendMsgToChar(vict, "&GВаше имя одобрено!&n\r\n");
 		agree_name(vict, GET_NAME(ch), god_level);
@@ -387,8 +387,8 @@ static void go_name(CharData *ch, CharData *vict, int action) {
 		//mudlog(buf, CMP, kLevelGod, SYSLOG, true);
 
 	} else {
-		NAME_GOD(vict) = god_level;
-		NAME_ID_GOD(vict) = ch->get_uid();
+		(vict)->player_specials->saved.NameGod = god_level;
+		(vict)->player_specials->saved.NameIDGod = ch->get_uid();
 		//SendMsgToChar("Имя запрещено!\r\n", ch);
 		SendMsgToChar(vict, "&RВаше имя запрещено!&n\r\n");
 		disagree_name(vict, GET_NAME(ch), god_level);

--- a/src/engine/core/iosystem.cpp
+++ b/src/engine/core/iosystem.cpp
@@ -1118,7 +1118,7 @@ std::string MakePrompt(DescriptorData *d) {
 		if (ch->IsFlagged(EPrf::kDispMana) && IS_MANA_CASTER(ch)) {
 			int current_mana = 100 * ch->mem_queue.stored;
 			fmt::format_to(std::back_inserter(out), "{}э{}{} ",
-					  GetColdValueColor(current_mana, GET_MAX_MANA((ch).get())), ch->mem_queue.stored, kColorNrm);
+					  GetColdValueColor(current_mana, mana[MIN(50, GetRealWis((ch).get()))]), ch->mem_queue.stored, kColorNrm);
 		}
 
 		if (ch->IsFlagged(EPrf::kDispExp)) {

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -736,11 +736,11 @@ void Player::save_char() {
 		fprintf(saved, "LogL:\n%s~\n", buffer.str().c_str());
 	}
 	fprintf(saved, "GdFl: %ld\n", this->player_specials->saved.GodsLike);
-	fprintf(saved, "NamG: %d\n", NAME_GOD(this));
-	fprintf(saved, "NaID: %ld\n", NAME_ID_GOD(this));
-	fprintf(saved, "StrL: %d\n", STRING_LENGTH(this));
-	fprintf(saved, "StrW: %d\n", STRING_WIDTH(this));
-	fprintf(saved, "NtfE: %ld\n", NOTIFY_EXCH_PRICE(this));
+	fprintf(saved, "NamG: %d\n", (this)->player_specials->saved.NameGod);
+	fprintf(saved, "NaID: %ld\n", (this)->player_specials->saved.NameIDGod);
+	fprintf(saved, "StrL: %d\n", (this)->player_specials->saved.stringLength);
+	fprintf(saved, "StrW: %d\n", (this)->player_specials->saved.stringWidth);
+	fprintf(saved, "NtfE: %ld\n", (this)->player_specials->saved.ntfyExchangePrice);
 
 	if (this->remember_get_num() != Remember::DEF_REMEMBER_NUM) {
 		fprintf(saved, "Rmbr: %u\n", this->remember_get_num());
@@ -1205,10 +1205,10 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 	this->set_max_move(44);
 	KARMA(this) = 0;
 	LOGON_LIST(this).clear();
-	NAME_GOD(this) = 0;
-	STRING_LENGTH(this) = 80;
-	STRING_WIDTH(this) = 30;
-	NAME_ID_GOD(this) = 0;
+	(this)->player_specials->saved.NameGod = 0;
+	(this)->player_specials->saved.stringLength = 80;
+	(this)->player_specials->saved.stringWidth = 30;
+	(this)->player_specials->saved.NameIDGod = 0;
 	GET_OLC_ZONE(this) = -1;
 	this->player_data.time.played = 0;
 	GET_LOADROOM(this) = kNowhere;
@@ -1224,7 +1224,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 	EXCHANGE_FILTER(this) = nullptr;
 	clear_ignores();
 	CREATE(GET_LOGS(this), 1 + LAST_LOG);
-	NOTIFY_EXCH_PRICE(this) = 0;
+	(this)->player_specials->saved.ntfyExchangePrice = 0;
 	this->player_specials->saved.HiredCost = 0;
 	this->player_specials->saved.brief_shields_mode = EBriefShieldsMode::kBrief;
 	this->set_who_mana(kWhoManaMax);
@@ -1569,11 +1569,11 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 				else if (!strcmp(tag, "NamD"))
 					NAME_DURATION(this) = lnum;
 				else if (!strcmp(tag, "NamG"))
-					NAME_GOD(this) = num;
+					(this)->player_specials->saved.NameGod = num;
 				else if (!strcmp(tag, "NaID"))
-					NAME_ID_GOD(this) = lnum;
+					(this)->player_specials->saved.NameIDGod = lnum;
 				else if (!strcmp(tag, "NtfE"))
-					NOTIFY_EXCH_PRICE(this) = lnum;
+					(this)->player_specials->saved.ntfyExchangePrice = lnum;
 				break;
 
 			case 'O':
@@ -1809,9 +1809,9 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 				} else if (!strcmp(tag, "Str "))
 					this->set_str(num);
 				else if (!strcmp(tag, "StrL"))
-					STRING_LENGTH(this) = num;
+					(this)->player_specials->saved.stringLength = num;
 				else if (!strcmp(tag, "StrW"))
-					STRING_WIDTH(this) = num;
+					(this)->player_specials->saved.stringWidth = num;
 				else if (!strcmp(tag, "St00"))
 					this->set_start_stat(G_STR, lnum);
 				else if (!strcmp(tag, "St01"))

--- a/src/engine/network/msdp/msdp_reporters.cpp
+++ b/src/engine/network/msdp/msdp_reporters.cpp
@@ -136,7 +136,7 @@ void MaxMoveReporter::get(Variable::shared_ptr &response) {
 }
 
 void MaxManaReporter::get(Variable::shared_ptr &response) {
-	const auto max_mana = std::to_string(GET_MAX_MANA((descriptor()->character).get()));
+	const auto max_mana = std::to_string(mana[MIN(50, GetRealWis((descriptor()->character).get()))]);
 	response = std::make_shared<Variable>("MAX_MANA",
 										  std::make_shared<StringValue>(max_mana));
 }
@@ -252,14 +252,14 @@ int GroupReporter::get_mem(const CharData *character) const {
 	int result = 0;
 	if (!character->IsNpc()
 		&& ((!IS_MANA_CASTER(character) && !character->mem_queue.Empty())
-			|| (IS_MANA_CASTER(character) && character->mem_queue.stored < GET_MAX_MANA(character)))) {
+			|| (IS_MANA_CASTER(character) && character->mem_queue.stored < mana[MIN(50, GetRealWis(character))]))) {
 		auto div = CalcManaGain(character);
 		if (div > 0) {
 			if (!IS_MANA_CASTER(character)) {
 				result = std::max(0, 1 + character->mem_queue.total - character->mem_queue.stored);
 				result = result * 60 / div;
 			} else {
-				result = std::max(0, 1 + GET_MAX_MANA(character) - character->mem_queue.stored);
+				result = std::max(0, 1 + mana[MIN(50, GetRealWis(character))] - character->mem_queue.stored);
 				result = result / div;
 			}
 		} else {

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -2365,7 +2365,7 @@ void find_replacement(void *go,
 				sprintf(str, "%d", mob->mem_queue.stored);
 			}
 		} else if (!str_cmp(field, "maxmana")) {
-			sprintf(str, "%d", GET_MAX_MANA(mob));
+			sprintf(str, "%d", mana[MIN(50, GetRealWis(mob))]);
 		} else if (!str_cmp(field, "getstat")) {
 			if (*subfield)  {
 				sprintf(str, "%lld", mob->GetStatistic(static_cast<CharStat::ECategory>(atoi(subfield))));

--- a/src/engine/scripting/scripting.cpp
+++ b/src/engine/scripting/scripting.cpp
@@ -577,7 +577,7 @@ class CharacterWrapper : public Wrapper<CharacterData> {
 		vict->set_hit(vict->get_real_max_hit());
 		vict->set_move(vict->get_real_max_move());
 		if (IS_MANA_CASTER(vict)) {
-			vict->mem_queue.stored = GET_MAX_MANA(vict);
+			vict->mem_queue.stored = mana[MIN(50, GetRealWis(vict))];
 		} else {
 			vict->mem_queue.stored = vict->mem_queue.total;
 		}

--- a/src/engine/ui/cmd/do_get.cpp
+++ b/src/engine/ui/cmd/do_get.cpp
@@ -171,7 +171,7 @@ void get_from_container(CharData *ch, ObjData *cont, char *local_arg, int mode, 
 	int obj_dotmode, found = 0;
 
 	obj_dotmode = find_all_dots(local_arg);
-	if (OBJVAL_FLAGGED(cont, EContainerFlag::kShutted))
+	if (IS_SET(GET_OBJ_VAL((cont), 1), (EContainerFlag::kShutted)))
 		act("$o закрыт$A.", false, ch, cont, nullptr, kToChar);
 	else if (obj_dotmode == kFindIndiv) {
 		if (!(obj = get_obj_in_list_vis(ch, local_arg, cont->get_contains()))) {

--- a/src/engine/ui/cmd/do_mode.cpp
+++ b/src/engine/ui/cmd/do_mode.cpp
@@ -562,11 +562,11 @@ void SetScreen(CharData *ch, char *argument, int flag) {
 	else if (flag == 1 && (size < 10 || size > 100))
 		SendMsgToChar("Высота экрана должна быть в пределах 10 - 100 строк.\r\n", ch);
 	else if (!flag) {
-		STRING_LENGTH(ch) = size;
+		(ch)->player_specials->saved.stringLength = size;
 		SendMsgToChar("Ладушки.\r\n", ch);
 		ch->save_char();
 	} else if (flag == 1) {
-		STRING_WIDTH(ch) = size;
+		(ch)->player_specials->saved.stringWidth = size;
 		SendMsgToChar("Ладушки.\r\n", ch);
 		ch->save_char();
 	} else {
@@ -589,12 +589,12 @@ void SetNotifyEchange(CharData *ch, char *argument) {
 					  "Вам будут приходить уведомления о продаже с базара ваших лотов стоимостью не менее чем %ld %s.\r\n",
 					  size,
 					  GetDeclensionInNumber(size, EWhat::kMoneyA));
-		NOTIFY_EXCH_PRICE(ch) = size;
+		(ch)->player_specials->saved.ntfyExchangePrice = size;
 		ch->save_char();
 	} else if (size >= 0 && size < 100) {
 		SendMsgToChar(ch,
 					  "Вам не будут приходить уведомления о продаже с базара ваших лотов, так как указана цена меньше 100 кун.\r\n");
-		NOTIFY_EXCH_PRICE(ch) = 0;
+		(ch)->player_specials->saved.ntfyExchangePrice = 0;
 		ch->save_char();
 	} else {
 		SendMsgToChar(ch, "Укажите стоимость лота от 0 до %d\r\n", 0x7fffffff);

--- a/src/engine/ui/cmd/do_put.cpp
+++ b/src/engine/ui/cmd/do_put.cpp
@@ -178,7 +178,7 @@ void do_put(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			SendMsgToChar(buf, ch);
 		} else if (cont->get_type() != EObjType::kContainer) {
 			act("В $o3 нельзя ничего положить.", false, ch, cont, nullptr, kToChar);
-		} else if (OBJVAL_FLAGGED(cont, EContainerFlag::kShutted)) {
+		} else if (IS_SET(GET_OBJ_VAL((cont), 1), (EContainerFlag::kShutted))) {
 			act("$o0 закрыт$A!", false, ch, cont, nullptr, kToChar);
 		} else {
 			if (obj_dotmode == kFindIndiv)    // put <obj> <container>

--- a/src/engine/ui/cmd/do_score.cpp
+++ b/src/engine/ui/cmd/do_score.cpp
@@ -127,7 +127,7 @@ void PrintScoreList(CharData *ch) {
 				  ch->get_move(), ch->get_real_max_move(), GetDeclensionInNumber(ch->get_move(), EWhat::kMoveU));
 	if (IS_MANA_CASTER(ch)) {
 		SendMsgToChar(ch, "Ваша магическая энергия %d(%d) и вы восстанавливаете %d в сек.\r\n",
-					  ch->mem_queue.stored, GET_MAX_MANA(ch), CalcManaGain(ch));
+					  ch->mem_queue.stored, mana[MIN(50, GetRealWis(ch))], CalcManaGain(ch));
 	}
 	SendMsgToChar(ch, "Ваша сила: %d(%d), ловкость: %d(%d), телосложение: %d(%d), ум: %d(%d), мудрость: %d(%d), обаяние: %d(%d).\r\n",
 				  ch->get_str(), GetRealStr(ch),
@@ -215,7 +215,7 @@ void PrintScoreList(CharData *ch) {
 			*buf2 = '\0';
 		}
 	}
-	if (!NAME_GOD(ch) && GetRealLevel(ch) <= kNameLevel) {
+	if (!(ch)->player_specials->saved.NameGod && GetRealLevel(ch) <= kNameLevel) {
 		SendMsgToChar(ch, "ВНИМАНИЕ! ваше имя не одобрил никто из богов!\r\n");
 		SendMsgToChar(ch, "Cкоро вы прекратите получать опыт, обратитесь к богам для одобрения имени.\r\n");
 	} else if (NAME_BAD(ch)) {
@@ -288,7 +288,7 @@ void PrintGloryInfo(CharData *ch, std::ostringstream &out) {
 }
 
 void PrintNameStatusInfo(CharData *ch, std::ostringstream &out) {
-	if (!NAME_GOD(ch) && GetRealLevel(ch) <= kNameLevel) {
+	if (!(ch)->player_specials->saved.NameGod && GetRealLevel(ch) <= kNameLevel) {
 		out << InfoStrPrefix(ch) << kColorBoldRed << "ВНИМАНИЕ! " << kColorNrm
 			<< "ваше имя не одобрил никто из богов!" << "\r\n";
 		out << InfoStrPrefix(ch) << kColorBoldRed << "ВНИМАНИЕ! " << kColorNrm
@@ -542,7 +542,7 @@ int PrintBaseStatsToTable(CharData *ch, table_wrapper::Table &table, std::size_t
 	table[++row][col] = "Выносливость";	table[row][col + 1] = std::to_string(ch->get_move()) + "(" + std::to_string(ch->get_real_max_move()) + ")";
 	table[++row][col] = "Восст. сил";	table[row][col + 1] = "+" + std::to_string(ch->get_movereg()) + "% (" + std::to_string(move_gain(ch)) + ")";
 	if (IS_MANA_CASTER(ch)) {
-		table[++row][col] = "Мана"; 		table[row][col + 1] = std::to_string(ch->mem_queue.stored) + "(" + std::to_string(GET_MAX_MANA(ch)) + ")";
+		table[++row][col] = "Мана"; 		table[row][col + 1] = std::to_string(ch->mem_queue.stored) + "(" + std::to_string(mana[MIN(50, GetRealWis(ch))]) + ")";
 		table[++row][col] = "Восст. маны";	table[row][col + 1] = "+" + std::to_string(CalcManaGain(ch)) + " сек.";
 	}
 
@@ -721,7 +721,7 @@ void PrintScoreBase(CharData *ch) {
 	if (IS_MANA_CASTER(ch)) {
 		sprintf(buf + strlen(buf),
 				"Ваша магическая энергия %d(%d) и вы восстанавливаете %d в сек.\r\n",
-				ch->mem_queue.stored, GET_MAX_MANA(ch), CalcManaGain(ch));
+				ch->mem_queue.stored, mana[MIN(50, GetRealWis(ch))], CalcManaGain(ch));
 	}
 
 	sprintf(buf + strlen(buf),

--- a/src/engine/ui/cmd/do_spells.cpp
+++ b/src/engine/ui/cmd/do_spells.cpp
@@ -81,7 +81,7 @@ void DisplaySpells(CharData *ch, CharData *vict, bool all) {
 		if (IS_MANA_CASTER(ch)) {
 			if (!spell_create.contains(spell_id))
 				continue;
-			if (CalcSpellManacost(ch, spell_id) > GET_MAX_MANA(ch))
+			if (CalcSpellManacost(ch, spell_id) > mana[MIN(50, GetRealWis(ch))])
 				continue;
 			if (CheckRecipeItems(ch, spell_id, ESpellType::kRunes, false)) {
 				slots[slot_num] += sprintf(names[slot_num] + slots[slot_num],

--- a/src/engine/ui/cmd/do_toggle.cpp
+++ b/src/engine/ui/cmd/do_toggle.cpp
@@ -92,8 +92,8 @@ void do_toggle(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 			 BoolToOnOffStr(ch->IsFlagged(EPrf::kAutomoney)),
 			 BoolToOnOffStr(!ch->IsFlagged(EPrf::kNoArena)),
 			 buf2,
-			 STRING_LENGTH(ch),
-			 STRING_WIDTH(ch),
+			 (ch)->player_specials->saved.stringLength,
+			 (ch)->player_specials->saved.stringWidth,
 #if defined(HAVE_ZLIB)
 			 ch->desc->deflate == nullptr ? "нет" : (ch->desc->mccp_version == 2 ? "MCCPv2" : "MCCPv1"),
 #else
@@ -111,8 +111,8 @@ void do_toggle(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 			 BoolToOnOffStr(ch->IsFlagged(EPrf::kNoIngrMode)),
 			 ch->remember_get_num());
 	SendMsgToChar(buf, ch);
-	if (NOTIFY_EXCH_PRICE(ch) > 0) {
-		sprintf(buf, " Уведомления   : %-7ld ", NOTIFY_EXCH_PRICE(ch));
+	if ((ch)->player_specials->saved.ntfyExchangePrice > 0) {
+		sprintf(buf, " Уведомления   : %-7ld ", (ch)->player_specials->saved.ntfyExchangePrice);
 	} else {
 		sprintf(buf, " Уведомления   : %-7s ", "Нет");
 	}

--- a/src/engine/ui/cmd/do_who.cpp
+++ b/src/engine/ui/cmd/do_who.cpp
@@ -146,7 +146,7 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		if (showclass != ECharClass::kUndefined && showclass != tch->GetClass()) {
 			continue;
 		}
-		if (showname && !(!NAME_GOD(tch) && GetRealLevel(tch) <= kNameLevel)) {
+		if (showname && !(!(tch)->player_specials->saved.NameGod && GetRealLevel(tch) <= kNameLevel)) {
 			continue;
 		}
 		if (tch->IsFlagged(EPlrFlag::kNameDenied) && NAME_DURATION(tch)
@@ -211,7 +211,7 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				sprintf(buf + strlen(buf), " (нем%s)", GET_CH_SUF_6(tch));
 			if (tch->IsFlagged(EPlrFlag::kKiller) == EPlrFlag::kKiller)
 				sprintf(buf + strlen(buf), "&R (ДУШЕГУБ)&n");
-			if ((ch->IsImmortal() || GET_GOD_FLAG(ch, EGf::kDemigod)) && !NAME_GOD(tch)
+			if ((ch->IsImmortal() || GET_GOD_FLAG(ch, EGf::kDemigod)) && !(tch)->player_specials->saved.NameGod
 				&& GetRealLevel(tch) <= kNameLevel) {
 				sprintf(buf + strlen(buf), " &W!НЕ ОДОБРЕНО!&n");
 				if (showname) {
@@ -226,7 +226,7 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			if ((GetRealLevel(ch) == kLvlImplementator) && (NORENTABLE(tch)))
 				sprintf(buf + strlen(buf), " &R(В КРОВИ)&n");
 			else if ((ch->IsImmortal() || ch->IsFlagged(EPrf::kCoderinfo)) && NAME_BAD(tch)) {
-				sprintf(buf + strlen(buf), " &Wзапрет %s!&n", GetNameById(NAME_ID_GOD(tch)).c_str());
+				sprintf(buf + strlen(buf), " &Wзапрет %s!&n", GetNameById((tch)->player_specials->saved.NameIDGod).c_str());
 			}
 			if (ch->IsGod() && (GET_GOD_FLAG(tch, EGf::kAllowTesterMode)))
 				sprintf(buf + strlen(buf), " &G(ТЕСТЕР!)&n");

--- a/src/engine/ui/cmd/do_who_am_i.cpp
+++ b/src/engine/ui/cmd/do_who_am_i.cpp
@@ -22,19 +22,19 @@ void DoWhoAmI(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	sprintf(buf + strlen(buf), "Дата вашего рождения : %s\r\n", rustime(localtime(&birt)));
 	sprintf(buf + strlen(buf), "Ваш IP-адрес : %s\r\n", ch->desc ? ch->desc->host : "Unknown");
 	SendMsgToChar(buf, ch);
-	if (!NAME_GOD(ch)) {
+	if (!(ch)->player_specials->saved.NameGod) {
 		sprintf(buf, "Имя никем не одобрено!\r\n");
 		SendMsgToChar(buf, ch);
 	} else {
-		const int god_level = NAME_GOD(ch) > 1000 ? NAME_GOD(ch) - 1000 : NAME_GOD(ch);
-		sprintf(buf1, "%s", GetNameById(NAME_ID_GOD(ch)).c_str());
+		const int god_level = (ch)->player_specials->saved.NameGod > 1000 ? (ch)->player_specials->saved.NameGod - 1000 : (ch)->player_specials->saved.NameGod;
+		sprintf(buf1, "%s", GetNameById((ch)->player_specials->saved.NameIDGod).c_str());
 		*buf1 = UPPER(*buf1);
 
 		static const char *by_rank_god = "Богом";
 		static const char *by_rank_privileged = "привилегированным игроком";
 		const char *by_rank = god_level < kLvlImmortal ? by_rank_privileged : by_rank_god;
 
-		if (NAME_GOD(ch) < 1000)
+		if ((ch)->player_specials->saved.NameGod < 1000)
 			snprintf(buf, kMaxStringLength, "&RИмя запрещено %s %s&n\r\n", by_rank, buf1);
 		else
 			snprintf(buf, kMaxStringLength, "&WИмя одобрено %s %s&n\r\n", by_rank, buf1);

--- a/src/engine/ui/cmd_god/do_arena_restore.cpp
+++ b/src/engine/ui/cmd_god/do_arena_restore.cpp
@@ -22,7 +22,7 @@ void DoArenaRestore(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		vict->set_hit(vict->get_real_max_hit());
 		vict->set_move(vict->get_real_max_move());
 		if (IS_MANA_CASTER(vict)) {
-			vict->mem_queue.stored = GET_MAX_MANA(vict);
+			vict->mem_queue.stored = mana[MIN(50, GetRealWis(vict))];
 		} else {
 			vict->mem_queue.stored = vict->mem_queue.total;
 		}

--- a/src/engine/ui/cmd_god/do_restore.cpp
+++ b/src/engine/ui/cmd_god/do_restore.cpp
@@ -32,7 +32,7 @@ void DoRestore(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		vict->set_hit(vict->get_real_max_hit());
 		vict->set_move(vict->get_real_max_move());
 		if (IS_MANA_CASTER(vict)) {
-			vict->mem_queue.stored = GET_MAX_MANA(vict);
+			vict->mem_queue.stored = mana[MIN(50, GetRealWis(vict))];
 		} else {
 			vict->mem_queue.stored = vict->mem_queue.total;
 		}

--- a/src/engine/ui/cmd_god/do_show.cpp
+++ b/src/engine/ui/cmd_god/do_show.cpp
@@ -580,14 +580,14 @@ void do_show(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			sprintf(buf + strlen(buf), "Падежи : %s/%s/%s/%s/%s/%s\r\n",
 					GET_PAD(vict, 0), GET_PAD(vict, 1), GET_PAD(vict, 2),
 					GET_PAD(vict, 3), GET_PAD(vict, 4), GET_PAD(vict, 5));
-			if (!NAME_GOD(vict)) {
+			if (!(vict)->player_specials->saved.NameGod) {
 				sprintf(buf + strlen(buf), "Имя никем не одобрено!\r\n");
-			} else if (NAME_GOD(vict) < 1000) {
-				sprintf(buf1, "%s", GetNameById(NAME_ID_GOD(vict)).c_str());
+			} else if ((vict)->player_specials->saved.NameGod < 1000) {
+				sprintf(buf1, "%s", GetNameById((vict)->player_specials->saved.NameIDGod).c_str());
 				*buf1 = UPPER(*buf1);
 				snprintf(buf + strlen(buf), kMaxStringLength, "Имя запрещено богом %s\r\n", buf1);
 			} else {
-				sprintf(buf1, "%s", GetNameById(NAME_ID_GOD(vict)).c_str());
+				sprintf(buf1, "%s", GetNameById((vict)->player_specials->saved.NameIDGod).c_str());
 				*buf1 = UPPER(*buf1);
 				snprintf(buf + strlen(buf), kMaxStringLength, "Имя одобрено богом %s\r\n", buf1);
 			}

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -148,14 +148,14 @@ void do_stat_character(CharData *ch, CharData *k, const int virt = 0) {
 
 	if (!k->IsNpc()) {
 
-		if (!NAME_GOD(k)) {
+		if (!(k)->player_specials->saved.NameGod) {
 			sprintf(buf, "Имя никем не одобрено!\r\n");
 			SendMsgToChar(buf, ch);
-		} else if (NAME_GOD(k) < 1000) {
-			sprintf(buf, "Имя запрещено! - %s\r\n", GetNameById(NAME_ID_GOD(k)).c_str());
+		} else if ((k)->player_specials->saved.NameGod < 1000) {
+			sprintf(buf, "Имя запрещено! - %s\r\n", GetNameById((k)->player_specials->saved.NameIDGod).c_str());
 			SendMsgToChar(buf, ch);
 		} else {
-			sprintf(buf, "Имя одобрено! - %s\r\n", GetNameById(NAME_ID_GOD(k)).c_str());
+			sprintf(buf, "Имя одобрено! - %s\r\n", GetNameById((k)->player_specials->saved.NameIDGod).c_str());
 			SendMsgToChar(buf, ch);
 		}
 
@@ -324,7 +324,7 @@ void do_stat_character(CharData *ch, CharData *k, const int virt = 0) {
 	SendMsgToChar(buf, ch);
 	if (IS_MANA_CASTER(k)) {
 		sprintf(buf, " Мана :[%s%d/%d+%d%s]\r\n",
-				kColorGrn, k->mem_queue.stored, GET_MAX_MANA(k), CalcManaGain(k), kColorNrm);
+				kColorGrn, k->mem_queue.stored, mana[MIN(50, GetRealWis(k))], CalcManaGain(k), kColorNrm);
 	} else {
 		sprintf(buf, "\r\n");
 	}

--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -2248,9 +2248,9 @@ void init_char(CharData *ch, PlayerIndexElement &element) {
 	ch->SetFlag(EPrf::kDispFight);
 	ch->UnsetFlag(EPrf::KSummonable);
 	ch->SetFlag(EPrf::kColor2);
-	STRING_LENGTH(ch) = 80;
-	STRING_WIDTH(ch) = 30;
-	NOTIFY_EXCH_PRICE(ch) = 0;
+	(ch)->player_specials->saved.stringLength = 80;
+	(ch)->player_specials->saved.stringWidth = 30;
+	(ch)->player_specials->saved.ntfyExchangePrice = 0;
 
 	ch->save_char();
 }

--- a/src/engine/ui/modify.cpp
+++ b/src/engine/ui/modify.cpp
@@ -1091,7 +1091,7 @@ char *next_page(char *str, CharData *ch) {
 			return (nullptr);
 
 			// If we're at the start of the next page, return this fact. //
-		else if (STRING_WIDTH(ch) && line > STRING_WIDTH(ch))
+		else if ((ch)->player_specials->saved.stringWidth && line > (ch)->player_specials->saved.stringWidth)
 			return (str);
 
 			// Check for the begining of an ANSI color code block. //
@@ -1154,7 +1154,7 @@ char *next_page(char *str, CharData *ch) {
 
 				// * We need to check here and see if we are over the page width,
 				// * and if so, compensate by going to the begining of the next line.
-			else if (STRING_LENGTH(ch) && ++col > STRING_LENGTH(ch)) {
+			else if ((ch)->player_specials->saved.stringLength && ++col > (ch)->player_specials->saved.stringLength) {
 				col = 1;
 				line++;
 			}

--- a/src/gameplay/ai/mob_memory.cpp
+++ b/src/gameplay/ai/mob_memory.cpp
@@ -116,7 +116,7 @@ CharData *FimdRememberedEnemyInRoom(CharData *mob, int check_sneak, bool skip_hi
 				}
 				if (check_sneak) {
 					SkipSneaking(vict, mob);
-					if (EXTRA_FLAGGED(vict, EXTRA_FAILSNEAK)) {
+					if ((vict)->Temporary.get(EXTRA_FAILSNEAK)) {
 						AFF_FLAGS(vict).unset(EAffect::kSneak);
 					}
 					if (AFF_FLAGGED(vict, EAffect::kSneak))
@@ -124,11 +124,11 @@ CharData *FimdRememberedEnemyInRoom(CharData *mob, int check_sneak, bool skip_hi
 				}
 				if (!skip_hide_camouflage_checks) {
 					SkipHiding(vict, mob);
-					if (EXTRA_FLAGGED(vict, EXTRA_FAILHIDE)) {
+					if ((vict)->Temporary.get(EXTRA_FAILHIDE)) {
 						AFF_FLAGS(vict).unset(EAffect::kHide);
 					}
 					SkipCamouflage(vict, mob);
-					if (EXTRA_FLAGGED(vict, EXTRA_FAILCAMOUFLAGE)) {
+					if ((vict)->Temporary.get(EXTRA_FAILCAMOUFLAGE)) {
 						AFF_FLAGS(vict).unset(EAffect::kDisguise);
 					}
 				}

--- a/src/gameplay/ai/mobact.cpp
+++ b/src/gameplay/ai/mobact.cpp
@@ -399,7 +399,7 @@ CharData *find_best_stupidmob_victim(CharData *ch, int extmode) {
 		// skip sneaking, hiding and camouflaging pc
 		if (IS_SET(extmode, SKIP_SNEAKING)) {
 			SkipSneaking(vict, ch);
-			if ((EXTRA_FLAGGED(vict, EXTRA_FAILSNEAK))) {
+			if (((vict)->Temporary.get(EXTRA_FAILSNEAK))) {
 				AFF_FLAGS(vict).unset(EAffect::kSneak);
 			}
 			if (AFF_FLAGGED(vict, EAffect::kSneak))
@@ -408,14 +408,14 @@ CharData *find_best_stupidmob_victim(CharData *ch, int extmode) {
 
 		if (IS_SET(extmode, SKIP_HIDING)) {
 			SkipHiding(vict, ch);
-			if (EXTRA_FLAGGED(vict, EXTRA_FAILHIDE)) {
+			if ((vict)->Temporary.get(EXTRA_FAILHIDE)) {
 				AFF_FLAGS(vict).unset(EAffect::kHide);
 			}
 		}
 
 		if (IS_SET(extmode, SKIP_CAMOUFLAGE)) {
 			SkipCamouflage(vict, ch);
-			if (EXTRA_FLAGGED(vict, EXTRA_FAILCAMOUFLAGE)) {
+			if ((vict)->Temporary.get(EXTRA_FAILCAMOUFLAGE)) {
 				AFF_FLAGS(vict).unset(EAffect::kDisguise);
 			}
 		}
@@ -547,7 +547,7 @@ bool filter_victim (CharData *ch, CharData *vict, int extmode) {
 	}
 	if (IS_SET(extmode, SKIP_SNEAKING)) {
 		SkipSneaking(vict, ch);
-		if (EXTRA_FLAGGED(vict, EXTRA_FAILSNEAK)) {
+		if ((vict)->Temporary.get(EXTRA_FAILSNEAK)) {
 			AFF_FLAGS(vict).unset(EAffect::kSneak);
 		}
 
@@ -557,14 +557,14 @@ bool filter_victim (CharData *ch, CharData *vict, int extmode) {
 	}
 	if (IS_SET(extmode, SKIP_HIDING)) {
 		SkipHiding(vict, ch);
-		if (EXTRA_FLAGGED(vict, EXTRA_FAILHIDE)) {
+		if ((vict)->Temporary.get(EXTRA_FAILHIDE)) {
 			AFF_FLAGS(vict).unset(EAffect::kHide);
 		}
 	}
 
 	if (IS_SET(extmode, SKIP_CAMOUFLAGE)) {
 		SkipCamouflage(vict, ch);
-		if (EXTRA_FLAGGED(vict, EXTRA_FAILCAMOUFLAGE)) {
+		if ((vict)->Temporary.get(EXTRA_FAILCAMOUFLAGE)) {
 			AFF_FLAGS(vict).unset(EAffect::kDisguise);
 		}
 	}

--- a/src/gameplay/ai/spec_procs.cpp
+++ b/src/gameplay/ai/spec_procs.cpp
@@ -220,27 +220,27 @@ int npc_scavenge(CharData *ch) {
 				}
 
 				// Заперто, открываем, если есть ключ
-				if (OBJVAL_FLAGGED(obj, EContainerFlag::kLockedUp)
+				if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kLockedUp))
 					&& HasKey(ch, GET_OBJ_VAL(obj, 2))) {
 					do_doorcmd(ch, obj, 0, kScmdUnlock);
 				}
 
 				// Заперто, взламываем, если умеем
-				if (OBJVAL_FLAGGED(obj, EContainerFlag::kLockedUp)
+				if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kLockedUp))
 					&& ch->GetSkill(ESkill::kPickLock)
 					&& IsPickLockSucessdul(ch, 0, obj, EDirection::kUndefinedDir, kScmdPick)) {
 					do_doorcmd(ch, obj, EDirection::kUndefinedDir, kScmdPick);
 				}
 				// Все равно заперто, ну тогда фиг с ним
-				if (OBJVAL_FLAGGED(obj, EContainerFlag::kLockedUp)) {
+				if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kLockedUp))) {
 					continue;
 				}
 
-				if (OBJVAL_FLAGGED(obj, EContainerFlag::kShutted)) {
+				if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kShutted))) {
 					do_doorcmd(ch, obj, 0, kScmdOpen);
 				}
 
-				if (OBJVAL_FLAGGED(obj, EContainerFlag::kShutted)) {
+				if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kShutted))) {
 					continue;
 				}
 
@@ -319,7 +319,7 @@ int npc_loot(CharData *ch) {
 					next_loot = loot_obj->get_next_content();
 					if (loot_obj->get_type() == EObjType::kContainer) {
 						if (IS_CORPSE(loot_obj)
-							|| OBJVAL_FLAGGED(loot_obj, EContainerFlag::kLockedUp)
+							|| IS_SET(GET_OBJ_VAL((loot_obj), 1), (EContainerFlag::kLockedUp))
 							|| system_obj::is_purse(loot_obj)) {
 							continue;
 						}
@@ -348,26 +348,26 @@ int npc_loot(CharData *ch) {
 					next_loot = loot_obj->get_next_content();
 					if (loot_obj->get_type() == EObjType::kContainer) {
 						if (IS_CORPSE(loot_obj)
-							|| !OBJVAL_FLAGGED(loot_obj, EContainerFlag::kLockedUp)
+							|| !IS_SET(GET_OBJ_VAL((loot_obj), 1), (EContainerFlag::kLockedUp))
 							|| system_obj::is_purse(loot_obj)) {
 							continue;
 						}
 
 						// Есть ключ?
-						if (OBJVAL_FLAGGED(loot_obj, EContainerFlag::kLockedUp)
+						if (IS_SET(GET_OBJ_VAL((loot_obj), 1), (EContainerFlag::kLockedUp))
 							&& HasKey(ch, GET_OBJ_VAL(loot_obj, 2))) {
 							loot_obj->toggle_val_bit(1, EContainerFlag::kLockedUp);
 						}
 
 						// ...или взломаем?
-						if (OBJVAL_FLAGGED(loot_obj, EContainerFlag::kLockedUp)
+						if (IS_SET(GET_OBJ_VAL((loot_obj), 1), (EContainerFlag::kLockedUp))
 							&& ch->GetSkill(ESkill::kPickLock)
 							&& IsPickLockSucessdul(ch, 0, loot_obj, EDirection::kUndefinedDir, kScmdPick)) {
 							loot_obj->toggle_val_bit(1, EContainerFlag::kLockedUp);
 						}
 
 						// Эх, не открыть. Ну ладно.
-						if (OBJVAL_FLAGGED(loot_obj, EContainerFlag::kLockedUp)) {
+						if (IS_SET(GET_OBJ_VAL((loot_obj), 1), (EContainerFlag::kLockedUp))) {
 							continue;
 						}
 

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -786,16 +786,16 @@ void beat_points_update(int pulse) {
 		}
 
 		// Гейн маны у волхвов
-		if (IS_MANA_CASTER(d->character.get()) && d->character->mem_queue.stored < GET_MAX_MANA(d->character.get())) {
+		if (IS_MANA_CASTER(d->character.get()) && d->character->mem_queue.stored < mana[MIN(50, GetRealWis(d->character.get()))]) {
 			d->character->mem_queue.stored += CalcManaGain(d->character.get());
-			if (d->character->mem_queue.stored >= GET_MAX_MANA(d->character.get())) {
-				d->character->mem_queue.stored = GET_MAX_MANA(d->character.get());
+			if (d->character->mem_queue.stored >= mana[MIN(50, GetRealWis(d->character.get()))]) {
+				d->character->mem_queue.stored = mana[MIN(50, GetRealWis(d->character.get()))];
 				SendMsgToChar("Ваша магическая энергия полностью восстановилась\r\n", d->character.get());
 			}
 		}
 
-		if (IS_MANA_CASTER(d->character.get()) && d->character->mem_queue.stored > GET_MAX_MANA(d->character.get())) {
-			d->character->mem_queue.stored = GET_MAX_MANA(d->character.get());
+		if (IS_MANA_CASTER(d->character.get()) && d->character->mem_queue.stored > mana[MIN(50, GetRealWis(d->character.get()))]) {
+			d->character->mem_queue.stored = mana[MIN(50, GetRealWis(d->character.get()))];
 		}
 
 		// Restore moves

--- a/src/gameplay/economics/exchange.cpp
+++ b/src/gameplay/economics/exchange.cpp
@@ -608,7 +608,7 @@ int exchange_purchase(CharData *ch, char *arg) {
 		seller->add_bank(GET_EXCHANGE_ITEM_COST(item), true);
 		ch->remove_both_gold(GET_EXCHANGE_ITEM_COST(item), true);
 
-		if (NOTIFY_EXCH_PRICE(seller) && GET_EXCHANGE_ITEM_COST(item) >= NOTIFY_EXCH_PRICE(seller)) {
+		if ((seller)->player_specials->saved.ntfyExchangePrice && GET_EXCHANGE_ITEM_COST(item) >= (seller)->player_specials->saved.ntfyExchangePrice) {
 			sprintf(tmpbuf, "Базар : лот %d(%s) продан%s. %d %s переведено на ваш счет.\r\n", lot,
 					GET_EXCHANGE_ITEM(item)->get_PName(ECase::kNom).c_str(), GET_OBJ_SUF_6(GET_EXCHANGE_ITEM(item)),
 					GET_EXCHANGE_ITEM_COST(item), GetDeclensionInNumber(GET_EXCHANGE_ITEM_COST(item), EWhat::kMoneyA));

--- a/src/gameplay/fight/fight_stuff.cpp
+++ b/src/gameplay/fight/fight_stuff.cpp
@@ -796,7 +796,7 @@ void perform_group_gain(CharData *ch, CharData *victim, int members, int koef) {
 		EndowExpToChar(ch, exp);
 		change_alignment(ch, victim);
 		TopPlayer::Refresh(ch);
-		if (!EXTRA_FLAGGED(victim, EXTRA_GRP_KILL_COUNT)
+		if (!(victim)->Temporary.get(EXTRA_GRP_KILL_COUNT)
 				&& !ch->IsNpc()
 				&& !ch->IsImmortal()
 				&& victim->IsNpc()

--- a/src/gameplay/mechanics/doors.cpp
+++ b/src/gameplay/mechanics/doors.cpp
@@ -75,7 +75,7 @@ ObjVnum GetDoorKeyVnum(CharData *ch, ObjData *obj, EDirection dir) {
 
 bool IsdoorOpenable(CharData *ch, ObjData *obj, EDirection dir) {
 	if (obj) {
-		return (obj->get_type() == EObjType::kContainer) && OBJVAL_FLAGGED(obj, EContainerFlag::kCloseable);
+		return (obj->get_type() == EObjType::kContainer) && IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kCloseable));
 	} else {
 		return EXIT_FLAGGED(EXIT(ch, dir), EExitFlag::kHasDoor);
 	}
@@ -83,7 +83,7 @@ bool IsdoorOpenable(CharData *ch, ObjData *obj, EDirection dir) {
 
 bool IsDoorBroken(CharData *ch, ObjData *obj, EDirection dir) {
 	if (obj) {
-		return OBJVAL_FLAGGED(obj, EContainerFlag::kLockIsBroken);
+		return IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kLockIsBroken));
 	} else {
 		return EXIT_FLAGGED(EXIT(ch, dir), EExitFlag::kBrokenLock);
 	}
@@ -95,7 +95,7 @@ bool IdDoorExist(CharData *ch, EDirection dir) {
 
 bool IsDoorPickroof(CharData *ch, ObjData *obj, EDirection dir) {
 	if (obj) {
-		return OBJVAL_FLAGGED(obj, EContainerFlag::kUncrackable) || OBJVAL_FLAGGED(obj, EContainerFlag::kLockIsBroken);
+		return IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kUncrackable)) || IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kLockIsBroken));
 	} else {
 		return EXIT_FLAGGED(EXIT(ch, dir), EExitFlag::kPickroof)
 			|| EXIT_FLAGGED(EXIT(ch, dir), EExitFlag::kBrokenLock);
@@ -112,7 +112,7 @@ ubyte GetLockComplexity(CharData *ch, ObjData *obj, EDirection dir) {
 
 bool IsDoorOpen(CharData *ch, ObjData *obj, EDirection dir) {
 	if (obj) {
-		return !OBJVAL_FLAGGED(obj, EContainerFlag::kShutted);
+		return !IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kShutted));
 	} else {
             return !EXIT_FLAGGED(EXIT(ch, dir), EExitFlag::kClosed);
 	}
@@ -120,7 +120,7 @@ bool IsDoorOpen(CharData *ch, ObjData *obj, EDirection dir) {
 
 bool IsDoorUnlocked(CharData *ch, ObjData *obj, EDirection dir) {
 	if (obj) {
-		return !OBJVAL_FLAGGED(obj, EContainerFlag::kLockedUp);
+		return !IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kLockedUp));
 	} else {
 		return !EXIT_FLAGGED(EXIT(ch, dir), EExitFlag::kLocked);
 	}

--- a/src/gameplay/mechanics/groups.cpp
+++ b/src/gameplay/mechanics/groups.cpp
@@ -243,14 +243,14 @@ void group::print_one_line(CharData *ch, CharData *k, int leader, int header) {
 	auto generate_mem_string = [](CharData *k) -> std::string {
 	  int ok, ok2, div;
 	  if ((!IS_MANA_CASTER(k) && !k->mem_queue.Empty()) ||
-		  (IS_MANA_CASTER(k) && k->mem_queue.stored < GET_MAX_MANA(k))) {
+		  (IS_MANA_CASTER(k) && k->mem_queue.stored < mana[MIN(50, GetRealWis(k))])) {
 		  div = CalcManaGain(k);
 		  if (div > 0) {
 			  if (!IS_MANA_CASTER(k)) {
 				  ok2 = std::max(0, 1 + k->mem_queue.total - k->mem_queue.stored);
 				  ok2 = ok2 * 60 / div;    // время мема в сек
 			  } else {
-				  ok2 = std::max(0, 1 + GET_MAX_MANA(k) - k->mem_queue.stored);
+				  ok2 = std::max(0, 1 + mana[MIN(50, GetRealWis(k))] - k->mem_queue.stored);
 				  ok2 = ok2 / div;    // время восстановления в секундах
 			  }
 			  ok = ok2 / 60;
@@ -571,7 +571,7 @@ void do_report(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					GET_NAME(ch), GET_CH_SUF_1(ch),
 					ch->get_hit(), ch->get_real_max_hit(),
 					ch->get_move(), ch->get_real_max_move(),
-					ch->mem_queue.stored, GET_MAX_MANA(ch));
+					ch->mem_queue.stored, mana[MIN(50, GetRealWis(ch))]);
 		} else if (AFF_FLAGGED(ch, EAffect::kCharmed)) {
 			int loyalty = 0;
 

--- a/src/gameplay/mechanics/sight.cpp
+++ b/src/gameplay/mechanics/sight.cpp
@@ -1098,17 +1098,17 @@ void look_in_obj(CharData *ch, char *arg) {
 		}
 
 		if (obj->get_type() == EObjType::kContainer) {
-			if (OBJVAL_FLAGGED(obj, EContainerFlag::kShutted)) {
+			if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kShutted))) {
 				act("Закрыт$A.", false, ch, obj, nullptr, kToChar);
 				const int skill_pick = ch->GetSkill(ESkill::kPickLock);
 				int count = sprintf(buf, "Заперт%s.", GET_OBJ_SUF_6(obj));
-				if (OBJVAL_FLAGGED(obj, EContainerFlag::kLockedUp) && skill_pick) {
-					if (OBJVAL_FLAGGED(obj, EContainerFlag::kUncrackable))
+				if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kLockedUp)) && skill_pick) {
+					if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kUncrackable)))
 						count += sprintf(buf + count,
 										 "%s Вы никогда не сможете ЭТО взломать!%s\r\n",
 										 kColorBoldCyn,
 										 kColorNrm);
-					else if (OBJVAL_FLAGGED(obj, EContainerFlag::kLockIsBroken))
+					else if (IS_SET(GET_OBJ_VAL((obj), 1), (EContainerFlag::kLockIsBroken)))
 						count += sprintf(buf + count, "%s Замок сломан... %s\r\n", kColorRed, kColorNrm);
 					else {
 						const PickProbabilityInformation &pbi = get_pick_probability(ch, GET_OBJ_VAL(obj, 3));
@@ -1227,7 +1227,7 @@ const char *show_obj_to_char(ObjData *object, CharData *ch, int mode, int show_s
 				}
 			}
 			if ((object->get_type() == EObjType::kContainer)
-				&& !OBJVAL_FLAGGED(object, EContainerFlag::kShutted)) // если закрыто, содержимое не показываем
+				&& !IS_SET(GET_OBJ_VAL((object), 1), (EContainerFlag::kShutted))) // если закрыто, содержимое не показываем
 			{
 				if (object->get_contains()) {
 					strcat(buf2, " (есть содержимое)");

--- a/src/gameplay/skills/manadrain.cpp
+++ b/src/gameplay/skills/manadrain.cpp
@@ -72,8 +72,8 @@ void do_manadrain(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	bool success = percent <= prob;
 	if (success) {
 		skill = std::max(10, skill - 10 * std::max(0, GetRealLevel(ch) - GetRealLevel(vict)));
-		drained_mana = (GET_MAX_MANA(ch) - ch->mem_queue.stored) * skill / 100;
-		ch->mem_queue.stored = std::min(GET_MAX_MANA(ch), ch->mem_queue.stored + drained_mana);
+		drained_mana = (mana[MIN(50, GetRealWis(ch))] - ch->mem_queue.stored) * skill / 100;
+		ch->mem_queue.stored = std::min(mana[MIN(50, GetRealWis(ch))], ch->mem_queue.stored + drained_mana);
 		manadrainDamage.dam = 10;
 	}
 	manadrainDamage.flags.set(fight::kIgnoreBlink);

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -323,10 +323,8 @@ inline void TOGGLE_BIT(T &var, const Bitvector bit) {
 
 
 #define NPC_FLAGGED(ch, flag)   ((ch)->mob_specials.npc_flags.get(flag))
-#define EXTRA_FLAGGED(ch, flag) ((ch)->Temporary.get(flag))
 #define ROOM_FLAGGED(loc, flag) (world[(loc)]->get_flag(flag))
 #define EXIT_FLAGGED(exit, flag)     (IS_SET((exit)->exit_info, (flag)))
-#define OBJVAL_FLAGGED(obj, flag)    (IS_SET(GET_OBJ_VAL((obj), 1), (flag)))
 
 // room utils ***********************************************************
 #define SECT(room)   (world[(room)]->sector_type)
@@ -338,16 +336,8 @@ inline bool ValidRnum(int rnum) { return rnum > 0 && rnum <= top_of_world; }
 #define IS_MANA_CASTER(ch) ((ch)->GetClass() == ECharClass::kMagus)
 #define GET_PC_NAME(ch) ((ch)->GetCharAliases().c_str())
 #define GET_NAME(ch)    ((ch)->get_name().c_str())
-#define GET_MAX_MANA(ch)      (mana[MIN(50, GetRealWis(ch))])
-
 #define GET_EMAIL(ch)          ((ch)->player_specials->saved.EMail)
 #define GET_GOD_FLAG(ch, flag)  (IS_SET((ch)->player_specials->saved.GodsLike, flag))
-#define NAME_GOD(ch)  ((ch)->player_specials->saved.NameGod)
-#define NAME_ID_GOD(ch)  ((ch)->player_specials->saved.NameIDGod)
-
-#define STRING_LENGTH(ch)  ((ch)->player_specials->saved.stringLength)
-#define STRING_WIDTH(ch)  ((ch)->player_specials->saved.stringWidth)
-#define NOTIFY_EXCH_PRICE(ch)  ((ch)->player_specials->saved.ntfyExchangePrice)
 
 inline int Posi(int val) { return std::clamp(val, 1, 50); }
 
@@ -414,8 +404,8 @@ const int kAligGoodMore = 300;
 #define GET_ALIGNMENT(ch)     ((ch)->char_specials.saved.alignment)
 
 const int kNameLevel = 5;
-#define NAME_FINE(ch)          (NAME_GOD(ch)>1000)
-#define NAME_BAD(ch)           (NAME_GOD(ch)<1000 && NAME_GOD(ch))
+#define NAME_FINE(ch)          ((ch)->player_specials->saved.NameGod>1000)
+#define NAME_BAD(ch)           ((ch)->player_specials->saved.NameGod<1000 && (ch)->player_specials->saved.NameGod)
 
 #define GET_COND(ch, i)        ((ch)->player_specials->saved.conditions[(i)])
 #define GET_LOADROOM(ch)    ((ch)->player_specials->saved.load_room)


### PR DESCRIPTION
## Summary
Четвёртая партия — 8 макросов (31 файл, ~103 замены):

- `STRING_LENGTH` / `STRING_WIDTH` → прямой доступ к полю
- `NOTIFY_EXCH_PRICE` → прямой доступ
- `NAME_ID_GOD` / `NAME_GOD` → прямой доступ
- `EXTRA_FLAGGED` → прямой `ch->Temporary.get(flag)`
- `OBJVAL_FLAGGED` → прямой `IS_SET(GET_OBJ_VAL(obj, 1), flag)`
- `GET_MAX_MANA` → прямой `mana[MIN(50, GetRealWis(ch))]`

## Test plan
- [x] Сборка без ошибок
- [ ] Тестирование стабильности на мастере

🤖 Generated with [Claude Code](https://claude.com/claude-code)