### PR TITLE
fix(obj_save): persist decayed timer instead of raw m_timer (#3189)

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -613,13 +613,15 @@ void write_one_object(std::stringstream &out, ObjData *object, int location) {
 		if (GET_OBJ_SEX(object) != GET_OBJ_SEX(p)) {
 			out << "Sexx: " << static_cast<int>(GET_OBJ_SEX(object)) << "~\n";
 		}
-		// Таймер. ObjData::get_timer() дёргает глобальный
-		// world_objects.decay_manager() (not thread-safe), здесь это и
-		// избыточно, и препятствует параллельному сохранению. Берём
-		// сырое значение m_timer напрямую. Ранее здесь был clamp
-		// "object->set_timer(proto_timer)" -- он удалён как говнокод:
-		// та же коррекция применяется в read_one_object_new при загрузке.
-		const int obj_timer = object->CObjectPrototype::get_timer();
+		// Таймер. Сохраняем актуальный остаток: ObjData::get_timer()
+		// учитывает deadline в decay_manager, поэтому для свежезагруженного
+		// объекта с m_timer == proto_timer уже после пары игровых часов мы
+		// увидим правильное оставшееся время. Без этого Tmer не писался в
+		// файл игрока (m_timer сам по себе не тикает), и прогресс распада
+		// терялся на save/reload (issue #3189).
+		// Сохранение идёт из главного цикла (heartbeat, shutdown), обращение
+		// к decay_manager здесь безопасно.
+		const int obj_timer = object->get_timer();
 		const int proto_timer = p->get_timer();
 		if (obj_timer != proto_timer) {
 			out << "Tmer: " << obj_timer << "~\n";


### PR DESCRIPTION
## Summary

После `load obj <vnum>` + `save` в файле игрока отсутствовало поле `Tmer:`, несмотря на то что у объекта уже начал идти отсчёт распада в `decay_manager`. Поле появлялось только после `постой` + повторного входа + `save` — то есть, прогресс распада между первой загрузкой и save фактически терялся.

**Причина**: `write_one_object()` использовал `object->CObjectPrototype::get_timer()` (сырое `m_timer`), а `m_timer` сам по себе не тикает — его значение равно `proto.m_timer` до тех пор, пока кто-то не вызовет `set_timer()`. Реальный обратный отсчёт живёт в `decay_manager` (в `deadline` относительно `m_counter`). Сравнение `obj_timer == proto_timer` всегда было истинным для свежезагруженного объекта → `Tmer:` не писался.

**Фикс**: использовать виртуальный `ObjData::get_timer()`, который возвращает `deadline - now` из decay_manager. Тогда через пару игровых часов значение уже отличается от proto, и `Tmer:` попадает в файл.

Комментарий в коде предупреждал о thread-safety `decay_manager`, но `Crash_save_all()` вызывается из главного цикла (heartbeat / shutdown) — обращение к `decay_manager` оттуда безопасно. Комментарий обновлён.

## Test plan

- [x] `make circle -j$(nproc)/2` проходит.
- [x] Имеющиеся `ObjDecayManagerTest.*` (14 тестов) проходят — они уже покрывают корректность `ObjData::get_timer()` в разных состояниях decay_manager (с deadline, без deadline, с UINT64_MAX).
- [x] Ручная проверка: `load obj 1073`, подождать пару тиков, `save` — в файле игрока должен появиться `Tmer: <остаток>`. Постой + вход + save — те же значения (без потери прогресса).

Fixes #3189