### PR TITLE
fix: recalculate affect_total on SetFeat/UnsetFeat (#3160)

### DIFF
--- a/src/engine/entities/char_data.h
+++ b/src/engine/entities/char_data.h
@@ -341,8 +341,8 @@ class CharData : public ProtectedCharData {
 	friend void do_mtransform(CharData *ch, char *argument, int cmd, int subcmd);
 	friend void medit_mobile_copy(CharData *dst, CharData *src);
 
-	void SetFeat(EFeat feat_id) { real_abils.Feats.set(to_underlying(feat_id)); };
-	void UnsetFeat(EFeat feat_id) { real_abils.Feats.reset(to_underlying(feat_id)); };
+	void SetFeat(EFeat feat_id) { real_abils.Feats.set(to_underlying(feat_id)); affect_total(this); };
+	void UnsetFeat(EFeat feat_id) { real_abils.Feats.reset(to_underlying(feat_id)); affect_total(this); };
 	bool HaveFeat(EFeat feat_id) const { return real_abils.Feats.test(to_underlying(feat_id)); };
 
 	void set_skill(ESkill skill_id, int percent);

--- a/src/gameplay/affects/affect_data.cpp
+++ b/src/gameplay/affects/affect_data.cpp
@@ -656,6 +656,9 @@ void affect_total(CharData *ch) {
 	if (ch->purged()) {
 		return;
 	}
+	if (ch->in_room == kNowhere) {
+		return;
+	}
 	bool domination = false;
 
 	if (!ch->IsNpc() && ch->in_room != kNowhere && ch->in_room >= 0


### PR DESCRIPTION
## Summary

- `SetFeat` и `UnsetFeat` теперь вызывают `affect_total(this)` — изменение фита применяется немедленно, без необходимости переодеваться
- `affect_total` пропускает пересчёт если `ch->in_room == kNowhere` — исключает лишние вызовы при загрузке персонажа/прототипов мобов

## Причина

При изменении фита через триггер или бог-команду пересчёт характеристик не происходил до вызова `affect_total` из другого источника (например, переодевания).

## Test plan

- [ ] Изменить фит персонажу через триггер/команду — убедиться что эффект применяется сразу
- [ ] Проверить что загрузка сервера не замедлилась (нет лишних вызовов affect_total при загрузке мобов)
- [ ] Проверить логин игрока — affect_total не вызывается N раз при загрузке фитов

🤖 Generated with [Claude Code](https://claude.com/claude-code)