### PR TITLE
fix(yaml/sqlite): создавать рантайм-инстансы триггеров для комнат

### DIFF
--- a/src/engine/db/world_data_source_base.cpp
+++ b/src/engine/db/world_data_source_base.cpp
@@ -9,6 +9,7 @@
 #include "engine/entities/zone.h"
 #include "engine/entities/room_data.h"
 #include "engine/scripting/dg_scripts.h"
+#include "engine/scripting/dg_db_scripts.h"
 #include "engine/scripting/dg_olc.h"
 
 #include <sstream>
@@ -18,6 +19,7 @@
 extern IndexData **trig_index;
 extern int top_of_trigt;
 extern CharData *mob_proto;
+extern void ExtractTrigger(Trigger *trig);
 
 namespace world_loader
 
@@ -125,13 +127,28 @@ void WorldDataSourceBase::AttachTriggerToRoom(RoomRnum room_rnum, int trigger_vn
 		world[room_rnum]->proto_script = std::make_shared<ObjData::triggers_list_t>();
 	}
 
-	if (GetTriggerRnum(trigger_vnum) >= 0)
+	const auto trigger_rnum = GetTriggerRnum(trigger_vnum);
+	if (trigger_rnum < 0)
 	{
-		world[room_rnum]->proto_script->push_back(trigger_vnum);
+		log("SYSERR: Room %d references non-existent trigger %d, skipping.", room_vnum, trigger_vnum);
+		return;
+	}
+	world[room_rnum]->proto_script->push_back(trigger_vnum);
+
+	// п■п╩я▐ п╨п╬п╪п╫п╟я┌, п╡ п╬я┌п╩п╦я┤п╦п╣ п╬я┌ п╪п╬п╠п╬п╡ п╦ п╬п╠я┼п╣п╨я┌п╬п╡, п╫п╣я┌ "п╪п╬п╪п╣п╫я┌п╟ п╦п╫я│я┌п╟п╫я├п╦п╟я├п╦п╦" -
+	// я│п╟п╪п╟ RoomData п╦ п╣я│я┌я▄ я─п╟п╫я┌п╟п╧п╪-я│я┐я┴п╫п╬я│я┌я▄. п÷п╬я█я┌п╬п╪я┐ п©п╬п╪п╦п╪п╬ proto_script п╫п╟п╢п╬
+	// я│я─п╟п╥я┐ я│п╬п╥п╢п╟я┌я▄ я─п╟п╫я┌п╟п╧п╪-п╦п╫я│я┌п╟п╫я│ я┌я─п╦пЁпЁп╣я─п╟ п╦ п©п╬п╩п╬п╤п╦я┌я▄ п╡ SCRIPT(room),
+	// п╦п╫п╟я┤п╣ reset_wtrigger / random_wtrigger п╫п╦п╨п╬пЁп╢п╟ п╫п╣ п╫п╟п╧п╢я┐я┌ п╣пЁп╬ п╡
+	// script_trig_list. п╜я┌п╬ я│п╬п╡п©п╟п╢п╟п╣я┌ я│ я┌п╣п╪, я┤я┌п╬ п╢п╣п╩п╟п╣я┌ п╩п╣пЁп╟я│п╫я▀п╧
+	// dg_read_trigger п╡ boot_data_files.cpp:221.
+	auto *trigger_instance = read_trigger(trigger_rnum);
+	if (add_trigger(SCRIPT(world[room_rnum]).get(), trigger_instance, -1))
+	{
+		add_trig_to_owner(-1, trigger_vnum, room_vnum);
 	}
 	else
 	{
-		log("SYSERR: Room %d references non-existent trigger %d, skipping.", room_vnum, trigger_vnum);
+		ExtractTrigger(trigger_instance);
 	}
 }
 


### PR DESCRIPTION
## Суть

При сборке с `-DHAVE_YAML=ON` (и `-DHAVE_SQLITE=ON`) в зонах с WTRIG_RESET-триггерами мобы не загружались. Конкретно в зоне 974: комната 97402 (и далее по зоне) ссылается на триггер 97433 («загрузка мобов при репопе»), но при зон-ресете `reset_wtrigger` ничего не делал — комнаты появлялись пустые.

## Где сидела ошибка

`WorldDataSourceBase::AttachTriggerToRoom` (общая для YAML и SQLite) добавляет vnum в `room->proto_script`, но **не создаёт рантайм-инстанс** `Trigger` в `SCRIPT(room)`. В отличие от мобов и объектов, у комнаты нет "момента инстанциации" — сама `RoomData` это и есть рантайм-сущность. Поэтому легасный `dg_read_trigger` для `WLD_TRIGGER` (`boot_data_files.cpp:221-229`) делает два шага:

```cpp
room->proto_script->push_back(vnum);                    // 1
const auto trigger_instance = read_trigger(rnum);
if (add_trigger(SCRIPT(room).get(), trigger_instance, -1)) {  // 2
    add_trig_to_owner(-1, vnum, room->vnum);
}
```

YAML/SQLite-загрузчики делали только шаг 1, поэтому `SCRIPT(room)->script_trig_list` оставался пустым. `reset_wtrigger` (и `random_wtrigger`) перебирают именно этот список, не `proto_script`.

## Что меняется

В `WorldDataSourceBase::AttachTriggerToRoom` после добавления в `proto_script` создаём рантайм-инстанс через `read_trigger(rnum)` и кладём в `SCRIPT(room)` через `add_trigger`. Симметрично легасной ветке. SQLite-загрузчик использует ту же базовую функцию, фикс покрывает обе ветки.

Для мобов и объектов этот шаг **не нужен** — `assign_triggers` создаёт рантайм-инстансы при `ReadMobile` / `create_from_prototype`.

## Тест

- [x] `make circle` (legacy) проходит — поведение не меняется (легасный путь использует `dg_read_trigger`, в `AttachTriggerToRoom` не заходит).
- [ ] `-DHAVE_YAML=ON` сборка: пройти в зону 974, дождаться зон-ресета — мобы должны загружаться.
- [ ] `-DHAVE_SQLITE=ON` сборка — то же самое.
