### PR TITLE
perf: dirty-tracking + пул + LPT для сохранения клановых сундуков (#3165)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCES
 		src/engine/db/help.cpp
 		src/gameplay/clans/house.cpp
 		src/gameplay/clans/house_exp.cpp
+		src/gameplay/clans/ingr_chest_saver.cpp
 		src/gameplay/communication/ignores.cpp
 		src/gameplay/communication/ignores_loader.cpp
 		src/gameplay/crafting/im.cpp
@@ -612,6 +613,7 @@ set(HEADERS
 		src/engine/db/help.h
 		src/gameplay/clans/house_exp.h
 		src/gameplay/clans/house.h
+		src/gameplay/clans/ingr_chest_saver.h
 		src/gameplay/communication/ignores.h
 		src/gameplay/communication/ignores_loader.h
 		src/gameplay/crafting/im.h

--- a/src/engine/db/global_objects.cpp
+++ b/src/engine/db/global_objects.cpp
@@ -55,6 +55,7 @@ struct GlobalObjectsStorage {
 	Strengthening strengthening;
 	obj2triggers_t obj2triggers;
 	RoomDescriptions room_descriptions;
+	ClanSystem::IngrChestSaver ingr_chest_saver;
 };
 
 GlobalObjectsStorage::GlobalObjectsStorage() :
@@ -255,6 +256,10 @@ logging::LogManager &GlobalObjects::log_manager() {
 }
 RoomDescriptions &GlobalObjects::descriptions() {
 	return global_objects().room_descriptions;
+}
+
+ClanSystem::IngrChestSaver &GlobalObjects::ingr_chest_saver() {
+	return global_objects().ingr_chest_saver;
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/db/global_objects.h
+++ b/src/engine/db/global_objects.h
@@ -6,6 +6,7 @@
 #include "gameplay/fight/pk.h"
 #include "gameplay/economics/currencies.h"
 #include "gameplay/magic/spells_info.h"
+#include "gameplay/clans/ingr_chest_saver.h"
 #include "gameplay/mechanics/celebrates.h"
 #include "gameplay/mechanics/guilds.h"
 #include "gameplay/abilities/feats.h"
@@ -95,6 +96,7 @@ class GlobalObjects {
 	static Strengthening &strengthening();
 	static obj2triggers_t &obj_triggers();
 	static RoomDescriptions &descriptions();
+	static ClanSystem::IngrChestSaver &ingr_chest_saver();
 };
 
 using MUD = GlobalObjects;

--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -42,6 +42,7 @@
 #include "engine/db/help.h"
 #include "engine/core/conf.h"
 #include "engine/db/global_objects.h"
+#include "ingr_chest_saver.h"
 #include "engine/ui/objects_filter.h"
 #include "engine/ui/table_wrapper.h"
 #include "gameplay/mechanics/sight.h"
@@ -4243,122 +4244,8 @@ void Clan::init_ingr_chest() {
 	delete[] databuf;
 }
 
-// Сохраняет один чест в файл. Чистая функция, не лезет в глобалы, не
-// логирует -- предназначена для запуска в worker thread'е.
-static bool save_one_ingr_chest(ObjData *chest, const std::string &filename) {
-	// Преаллокация буфера сериализации: берём размер предыдущего сохранения
-	// файла как подсказку (+10%). Исключает серию realloc-ов stringbuf при
-	// росте. На бенче (500 итераций, 2 CPU): 3200 объектов -13%,
-	// 1300 объектов -5%, меньше 1000 -- в пределах шума.
-	std::size_t prealloc = 64 * 1024;
-	struct stat st {};
-	if (::stat(filename.c_str(), &st) == 0 && st.st_size > 0) {
-		prealloc = static_cast<std::size_t>(st.st_size)
-			+ static_cast<std::size_t>(st.st_size / 10);
-	}
-
-	std::stringstream out;
-	out.str(std::string(prealloc, '\0'));
-	out.seekp(0);
-	out << "* Items file\n";
-	for (ObjData *temp = chest->get_contains(); temp; temp = temp->get_next_content()) {
-		write_one_object(out, temp, 0);
-	}
-	out << "\n$\n$\n";
-
-	std::ofstream file(filename.c_str());
-	if (!file.is_open()) {
-		return false;
-	}
-	// Не file << out.rdbuf() -- stringbuf из-за преаллокации содержит "хвост"
-	// из нулевых байт после последнего write. Берём только реально
-	// заполненную часть по tellp().
-	const auto written = out.tellp();
-	const auto contents = out.str();
-	file.write(contents.data(), static_cast<std::streamsize>(written));
-	file.close();
-	return true;
-}
-
-// Сохраняем сундуки с ингредиентами всех кланов в файлы.
-//
-// Сохранение распараллелено: главный поток блокируется на WaitAll(), но
-// каждый сундук сериализуется и пишется в собственном потоке из пула.
-// Условия безопасности:
-//   - write_one_object выполняет только чтение ObjData и не дёргает
-//     изменяемые глобальные индексы (см. obj_save.cpp: убраны
-//     set_timer-clamp и set/unset флагов kBloody/kNosell);
-//   - главный поток не обрабатывает входящие события от игроков, пока
-//     save_ingr_chests не завершится, потому что вызов идёт из heartbeat.
-// Логирование собирается в главном потоке после WaitAll() ради порядка
-// строк в файле и независимости от того, включён ли OutputThread.
 void ClanSystem::save_ingr_chests() {
-	struct SaveJob {
-		Clan *clan;
-		ObjData *chest;
-		std::string filename;
-	};
-
-	std::vector<SaveJob> jobs;
-	jobs.reserve(Clan::ClanList.size());
-	for (const auto &clan : Clan::ClanList) {
-		if (!clan->ingr_chest_active()) {
-			continue;
-		}
-		const auto file_abbrev = clan->get_file_abbrev();
-		const auto filename = LIB_HOUSE + file_abbrev + "/" + file_abbrev + ".ing";
-		for (auto chest : world[clan->get_ingr_chest_room_rnum()]->contents) {
-			if (!is_ingr_chest(chest)) {
-				continue;
-			}
-			jobs.push_back({clan.get(), chest, filename});
-			break;
-		}
-	}
-
-	if (jobs.empty()) {
-		return;
-	}
-
-	struct SaveResult {
-		std::string abbrev;
-		double seconds;
-		bool success;
-	};
-
-	// Размер пула: не больше количества задач и не больше числа ядер.
-	const size_t hw = std::max<size_t>(1, std::thread::hardware_concurrency());
-	const size_t pool_size = std::min(jobs.size(), hw);
-
-	utils::CExecutionTimer wall_timer;
-	utils::ThreadPool pool(pool_size);
-
-	std::vector<std::future<SaveResult>> futures;
-	futures.reserve(jobs.size());
-	for (const auto &job : jobs) {
-		futures.push_back(pool.Enqueue([job]() -> SaveResult {
-			utils::CExecutionTimer timer;
-			const bool ok = save_one_ingr_chest(job.chest, job.filename);
-			return SaveResult{
-				std::string(job.clan->GetAbbrev()),
-				timer.delta().count(),
-				ok,
-			};
-		}));
-	}
-
-	for (auto &f : futures) {
-		const SaveResult r = f.get();
-		if (!r.success) {
-			log("Error saving clan chest %s: cannot open file", r.abbrev.c_str());
-			continue;
-		}
-		log(fmt::format("saving clan chest {} done, timer {:.10f}",
-			r.abbrev, r.seconds));
-	}
-	const double wall = wall_timer.delta().count();
-	log(fmt::format("save_ingr_chests: {} chests on {} threads, wall {:.10f}",
-		jobs.size(), pool_size, wall));
+	GlobalObjects::ingr_chest_saver().run();
 }
 
 bool Clan::put_ingr_chest(CharData *ch, ObjData *obj, ObjData *chest) {
@@ -4403,6 +4290,7 @@ bool Clan::put_ingr_chest(CharData *ch, ObjData *obj, ObjData *chest) {
 		PlaceObjIntoObj(obj, chest);
 		act("Вы положили $o3 в $O3.", false, ch, obj, chest, kToChar);
 		CLAN(ch)->ingr_chest_objcount_++;
+		GlobalObjects::ingr_chest_saver().mark_dirty(CLAN(ch).get());
 	}
 	return true;
 }
@@ -4419,6 +4307,7 @@ bool Clan::take_ingr_chest(CharData *ch, ObjData *obj, ObjData *chest) {
 	if (obj->get_carried_by() == ch) {
 		act("Вы взяли $o3 из $O1.", false, ch, obj, chest, kToChar);
 		CLAN(ch)->ingr_chest_objcount_--;
+		GlobalObjects::ingr_chest_saver().mark_dirty(CLAN(ch).get());
 	}
 	return true;
 }
@@ -4483,6 +4372,7 @@ void Clan::purge_ingr_chest() {
 			break;
 		}
 	}
+	GlobalObjects::ingr_chest_saver().mark_dirty(this);
 }
 
 int Clan::calculate_clan_tax() const {

--- a/src/gameplay/clans/ingr_chest_saver.cpp
+++ b/src/gameplay/clans/ingr_chest_saver.cpp
@@ -1,0 +1,183 @@
+// Part of Bylins http://www.mud.ru
+
+#include "ingr_chest_saver.h"
+
+#include "house.h"
+
+#include "engine/db/db.h"
+#include "engine/db/obj_save.h"
+#include "engine/entities/obj_data.h"
+#include "engine/entities/room_data.h"
+#include "utils/logger.h"
+#include "utils/thread_pool.h"
+#include "utils/utils.h"
+#include "utils/utils_time.h"
+
+#include <third_party_libs/fmt/include/fmt/format.h>
+
+#include <sys/stat.h>
+
+#include <algorithm>
+#include <fstream>
+#include <future>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace ClanSystem {
+
+namespace {
+
+// Сериализация одного сундука. Читает ObjData, не мутирует. Размер
+// буфера заранее резервируется под предыдущий размер файла +10%, чтобы
+// не было серии realloc в stringbuf при росте.
+bool save_one_chest(ObjData *chest, const std::string &filename) {
+	std::size_t prealloc = 64 * 1024;
+	struct stat st {};
+	if (::stat(filename.c_str(), &st) == 0 && st.st_size > 0) {
+		prealloc = static_cast<std::size_t>(st.st_size)
+			+ static_cast<std::size_t>(st.st_size / 10);
+	}
+
+	std::stringstream out;
+	out.str(std::string(prealloc, '\0'));
+	out.seekp(0);
+	out << "* Items file\n";
+	for (ObjData *temp = chest->get_contains(); temp; temp = temp->get_next_content()) {
+		write_one_object(out, temp, 0);
+	}
+	out << "\n$\n$\n";
+
+	std::ofstream file(filename.c_str());
+	if (!file.is_open()) {
+		return false;
+	}
+	// Преаллокация оставляет нули в хвосте буфера, write() пишет только
+	// реально заполненную часть по tellp().
+	const auto written = out.tellp();
+	const auto contents = out.str();
+	file.write(contents.data(), static_cast<std::streamsize>(written));
+	file.close();
+	return true;
+}
+
+}  // namespace
+
+class IngrChestSaver::Impl {
+ public:
+	Impl() : pool(std::max<std::size_t>(1, std::thread::hardware_concurrency())) {}
+
+	utils::ThreadPool pool;
+	// Клан попадает сюда, когда содержимое его сундука изменилось.
+	// Обращения из главного потока, синхронизация не требуется.
+	std::unordered_set<Clan *> dirty;
+};
+
+IngrChestSaver::IngrChestSaver() : m_impl(std::make_unique<Impl>()) {}
+
+IngrChestSaver::~IngrChestSaver() = default;
+
+void IngrChestSaver::mark_dirty(Clan *clan) {
+	if (clan) {
+		m_impl->dirty.insert(clan);
+	}
+}
+
+void IngrChestSaver::run() {
+	struct Job {
+		Clan *clan;
+		ObjData *chest;
+		std::string filename;
+		int objcount;
+	};
+
+	struct Result {
+		Clan *clan;
+		std::string abbrev;
+		double seconds;
+		bool success;
+	};
+
+	std::vector<Job> jobs;
+	jobs.reserve(m_impl->dirty.size());
+	for (const auto &clan : Clan::ClanList) {
+		Clan *raw = clan.get();
+		if (!m_impl->dirty.count(raw)) {
+			continue;
+		}
+		if (!raw->ingr_chest_active()) {
+			m_impl->dirty.erase(raw);
+			continue;
+		}
+		const auto file_abbrev = raw->get_file_abbrev();
+		std::string filename = LIB_HOUSE + file_abbrev + "/" + file_abbrev + ".ing";
+		for (auto chest : world[raw->get_ingr_chest_room_rnum()]->contents) {
+			if (!ClanSystem::is_ingr_chest(chest)) {
+				continue;
+			}
+			Job job;
+			job.clan = raw;
+			job.chest = chest;
+			job.filename = std::move(filename);
+			job.objcount = raw->get_ingr_chest_objcount();
+			jobs.push_back(std::move(job));
+			break;
+		}
+	}
+
+	// Снимаем dirty до постановки в очередь: параллельный put_ingr_chest
+	// взведёт флаг заново, и следующий вызов run() поднимет обновлённое
+	// состояние. При ошибке записи флаг будет восстановлен ниже.
+	for (const auto &job : jobs) {
+		m_impl->dirty.erase(job.clan);
+	}
+
+	if (jobs.empty()) {
+		return;
+	}
+
+	// Longest Processing Time. Время сериализации одного сундука линейно
+	// зависит от числа объектов в нём; используем это как вес задачи,
+	// чтобы самая тяжёлая стартовала первой и wall time был близок к
+	// теоретическому минимуму max(longest, total / threads).
+	std::sort(jobs.begin(), jobs.end(),
+		[](const Job &a, const Job &b) { return a.objcount > b.objcount; });
+
+	utils::CExecutionTimer wall_timer;
+
+	std::vector<std::future<Result>> futures;
+	futures.reserve(jobs.size());
+	for (const auto &job : jobs) {
+		futures.push_back(m_impl->pool.Enqueue([job]() -> Result {
+			utils::CExecutionTimer timer;
+			const bool ok = save_one_chest(job.chest, job.filename);
+			return Result{
+				job.clan,
+				std::string(job.clan->GetAbbrev()),
+				timer.delta().count(),
+				ok,
+			};
+		}));
+	}
+
+	for (auto &f : futures) {
+		const Result r = f.get();
+		if (r.success) {
+			log(fmt::format("saving clan chest {} done, timer {:.10f}",
+				r.abbrev, r.seconds));
+		} else {
+			// Сундук остаётся изменённым: следующий run() повторит попытку.
+			m_impl->dirty.insert(r.clan);
+			log("Error saving clan chest %s: cannot open file", r.abbrev.c_str());
+		}
+	}
+
+	const double wall = wall_timer.delta().count();
+	log(fmt::format("save_ingr_chests: {} chests on {} threads, wall {:.10f}",
+		jobs.size(), m_impl->pool.NumThreads(), wall));
+}
+
+}  // namespace ClanSystem
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/gameplay/clans/ingr_chest_saver.h
+++ b/src/gameplay/clans/ingr_chest_saver.h
@@ -1,0 +1,42 @@
+// Part of Bylins http://www.mud.ru
+//
+// Сохранение сундуков с ингредиентами всех кланов в файлы.
+// Интерфейс минимален: все детали реализации (пул потоков, dirty-set,
+// порядок обхода) инкапсулированы в Impl.
+
+#ifndef INGR_CHEST_SAVER_H_
+#define INGR_CHEST_SAVER_H_
+
+#include <memory>
+
+class Clan;
+
+namespace ClanSystem {
+
+class IngrChestSaver {
+ public:
+	IngrChestSaver();
+	~IngrChestSaver();
+
+	IngrChestSaver(const IngrChestSaver &) = delete;
+	IngrChestSaver &operator=(const IngrChestSaver &) = delete;
+
+	// Пометить сундук клана как изменённый с последнего сохранения.
+	// Вызывается из put/take/purge_ingr_chest.
+	void mark_dirty(Clan *clan);
+
+	// Пройти по Clan::ClanList и сохранить помеченные сундуки в
+	// параллельном пуле потоков. Логирует результат каждого сундука
+	// и общий wall time.
+	void run();
+
+ private:
+	class Impl;
+	std::unique_ptr<Impl> m_impl;
+};
+
+}  // namespace ClanSystem
+
+#endif  // INGR_CHEST_SAVER_H_
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
## Контекст

Issue #3165.

После PR #3181 сохранение клановых сундуков с ингредиентами на боевом сервере не укладывается в бюджет одного heartbeat-пульса (`kPassesPerSec = 25`, то есть 40 мс на пульс):

```
save_ingr_chests: 6 chests on 2 threads, wall 0.0491128710
save_ingr_chests: 6 chests on 2 threads, wall 0.0520457770
save_ingr_chests: 6 chests on 2 threads, wall 0.0554127890
save_ingr_chests: 6 chests on 2 threads, wall 0.0541249320
...
save_ingr_chests: 6 chests on 2 threads, wall 0.0660855630
```

Главный поток блокируется на `WaitAll()` примерно на 50 мс — пульс не успевает.

## Что в PR

Подсистема сохранения клановых ингредиентных сундуков вынесена в отдельный компонент.

### Новый компонент `ClanSystem::IngrChestSaver`

Файлы `src/gameplay/clans/ingr_chest_saver.{h,cpp}`. Заголовок минимальный:

```cpp
class IngrChestSaver {
 public:
    IngrChestSaver();
    ~IngrChestSaver();

    void mark_dirty(Clan *clan);
    void run();

 private:
    class Impl;
    std::unique_ptr<Impl> m_impl;
};
```

Pimpl: пул потоков, `std::unordered_set<Clan*>`, логика сериализации и LPT-сортировка — всё в приватном `Impl`, спрятано за указателем. Изменения реализации не вызывают перекомпиляцию пользователей заголовка.

### Экземпляр в `GlobalObjects`

Поле `ClanSystem::IngrChestSaver ingr_chest_saver` в `GlobalObjectsStorage` + геттер `GlobalObjects::ingr_chest_saver()`. В той же куче, что `trigger_list`, `world_objects`, `zone_table`, `heartbeat` и прочее глобальное состояние — явно и видно.

`ClanSystem` — это `namespace` со свободными функциями, положить пул туда как поле нельзя без переделки всего `namespace` в `class`. Переделка пространства имён в класс — отдельная большая задача (лучше в рамках #3180 про глобалы), здесь не трогаю.

### Dirty-tracking

`Clan::put_ingr_chest`, `Clan::take_ingr_chest`, `Clan::purge_ingr_chest` вызывают `GlobalObjects::ingr_chest_saver().mark_dirty(this)`. Других путей изменить содержимое сундука с ингредиентами в коде нет (проверено: только эти три функции управляют списком `chest->contains`, DG-скрипты прямого доступа не имеют).

В `Clan` нет ни поля, ни методов для отслеживания изменений — набор грязных сундуков живёт внутри `IngrChestSaver::Impl`.

### LPT-сортировка

Время сериализации одного сундука линейно зависит от числа объектов в нём. Вес задачи — `Clan::get_ingr_chest_objcount()`, никаких syscall'ов не делаем. Сортировка задач по убыванию: самая большая стартует первой, wall time близок к нижней границе `max(longest, total / threads)`.

### Постоянный пул потоков

`utils::ThreadPool` живёт внутри `IngrChestSaver::Impl` и переиспользуется. Раньше пул создавался и уничтожался на каждый вызов `save_ingr_chests`, что давало лишние `pthread_create` + `join` каждые 10 минут.

### `ClanSystem::save_ingr_chests`

Тонкая обёртка над `GlobalObjects::ingr_chest_saver().run()`. Вызовы из heartbeat и `hcontrol save` не менялись.

## Ожидаемый эффект

Оценка на боевом сервере (6 активных сундуков, 2 ядра):

| Ситуация | wall time |
|---|---|
| Пустой цикл (10 минут без put/take/purge) | **<1 мс** (только проход по `Clan::ClanList` + проверка в unordered_set) |
| 1 изменившийся сундук | ≈ времени его сериализации, для большинства — единицы мс |
| 2 изменившихся сундука | `max(их размеров)`, обычно <30 мс |
| 6 изменившихся сразу | как раньше, ≈50 мс (этот случай редкий) |

В часы низкой активности большинство вызовов `run()` будут пустыми.

## Изменения

- `src/gameplay/clans/ingr_chest_saver.{h,cpp}` — новый компонент.
- `src/engine/db/global_objects.{h,cpp}` — поле + геттер.
- `src/gameplay/clans/house.cpp`:
  - `put_ingr_chest`, `take_ingr_chest`, `purge_ingr_chest` — `mark_dirty(this)`.
  - `save_ingr_chests` ужата до одной строки вызова `run()`.
  - Удалены `save_one_ingr_chest` и прежнее тело `save_ingr_chests` (они теперь в `IngrChestSaver::Impl`).
- `CMakeLists.txt` — регистрация новых файлов.

Заголовок `house.h` не меняется, то есть для всех включающих его файлов пересборка не требуется.

## Безопасность многопоточности

`write_one_object` (после PR #3181) читает `ObjData` без мутаций. Рабочие потоки пула только читают объекты, не трогают `dirty`-множество. `mark_dirty` и `run` вызываются из главного потока. Никаких атомиков и мьютексов не нужно.

## Test plan

- [x] `make tests && ./tests/tests` — 372 теста зелёные.
- [x] `make circle` — собирается.
- [ ] Прогон на боевом сервере, сверка wall time в логе: ожидаем большинство пустых циклов с `wall <0.001` и отдельные рабочие циклы с `wall <0.030` для 1–2 сундуков.
