### PR TITLE
perf: batch affect_total in CastAffect (#3106)

### DIFF
--- a/src/gameplay/affects/affect_data.cpp
+++ b/src/gameplay/affects/affect_data.cpp
@@ -956,6 +956,71 @@ void affect_to_char(CharData *ch, const Affect<EApply> &af) {
 	affect_total(ch);
 }
 
+// Same as affect_to_char but without affect_total() recalculation.
+// Caller MUST call affect_total(ch) after all affects are applied.
+void affect_to_char_no_recalc(CharData *ch, const Affect<EApply> &af) {
+	Affect<EApply>::shared_ptr affected_alloc(new Affect<EApply>(af));
+
+	if (ch->IsNpc()) {
+		affected_mobs.insert(ch);
+	}
+	ch->affected.push_front(affected_alloc);
+
+	AFF_FLAGS(ch) += af.aff;
+	if (af.bitvector)
+		affect_modify(ch, af.location, af.modifier, static_cast<EAffect>(af.bitvector), true);
+}
+
+// Same as ImposeAffect but without affect_total() recalculation.
+// Caller MUST call affect_total(ch) after all affects are applied.
+void ImposeAffectNoRecalc(CharData *ch, const Affect<EApply> &af) {
+	for (const auto &affect : ch->affected) {
+		const bool same_affect = (af.location == EApply::kNone) && (affect->bitvector == af.bitvector);
+		const bool same_type = (af.location != EApply::kNone) && (affect->type == af.type) && (affect->location == af.location);
+		if (same_affect || same_type) {
+			if (affect->modifier < af.modifier) {
+				affect->modifier = af.modifier;
+			}
+			if (affect->duration < af.duration) {
+				affect->duration = af.duration;
+			}
+			return;
+		}
+	}
+	affect_to_char_no_recalc(ch, af);
+}
+
+// Same as ImposeAffect (with accumulation) but without affect_total() recalculation.
+// Caller MUST call affect_total(ch) after all affects are applied.
+void ImposeAffectNoRecalc(CharData *ch, Affect<EApply> &af, bool add_dur, bool max_dur, bool add_mod, bool max_mod) {
+	if (af.location) {
+		auto it = ch->affected.begin();
+
+		while (it != ch->affected.end()) {
+			const auto &affect = *it;
+			if (affect->type == af.type
+				&& affect->location == af.location) {
+				if (add_dur) {
+					af.duration += affect->duration;
+				} else if (max_dur) {
+					af.duration = std::max(af.duration, affect->duration);
+				}
+				if (add_mod) {
+					af.modifier += affect->modifier;
+				} else if (max_mod) {
+					af.modifier = std::max(af.modifier, affect->modifier);
+				}
+				ch->AffectRemove(it);
+				affect_to_char_no_recalc(ch, af);
+				return;
+			} else {
+				++it;
+			}
+		}
+	}
+	affect_to_char_no_recalc(ch, af);
+}
+
 void affect_modify(CharData *ch, EApply loc, int mod, const EAffect bitv, bool add) {
 	if (add) {
 		AFF_FLAGS(ch).set(bitv);

--- a/src/gameplay/affects/affect_data.h
+++ b/src/gameplay/affects/affect_data.h
@@ -82,6 +82,8 @@ bool IsAffectedBySpell(CharData *ch, ESpell type);
 bool IsAffectedBySpellWithCasterId(CharData *ch, CharData *vict, ESpell type);
 void ImposeAffect(CharData *ch, const Affect<EApply> &af);
 void ImposeAffect(CharData *ch, Affect<EApply> &af, bool add_dur, bool max_dur, bool add_mod, bool max_mod);
+void ImposeAffectNoRecalc(CharData *ch, const Affect<EApply> &af);
+void ImposeAffectNoRecalc(CharData *ch, Affect<EApply> &af, bool add_dur, bool max_dur, bool add_mod, bool max_mod);
 void reset_affects(CharData *ch);
 bool no_bad_affects(ObjData *obj);
 bool IsNegativeApply(EApply location);

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -2666,13 +2666,14 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 			af[i].duration = CalcComplexSpellMod(ch, spell_id, GAPPLY_SPELL_EFFECT, af[i].duration);
 
 			if (update_spell)
-				ImposeAffect(victim, af[i]);
+				ImposeAffectNoRecalc(victim, af[i]);
 			else
-				ImposeAffect(victim, af[i], accum_duration, false, accum_affect, false);
+				ImposeAffectNoRecalc(victim, af[i], accum_duration, false, accum_affect, false);
 		}
 		// тут мы ездим по циклу 16 раз, хотя аффектов 1-3...
 //		ch->send_to_TC(true, true, true, "Applied affect type %i\r\n", af[i].type);
 	}
+	affect_total(victim);
 
 	if (success) {
 		// вот некрасиво же тут это делать...


### PR DESCRIPTION
## Summary
- Add `ImposeAffectNoRecalc` — variant of `ImposeAffect` that skips `affect_total()` recalculation
- Update `CastAffect` loop to use `ImposeAffectNoRecalc`, call `affect_total(victim)` once after the loop
- Reduces N calls to `affect_total` per spell to exactly 1

## Context
Profiler data from #3106 shows `affect_total()` takes ~6-10ms per call (iterates 20 equipment slots × 8 obj affects × ~48 weapon affects + character affects). `CastAffect` called `ImposeAffect` up to 16 times in a loop, each triggering a full `affect_total` recalculation.

```
Step 'Punctual' took 0.009294 second(s) (90.526069%);
Step 'main_hit' took 0.005989-0.010408 second(s) (98-99%);
```

## Test plan
- [x] Builds without errors
- [ ] Verify spell affects still apply correctly (duration, modifier, bitvector)
- [ ] Compare profiler output before/after for `hit()` and `PlayerAttack`
- [ ] Stress test with multiple casters in combat

🤖 Generated with [Claude Code](https://claude.com/claude-code)