### PR TITLE
debug: profile ProcessDeath/raw_kill internals (#3106)

### DIFF
--- a/src/gameplay/fight/fight_stuff.cpp
+++ b/src/gameplay/fight/fight_stuff.cpp
@@ -532,10 +532,13 @@ void real_kill(CharData *ch, CharData *killer) {
 }
 
 void raw_kill(CharData *ch, CharData *killer) {
+	utils::CSteppedProfiler rk_profiler("raw_kill", 0.001);
+	rk_profiler.next_step("SpellCapable");
 	check_spell_capable(ch, killer);
 	if (ch->GetEnemy()) {
 		stop_fighting(ch, true);
 	}
+	rk_profiler.next_step("CombatList");
 	for (auto &hitter : combat_list) {
 		if (hitter.deleted)
 			continue;
@@ -565,10 +568,12 @@ void raw_kill(CharData *ch, CharData *killer) {
 
 	if (!ROOM_FLAGGED(ch->in_room, ERoomFlag::kDominationArena)) {
 		if (!ch->IsNpc()) {
+			rk_profiler.next_step("ResetAffects");
 			reset_affects_no_recalc(ch);
 		}
 	}
 	// для начала проверяем, активны ли евенты
+	rk_profiler.next_step("DeathTrigger");
 	if ((!killer || death_mtrigger(ch, killer)) && ch->in_room != kNowhere) {
 		death_cry(ch, killer);
 	}
@@ -595,6 +600,7 @@ void raw_kill(CharData *ch, CharData *killer) {
 	}
 	if (ch->in_room != kNowhere) {
 		if (killer && (!killer->IsNpc() || IS_CHARMICE(killer)) && !ch->IsNpc())
+	rk_profiler.next_step("RealKill");
  			kill_pc_wtrigger(killer, ch);
 		if (!ch->IsNpc() && (!NORENTABLE(ch) && ROOM_FLAGGED(ch->in_room, ERoomFlag::kArena))) {
 			//Если убили на арене

--- a/src/gameplay/mechanics/damage.cpp
+++ b/src/gameplay/mechanics/damage.cpp
@@ -447,6 +447,8 @@ void Damage::ProcessBlink(CharData *ch, CharData *victim) {
 
 void Damage::ProcessDeath(CharData *ch, CharData *victim) const {
 	CharData *killer = nullptr;
+	utils::CSteppedProfiler death_profiler("ProcessDeath", 0.001);
+	death_profiler.next_step("FindKiller");
 
 	if (victim->IsNpc() || victim->desc) {
 		if (victim == ch && victim->in_room != kNowhere) {
@@ -470,6 +472,7 @@ void Damage::ProcessDeath(CharData *ch, CharData *victim) const {
 			killer = ch;
 		}
 	}
+	death_profiler.next_step("GroupGain");
 	if (killer) {
 		if (AFF_FLAGGED(killer, EAffect::kGroup)) {
 			// т.к. помечен флагом AFF_GROUP - точно PC
@@ -523,6 +526,7 @@ void Damage::ProcessDeath(CharData *ch, CharData *victim) const {
 	if (killer) {
 		ch = killer;
 	}
+	death_profiler.next_step("die");
 	die(victim, ch);
 }
 


### PR DESCRIPTION
DeathCheck takes 3-4ms (78-86%) in Damage::Process. Need to find which part of the death chain is slow. Added 1ms threshold profilers to ProcessDeath and raw_kill.