### PR TITLE
cleanup: remove combat-chain profilers from #3142

### DIFF
--- a/src/gameplay/fight/fight.cpp
+++ b/src/gameplay/fight/fight.cpp
@@ -1851,7 +1851,6 @@ void process_npc_attack(CharData *ch) {
 }
 
 void process_player_attack(CharData *ch, int min_init) {
-	utils::CSteppedProfiler atk_profiler("PlayerAttack", 0.005);
 
 	if (ch->GetPosition() > EPosition::kStun
 		&& ch->GetPosition() < EPosition::kFight
@@ -1862,11 +1861,9 @@ void process_player_attack(CharData *ch, int min_init) {
 	}
 
 	// Срабатывание батл-триггеров амуниции
-	atk_profiler.next_step("fight_otrigger");
 	Bitvector trigger_code = fight_otrigger(ch);
 
 	//* каст заклинания
-	atk_profiler.next_step("cast_spell");
 	if (ch->GetCastSpell() != ESpell::kUndefined && ch->get_wait() <= 0 && !IS_SET(trigger_code, kNoCastMagic)) {
 		if (AFF_FLAGGED(ch, EAffect::kSilence)) {
 			SendMsgToChar("Вы не смогли вымолвить и слова.\r\n", ch);
@@ -1886,7 +1883,6 @@ void process_player_attack(CharData *ch, int min_init) {
 	if (ch->battle_affects.get(kEafMultyparry))
 		return;
 	//* применение экстра скилл-атак (пнуть, оглушить и прочая)
-	atk_profiler.next_step("extra_attack");
 	if (!IS_SET(trigger_code, kNoExtraAttack) 
 			&& ch->GetExtraVictim()
 			&& ch->in_room == ch->GetExtraVictim()->in_room
@@ -1902,7 +1898,6 @@ void process_player_attack(CharData *ch, int min_init) {
 		return;
 	}
 	//**** удар основным оружием или рукой
-	atk_profiler.next_step("main_hand");
 	if (ch->battle_affects.get(kEafFirst)) {
 		if (!IS_SET(trigger_code, kNoRightHandAttack) && !AFF_FLAGGED(ch, EAffect::kStopRight)
 			&& (ch->IsImmortal() || GET_GOD_FLAG(ch, EGf::kGodsLike) || !ch->battle_affects.get(kEafUsedright))) {
@@ -1935,7 +1930,6 @@ void process_player_attack(CharData *ch, int min_init) {
 		}
 	}
 	//**** удар вторым оружием если оно есть и умение позволяет
-	atk_profiler.next_step("off_hand");
 	if (!IS_SET(trigger_code, kNoLeftHandAttack) && GET_EQ(ch, EEquipPos::kHold)
 		&& GET_EQ(ch, EEquipPos::kHold)->get_type() == EObjType::kWeapon
 		&& ch->battle_affects.get(kEafSecond)
@@ -1962,7 +1956,6 @@ void process_player_attack(CharData *ch, int min_init) {
 	}
 	// немного коряво, т.к. зависит от инициативы кастера
 	// check if angel is in fight, and go_rescue if it is not
-	atk_profiler.next_step("tutelar_rescue");
 	TryToRescueWithTutelar(ch);
 }
 

--- a/src/gameplay/fight/fight_hit.cpp
+++ b/src/gameplay/fight/fight_hit.cpp
@@ -865,7 +865,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 		return;
 	}
 
-	utils::CSteppedProfiler hit_profiler("hit", 0.005);
 
 	// OpenTelemetry: Measure hit duration
 	observability::ScopedMetric hit_metric("combat.hit.duration");
@@ -886,7 +885,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 		set_battle_pos(victim);
 	}
 
-	hit_profiler.next_step("breath_attack");
 	// дышащий моб может оглушить, и нанесёт физ.дамаг!!
 	if (type == ESkill::kUndefined) {
 		ESpell spell_id;
@@ -917,7 +915,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 
 	//go_autoassist(ch);
 
-	hit_profiler.next_step("HitData_Init");
 	// старт инициализации полей для удара
 	HitData hit_params;
 	//конвертация скиллов, которые предполагают вызов hit()
@@ -925,7 +922,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 	hit_params.skill_num = type != ESkill::kOverwhelm && type != ESkill::kHammer ? type : ESkill::kUndefined;
 	hit_params.weapon = weapon;
 	hit_params.Init(ch, victim);
-	hit_profiler.next_step("CloudOfArrows");
 	//  дополнительный маг. дамаг независимо от попадания физ. атаки
 	if (AFF_FLAGGED(ch, EAffect::kCloudOfArrows)
 		&& hit_params.skill_num == ESkill::kUndefined
@@ -947,7 +943,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 		auto skillnum = GetMagicSkillId(ESpell::kCloudOfArrows);
 		TrainSkill(ch, skillnum, true, victim);
 	}
-	hit_profiler.next_step("CalcHitroll_AC_Dmg");
 	// вычисление хитролов/ац
 	hit_params.CalcBaseHitroll(ch);
 	hit_params.CalcCircumstantialHitroll(ch, victim);
@@ -959,7 +954,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 		int max_rnd = hit_params.dam + hit_params.dam / 4;
 		hit_params.dam = std::max(1, number(min_rnd, max_rnd));
 	}
-	hit_profiler.next_step("miss_check");
 	if (hit_params.skill_num  == ESkill::kUndefined && !hit_params.GetFlags()[fight::kCritLuck]) { //автоатака
 		const int victim_lvl_miss = GetRealLevel(victim) + GetRealRemort(victim);
 		const int ch_lvl_miss = GetRealLevel(ch) + GetRealRemort(ch);
@@ -992,7 +986,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 			return;
 		}
 	}
-	hit_profiler.next_step("CritHit_DamageEq");
 	// расчет критических ударов
 	hit_params.CalcCritHitChance(ch);
 	// зовется до DamageEquipment, чтобы не абузить повреждение пушек
@@ -1000,7 +993,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 		DamageEquipment(ch, hit_params.weapon_pos, hit_params.dam, 10);
 	}
 
-	hit_profiler.next_step("Backstab");
 	if (ProcessBackstab(ch, victim, hit_params)) {
 		return;
 	}
@@ -1015,7 +1007,6 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 		hit_params.ProcessExtradamage(ch, victim);
 		return;
 	}
-	hit_profiler.next_step("Punctual");
 	//Рассчёт шанса точного стиля:
 	if (!IS_CHARMICE(ch) && ch->battle_affects.get(kEafPunctual) && ch->punctual_wait <= 0 && ch->get_wait() <= 0
 		&& (hit_params.diceroll >= 18 - AFF_FLAGGED(victim, EAffect::kHold))) {
@@ -1044,11 +1035,9 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 		ch->battle_affects.unset(kEafHammer);
 	}
 
-	hit_profiler.next_step("DefensiveAbilities");
 	// обработка защитных скилов (захват, уклон, парир, веер, блок)
 	hit_params.ProcessDefensiveAbilities(ch, victim);
 
-	hit_profiler.next_step("ProcessExtradamage");
 	// итоговый дамаг
 	ch->send_to_TC(false, true, true, "&CНанёс: Регуляр дамаг = %d&n\r\n", hit_params.dam);
 	victim->send_to_TC(false, true, true, "&CПолучил: Регуляр дамаг = %d&n\r\n", hit_params.dam);
@@ -1086,12 +1075,8 @@ void ProcessExtrahits(CharData *ch, CharData *victim, ESkill type, fight::Attack
 		log("SYSERROR: ch = %s (%s:%d)", ch ? (ch->purged() ? "purged" : "true") : "false", __FILE__, __LINE__);
 		return;
 	}
-	utils::CSteppedProfiler extra_profiler("ProcessExtrahits", 0.005);
-	extra_profiler.next_step("IronWind");
 	ProcessIronWindHits(ch, weapon);
-	extra_profiler.next_step("MultyShot");
 	ProcessMultyShotHits(ch, victim, type, weapon);
-	extra_profiler.next_step("main_hit");
 	hit(ch, victim, type, weapon);
 }
 

--- a/src/gameplay/fight/fight_stuff.cpp
+++ b/src/gameplay/fight/fight_stuff.cpp
@@ -470,16 +470,12 @@ bool change_rep(CharData *ch, CharData *killer) {
 
 void real_kill(CharData *ch, CharData *killer) {
 	const long local_gold = ch->get_gold();
-	utils::CSteppedProfiler rp("real_kill", 0.001);
-	rp.next_step("make_corpse");
 	ObjData *corpse = make_corpse(ch, killer);
 
-	rp.next_step("handle_corpse");
 	bloody::handle_corpse(corpse, ch, killer);
 	// Перенес вызов pk_revenge_action из die, чтобы на момент создания
 	// трупа месть на убийцу была еще жива
 	if (ch->IsNpc() || !ROOM_FLAGGED(ch->in_room, ERoomFlag::kArena) || NORENTABLE(ch)) {
-		rp.next_step("pk_revenge");
 		pk_revenge_action(killer, ch);
 	}
 	if (!ch->IsNpc()) {
@@ -496,14 +492,12 @@ void real_kill(CharData *ch, CharData *killer) {
 	} else {
 		if (killer && (!killer->IsNpc() || IS_CHARMICE(killer))) {
 			log("Killed: %d %d %ld", GetRealLevel(ch), ch->get_max_hit(), ch->get_exp());
-			rp.next_step("obj_load_on_death");
 			obj_load_on_death(corpse, ch);
 		}
 		if (ch->IsFlagged(EMobFlag::kCorpse)) {
 			PerformDropGold(ch, local_gold);
 			ch->set_gold(0);
 		}
-		rp.next_step("LoadObjFromDeadLoad");
 		dead_load::LoadObjFromDeadLoad(corpse, ch, nullptr, dead_load::kOrdinary);
 #if defined WITH_SCRIPTING
 		//scripting::on_npc_dead(ch, killer, corpse);
@@ -527,19 +521,15 @@ void real_kill(CharData *ch, CharData *killer) {
 	// а здесь, после создания соответствующего трупа. Кроме того,
 	// если убил чармис и хозяин в комнате, то автолут происходит хозяину
 	if ((ch != nullptr) && (killer != nullptr)) {
-		rp.next_step("auto_loot");
 		auto_loot(ch, killer, corpse, local_gold);
 	}
 }
 
 void raw_kill(CharData *ch, CharData *killer) {
-	utils::CSteppedProfiler rk_profiler("raw_kill", 0.001);
-	rk_profiler.next_step("SpellCapable");
 	check_spell_capable(ch, killer);
 	if (ch->GetEnemy()) {
 		stop_fighting(ch, true);
 	}
-	rk_profiler.next_step("CombatList");
 	for (auto &hitter : combat_list) {
 		if (hitter.deleted)
 			continue;
@@ -569,17 +559,14 @@ void raw_kill(CharData *ch, CharData *killer) {
 
 	if (!ROOM_FLAGGED(ch->in_room, ERoomFlag::kDominationArena)) {
 		if (!ch->IsNpc()) {
-			rk_profiler.next_step("ResetAffects");
 			reset_affects_no_recalc(ch);
 		}
 	}
 	// для начала проверяем, активны ли евенты
-	rk_profiler.next_step("DeathMtrigger");
 	if ((!killer || death_mtrigger(ch, killer)) && ch->in_room != kNowhere) {
 		death_cry(ch, killer);
 	}
 
-	rk_profiler.next_step("KillMtrigger");
 	if (killer && killer->IsNpc() && !ch->IsNpc() && kill_mtrigger(killer, ch)) {
 		const auto it = std::find(killer->kill_list.begin(), killer->kill_list.end(), ch->get_uid());
 		if (it != killer->kill_list.end()) {
@@ -602,7 +589,6 @@ void raw_kill(CharData *ch, CharData *killer) {
 	}
 	if (ch->in_room != kNowhere) {
 		if (killer && (!killer->IsNpc() || IS_CHARMICE(killer)) && !ch->IsNpc())
-	rk_profiler.next_step("RealKill");
  			kill_pc_wtrigger(killer, ch);
 		if (!ch->IsNpc() && (!NORENTABLE(ch) && ROOM_FLAGGED(ch->in_room, ERoomFlag::kArena))) {
 			//Если убили на арене
@@ -611,7 +597,6 @@ void raw_kill(CharData *ch, CharData *killer) {
 			// клановые не теряют вещи
 			arena_kill(ch, killer);
 		} else {
-			rk_profiler.next_step("RealKill");
 			real_kill(ch, killer);
 			character_list.AddToExtractedList(ch);
 //			ExtractCharFromWorld(ch, true);

--- a/src/gameplay/mechanics/damage.cpp
+++ b/src/gameplay/mechanics/damage.cpp
@@ -447,8 +447,6 @@ void Damage::ProcessBlink(CharData *ch, CharData *victim) {
 
 void Damage::ProcessDeath(CharData *ch, CharData *victim) const {
 	CharData *killer = nullptr;
-	utils::CSteppedProfiler death_profiler("ProcessDeath", 0.001);
-	death_profiler.next_step("FindKiller");
 
 	if (victim->IsNpc() || victim->desc) {
 		if (victim == ch && victim->in_room != kNowhere) {
@@ -472,7 +470,6 @@ void Damage::ProcessDeath(CharData *ch, CharData *victim) const {
 			killer = ch;
 		}
 	}
-	death_profiler.next_step("GroupGain");
 	if (killer) {
 		if (AFF_FLAGGED(killer, EAffect::kGroup)) {
 			// т.к. помечен флагом AFF_GROUP - точно PC
@@ -526,7 +523,6 @@ void Damage::ProcessDeath(CharData *ch, CharData *victim) const {
 	if (killer) {
 		ch = killer;
 	}
-	death_profiler.next_step("die");
 	die(victim, ch);
 }
 
@@ -608,8 +604,6 @@ void Damage::PerformPostInit(CharData *ch, CharData *victim) {
 // возвращает сделанный дамаг
 int Damage::Process(CharData *ch, CharData *victim) {
 	PerformPostInit(ch, victim);
-	utils::CSteppedProfiler dmg_profiler("Damage::Process", 0.003);
-	dmg_profiler.next_step("Validation");
 	if (victim->in_room == kNowhere || ch->in_room == kNowhere || ch->in_room != victim->in_room) {
 		log("SYSERR: Attempt to damage '%s' in room kNowhere by '%s'.",
 			GET_NAME(victim), GET_NAME(ch));
@@ -648,7 +642,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 		}
 	}
 
-	dmg_profiler.next_step("SetFighting");
 	mob_ai::update_mob_memory(ch, victim);
 
 	// If you attack a pet, it hates your guts
@@ -780,7 +773,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 	}
 	// щиты, броня, поглощение
 	if (victim != ch) {
-	dmg_profiler.next_step("Shields");
 		bool shield_full_absorb = CalcMagisShieldsDmgAbsoption(ch, victim);
 		CalcArmorDmgAbsorption(victim);
 		bool armor_full_absorb = CalcDmgAbsorption(ch, victim);
@@ -812,7 +804,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 		return 0;
 	}
 	// внутри есть !боевое везение!, для какого типа дамага - не знаю
-	dmg_profiler.next_step("HandleAffects");
 	DamageActorParameters params(ch, victim, dam);
 	handle_affects(params);
 	dam = params.damage;
@@ -828,7 +819,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 		dam = std::min(dam, victim->get_hit() - 1);
 	}
 
-	dmg_profiler.next_step("DamageTrigger");
 	dam = std::clamp(dam, 0, kMaxHits);
 	if (dam >= 0) {
 		if (dmg_type == fight::kPhysDmg) {
@@ -843,7 +833,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 		}
 	}
 	if (!InTestZone(ch)) {
-	dmg_profiler.next_step("GainExp");
 		gain_battle_exp(ch, victim, dam);
 	}
 
@@ -856,7 +845,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 		over_dam = dam - real_dam;
 	}
 	// собственно нанесение дамага
-	dmg_profiler.next_step("ApplyDamage");
 	victim->set_hit(victim->get_hit() - dam);
 	victim->send_to_TC(false, true, true, "&MПолучен урон = %d&n\r\n", dam);
 	ch->send_to_TC(false, true, true, "&MПрименен урон = %d&n\r\n", dam);
@@ -885,7 +873,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 		victim->add_attacker(ch, ATTACKER_DAMAGE, real_dam);
 	}
 	// попытка спасти жертву через ангела
-	dmg_profiler.next_step("PostDamage");
 	CheckTutelarSelfSacrfice(ch, victim);
 
 	// обновление позиции после удара и ангела
@@ -932,7 +919,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 	// сообщения об ударах //
 	if (MUD::Skills().IsValid(skill_id) || spell_id > ESpell::kUndefined || hit_type < 0) {
 		// скилл, спелл, необычный дамаг
-	dmg_profiler.next_step("Messages");
 		SendSkillMessages(dam, ch, victim, msg_num, brief_shields_);
 	} else {
 		// простой удар рукой/оружием
@@ -964,7 +950,6 @@ int Damage::Process(CharData *ch, CharData *victim) {
 	} */
 
 	// жертва умирает //
-	dmg_profiler.next_step("DeathCheck");
 	if (victim->GetPosition() == EPosition::kDead) {
 		ProcessDeath(ch, victim);
 		return -1;


### PR DESCRIPTION
## Summary

Убираю профилинг боевого пути (`Damage::Process` / `ProcessDeath` / `raw_kill` / `real_kill` / `PlayerAttack` / `hit` / `ProcessExtrahits`), добавленный по ходу расследования #3142. Узкое место — в DG-скриптах (`death_mtrigger`), к этому вернёмся после переработки DG-движка.

Удалено — только инструментация в 4 файлах (`damage.cpp`, `fight_stuff.cpp`, `fight.cpp`, `fight_hit.cpp`), -52 строки.

Оставил:
- `utils::CSteppedProfiler` класс и headers — используются другими подсистемами
- Boot-профайлер в `db.cpp`
- Weather-профайлер в `weather.cpp`
- `mobile_affect_update_profiler.cpp` / `player_affect_update_profiler.cpp` — отдельная задача
- god-команду `do_profile`
- `CExecutionTimer` на `violence_timer` в `fight.cpp:2100`

## Test plan

- [x] `make circle` проходит.

Refs #3142