### PR TITLE
feat(map): включить все опции карты по умолчанию для нового игрока (#3202)

### DIFF
--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -1970,11 +1970,17 @@ void do_entergame(DescriptorData *d) {
 		d->character->SetFlag(EPrf::kAutoloot);
 		d->character->SetFlag(EPrf::kPklMode);
 		d->character->SetFlag(EPrf::kClanmembersMode); // соклан
-		d->character->map_set_option(MapSystem::MAP_MODE_MOB_SPEC_SHOP);
-		d->character->map_set_option(MapSystem::MAP_MODE_MOB_SPEC_RENT);
-		d->character->map_set_option(MapSystem::MAP_MODE_MOB_SPEC_BANK);
-		d->character->map_set_option(MapSystem::MAP_MODE_MOB_SPEC_TEACH);
-		d->character->map_set_option(MapSystem::MAP_MODE_BIG);
+		// По умолчанию для нового игрока включаем всё, кроме depth-флагов
+		// и godmode, аналогично пункту "включить все" в OLC карты (#3202).
+		for (int i = 0; i < MapSystem::TOTAL_MAP_OPTIONS; ++i) {
+			if (i == MapSystem::MAP_MODE_1_DEPTH
+				|| i == MapSystem::MAP_MODE_2_DEPTH
+				|| i == MapSystem::MAP_MODE_DEPTH_FIXED
+				|| i == MapSystem::MAP_MODE_GOD_BIG) {
+				continue;
+			}
+			d->character->map_set_option(i);
+		}
 		d->character->SetFlag(EPrf::kShowZoneNameOnEnter);
 		d->character->SetFlag(EPrf::kBoardMode);
 		d->character->set_last_exchange(time(nullptr));


### PR DESCRIPTION
## Суть

Раньше для свежего чара в `do_entergame` (`interpreter.cpp:1965`) выставлялся только узкий набор опций карты: `MOB_SPEC_SHOP`, `MOB_SPEC_RENT`, `MOB_SPEC_BANK`, `MOB_SPEC_TEACH`, `BIG`. Игрок видел в OLC, что почти все опции карты выключены.

Теперь по умолчанию включается всё, кроме depth-флагов (`MAP_MODE_1_DEPTH`, `MAP_MODE_2_DEPTH`, `MAP_MODE_DEPTH_FIXED`) и `MAP_MODE_GOD_BIG`. Это совпадает с поведением пункта «включить все» в OLC карты (`mapsystem.cpp:844-852`).

## Замечание про сейв

Стрибог отметил: «там битвектор, мы испортили сохранение добавив режим богов». Я разобрал, как `std::bitset(string)` читает старые сейвы:

- Старый сейв: 21-символьная строка (когда `TOTAL_MAP_OPTIONS = 21`).
- Новая `bitset<22>(str_21_chars)`: по стандарту C++, `min(str.size(), N) = 21` бит читаются. Бит `j` ← `str[20-j]`. Бит 21 (новый `MAP_MODE_GOD_BIG`) — 0 по умолчанию.
- Итог: `MAP_MODE_BIG` (бит 20) ← `str[0]`, что совпадает со старой семантикой. Старые сейвы должны загружаться корректно.

Если на проде живые игроки всё-таки видят странные настройки карты после добавления `MAP_MODE_GOD_BIG` (#3042) — стоит проверить отдельно (возможно, я что-то упустил).

## План проверки

- [x] `make circle` проходит.
- [ ] Создать нового персонажа на тест-сервере, зайти в OLC карты, проверить, что все опции (кроме depth и god) — `[x]`.

Closes #3202
