### PR TITLE
fix: replace strncat with snprintf to suppress -Wstringop-truncation (#3162)

### DIFF
--- a/src/engine/ui/cmd/do_affects.cpp
+++ b/src/engine/ui/cmd/do_affects.cpp
@@ -72,7 +72,7 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			} else {
 				if (aff->modifier) {
 					sprintf(buf2, "%-3d к параметру: %s", aff->modifier, apply_types[(int) aff->location]);
-					strncat(buf, buf2, sizeof(buf) - strlen(buf) - 1);
+					snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%s", buf2);
 				}
 				if (aff->bitvector) {
 					if (*buf2) {
@@ -82,7 +82,7 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					}
 					strncat(buf, kColorBoldRed, sizeof(buf) - strlen(buf) - 1);
 					sprintbit(aff->bitvector, affected_bits, buf2, sizeof(buf2));
-					strncat(buf, buf2, sizeof(buf) - strlen(buf) - 1);
+					snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%s", buf2);
 					strncat(buf, kColorNrm, sizeof(buf) - strlen(buf) - 1);
 				}
 			}
@@ -114,7 +114,7 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				if (aff->modifier) {
 					sprintf(buf2, "%s%-3d к параметру: %s%s%s", (aff->modifier > 0) ? "+" : "",
 							aff->modifier, kColorBoldRed, apply_types[(int) aff->location], kColorNrm);
-					strncat(buf, buf2, sizeof(buf) - strlen(buf) - 1);
+					snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%s", buf2);
 				}
 				strncat(buf, "\r\n", sizeof(buf) - strlen(buf) - 1);
 				SendMsgToChar(buf, ch);


### PR DESCRIPTION
## Summary

- Заменены три вызова `strncat(buf, buf2, sizeof(buf) - strlen(buf) - 1)` на `snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%s", buf2)` в `do_affects.cpp`
- Убирает предупреждения `-Wstringop-truncation` без изменения поведения

🤖 Generated with [Claude Code](https://claude.com/claude-code)