### PR TITLE
fix: crash in obj_point_update - dangling pointer in obj_update_list (#3092)

### DIFF
--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1375,8 +1375,11 @@ void obj_point_update() {
 	std::list<ObjData *> obj_decay_timer;
 	utils::CExecutionTimer timer;
 
-	for (auto &obj : obj_update_list) {
-		if (obj->get_script()->is_purged()) {
+	// итерация по копии - объект может быть удален из obj_update_list
+	// во время обработки (ExtractObjFromWorld вызывает erase)
+	auto obj_update_copy = obj_update_list;
+	for (auto *obj : obj_update_copy) {
+		if (obj_update_list.find(obj) == obj_update_list.end()) {
 			continue;
 		}
 		if (obj->get_where_obj() == EWhereObj::kSeller) {


### PR DESCRIPTION
## Summary
`obj_update_list` (`unordered_set<ObjData*>`) содержит dangling pointer после удаления объекта другим путём. Итерация по оригиналу крешит при `is_purged()` на freed памяти.

Фикс: итерация по копии сета + проверка `obj_update_list.find(obj)` перед обработкой.

Closes #3092

## Test plan
- [ ] Стабильность сервера без крешей в obj_point_update

🤖 Generated with [Claude Code](https://claude.com/claude-code)