### PR TITLE
fix: handle dots in help search query (#3121)

### DIFF
--- a/src/engine/db/help.cpp
+++ b/src/engine/db/help.cpp
@@ -4,6 +4,8 @@
 
 #include "help.h"
 
+#include <algorithm>
+
 #include <third_party_libs/fmt/include/fmt/format.h>
 
 #include "obj_prototypes.h"
@@ -1502,6 +1504,7 @@ void do_help(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			arg_str = arg_str.substr(dot_pos + 1);
 		} catch (...) {
 			user_search.topic_num = 0;
+			arg_str.erase(std::remove(arg_str.begin(), arg_str.end(), '.'), arg_str.end());
 		}
 	}
 	// если последний символ аргумента '!' -- включаем строгий поиск


### PR DESCRIPTION
## Summary
Fix `справка туман.смерти` returning "nothing found".

The dot parser tried `stoi("туман")` as a topic index (like `3.защита`), caught the exception, but left the dot in the search string. Search for `"туман.смерти"` didn't match keyword `"тумансмерти"`.

Now when the prefix before dot is not a number, dots are stripped: `"туман.смерти"` → `"тумансмерти"`.

## Test plan
- [ ] `справка туман.смерти` → shows deadly fog help
- [ ] `справка 3.защита` → still works (numeric index)
- [ ] `справка защита!` → strict search still works

Closes #3121

🤖 Generated with [Claude Code](https://claude.com/claude-code)