### PR TITLE
debug: add logging for crash #3116 investigation

### DIFF
--- a/src/engine/core/heartbeat.cpp
+++ b/src/engine/core/heartbeat.cpp
@@ -639,8 +639,14 @@ void Heartbeat::pulse(const int missed_pulses, pulse_label_t &label) {
 	label.clear();
 	advance_pulse_numbers();
 	log("Heartbeat pulse");
-	character_list.PurgeExtractedList();
-	world_objects.PurgeExtractedList();
+	{
+		auto span = tracing::TraceManager::Instance().StartSpan("Characters::PurgeExtractedList");
+		character_list.PurgeExtractedList();
+	}
+	{
+		auto span = tracing::TraceManager::Instance().StartSpan("WorldObjects::PurgeExtractedList");
+		world_objects.PurgeExtractedList();
+	}
 	for (std::size_t i = 0; i != m_steps.size(); ++i) {
 		auto &step = m_steps[i];
 		auto get_mem = TotalMemUse();

--- a/src/engine/db/world_characters.cpp
+++ b/src/engine/db/world_characters.cpp
@@ -179,6 +179,7 @@ void Characters::remove(CharData *character) {
 }
 
 void Characters::purge() {
+	log("Characters::purge() start, purge_list size=%zu", m_purge_list.size());
 	m_purge_set.clear();
 	for (const auto &character : m_purge_list) {
 		if (character->IsNpc()) {

--- a/src/engine/db/world_objects.cpp
+++ b/src/engine/db/world_objects.cpp
@@ -390,8 +390,8 @@ void WorldObjects::AddToExtractedList(ObjData *obj) {
 }
 
 void WorldObjects::PurgeExtractedList() {
+	log("Start obj PurgeExtractedList");
 	if (!m_extracted_list.empty()) {
-		log("Start obj PurgeExtractedList");
 		for (auto it : m_extracted_list) {
 			ExtractObjFromWorld(it, false);
 		}

--- a/src/gameplay/affects/affect_data.cpp
+++ b/src/gameplay/affects/affect_data.cpp
@@ -439,6 +439,7 @@ void battle_affect_update(CharData *ch) {
 
 // раз в минуту
 void mobile_affect_update() {
+	log("mobile_affect_update() start, affected_mobs size=%zu", affected_mobs.size());
 	using mobile_affect_update_profiler::Counter;
 	using mobile_affect_update_profiler::RunStats;
 	using mobile_affect_update_profiler::Section;


### PR DESCRIPTION
## Summary
- Add diagnostic logging and OpenTelemetry spans to investigate crash #3116 (use-after-free in `mobile_affect_update`)
- Move `WorldObjects::PurgeExtractedList` log outside `if` so it always writes (was missing from crash logs, making it unclear if we reached it)
- Add tracing spans for `PurgeExtractedList` calls in heartbeat pulse
- Add `Characters::purge()` log with `purge_list` size
- Add `mobile_affect_update()` log with `affected_mobs` size

## Context
Crash #3116: `mobile_affect_update` crashes at line 485 accessing corrupted `shared_ptr<Affect<EApply>>`. Logs show 0ms between angel extraction in `PurgeExtractedList` and crash. Need to determine exact order of `Characters::purge()` relative to the crash.

## Test plan
- [ ] Build and deploy
- [ ] Wait for next crash
- [ ] Check syslog for ordering: `Characters::purge()` → `PurgeExtractedList` → `mobile_affect_update`
- [ ] Check Grafana/Tempo traces for span timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)