### PR TITLE
fix(horse): убрать ложный syslog при покупке коня (#3207)

### DIFF
--- a/src/gameplay/ai/spec_procs.cpp
+++ b/src/gameplay/ai/spec_procs.cpp
@@ -84,8 +84,11 @@ int horse_keeper(CharData *ch, void *me, int cmd, char *argument) {
 				false, ch, 0, victim, kToChar);
 			return (true);
 		}
-		make_horse(horse, ch);
+		// Сначала поместить коня в комнату, иначе add_follower внутри
+		// make_horse видит лошадь в kNowhere и логирует "попытка
+		// загрупить игроков в разных комнатах" (#3207).
 		PlaceCharToRoom(horse, ch->in_room);
+		make_horse(horse, ch);
 		sprintf(buf, "$N оседлал$G %s и отдал$G %s вам.", GET_PAD(horse, 3), HSHR(horse));
 		act(buf, false, ch, 0, victim, kToChar);
 		sprintf(buf, "$N оседлал$G %s и отдал$G %s $n2.", GET_PAD(horse, 3), HSHR(horse));


### PR DESCRIPTION
## Суть

В syslog при покупке коня:

```
попытка загрупить игроков в разных комнатах,
лидер Стрибог #-1 фолловер конь #4014
Конюх оседлал коня и отдал его вам.
```

В `do_horsekeeper` (`spec_procs.cpp:87`) порядок был:

```cpp
make_horse(horse, ch);            // тут add_follower(horse)
PlaceCharToRoom(horse, ch->in_room);
```

`make_horse` внутри делает `ch->add_follower(horse)`, который сверяет `ch->in_room == horse->in_room`. Лошадь только что вышла из `ReadMobile` и в `kNowhere`, поэтому проверка проваливается, в syslog летит ошибка, и follow-связь не устанавливается.

## Что меняется

Меняем порядок: сначала `PlaceCharToRoom`, потом `make_horse`. Лошадь уже в комнате игрока на момент `add_follower`.

Другие два вызова `make_horse` (do_mount, do_givehorse) работают со скакуном, который уже в комнате игрока — там трогать нечего.

## Тест

- [x] `make circle` проходит.
- [ ] Купить коня у конюха в игре — syslog должен быть тихим, follow-связь установиться.

Closes #3207
