### PR TITLE
fix: check kNoalter flag in apply_enchant (#2620)

### DIFF
--- a/src/engine/ui/cmd/do_employ.cpp
+++ b/src/engine/ui/cmd/do_employ.cpp
@@ -132,6 +132,11 @@ void apply_enchant(CharData *ch, ObjData *obj, std::string text) {
 		return;
 	}
 
+	if (target->has_flag(EObjFlag::kNoalter)) {
+		act("$o устойчив$A к вашей магии.", true, ch, target, nullptr, kToChar);
+		return;
+	}
+
 	if (target->get_enchants().check(ObjectEnchant::ENCHANT_FROM_OBJ)) {
 		SendMsgToChar(ch, "На %s уже наложено зачарование.\r\n",
 					  target->get_PName(ECase::kAcc).c_str());


### PR DESCRIPTION
## Summary
Objects with `kNoalter` flag (\"устойчив к магии\") could be enchanted via enchant items (`EObjType::kEnchant`) through `apply_enchant()` in `do_employ.cpp`. This path bypasses `CastToAlterObjs()` which has the `kNoalter` check.

Added `kNoalter` check in `apply_enchant()` with the same message as `CastToAlterObjs`.

## Test plan
- [ ] Object with `kNoalter` flag cannot be enchanted via enchant item
- [ ] Object without `kNoalter` can still be enchanted normally
- [ ] Spell-based enchantment (`kEnchantWeapon`) still blocked by `kNoalter`

Closes #2620

🤖 Generated with [Claude Code](https://claude.com/claude-code)