### PR TITLE
fix: восстанавливать weapon_affect биты при надевании с no_cast (#3170)

### DIFF
--- a/src/engine/core/handler.cpp
+++ b/src/engine/core/handler.cpp
@@ -672,6 +672,10 @@ unsigned int ActivateStuff(CharData *ch, ObjData *obj, id_to_set_info_map::const
 								} else {
 									CastAffect(GetRealLevel(ch), ch, ch, i.aff_spell);
 								}
+							} else {
+								affect_modify(ch, GetApplyByWeaponAffect(i.aff_pos, ch).first,
+											  GetApplyByWeaponAffect(i.aff_pos, ch).second,
+											  static_cast<EAffect>(i.aff_bitvector), true);
 							}
 						}
 					}
@@ -703,6 +707,10 @@ unsigned int ActivateStuff(CharData *ch, ObjData *obj, id_to_set_info_map::const
 							} else {
 								CastAffect(GetRealLevel(ch), ch, ch, i.aff_spell);
 							}
+						} else {
+							affect_modify(ch, GetApplyByWeaponAffect(i.aff_pos, ch).first,
+										  GetApplyByWeaponAffect(i.aff_pos, ch).second,
+										  static_cast<EAffect>(i.aff_bitvector), true);
 						}
 					}
 				}
@@ -883,6 +891,10 @@ void EquipObj(CharData *ch, ObjData *obj, int pos, const CharEquipFlags& equip_f
 					} else {
 						CastAffect(GetRealLevel(ch), ch, ch, j.aff_spell);
 					}
+				} else {
+					affect_modify(ch, GetApplyByWeaponAffect(j.aff_pos, ch).first,
+								  GetApplyByWeaponAffect(j.aff_pos, ch).second,
+								  static_cast<EAffect>(j.aff_bitvector), true);
 				}
 			}
 		}

--- a/src/gameplay/affects/affect_data.h
+++ b/src/gameplay/affects/affect_data.h
@@ -75,6 +75,7 @@ void mobile_affect_update();
 
 void affect_total(CharData *ch);
 void affect_modify(CharData *ch, EApply loc, int mod, EAffect bitv, bool add);
+std::pair<EApply, int> GetApplyByWeaponAffect(EWeaponAffect element, CharData *ch);
 void affect_to_char(CharData *ch, const Affect<EApply> &af);
 void RemoveAffectFromChar(CharData *ch, ESpell spell_id);
 void RemoveAffectFromCharAndRecalculate(CharData *ch, ESpell spell_id);


### PR DESCRIPTION
## Проблема

При использовании `UnequipChar` с флагом `skip_total` и последующем `EquipObj` с `no_cast | skip_total` оружейные биты (`weapon_affect`) снимались, но не восстанавливались — `CastAffect` полностью пропускался. Единственным обходом было ручное вызов `affect_total`.

## Причина

В `UnequipChar` биты снимаются через `affect_modify(bitvec, false)`. В `EquipObj` при `no_cast` весь блок weapon_affect пропускается — нет ни `CastAffect`, ни `affect_modify`. `affect_total` же применяет биты напрямую через `affect_modify`, поэтому и "чинил" проблему.

## Исправление

При `no_cast` в `EquipObj` и `ActivateStuff` биты теперь применяются через `affect_modify` (как делает `affect_total`), без вызова заклинания. Декларация `GetApplyByWeaponAffect` добавлена в `affect_data.h`.

Closes #3170

🤖 Generated with [Claude Code](https://claude.com/claude-code)