### PR TITLE
fix: restore missing follower death message (#3090)

### DIFF
--- a/src/engine/ui/cmd/do_follow.cpp
+++ b/src/engine/ui/cmd/do_follow.cpp
@@ -119,6 +119,8 @@ void die_follower(CharData *ch) {
 	if (ch->has_master()) {
 		if (ch->get_master()->get_horse() == ch && ch->get_master()->IsOnHorse()) {
 			ch->DropFromHorse();
+		} else {
+			act("$n прекратил$g следовать за вами.", true, ch, 0, ch->get_master(), kToVict);
 		}
 
 		ch->get_master()->followers.remove(ch);


### PR DESCRIPTION
При рефакторинге die_follower (8ba6904b6) заменили stop_follower на прямой detach и потеряли сообщение мастеру.

Closes #3090

🤖 Generated with [Claude Code](https://claude.com/claude-code)