### PR TITLE
fix(clan): treat disbanded clan's ingr chest as inactive (#3191)

### DIFF
--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -169,7 +169,7 @@ Clan::Clan() :
 	exp(0), clan_exp(0), exp_buf(0), clan_level(0), rent(0),
 	pk(true),
 	chest_room(0), storehouse(true), exp_info(true), test_clan(false),
-	ingr_chest_room_rnum_(-1), gold_tax_pct_(0), reputation(10),
+	ingr_chest_room_rnum_(0), gold_tax_pct_(0), reputation(10),
 	chest_objcount(0), chest_discount(0), chest_weight(0),
 	ingr_chest_objcount_(0) {
 }
@@ -4445,7 +4445,7 @@ void Clan::disable_ingr_chest(CharData *ch) {
 			break;
 		}
 	}
-	ingr_chest_room_rnum_ = -1;
+	ingr_chest_room_rnum_ = 0;
 	SendMsgToChar("Хранилище отключено.\r\n", ch);
 }
 

--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -4387,10 +4387,13 @@ int Clan::calculate_clan_tax() const {
 }
 
 bool Clan::ingr_chest_active() const {
-	if (ingr_chest_room_rnum_ > 0) {
-		return true;
+	// Распущенная дружина (без членов) не должна считаться владельцем
+	// сундука для ингров: платить налог, отображать его в olc, etc.
+	// См. issue #3191.
+	if (m_members.empty()) {
+		return false;
 	}
-	return false;
+	return ingr_chest_room_rnum_ > 0;
 }
 
 void Clan::set_ingr_chest(CharData *ch) {

--- a/src/gameplay/clans/house.h
+++ b/src/gameplay/clans/house.h
@@ -153,6 +153,7 @@ class ClanMembersList : private std::unordered_map<long, ClanMember::shared_ptr>
   using base_t::end;
   using base_t::find;
   using base_t::size;
+  using base_t::empty;
   using base_t::clear;
 
   void set(const key_type &key, const mapped_type &value) { (*this)[key] = value; }


### PR DESCRIPTION
## Summary

`Clan::ingr_chest_active()` проверял только, что у дружины когда-то был назначен сундук (`ingr_chest_room_rnum_ > 0`). Для распущенной дружины (без членов) функция продолжала возвращать `true`, из-за чего сундук мог учитываться в налогах, отображаться в olc и прочих местах.

Добавлен early-return `false` если у дружины нет членов (`m_members.empty()`). Плюс экспортнул `empty()` в публичный интерфейс `ClanMembersList`, чтобы писать идиоматично, а не через `size() == 0`.

## Test plan

- [x] `make circle` проходит.
- [ ] Ручная проверка: `hcontrol destroy <rent>`, затем убедиться что сундук больше не считается активным (олц/налог/список).

Fixes #3191