### PR TITLE
perf: cache ObjRnum in oload_table at boot time (#3142)

### DIFF
--- a/src/gameplay/mechanics/stuff.cpp
+++ b/src/gameplay/mechanics/stuff.cpp
@@ -93,7 +93,7 @@ void oload_class::init() {
 	std::istringstream isstream;
 	bool in_block = false;
 	ObjVnum ovnum;
-	ObjRnum cur_obj_rnum = -1;
+	ObjRnum orn = -1;
 	MobVnum mvnum;
 	int oqty, lprob;
 
@@ -125,8 +125,8 @@ void oload_class::init() {
 			isstream.str(cppstr);
 			isstream >> std::noskipws >> ovnum;
 
-			cur_obj_rnum = GetObjRnum(ovnum);
-			if (!isstream.eof() || cur_obj_rnum < 0) {
+			orn = GetObjRnum(ovnum);
+			if (!isstream.eof() || orn < 0) {
 				isstream.clear();
 				cppstr = "oload_class:: Error in line '#" + cppstr + "' expected '#<RIGHT_obj_vnum>' !!!";
 				mudlog(cppstr.c_str(), LGH, kLvlImmortal, SYSLOG, true);
@@ -155,7 +155,7 @@ void oload_class::init() {
 
 			isstream.clear();
 
-			add_elem(mvnum, ovnum, obj_load_info(oqty, lprob, cur_obj_rnum));
+			add_elem(mvnum, orn, obj_load_info(oqty, lprob));
 		} else {
 			cppstr = "oload_class:: Error in line '" + cppstr + "' expected '#<RIGHT_obj_vnum>' !!!";
 			mudlog(cppstr.c_str(), LGH, kLvlImmortal, SYSLOG, true);
@@ -166,7 +166,7 @@ void oload_class::init() {
 oload_class oload_table;
 
 ObjRnum ornum_by_info(const std::pair<ObjVnum, obj_load_info> &it) {
-	ObjRnum i = it.second.rnum;
+	ObjRnum i = it.first;
 	ObjRnum resutl_obj = number(1, MAX_LOAD_PROB) <= it.second.load_prob
 						  ? (it.first >= 0 && i >= 0
 							 ? (obj_proto.actual_count(i) < it.second.obj_qty

--- a/src/gameplay/mechanics/stuff.cpp
+++ b/src/gameplay/mechanics/stuff.cpp
@@ -93,6 +93,7 @@ void oload_class::init() {
 	std::istringstream isstream;
 	bool in_block = false;
 	ObjVnum ovnum;
+	ObjRnum cur_obj_rnum = -1;
 	MobVnum mvnum;
 	int oqty, lprob;
 
@@ -124,7 +125,8 @@ void oload_class::init() {
 			isstream.str(cppstr);
 			isstream >> std::noskipws >> ovnum;
 
-			if (!isstream.eof() || GetObjRnum(ovnum) < 0) {
+			cur_obj_rnum = GetObjRnum(ovnum);
+			if (!isstream.eof() || cur_obj_rnum < 0) {
 				isstream.clear();
 				cppstr = "oload_class:: Error in line '#" + cppstr + "' expected '#<RIGHT_obj_vnum>' !!!";
 				mudlog(cppstr.c_str(), LGH, kLvlImmortal, SYSLOG, true);
@@ -153,7 +155,7 @@ void oload_class::init() {
 
 			isstream.clear();
 
-			add_elem(mvnum, ovnum, obj_load_info(oqty, lprob));
+			add_elem(mvnum, ovnum, obj_load_info(oqty, lprob, cur_obj_rnum));
 		} else {
 			cppstr = "oload_class:: Error in line '" + cppstr + "' expected '#<RIGHT_obj_vnum>' !!!";
 			mudlog(cppstr.c_str(), LGH, kLvlImmortal, SYSLOG, true);
@@ -164,7 +166,7 @@ void oload_class::init() {
 oload_class oload_table;
 
 ObjRnum ornum_by_info(const std::pair<ObjVnum, obj_load_info> &it) {
-	ObjRnum i = GetObjRnum(it.first);
+	ObjRnum i = it.second.rnum;
 	ObjRnum resutl_obj = number(1, MAX_LOAD_PROB) <= it.second.load_prob
 						  ? (it.first >= 0 && i >= 0
 							 ? (obj_proto.actual_count(i) < it.second.obj_qty

--- a/src/gameplay/mechanics/stuff.h
+++ b/src/gameplay/mechanics/stuff.h
@@ -24,8 +24,9 @@ const int MAX_LOAD_PROB = 1000;
 struct obj_load_info {
 	int obj_qty;
 	int load_prob;
-	obj_load_info() : obj_qty(0), load_prob(0) {}
-	obj_load_info(int __i, int __j) : obj_qty(__i), load_prob(__j) {}
+	ObjRnum rnum;
+	obj_load_info() : obj_qty(0), load_prob(0), rnum(-1) {}
+	obj_load_info(int __i, int __j, ObjRnum __r) : obj_qty(__i), load_prob(__j), rnum(__r) {}
 };
 
 typedef double_map<ObjVnum, MobVnum, obj_load_info> oload_map;

--- a/src/gameplay/mechanics/stuff.h
+++ b/src/gameplay/mechanics/stuff.h
@@ -24,9 +24,8 @@ const int MAX_LOAD_PROB = 1000;
 struct obj_load_info {
 	int obj_qty;
 	int load_prob;
-	ObjRnum rnum;
-	obj_load_info() : obj_qty(0), load_prob(0), rnum(-1) {}
-	obj_load_info(int __i, int __j, ObjRnum __r) : obj_qty(__i), load_prob(__j), rnum(__r) {}
+	obj_load_info() : obj_qty(0), load_prob(0) {}
+	obj_load_info(int __i, int __j) : obj_qty(__i), load_prob(__j) {}
 };
 
 typedef double_map<ObjVnum, MobVnum, obj_load_info> oload_map;


### PR DESCRIPTION
## Summary

- Добавлено поле `rnum` в `obj_load_info` — заполняется при `oload_class::init()` один раз при загрузке
- `ornum_by_info` теперь использует кешированный `rnum` вместо вызова `GetObjRnum()` (map::find по всем прототипам) при каждой смерти моба

## Контекст

Профайлер (#3142) показал `obj_load_on_death` = 3.1ms (68.6% от `real_kill`). `GetObjRnum` вызывался для каждого предмета в `oload_table` при каждой смерти моба.

## Test plan

- [ ] Проверить загрузку сервера — `stuff.lst` парсится без ошибок
- [ ] Убедиться что лут с мобов выпадает корректно

🤖 Generated with [Claude Code](https://claude.com/claude-code)