### PR TITLE
fix(obj_save): отбрасывать корруптные таймеры при загрузке (#3213)

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -239,7 +239,18 @@ ObjData::shared_ptr read_one_object_new(char **data, int *error) {
 				object->set_sex(static_cast<EGender>(atoi(buffer)));
 			} else if (!strcmp(read_line, "Tmer")) {
 				*error = 20;
-				object->set_timer(atoi(buffer));
+				const int saved_timer = atoi(buffer);
+				// Защита от мусорных таймеров (UNLIMITED_TIMER, INT_MAX и
+				// прочие следы старых багов decay_manager в otransform/
+				// oedit/обмена шмотками - см. #3213). При парсинге мира
+				// таймеры > 99999 уже клампятся, тут делаем то же для
+				// сохранений игроков. Если в пфайле плохое значение,
+				// оставляем то, что пришло из прототипа в
+				// create_from_prototype_by_vnum выше. Отрицательные значения
+				// валидны (например, -1 означает "таймер не уменьшается").
+				if (saved_timer <= 99999) {
+					object->set_timer(saved_timer);
+				}
 			} else if (!strcmp(read_line, "Spll")) {
 				*error = 21;
 				object->set_spell(atoi(buffer));


### PR DESCRIPTION
## Суть

Из комментария к #3213: после фиксов в otransform/oedit/decay_manager у части игроков в пфайлах остались записи вроде `Tmer: 2147481969` (UNLIMITED_TIMER минус несколько тиков). На загрузке такие значения попадают в живой объект и продолжают мешаться.

Парсер мира (`boot_data_files.cpp:651`) клампит `m_timer` прототипа до `99999` при загрузке мира. Делаем то же для пфайла: при чтении `Tmer:` если значение `> 99999`, считаем его мусором и оставляем то, что было выставлено из прототипа в `create_from_prototype_by_vnum` (т.е. вернёмся к чистому числу из обж-файла).

Отрицательные значения не отсеиваем — в проекте они используются как «таймер не уменьшается» ( сам по себе клампит к 0, но это не наша забота тут).

## Тест

- [x] `make circle` проходит.
- [ ] Старый пфайл с `Tmer: 2147481969` — на следующем входе таймер должен подтянуться до прототипного значения, а не остаться корруптным.
- [ ] Нормальные пфайлы с реальными таймерами 1-99999 — без изменений.

Closes #3213
