### PR TITLE
fix: guard MakePrompt against purged/nowhere character (#3153)

### DIFF
--- a/src/engine/core/iosystem.cpp
+++ b/src/engine/core/iosystem.cpp
@@ -1100,7 +1100,7 @@ std::string MakePrompt(DescriptorData *d) {
 				  d->showstr_page, d->showstr_count);
 	} else if (d->writer) {
 		fmt::format_to(std::back_inserter(out), "] ");
-	} else if (d->state == EConState::kPlaying && !ch->IsNpc()) {
+	} else if (d->state == EConState::kPlaying && ch && ch->in_room != kNowhere && !ch->IsNpc()) {
 		if (GET_INVIS_LEV(ch)) {
 			fmt::format_to(std::back_inserter(out), "i{} ", GET_INVIS_LEV(ch));
 		}


### PR DESCRIPTION
## Summary

- Добавлена проверка `ch && ch->in_room != kNowhere` в `MakePrompt` перед обращением к персонажу
- Предотвращает краш при генерации промпта когда персонаж удалён (purged) в ходе сессии

## Test plan

- [ ] Убедиться что сервер не крашится при purge персонажа во время активной сессии
- [ ] Проверить что промпт отображается корректно в штатных условиях

🤖 Generated with [Claude Code](https://claude.com/claude-code)