### PR TITLE
fix: print fatal boot errors to stderr (#3150)

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -37,8 +37,7 @@ bool DataFile::open() {
 	const std::string file_name = full_file_name();
 	m_file = fopen(file_name.c_str(), "r");
 	if (nullptr == m_file) {
-		log("SYSERR: %s: %s", file_name.c_str(), strerror(errno));
-		exit(1);
+		fatal_log("SYSERR: %s: %s", file_name.c_str(), strerror(errno));
 	}
 	return true;
 }
@@ -101,13 +100,11 @@ bool DiscreteFile::discrete_load(const EBootType mode) {
 		if (*m_line == '#') {
 			last = nr;
 			if (sscanf(m_line, "#%d", &nr) != 1) {
-				log("SYSERR: Format error after %s #%d", boot_mode_name(mode), last);
-				exit(1);
+				fatal_log("SYSERR: Format error after %s #%d", boot_mode_name(mode), last);
 			}
 
 			if (nr == 1) {
-				log("SYSERR: Entity with vnum 1, filename=%s", file_name().c_str());
-				exit(1);
+				fatal_log("SYSERR: Entity with vnum 1, filename=%s", file_name().c_str());
 			}
 
 			if (nr >= kMaxProtoNumber) {
@@ -121,8 +118,7 @@ bool DiscreteFile::discrete_load(const EBootType mode) {
 				file_name().c_str(),
 				boot_mode_name(mode),
 				nr);
-			log("SYSERR: ... offending line: '%s'", m_line);
-			exit(1);
+			fatal_log("SYSERR: ... offending line: '%s'", m_line);
 		}
 	}
 
@@ -139,6 +135,7 @@ void DiscreteFile::read_next_line(const int nr) {
 				"(maybe the file is not terminated with '$'?)", file_name().c_str(),
 				boot_mode_name(mode()), nr, boot_mode_name(mode()));
 		}
+		fprintf(stderr, "FATAL: boot file format error in %s\n", file_name().c_str());
 		exit(1);
 	}
 }
