### PR TITLE
fix(oedit): recompute decay deadline after saving to live obj (#3186)

### DIFF
--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -224,6 +224,13 @@ void olc_update_object(int robj_num, ObjData *obj, ObjData *olc_obj) {
 		obj->set_val(1, tmp.get_val(1));
 		obj->set_val(2, tmp.get_val(2));
 	}
+	// Пересчитываем deadline в ObjDecayManager на основании актуальных полей:
+	// *obj = *olc_obj выше затирает extra_flags значениями из прототипа
+	// (в частности kTicktimer, снятый при загрузке прототипа), и deadline в
+	// decay_manager становится рассогласованным с m_timer. Без этого вызова
+	// get_timer() у живого экземпляра начинает возвращать UNLIMITED_TIMER
+	// (2147483647), см. issue #3186.
+	world_objects.decay_manager().on_timer_changed(obj);
 }
 
 // * Обновление полей объектов при изменении их прототипа через олц.

--- a/tests/obj_decay_manager.cpp
+++ b/tests/obj_decay_manager.cpp
@@ -193,6 +193,38 @@ TEST_F(ObjDecayManagerTest, GetDeadline_Untracked) {
 	EXPECT_EQ(dl, UINT64_MAX);
 }
 
+// Regression for bylins/mud#3186: redactor (oedit) wiped extra_flags from a
+// living object via `*obj = *olc_obj`, temporarily clearing kTicktimer. If
+// on_timer_changed is called in that window the deadline is pinned to
+// UINT64_MAX (ObjData::get_timer() would then return UNLIMITED_TIMER =
+// 2147483647 even after the flag is restored). olc_update_object must
+// re-refresh the deadline after restoring kTicktimer so the live object keeps
+// a real countdown.
+TEST_F(ObjDecayManagerTest, OnTimerChanged_RefreshAfterTicktimerRestore) {
+	auto obj = make_obj(100);
+	decay_mgr.insert(obj.get());
+
+	auto now = decay_mgr.current_mud_hour();
+	EXPECT_EQ(decay_mgr.get_deadline(obj.get()), now + 100);
+
+	// Simulate `*obj = *olc_obj`: the prototype has kTicktimer cleared,
+	// so the assignment wipes it on the live object.
+	obj->unset_extraflag(EObjFlag::kTicktimer);
+	decay_mgr.on_timer_changed(obj.get());
+	EXPECT_EQ(decay_mgr.get_deadline(obj.get()), UINT64_MAX);
+	EXPECT_EQ(obj->get_timer(), CObjectPrototype::UNLIMITED_TIMER);
+
+	// Restoration path in olc_update_object: the flag is put back and
+	// the deadline must be recomputed. Without the explicit refresh at
+	// the end of olc_update_object the deadline would stay at UINT64_MAX.
+	obj->set_extra_flag(EObjFlag::kTicktimer);
+	decay_mgr.on_timer_changed(obj.get());
+
+	now = decay_mgr.current_mud_hour();
+	EXPECT_EQ(decay_mgr.get_deadline(obj.get()), now + 100);
+	EXPECT_EQ(obj->get_timer(), 100);
+}
+
 // ---------------------------------------------------------------------------
 // Regression tests for GitHub issue #3178:
 //   - kZonedecay objects must "crumble" only when located outside their


### PR DESCRIPTION
## Summary

После `oedit <vnum>` + save у живого экземпляра того же объекта в `stat` начинал показываться `Таймер: 2147483647` (= `INT_MAX` = `UNLIMITED_TIMER`) вместо нормального обратного отсчёта.

**Причина**: в `olc_update_object()` (src/engine/olc/oedit.cpp) строка `*obj = *olc_obj;` переливает все поля прототипа в живой экземпляр, в том числе `extra_flags` — а на прототипе загрузчик снимает `kTicktimer`. Если в окне "флаг снят, но ещё не восстановлен" (или после будущих правок, которые дропают флаг) где-то вызывается `decay_manager.on_timer_changed()`, `compute_and_store_deadline()` уходит в ветку "timer не тикает" и фиксирует `deadline = UINT64_MAX`. После этого `ObjData::get_timer()` возвращает `UNLIMITED_TIMER = 2147483647`, даже когда `kTicktimer` уже обратно на месте.

**Фикс**: в конце `olc_update_object`, после всей реставрации runtime-флагов, явно вызвать `world_objects.decay_manager().on_timer_changed(obj)` — это пересчитает deadline по финальному состоянию полей. Для объектов не в `decay_manager` вызов — no-op.

## Test plan

- [x] Добавлен unit-тест `ObjDecayManagerTest.OnTimerChanged_RefreshAfterTicktimerRestore`, воспроизводящий цепочку: insert → drop `kTicktimer` → on_timer_changed (deadline = UINT64_MAX, get_timer = `UNLIMITED_TIMER`) → restore `kTicktimer` → on_timer_changed (deadline пересчитан → get_timer = исходный таймер).
- [x] `./tests --gtest_filter="ObjDecayManagerTest.*"` — 14/14 прошли.
- [x] Полный тест-ран — добавленный тест зелёный, остальные упавшие (FightPenalties, Boards_Changelog, MobClassesLoaderTest) падают и без изменений, фикс их не затрагивает.
- [x] Ручная проверка in-game: `oedit 10000` на `заячий тулупчик`, save, `stat тулу` — таймер должен остаться реальным числом, а не `2147483647`.

Fixes #3186