### PR TITLE
fix(otransform): пересчитать deadline после восстановления kTicktimer (#3213)

### DIFF
--- a/src/engine/scripting/dg_objcmd.cpp
+++ b/src/engine/scripting/dg_objcmd.cpp
@@ -325,6 +325,12 @@ void do_otransform(ObjData *obj, char *argument, int/* cmd*/, int/* subcmd*/, Tr
 		if (o->has_flag(EObjFlag::kTicktimer)) {
 			obj->set_extra_flag(EObjFlag::kTicktimer);
 		}
+		// После swap obj получил extra_flags новой формы (без kTicktimer),
+		// и set_timer внутри swap уже посчитал deadline по этим неполным
+		// флагам - получался UINT64_MAX и get_timer() начинал возвращать
+		// UNLIMITED_TIMER (2147483647). Восстановили kTicktimer выше -
+		// теперь надо пересчитать deadline по актуальному состоянию (#3213).
+		world_objects.decay_manager().on_timer_changed(obj);
 
 		if (wearer) {
 			EquipObj(wearer, obj, pos, CharEquipFlags());


### PR DESCRIPTION
## Суть

Из issue #3213: после `перевернуть браслет` (триггер 37729 на `белом браслете мага` 37715, делает `otransform 37716`) таймер предмета становится `2147483647` (UNLIMITED_TIMER).

Та же яма, что мы уже чинили в #3186 (oedit) и #3189 (obj_save):

1. `do_otransform` вызывает `obj->swap(*o)` — внутри `*this = tmpobj` затирает все extra_flags новой формой предмета (без `kTicktimer`).
2. Внутри swap зовётся `set_timer(...)`, который дёргает `decay_manager.on_timer_changed(this)`. `compute_and_store_deadline` смотрит на actuel state (без kTicktimer) → пишет `deadline = UINT64_MAX`.
3. Дальше `do_otransform` восстанавливает kTicktimer: `obj->set_extra_flag(EObjFlag::kTicktimer)`. Но deadline в decay_manager уже UINT64_MAX.
4. `ObjData::get_timer()` видит UINT64_MAX и возвращает `UNLIMITED_TIMER = 2147483647`.

Фикс: после восстановления kTicktimer вызвать `decay_manager().on_timer_changed(obj)` — он пересчитает deadline по актуальному состоянию (с правильными флагами). Если obj не в decay_manager (валяется на земле), вызов no-op.

## Тест

- [x] `make circle` проходит.
- [ ] Загрузить браслет 37715, надеть, набрать `перевернуть браслет`. Таймер должен остаться нормальным числом, не INT_MAX.
- [ ] То же самое для других триггеров с otransform (например, артефактов с трансформацией).

Closes #3213
