### PR TITLE
fix: alias =1..=9 substitutes command name instead of argument (#3082)

### DIFF
--- a/src/engine/ui/alias.cpp
+++ b/src/engine/ui/alias.cpp
@@ -132,12 +132,16 @@ void perform_complex_alias(struct iosystem::TextBlocksQueue *input_q, char *orig
 	struct iosystem::TextBlocksQueue temp_queue;
 	temp_queue.head = temp_queue.tail = nullptr;
 
-	// разбиваем аргументы (пропуская первое слово - имя алиаса)
+	// разбиваем аргументы (пропуская первое слово если это имя алиаса)
 	std::vector<std::string> tokens;
 	std::string orig_str(orig);
 	std::istringstream stream(orig_str);
 	std::string word;
-	if (stream >> word) { // пропускаем имя алиаса
+	if (stream >> word) {
+		// первое слово может быть именем алиаса - пропускаем его
+		if (str_cmp(word.c_str(), a->alias) != 0) {
+			tokens.push_back(word);
+		}
 		while (stream >> word && tokens.size() < static_cast<size_t>(kNumTokens)) {
 			tokens.push_back(word);
 		}


### PR DESCRIPTION
## Summary
- `=1` подставлял имя алиаса ("тест") вместо первого аргумента ("вававава")
- `tokens[0]` содержал первое слово из `orig` (имя команды-алиаса)
- Исправлено: пропускаем имя алиаса при разборе аргументов
- Переписано с `char*`/`strtok` на `std::string`/`istringstream`/`vector`

Closes #3082

## Test plan
- [ ] `синон тест эм =1` → `тест вававава` → должно выполнить `эмоция вававава`
- [ ] `синон тест2 эм =1+эм =2` → `тест2 а б` → две эмоции
- [ ] `синон тест3 эм =*` → `тест3 а б` → `эмоция тест3 а б` (=* подставляет всё)

🤖 Generated with [Claude Code](https://claude.com/claude-code)