### PR TITLE
fix: отложенное удаление моба в paste_mob (#3176)

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -2170,7 +2170,7 @@ void paste_mob(CharData *ch, RoomRnum room) {
 
 			if (GET_LASTROOM(ch) == kNowhere)
 			{
-				ExtractCharFromWorld(ch, false, true);
+				character_list.AddToExtractedList(ch);
 				return;
 			}
 
@@ -2312,8 +2312,7 @@ void paste_obj(ObjData *obj, RoomRnum room) {
 void PasteMobiles() {
 	utils::CExecutionTimer time;
 
-	const auto chars_copy = character_list.get_list();
-	for (const auto &it : chars_copy) {
+	for (auto &it : character_list) {
 	  paste_mob(it.get(), it->in_room);
 	}
 	log("Paste Mobiles() finished, time %f", time.delta().count());

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -2312,7 +2312,8 @@ void paste_obj(ObjData *obj, RoomRnum room) {
 void PasteMobiles() {
 	utils::CExecutionTimer time;
 
-	for (auto &it : character_list) {
+	const auto chars_copy = character_list.get_list();
+	for (const auto &it : chars_copy) {
 	  paste_mob(it.get(), it->in_room);
 	}
 	log("Paste Mobiles() finished, time %f", time.delta().count());


### PR DESCRIPTION
## Проблема

Closes #3176

`paste_mob` в ветке `GET_LASTROOM(ch) == kNowhere` вызывал `ExtractCharFromWorld(ch, false, true)` — немедленное удаление из внутреннего `std::list` в `character_list`. При этом `PasteMobiles` итерируется по `character_list` через range-based for, и удаление текущего элемента инвалидирует итератор → UB → SIGSEGV.

## Решение

Заменить `ExtractCharFromWorld(ch, false, true)` на `character_list.AddToExtractedList(ch)` — отложенное удаление, аналогично тому, как сделано в `paste_obj` (появилось в 2024). Реальное извлечение откладывается до следующего вызова `PurgeExtractedList`, итератор в `PasteMobiles` остаётся валидным.

Моб попадает в эту ветку только если у него нет `LASTROOM` (аномальное состояние — никогда не был размещён в реальной комнате), поэтому разница в `zone_reset` для дропа инвентаря несущественна.

## Изменения

- `src/engine/db/db.cpp` — в `paste_mob` заменён `ExtractCharFromWorld` на `character_list.AddToExtractedList`

🤖 Generated with [Claude Code](https://claude.com/claude-code)