### PR TITLE
debug: profile ProcessDeath and raw_kill internals (#3106)

### DIFF
--- a/src/gameplay/fight/fight_stuff.cpp
+++ b/src/gameplay/fight/fight_stuff.cpp
@@ -567,11 +567,12 @@ void raw_kill(CharData *ch, CharData *killer) {
 		}
 	}
 	// для начала проверяем, активны ли евенты
-	rk_profiler.next_step("DeathTrigger");
+	rk_profiler.next_step("DeathMtrigger");
 	if ((!killer || death_mtrigger(ch, killer)) && ch->in_room != kNowhere) {
 		death_cry(ch, killer);
 	}
 
+	rk_profiler.next_step("KillMtrigger");
 	if (killer && killer->IsNpc() && !ch->IsNpc() && kill_mtrigger(killer, ch)) {
 		const auto it = std::find(killer->kill_list.begin(), killer->kill_list.end(), ch->get_uid());
 		if (it != killer->kill_list.end()) {
@@ -603,6 +604,7 @@ void raw_kill(CharData *ch, CharData *killer) {
 			// клановые не теряют вещи
 			arena_kill(ch, killer);
 		} else {
+			rk_profiler.next_step("RealKill");
 			real_kill(ch, killer);
 			character_list.AddToExtractedList(ch);
 //			ExtractCharFromWorld(ch, true);


### PR DESCRIPTION
ProcessDeath: FindKiller, GroupGain, PkLogs, die (threshold 1ms)
raw_kill: SpellCapable, CombatList, ResetAffects, DeathTrigger, RealKill (threshold 1ms)

DeathCheck takes 3-4ms in Damage::Process - need to find which part of the death chain is slow.