### PR TITLE
fix: remove hardcoded madschool death handler (#3079)

### DIFF
--- a/src/gameplay/fight/fight_stuff.cpp
+++ b/src/gameplay/fight/fight_stuff.cpp
@@ -243,22 +243,6 @@ void die(CharData *ch, CharData *killer) {
 	if (stone_rebirth(ch, killer)) {
 		return;
 	}
-	if (!ch->IsNpc() && (GetZoneVnumByCharPlace(ch) == 759)
-		&& (GetRealLevel(ch) < 15)) //нуб помер в мадшколе
-	{
-		act("$n глупо погиб$q не закончив обучение.", false, ch, nullptr, nullptr, kToRoom);
-		RemoveCharFromRoom(ch);
-		PlaceCharToRoom(ch, GetRoomRnum(75989));
-		ch->dismount();
-		ch->set_hit(1);
-		update_pos(ch);
-		act("$n медленно появил$u откуда-то.", false, ch, nullptr, nullptr, kToRoom);
-		look_at_room(ch, 0);
-		greet_mtrigger(ch, -1);
-		greet_otrigger(ch, -1);
-//		WAIT_STATE(ch, 10 * kBattleRound); лаг лучше ставить триггерами
-		return;
-	}
 
 	if (ch->IsNpc()
 		|| !ROOM_FLAGGED(ch->in_room, ERoomFlag::kArena)


### PR DESCRIPTION
## Summary
- Убран хардкод проверки зоны 759 и телепорта в 75989 при смерти нуба
- Камень возрождения (vnum 1000) добавлен в комнату 75989 в zon/759.zon
- Теперь используется общий `stone_rebirth()` который ищет предмет 1000 в зоне

**Важно:** изменения в world (zon/759.zon) нужно запушить отдельно в репу world

Closes #3079

## Test plan
- [ ] Умереть нубом (<15 уровень) в мадшколе — должен воскреснуть у алтаря в 75989

🤖 Generated with [Claude Code](https://claude.com/claude-code)