### PR TITLE
perf: registered lists for timechange triggers (#3062)

### DIFF
--- a/src/engine/core/handler.cpp
+++ b/src/engine/core/handler.cpp
@@ -12,6 +12,7 @@
 
 //#include "handler.h"
 
+#include "engine/scripting/dg_scripts.h"
 #include "gameplay/economics/auction.h"
 #include "utils/backtrace.h"
 #include "utils_char_obj.inl"
@@ -1459,6 +1460,7 @@ RoomVnum get_room_where_obj(ObjData *obj, bool deep) {
 }
 
 void ExtractObjFromWorld(ObjData *obj, bool showlog) {
+	timechange_unregister_obj(obj);
 	char name[kMaxStringLength];
 	ObjData *temp;
 	int roomload = get_room_where_obj(obj, false);
@@ -1654,6 +1656,7 @@ void DropInventory(CharData *ch, bool zone_reset) {
 * \param zone_reset - 0 обычный пурж когда угодно (по умолчанию), 1 - пурж при резете зоны
 */
 void ExtractCharFromWorld(CharData *ch, int clear_objs, bool zone_reset) {
+	timechange_unregister_mob(ch);
 	if (ch->purged()) {
 		log("SYSERROR: double extract_char (%s:%d)", __FILE__, __LINE__);
 		return;

--- a/src/engine/scripting/dg_db_scripts.cpp
+++ b/src/engine/scripting/dg_db_scripts.cpp
@@ -211,6 +211,7 @@ void assign_triggers(void *i, int type) {
 					}
 				}
 			}
+			timechange_register_mob(mob);
 			break;
 
 		case OBJ_TRIGGER: obj = (ObjData *) i;
@@ -241,6 +242,7 @@ void assign_triggers(void *i, int type) {
 					}
 				}
 			}
+			timechange_register_obj(obj);
 			break;
 
 		case WLD_TRIGGER: room = (RoomData *) i;
@@ -270,6 +272,7 @@ void assign_triggers(void *i, int type) {
 					}
 				}
 			}
+			timechange_register_room(room);
 			break;
 
 		default: log("SYSERR: unknown type for assign_triggers()");

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -63,6 +63,32 @@ int last_trig_vnum = 0;
 int curr_trig_vnum = 0;
 int last_trig_line_num = 0;
 
+// списки сущностей с триггерами смены времени
+std::unordered_set<CharData *> timechange_mobs;
+std::unordered_set<ObjData *> timechange_objs;
+std::unordered_set<RoomData *> timechange_rooms;
+
+void timechange_register_mob(CharData *ch) {
+	if (SCRIPT(ch)->has_triggers() && IS_SET(SCRIPT_TYPES(SCRIPT(ch).get()), MTRIG_TIMECHANGE)) {
+		timechange_mobs.insert(ch);
+	}
+}
+void timechange_unregister_mob(CharData *ch) { timechange_mobs.erase(ch); }
+
+void timechange_register_obj(ObjData *obj) {
+	if (obj->get_script()->has_triggers() && IS_SET(SCRIPT_TYPES(obj->get_script().get()), OTRIG_TIMECHANGE)) {
+		timechange_objs.insert(obj);
+	}
+}
+void timechange_unregister_obj(ObjData *obj) { timechange_objs.erase(obj); }
+
+void timechange_register_room(RoomData *room) {
+	if (SCRIPT(room)->has_triggers() && IS_SET(SCRIPT_TYPES(SCRIPT(room).get()), WTRIG_TIMECHANGE)) {
+		timechange_rooms.insert(room);
+	}
+}
+void timechange_unregister_room(RoomData *room) { timechange_rooms.erase(room); }
+
 // other external vars
 
 extern void add_trig_to_owner(int vnum_owner, int vnum_trig, int vnum);
@@ -753,41 +779,30 @@ void script_trigger_check(int mode) {
 }
 
 // проверка каждый час на триги изменении времени