@@ -400,16 +397,14 @@ void WorldFile::parse_room(int virtual_nr) {
 	char letter;
 
 	if (virtual_nr <= (zone ? zone_table[zone - 1].top : -1)) {
-		log("SYSERR: Room #%d is below zone %d.", virtual_nr, zone);
-		exit(1);
+		fatal_log("SYSERR: Room #%d is below zone %d.", virtual_nr, zone);
 	}
 //	if (zone == 0 && zone_table[zone].RnumRoomsLocation.first == -1) {
 //		zone_table[zone].RnumRoomsLocation.first = 1;
 //	}
 	while (virtual_nr > zone_table[zone].top) {
 		if (++zone >= static_cast<ZoneRnum>(zone_table.size())) {
-			log("SYSERR: Room %d is outside of any zone.", virtual_nr);
-			exit(1);
+			fatal_log("SYSERR: Room %d is outside of any zone.", virtual_nr);
 		}
 	}
 	// Создаем новую комнату
@@ -430,13 +425,11 @@ void WorldFile::parse_room(int virtual_nr) {
 	world[room_realnum]->description_num = GlobalObjects::descriptions().add(desc);
 
 	if (!get_line(file(), line)) {
-		log("SYSERR: Expecting roomflags/sector type of room #%d but file ended!", virtual_nr);
-		exit(1);
+		fatal_log("SYSERR: Expecting roomflags/sector type of room #%d but file ended!", virtual_nr);
 	}
 
 	if (sscanf(line, " %d %s %d ", t, flags, t + 2) != 3) {
-		log("SYSERR: Format error in roomflags/sector type of room #%d", virtual_nr);
-		exit(1);
+		fatal_log("SYSERR: Format error in roomflags/sector type of room #%d", virtual_nr);
 	}
 	// t[0] is the zone number; ignored with the zone-file system
 	world[room_realnum]->flags_from_string(flags);
@@ -462,8 +455,7 @@ void WorldFile::parse_room(int virtual_nr) {
 
 	for (;;) {
 		if (!get_line(file(), line)) {
-			log("%s", buf);
-			exit(1);
+			fatal_log("%s", buf);
 		}
 		switch (*line) {
 			case 'D': setup_dir(room_realnum, atoi(line + 1));
@@ -502,8 +494,7 @@ void WorldFile::parse_room(int virtual_nr) {
 				} while (letter != 0);
 				return;
 
-			default: log("%s", buf);
-				exit(1);
+			default: fatal_log("%s", buf);
 		}
 	}
 }
@@ -526,8 +517,7 @@ void WorldFile::setup_dir(int room, unsigned dir) {
 	world[room]->dir_option_proto[dir]->set_keywords(fread_string());
 
 	if (!get_line(file(), line)) {
-		log("SYSERR: Format error, %s", line);
-		exit(1);
+		fatal_log("SYSERR: Format error, %s", line);
 	}
 	int result = sscanf(line, " %d %d %d %d", t, t + 1, t + 2, t + 3);
 	if (result == 3) {
@@ -545,8 +535,7 @@ void WorldFile::setup_dir(int room, unsigned dir) {
 		world[room]->dir_option_proto[dir]->exit_info = t[0];
 		world[room]->dir_option_proto[dir]->lock_complexity = t[3];
 	} else {
-		log("SYSERR: Format error, %s", buf2);
-		exit(1);
+		fatal_log("SYSERR: Format error, %s", buf2);
 	}
 
 	world[room]->dir_option_proto[dir]->key = t[1];
@@ -614,8 +603,7 @@ void ObjectFile::parse_object(const int nr) {
 	// *** string data ***
 	std::string aliases(fread_string());
 	if (aliases.empty()) {
-		log("SYSERR: Empty obj name or format error at or near %s", m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Empty obj name or format error at or near %s", m_buffer);
 	}
 	tobj->set_aliases(aliases);
 	tobj->set_short_description(utils::colorLOW(fread_string()));
@@ -631,14 +619,12 @@ void ObjectFile::parse_object(const int nr) {
 	tobj->set_action_description(fread_string());
 
 	if (!get_line(file(), m_line)) {
-		log("SYSERR: Expecting *1th* numeric line of %s, but file ended!", m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Expecting *1th* numeric line of %s, but file ended!", m_buffer);
 	}
 
 	int parsed_entries = sscanf(m_line, " %s %d %d %d", f0, t + 1, t + 2, t + 3);
 	if (parsed_entries != 4) {
-		log("SYSERR: Format error in *1th* numeric line (expecting 4 args, got %d), %s", parsed_entries, m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Format error in *1th* numeric line (expecting 4 args, got %d), %s", parsed_entries, m_buffer);
 	}
 
 	int sparam = 0;
@@ -654,14 +640,12 @@ void ObjectFile::parse_object(const int nr) {
 	}
 
 	if (!get_line(file(), m_line)) {
-		log("SYSERR: Expecting *2th* numeric line of %s, but file ended!", m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Expecting *2th* numeric line of %s, but file ended!", m_buffer);
 	}
 
 	parsed_entries = sscanf(m_line, " %d %d %d %d", t, t + 1, t + 2, t + 3);
 	if (parsed_entries != 4) {
-		log("SYSERR: Format error in *2th* numeric line (expecting 4 args, got %d), %s", parsed_entries, m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Format error in *2th* numeric line (expecting 4 args, got %d), %s", parsed_entries, m_buffer);
 	}
 	tobj->set_sex(static_cast<EGender>(t[0]));
 	int timer = t[1] > 0 ? t[1] : ObjData::SEVEN_DAYS;
@@ -673,14 +657,12 @@ void ObjectFile::parse_object(const int nr) {
 	tobj->set_level(t[3]);
 
 	if (!get_line(file(), m_line)) {
-		log("SYSERR: Expecting *3th* numeric line of %s, but file ended!", m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Expecting *3th* numeric line of %s, but file ended!", m_buffer);
 	}
 
 	parsed_entries = sscanf(m_line, " %s %s %s", f0, f1, f2);
 	if (parsed_entries != 3) {
-		log("SYSERR: Format error in *3th* numeric line (expecting 3 args, got %d), %s", parsed_entries, m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Format error in *3th* numeric line (expecting 3 args, got %d), %s", parsed_entries, m_buffer);
 	}
 
 	tobj->load_affect_flags(f0);
@@ -691,14 +673,12 @@ void ObjectFile::parse_object(const int nr) {
 	// ** Deny for ...
 
 	if (!get_line(file(), m_line)) {
-		log("SYSERR: Expecting *3th* numeric line of %s, but file ended!", m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Expecting *3th* numeric line of %s, but file ended!", m_buffer);
 	}
 
 	parsed_entries = sscanf(m_line, " %d %s %s", t, f1, f2);
 	if (parsed_entries != 3) {
-		log("SYSERR: Format error in *3th* misc line (expecting 3 args, got %d), %s", parsed_entries, m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Format error in *3th* misc line (expecting 3 args, got %d), %s", parsed_entries, m_buffer);
 	}
 
 	tobj->set_type(static_cast<EObjType>(t[0]));        // ** What's a object
@@ -710,14 +690,12 @@ void ObjectFile::parse_object(const int nr) {
 	// ** Wear on ...
 
 	if (!get_line(file(), m_line)) {
-		log("SYSERR: Expecting *5th* numeric line of %s, but file ended!", m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Expecting *5th* numeric line of %s, but file ended!", m_buffer);
 	}
 
 	parsed_entries = sscanf(m_line, "%s %d %d %d", f0, t + 1, t + 2, t + 3);
 	if (parsed_entries != 4) {
-		log("SYSERR: Format error in *5th* numeric line (expecting 4 args, got %d), %s", parsed_entries, m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Format error in *5th* numeric line (expecting 4 args, got %d), %s", parsed_entries, m_buffer);
 	}
 
 	int first_value = 0;
@@ -728,14 +706,12 @@ void ObjectFile::parse_object(const int nr) {
 	tobj->set_val(3, t[3]);
 
 	if (!get_line(file(), m_line)) {
-		log("SYSERR: Expecting *6th* numeric line of %s, but file ended!", m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Expecting *6th* numeric line of %s, but file ended!", m_buffer);
 	}
 
 	parsed_entries = sscanf(m_line, "%d %d %d %d", t, t + 1, t + 2, t + 3);
 	if (parsed_entries != 4) {
-		log("SYSERR: Format error in *6th* numeric line (expecting 4 args, got %d), %s", parsed_entries, m_buffer);
-		exit(1);
+		fatal_log("SYSERR: Format error in *6th* numeric line (expecting 4 args, got %d), %s", parsed_entries, m_buffer);
 	}
 	tobj->set_weight(t[0]);
 	tobj->set_cost(t[1]);
@@ -758,8 +734,7 @@ void ObjectFile::parse_object(const int nr) {
 
 	for (;;) {
 		if (!get_line(file(), m_line)) {
-			log("SYSERR: Format error in %s", m_buffer);
-			exit(1);
+			fatal_log("SYSERR: Format error in %s", m_buffer);
 		}
 		switch (*m_line) {
 			case 'E': {
@@ -781,22 +756,19 @@ void ObjectFile::parse_object(const int nr) {
 
 			case 'A':
 				if (j >= kMaxObjAffect) {
-					log("SYSERR: Too many A fields (%d max), %s", kMaxObjAffect, m_buffer);
-					exit(1);
+					fatal_log("SYSERR: Too many A fields (%d max), %s", kMaxObjAffect, m_buffer);
 				}
 
 				if (!get_line(file(), m_line)) {
-					log("SYSERR: Format error in 'A' field, %s\n"
+					fatal_log("SYSERR: Format error in 'A' field, %s\n"
 						"...expecting 2 numeric constants but file ended!", m_buffer);
-					exit(1);
 				}
 
 				parsed_entries = sscanf(m_line, " %d %d ", t, t + 1);
 				if (parsed_entries != 2) {
-					log("SYSERR: Format error in 'A' field, %s\n"
+					fatal_log("SYSERR: Format error in 'A' field, %s\n"
 						"...expecting 2 numeric arguments, got %d\n"
 						"...offending line: '%s'", m_buffer, parsed_entries, m_line);
-					exit(1);
 				}
 
 				tobj->set_affected(j, static_cast<EApply>(t[0]), t[1]);
@@ -815,17 +787,15 @@ void ObjectFile::parse_object(const int nr) {
 
 			case 'S':
 				if (!get_line(file(), m_line)) {
-					log("SYSERR: Format error in 'S' field, %s\n"
+					fatal_log("SYSERR: Format error in 'S' field, %s\n"
 						"...expecting 2 numeric constants but file ended!", m_buffer);
-					exit(1);
 				}
 
 				parsed_entries = sscanf(m_line, " %d %d ", t, t + 1);
 				if (parsed_entries != 2) {
-					log("SYSERR: Format error in 'S' field, %s\n"
+					fatal_log("SYSERR: Format error in 'S' field, %s\n"
 						"...expecting 2 numeric arguments, got %d\n"
 						"...offending line: '%s'", m_buffer, parsed_entries, m_line);
-					exit(1);
 				}
 				tobj->set_skill(static_cast<ESkill>(t[0]), t[1]);
 				break;
@@ -841,8 +811,7 @@ void ObjectFile::parse_object(const int nr) {
 				obj_proto.add(tobj, nr);
 				return;
 
-			default: log("SYSERR: Format error in %s", m_buffer);
-				exit(1);
+			default: fatal_log("SYSERR: Format error in %s", m_buffer);
 		}
 	}
 }
@@ -1025,15 +994,13 @@ void MobileFile::parse_mobile(const int nr) {
 
 	// *** Numeric data ***
 	if (!get_line(file(), line)) {
-		log("SYSERR: Format error after string section of mob #%d\n"
+		fatal_log("SYSERR: Format error after string section of mob #%d\n"
 			"...expecting line of form '# # # {S | E}', but file ended!\n%s", nr, line);
-		exit(1);
 	}
 
 	if (sscanf(line, "%s %s %d %c", f1, f2, t + 2, &letter) != 4) {
-		log("SYSERR: Format error after string section of mob #%d\n"
+		fatal_log("SYSERR: Format error after string section of mob #%d\n"
 			"...expecting line of form '# # # {S | E}'\n%s", nr, line);
-		exit(1);
 	}
 	mob_proto[i].SetFlagsFromString(f1);
 	mob_proto[i].SetNpcAttribute(true); 
@@ -1049,8 +1016,7 @@ void MobileFile::parse_mobile(const int nr) {
 			break;
 
 			// add new mob types here..
-		default: log("SYSERR: Unsupported mob type '%c' in mob #%d", letter, nr);
-			exit(1);
+		default: fatal_log("SYSERR: Unsupported mob type '%c' in mob #%d", letter, nr);
 	}
 
 	// DG triggers -- script info follows mob S/E section
@@ -1119,13 +1085,11 @@ void MobileFile::parse_simple_mob(int i, int nr) {
 
 	mob_proto[i].player_specials->saved.NameGod = 1001; // у мобов имя всегда одобрено
 	if (!get_line(file(), line)) {
-		log("SYSERR: Format error in mob #%d, file ended after S flag!", nr);
-		exit(1);
+		fatal_log("SYSERR: Format error in mob #%d, file ended after S flag!", nr);
 	}
 	if (sscanf(line, " %d %d %d %dd%d+%d %dd%d+%d ",
 			   t, t + 1, t + 2, t + 3, t + 4, t + 5, t + 6, t + 7, t + 8) != 9) {
-		log("SYSERR: Format error in mob #%d, 1th line\n" "...expecting line of form '# # # #d#+# #d#+#'", nr);
-		exit(1);
+		fatal_log("SYSERR: Format error in mob #%d, 1th line\n" "...expecting line of form '# # # #d#+# #d#+#'", nr);
 	}
 
 	mob_proto[i].set_level(t[0]);
@@ -1146,13 +1110,11 @@ void MobileFile::parse_simple_mob(int i, int nr) {
 	mob_proto[i].real_abils.damroll = t[8];
 
 	if (!get_line(file(), line)) {
-		log("SYSERR: Format error in mob #%d, 2th line\n"
+		fatal_log("SYSERR: Format error in mob #%d, 2th line\n"
 			"...expecting line of form '#d#+# #', but file ended!", nr);
-		exit(1);
 	}
 	if (sscanf(line, " %dd%d+%d %d", t, t + 1, t + 2, t + 3) != 4) {
-		log("SYSERR: Format error in mob #%d, 2th line\n" "...expecting line of form '#d#+# #'", nr);
-		exit(1);
+		fatal_log("SYSERR: Format error in mob #%d, 2th line\n" "...expecting line of form '#d#+# #'", nr);
 	}
 
 	mob_proto[i].set_gold(t[2], false);
@@ -1161,9 +1123,8 @@ void MobileFile::parse_simple_mob(int i, int nr) {
 	mob_proto[i].set_exp(t[3]);
 
 	if (!get_line(file(), line)) {
-		log("SYSERR: Format error in 3th line of mob #%d\n"
+		fatal_log("SYSERR: Format error in 3th line of mob #%d\n"
 			"...expecting line of form '# # #', but file ended!", nr);
-		exit(1);
 	}
 
 	switch (sscanf(line, " %d %d %d %d", t, t + 1, t + 2, t + 3)) {
@@ -1171,8 +1132,7 @@ void MobileFile::parse_simple_mob(int i, int nr) {
 			break;
 		case 4: mob_proto[i].mob_specials.speed = t[3];
 			break;
-		default: log("SYSERR: Format error in 3th line of mob #%d\n" "...expecting line of form '# # # #'", nr);
-			exit(1);
+		default: fatal_log("SYSERR: Format error in 3th line of mob #%d\n" "...expecting line of form '# # # #'", nr);
 	}
 
 	mob_proto[i].SetPosition(static_cast<EPosition>(t[0]));
@@ -1211,16 +1171,14 @@ void MobileFile::parse_enhanced_mob(int i, int nr) {
 			return;
 		} else if (*line == '#')    // we've hit the next mob, maybe?
 		{
-			log("SYSERR: Unterminated E section in mob #%d", nr);
-			exit(1);
+			fatal_log("SYSERR: Unterminated E section in mob #%d", nr);
 		} else {
 			parse_espec(line, i, nr);
 
 		}
 	}
 
-	log("SYSERR: Unexpected end of file reached after mob #%d", nr);
-	exit(1);
+	fatal_log("SYSERR: Unexpected end of file reached after mob #%d", nr);
 }
 
 void MobileFile::parse_espec(char *buf, int i, int nr) {
@@ -1510,14 +1468,12 @@ bool ZoneFile::load_zone() {
 		char type[BUFFER_SIZE];
 		const auto count = sscanf(buf, "#%d %s", &zone.vnum, type);
 		if (count < 1) {
-			log("SYSERR: Format error in %s, line 1", full_file_name().c_str());
-			exit(1);
+			fatal_log("SYSERR: Format error in %s, line 1", full_file_name().c_str());
 		}
 		size_t digits = full_file_name().find_first_of("1234567890");
 		if (digits <= full_file_name().size()) {
 			if (zone.vnum != atoi(full_file_name().c_str() + digits)) {
-				log("SYSERR: файл %s содержит неверный номер зоны %d", full_file_name().c_str(), zone.vnum);
-				exit(1);
+				fatal_log("SYSERR: файл %s содержит неверный номер зоны %d", full_file_name().c_str(), zone.vnum);
 			}
 		}
 		if (2 == count) {
@@ -1573,8 +1529,7 @@ bool ZoneFile::load_regular_zone() {
 	}
 
 	if (num_of_cmds == 0) {
-		log("SYSERR: %s is empty!", full_file_name().c_str());
-		exit(1);
+		fatal_log("SYSERR: %s is empty!", full_file_name().c_str());
 	} else {
 		CREATE(zone.cmd, num_of_cmds);
 	}
@@ -1622,14 +1577,12 @@ bool ZoneFile::load_regular_zone() {
 	}
 
 	if (*buf != '#') {
-		log("SYSERR: ERROR!!! not # in file %s", full_file_name().c_str());
-		exit(1);
+		fatal_log("SYSERR: ERROR!!! not # in file %s", full_file_name().c_str());
 	}
 	auto group = 0;
 	const auto count = sscanf(buf, "#%d %d %d %d", &zone.level, &zone.type, &group, &zone.entrance);
 	if (count < 2) {
-		log("SYSERR: ошибка чтения z.level, z.type, z.group, z.entrance: %s", buf);
-		exit(1);
+		fatal_log("SYSERR: ошибка чтения z.level, z.type, z.group, z.entrance: %s", buf);
 	}
 	zone.group = (group == 0) ? 1 : group; //группы в 0 рыл не бывает
 	line_num += get_line(file(), buf);
@@ -1648,8 +1601,7 @@ bool ZoneFile::load_regular_zone() {
 								  t1,
 								  t2);
 		if (count < 3) {
-			log("SYSERR: Format error in 3-constant line of %s", full_file_name().c_str());
-			exit(1);
+			fatal_log("SYSERR: Format error in 3-constant line of %s", full_file_name().c_str());
 		}
 	}
 	zone.reset_idle = 0 != tmp_reset_idle;
@@ -1663,8 +1615,7 @@ bool ZoneFile::load_regular_zone() {
 		const auto lines_read = get_line(file(), buf);
 
 		if (lines_read == 0) {
-			log("SYSERR: Format error in %s - premature end of file", full_file_name().c_str());
-			exit(1);
+			fatal_log("SYSERR: Format error in %s - premature end of file", full_file_name().c_str());
 		}
 
 		line_num += lines_read;
@@ -1746,8 +1697,7 @@ bool ZoneFile::load_regular_zone() {
 		zone.cmd[cmd_no].if_flag = if_flag;
 
 		if (error) {
-			log("SYSERR: Format error in %s, line %d: '%s'", full_file_name().c_str(), line_num, buf);
-			exit(1);
+			fatal_log("SYSERR: Format error in %s, line %d: '%s'", full_file_name().c_str(), line_num, buf);
 		}
 		zone.cmd[cmd_no].line = line_num;
 		cmd_no++;
@@ -1869,8 +1819,7 @@ bool SocialsFile::load_socials() {
 				switch (what) {
 					case 0:
 						if (sscanf(scan, " %d %d %d %d \n", &c_min_pos, &c_max_pos, &v_min_pos, &v_max_pos) < 4) {
-							log("SYSERR: format error in %d social file near social '%s' #d #d #d #d\n", message, line);
-							exit(1);
+							fatal_log("SYSERR: format error in %d social file near social '%s' #d #d #d #d\n", message, line);
 						}
 						soc_mess_list[message].ch_min_pos = static_cast<EPosition>(c_min_pos);
 						soc_mess_list[message].ch_max_pos = static_cast<EPosition>(c_max_pos);

--- a/src/engine/boot/boot_index.cpp
+++ b/src/engine/boot/boot_index.cpp
@@ -77,8 +77,7 @@ int IndexFileImplementation::load() {
 
 	// Exit if 0 records, unless this is shops
 	if (!rec_count) {
-		log("SYSERR: boot error - 0 records counted in %s/%s.", prefix.c_str(), INDEX_FILE);
-		exit(1);
+		fatal_log("SYSERR: boot error - 0 records counted in %s/%s.", prefix.c_str(), INDEX_FILE);
 	}
 
 	return rec_count;
@@ -161,8 +160,7 @@ int HelpIndexFile::process_file() {
 int HelpIndexFile::count_social_records() {
 	while (read_entry()) {
 		if (m_unexpected_eof) {
-			log("SYSERR: Unexpected end of help file.");
-			exit(1);
+			fatal_log("SYSERR: Unexpected end of help file.");
 		}
 	}
 

--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -764,8 +764,7 @@ void stop_game(ush_int port) {
 	mother_desc = init_socket(port);
 	if (mother_desc < 0) {
 		log("SYSERR: Failed to bind to port %d. Server cannot start.", port);
-		log("Please check if another instance is running or if you have permission to use this port.");
-		exit(1);
+		fatal_log("Please check if another instance is running or if you have permission to use this port.");
 	}
 
 #ifdef ENABLE_ADMIN_API
@@ -953,8 +952,7 @@ socket_t init_socket(ush_int port) {
 
 		if (WSAStartup(wVersionRequested, &wsaData) != 0)
 		{
-			log("SYSERR: WinSock not available!");
-			exit(1);
+			fatal_log("SYSERR: WinSock not available!");
 		}
 		if ((wsaData.iMaxSockets - 4) < max_players)
 		{
@@ -964,8 +962,7 @@ socket_t init_socket(ush_int port) {
 
 		if ((s = socket(PF_INET, SOCK_STREAM, 0)) == static_cast<socket_t>(SOCKET_ERROR))
 		{
-			log("SYSERR: Error opening network connection: Winsock error #%d", WSAGetLastError());
-			exit(1);
+			fatal_log("SYSERR: Error opening network connection: Winsock error #%d", WSAGetLastError());
 		}
 	}
 #else
@@ -1036,8 +1033,7 @@ socket_t init_unix_socket(const char *path) {
 
 	s = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (s < 0) {
-		log("SYSERR: Error creating Unix domain socket: %s", strerror(errno));
-		exit(1);
+		fatal_log("SYSERR: Error creating Unix domain socket: %s", strerror(errno));
 	}
 
 	memset(&sa, 0, sizeof(sa));
@@ -1047,6 +1043,7 @@ socket_t init_unix_socket(const char *path) {
 	unlink(path);
 
 	if (bind(s, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+		fprintf(stderr, "FATAL: Cannot bind Unix socket to %s: %s\n", path, strerror(errno));
 		log("SYSERR: Cannot bind Unix socket to %s: %s", path, strerror(errno));
 		CLOSE_SOCKET(s);
 		exit(1);
@@ -1056,6 +1053,7 @@ socket_t init_unix_socket(const char *path) {
 	nonblock(s);
 
 	if (listen(s, 1) < 0) {
+		fprintf(stderr, "FATAL: Cannot listen on Unix socket: %s\n", strerror(errno));
 		log("SYSERR: Cannot listen on Unix socket: %s", strerror(errno));
 		CLOSE_SOCKET(s);
 		exit(1);

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -196,8 +196,7 @@ char *ReadActionMsgFromFile(FILE *fl, int nr) {
 	UNUSED_ARG(result);
 
 	if (feof(fl)) {
-		log("SYSERR: ReadActionMsgFromFile: unexpected EOF near action #%d", nr);
-		exit(1);
+		fatal_log("SYSERR: ReadActionMsgFromFile: unexpected EOF near action #%d", nr);
 	}
 	if (*local_buf == '#')
 		return (nullptr);
@@ -662,8 +661,7 @@ void LoadMessages() {
 	char chk[128];
 
 	if (!(fl = fopen(MESS_FILE, "r"))) {
-		log("SYSERR: Error reading combat message file %s: %s", MESS_FILE, strerror(errno));
-		exit(1);
+		fatal_log("SYSERR: Error reading combat message file %s: %s", MESS_FILE, strerror(errno));
 	}
 	for (i = 0; i < kMaxMessages; i++) {
 		fight_messages[i].attack_type = 0;
@@ -685,8 +683,7 @@ void LoadMessages() {
 		for (i = 0; (i < kMaxMessages) &&
 			(fight_messages[i].attack_type != type) && (fight_messages[i].attack_type); i++);
 		if (i >= kMaxMessages) {
-			log("SYSERR: Too many combat messages.  Increase kMaxMessages and recompile.");
-			exit(1);
+			fatal_log("SYSERR: Too many combat messages.  Increase kMaxMessages and recompile.");
 		}
 		//log("BATTLE MESSAGE %d(%d)", i, type); Лишний спам
 		CREATE(messages, 1);
@@ -968,7 +965,7 @@ void BootMudDataBase() {
 	boot_profiler.next_step("Loading grouping parameters");
 	log("Booting grouping parameters");
 	if (grouping.init()) {
-		exit(1);
+		fatal_log("Failed to load grouping parameters");
 	}
 
 	boot_profiler.next_step("Loading special assignments");
@@ -1239,7 +1236,7 @@ void GameLoader::BootIndex(const EBootType mode) {
 
 	auto index = IndexFileFactory::get_index(mode);
 	if (!index->open()) {
-		exit(1);
+		fatal_log("Failed to open index file (mode=%d)", static_cast<int>(mode));
 	}
 	const int rec_count = index->load();
 
@@ -1333,8 +1330,7 @@ void CheckRoomForIncompatibleFlags(int rnum) {
 // make sure the start rooms exist & resolve their vnums to rnums
 void CheckStartRooms() {
 	if ((r_mortal_start_room = GetRoomRnum(mortal_start_room)) == kNowhere) {
-		log("SYSERR:  Mortal start room does not exist.  Change in config.c. %d", mortal_start_room);
-		exit(1);
+		fatal_log("SYSERR:  Mortal start room does not exist.  Change in config.c. %d", mortal_start_room);
 	}
 
 	if ((r_immort_start_room = GetRoomRnum(immort_start_room)) == kNowhere) {
@@ -1506,8 +1502,7 @@ void SetZoneRnumForTriggers() {
 			log("FATAL: Trigger %d belongs to non-existent zone %d (zone_table has %zu zones)",
 				trig_vnum, zone_vnum, zone_table.size());
 			log("FATAL: This indicates broken world data or initialization order bug.");
-			log("FATAL: Boot aborted. Triggers cannot function without valid zone assignment.");
-			exit(1);
+			fatal_log("FATAL: Boot aborted. Triggers cannot function without valid zone assignment.");
 		}
 
 		// Set first trigger for this zone (if not set yet)

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -451,8 +451,7 @@ std::vector<int> YamlWorldDataSource::GetMobList()
 		}
 		catch (const YAML::Exception &e)
 		{
-			log("SYSERR: Failed to load mobs index for zone %d ('%s'): %s", zone_vnum, index_path.c_str(), e.what());
-			exit(1);
+			fatal_log("SYSERR: Failed to load mobs index for zone %d ('%s'): %s", zone_vnum, index_path.c_str(), e.what());
 		}
 	}
 
@@ -481,8 +480,7 @@ std::vector<int> YamlWorldDataSource::GetObjectList()
 		}
 		catch (const YAML::Exception &e)
 		{
-			log("SYSERR: Failed to load objects index for zone %d ('%s'): %s", zone_vnum, index_path.c_str(), e.what());
-			exit(1);
+			fatal_log("SYSERR: Failed to load objects index for zone %d ('%s'): %s", zone_vnum, index_path.c_str(), e.what());
 		}
 	}
 
@@ -511,8 +509,7 @@ std::vector<int> YamlWorldDataSource::GetTriggerList()
 		}
 		catch (const YAML::Exception &e)
 		{
-			log("SYSERR: Failed to load triggers index for zone %d ('%s'): %s", zone_vnum, index_path.c_str(), e.what());
-			exit(1);
+			fatal_log("SYSERR: Failed to load triggers index for zone %d ('%s'): %s", zone_vnum, index_path.c_str(), e.what());
 		}
 	}
 
@@ -791,8 +788,7 @@ void YamlWorldDataSource::LoadZonesParallel()
 
 	if (error_count > 0)
 	{
-		log("FATAL: %d zone(s) failed to load. Aborting.", error_count.load());
-		exit(1);
+		fatal_log("FATAL: %d zone(s) failed to load. Aborting.", error_count.load());
 	}
 
 	log("Loaded %d zones from YAML (parallel).", zone_count);
@@ -805,8 +801,7 @@ void YamlWorldDataSource::LoadZones()
 	// Load dictionaries first (sequential, writes to singleton)
 	if (!LoadDictionaries())
 	{
-		log("FATAL: Cannot continue without dictionaries. Aborting.");
-		exit(1);
+		fatal_log("FATAL: Cannot continue without dictionaries. Aborting.");
 	}
 
 	// Get thread count and create thread pool
@@ -1137,8 +1132,7 @@ void YamlWorldDataSource::LoadTriggersParallel()
 
 	if (error_count > 0)
 	{
-		log("FATAL: %d trigger(s) failed to load. Aborting.", error_count.load());
-		exit(1);
+		fatal_log("FATAL: %d trigger(s) failed to load. Aborting.", error_count.load());
 	}
 
 	// Merge results into trig_index (sequential, sorted by vnum)
@@ -1306,8 +1300,7 @@ void YamlWorldDataSource::LoadRoomsParallel()
 		}
 		catch (const YAML::Exception &e)
 		{
-			log("SYSERR: Failed to load rooms index for zone %d: %s", zone_vnum, e.what());
-			exit(1);
+			fatal_log("SYSERR: Failed to load rooms index for zone %d: %s", zone_vnum, e.what());
 		}
 	}
 
@@ -1396,8 +1389,7 @@ void YamlWorldDataSource::LoadRoomsParallel()
 
 	if (error_count > 0)
 	{
-		log("FATAL: %d room(s) failed to load. Aborting.", error_count.load());
-		exit(1);
+		fatal_log("FATAL: %d room(s) failed to load. Aborting.", error_count.load());
 	}
 
 	// Merge descriptions from all batches
@@ -1912,8 +1904,7 @@ void YamlWorldDataSource::LoadMobsParallel()
 
 	if (error_count > 0)
 	{
-		log("FATAL: %d mob(s) failed to load. Aborting.", error_count.load());
-		exit(1);
+		fatal_log("FATAL: %d mob(s) failed to load. Aborting.", error_count.load());
 	}
 
 	// Sequential post-processing: setup mob_index and zone locations
@@ -2277,8 +2268,7 @@ void YamlWorldDataSource::LoadObjectsParallel()
 
 	if (error_count > 0)
 	{
-		log("FATAL: %d object(s) failed to load. Aborting.", error_count.load());
-		exit(1);
+		fatal_log("FATAL: %d object(s) failed to load. Aborting.", error_count.load());
 	}
 
 	// Merge results into obj_proto (sequential, sorted by vnum)

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -282,6 +282,24 @@ void err_log(const char *format, ...) {
 	mudlog(buf_, LGH, kLvlImmortal, SYSLOG, true);
 }
 
+
+void fatal_log(const char *format, ...) {
+	char buf_[kMaxRawInputLength];
+
+	va_list args;
+	va_start(args, format);
+	vsnprintf(buf_, sizeof(buf_), format, args);
+	va_end(args);
+
+	// Print to stderr so the user sees the error when running from terminal
+	fprintf(stderr, "FATAL: %s\n", buf_);
+
+	// Also write to syslog for post-mortem analysis
+	log("FATAL: %s", buf_);
+
+	exit(1);
+}
+
 void ip_log(const char *ip) {
 	FILE *iplog;
 

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -22,6 +22,7 @@ void shop_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void olc_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void imm_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void err_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
+[[noreturn]] void fatal_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void ip_log(const char *ip);
 
 // defines for mudlog() //


### PR DESCRIPTION
## Summary
MUD silently exited when boot files were missing — SYSERR went to syslog only, terminal showed nothing.

## Fix
Added `fatal_log(fmt, ...)` helper that writes to **stderr** AND syslog before `exit(1)`.

Replaced ~40 `log("SYSERR...") + exit(1)` pairs in:
- `boot_data_files.cpp`
- `boot_index.cpp`

Closes #3150

🤖 Generated with [Claude Code](https://claude.com/claude-code)