### PR TITLE
feat(look): смотреть по ключевым словам дверей (#3209)

### DIFF
--- a/src/gameplay/mechanics/sight.cpp
+++ b/src/gameplay/mechanics/sight.cpp
@@ -496,6 +496,24 @@ bool look_at_target(CharData *ch, char *arg, int subcmd) {
 		return false;
 	}
 
+	// Совпадает ли аргумент с ключевыми словами какой-нибудь двери в комнате?
+	// Тогда покажем описание этого направления (#3209).
+	for (int d = 0; d < EDirection::kMaxDirNum; ++d) {
+		const auto &exit = world[ch->in_room]->dir_option[d];
+		if (!exit || !exit->keyword || !*exit->keyword) {
+			continue;
+		}
+		if (!isname(what, exit->keyword)) {
+			continue;
+		}
+		if (!exit->general_description.empty()) {
+			SendMsgToChar(exit->general_description.c_str(), ch);
+		} else {
+			SendMsgToChar("Вы не видите ничего особенного.\r\n", ch);
+		}
+		return false;
+	}
+
 	// If an object was found back in generic_find
 	if (bits && (found_obj != nullptr)) {
 


### PR DESCRIPTION
## Суть

Сейчас, чтобы увидеть описание двери, нужно набрать `смотреть <направление>`. Игрокам естественнее писать `смотреть <название_двери>` — по тем же ключевым словам, по которым работают `открыть` / `закрыть`.

В `look_at_target` (`sight.cpp`) после проверки extra-описаний комнаты пробегаем по всем 6 направлениям и сравниваем аргумент с `exit->keyword` через тот же `isname`. Если совпало — выводим `exit->general_description` (то же текст, что показывает `смотреть <направление>`). Если описания нет — печатаем заглушку «Вы не видите ничего особенного».

## Не меняется

- `смотреть <направление>` — отдельный кодпуть, не трогали.
- `смотреть в <контейнер>` — отдельный кодпуть.
- Door-keyword проверка вступает только если generic_find и ex_desc уже ничего не нашли.

## Тест

- [x] `make circle` проходит.
- [x] В комнате с дверью «ворота» (keyword «ворота врата ferrous gates»): `смотреть ворота` должна показать general_description, как при `смотреть юг` (если ворота на юг).
- [ ] Если в комнате есть и предмет с алиасом, совпадающим с keyword двери, — приоритет за предметом (так и сейчас, потому что `generic_find` отрабатывает раньше).

Closes #3209
