### PR TITLE
fix: corpses and objects don't decay - return instead of continue

### DIFF
--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1377,11 +1377,11 @@ void obj_point_update() {
 
 	for (auto &obj : obj_update_list) {
 		if (obj->get_where_obj() == EWhereObj::kSeller) {
-			return;
+			continue;
 		}
 		if (CheckObjDecay(obj, false)) {
 			obj_destroy.push_back(obj);
-			return;
+			continue;
 		}
 		if (obj->get_destroyer() > 0 && !NO_DESTROY(obj)) {
 			obj->dec_destroyer();


### PR DESCRIPTION
## Summary
В `obj_point_update()` два `return` вместо `continue` в цикле `for`:

```cpp
if (obj->get_where_obj() == EWhereObj::kSeller) {
    return;  // ← выходит из ФУНКЦИИ, а не пропускает объект
}
if (CheckObjDecay(obj, false)) {
    obj_destroy.push_back(obj);
    return;  // ← выходит из ФУНКЦИИ
}
```

При встрече первого предмета у продавца или с decay — функция завершалась полностью. Все последующие объекты не обрабатывались: таймеры не уменьшались, трупы не исчезали.

Баг появился при рефакторинге `foreach_on_copy` (лямбда) → обычный `for` цикл. В лямбде `return` работал как `continue`.

## Test plan
- [x] Трупы мобов должны исчезать по таймеру
- [x] Предметы с таймером должны разрушаться

🤖 Generated with [Claude Code](https://claude.com/claude-code)