+// итерация по спискам зарегистрированных сущностей вместо перебора всего мира
 void script_timechange_trigger_check(const int time, const int time_day) {
 	utils::CExecutionTimer timercheck;
-	std::stringstream buffer;
 
-	for (const auto &ch : character_list) {
-		if (SCRIPT(ch)->has_triggers()) {
-			auto sc = SCRIPT(ch).get();
-			if (IS_SET(SCRIPT_TYPES(sc), MTRIG_TIMECHANGE)
-					&& (!IsZoneEmpty(world[ch->in_room]->zone_rn))) {
-				timechange_mtrigger(ch.get(), time, time_day);
-			}
+	for (auto *ch : timechange_mobs) {
+		if (!ch->IsNpc() || ch->IsNpc() && ch->in_room != kNowhere
+			&& !IsZoneEmpty(world[ch->in_room]->zone_rn)) {
+			timechange_mtrigger(ch, time, time_day);
 		}
 	}
 
-	world_objects.foreach_on_copy([&](const ObjData::shared_ptr &obj) {
-		if (obj->get_script()->has_triggers()) {
-			auto sc = obj->get_script().get();
-			if (IS_SET(SCRIPT_TYPES(sc), OTRIG_TIMECHANGE)) {
-				timechange_otrigger(obj.get(), time, time_day);
-			}
-		}
-	});
+	for (auto *obj : timechange_objs) {
+		timechange_otrigger(obj, time, time_day);
+	}
 
-	for (std::size_t nr = kFirstRoom; nr <= static_cast<std::size_t>(top_of_world); nr++) {
-		if (SCRIPT(world[nr])->has_triggers()) {
-			auto room = world[nr];
-			auto sc = SCRIPT(room).get();
-			if (IS_SET(SCRIPT_TYPES(sc), WTRIG_TIMECHANGE)
-					&& (!IsZoneEmpty(room->zone_rn))) {
-				timechange_wtrigger(room, time, time_day);
-			}
+	for (auto *room : timechange_rooms) {
+		if (!IsZoneEmpty(room->zone_rn)) {
+			timechange_wtrigger(room, time, time_day);
 		}
 	}
-	buffer << "script_timechange_check() всего: " << timercheck.delta().count() <<" ms.";
-	log("%s", buffer.str().c_str());
+
+	log("script_timechange_check() mobs=%zu objs=%zu rooms=%zu time: %f ms.",
+		timechange_mobs.size(), timechange_objs.size(), timechange_rooms.size(),
+		timercheck.delta().count());
 }
 
 EVENT(trig_wait_event) {
@@ -1104,6 +1119,7 @@ void do_attach(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					SendMsgToChar(buf, ch);
 					if (add_trigger(SCRIPT(victim).get(), trig, loc)) {
 						add_trig_to_owner(-1, tn, GET_MOB_VNUM(victim));
+						timechange_register_mob(victim);
 					} else {
 						ExtractTrigger(trig);
 					}
@@ -1127,6 +1143,7 @@ void do_attach(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				SendMsgToChar(buf, ch);
 				if (add_trigger(object->get_script().get(), trig, loc)) {
 					add_trig_to_owner(-1, tn, GET_OBJ_VNUM(object));
+						timechange_register_obj(object);
 				} else {
 					ExtractTrigger(trig);
 				}
@@ -1145,6 +1162,7 @@ void do_attach(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					SendMsgToChar(buf, ch);
 					if (add_trigger(world[room]->script.get(), trig, loc)) {
 						add_trig_to_owner(-1, tn, world[room]->vnum);
+						timechange_register_room(world[room]);
 					} else {
 						ExtractTrigger(trig);
 					}

--- a/src/engine/scripting/dg_scripts.h
+++ b/src/engine/scripting/dg_scripts.h
@@ -12,6 +12,7 @@
 #ifndef DG_SCRIPTS_H_
 #define DG_SCRIPTS_H_
 
+#include <unordered_set>
 #include "gameplay/skills/skills.h"
 #include "engine/structs/structs.h"
 #include "utils/logger.h"
@@ -495,6 +496,20 @@ extern int last_trig_vnum;//последний триг в котором про
 extern int last_trig_line_num;
 
 void save_char_vars(CharData *ch);
+
+// списки сущностей с триггерами смены времени - для быстрой итерации
+// вместо перебора всего мира
+extern std::unordered_set<CharData *> timechange_mobs;
+extern std::unordered_set<ObjData *> timechange_objs;
+extern std::unordered_set<RoomData *> timechange_rooms;
+
+// регистрация/снятие при attach/detach триггера
+void timechange_register_mob(CharData *ch);
+void timechange_unregister_mob(CharData *ch);
+void timechange_register_obj(ObjData *obj);
+void timechange_unregister_obj(ObjData *obj);
+void timechange_register_room(RoomData *room);
+void timechange_unregister_room(RoomData *room);
 
 #endif
 


### PR DESCRIPTION
## Summary
- Три глобальных списка (`timechange_mobs/objs/rooms`) вместо перебора всего мира
- Регистрация при `assign_triggers` (boot) и `do_attach` (runtime)
- Снятие при `ExtractCharFromWorld` / `ExtractObjFromWorld`
- Убрана `foreach_on_copy` (копия всех объектов мира ~5ms)
- Лог показывает размеры списков

Closes #3062

## Test plan
- [ ] Проверить что триггеры смены времени работают (событие прошёл час)
- [ ] Проверить лог `script_timechange_check() mobs=X objs=Y rooms=Z`
- [ ] Проверить что после purge моба/объекта он не остаётся в списке

🤖 Generated with [Claude Code](https://claude.com/claude-code)