### PR TITLE
fix(boot): подключать триггера комнат до первого зон-ресета

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1037,6 +1037,17 @@ void BootMudDataBase() {
 	log("Load Celebrates.");
 	celebrates::Load();
 
+	// Триггера комнат должны быть подключены ДО первого ResetZone, иначе
+	// reset_wtrigger / random_wtrigger не найдут их в SCRIPT(room) и не
+	// сработают на boot-ресете - и зоны с WTRIG_RESET (например 974, где
+	// мобы лоадятся через триггер 97433) выходят из бута пустыми. Для
+	// legacy-загрузчика двойной аттач не случится: TriggersList::add
+	// дедуп по rnum, dg_read_trigger уже подключил инстансы при чтении
+	// wld-файла. Для YAML/SQLite это единственное место, где триггеры
+	// комнат попадают в SCRIPT(room).
+	boot_profiler.next_step("Assigning triggers to rooms");
+	world_loader::WorldDataSourceBase::AssignTriggersToLoadedRooms();
+
 	// резет должен идти после лоада всех шмоток вне зон (хранилища и т.п.)
 	boot_profiler.next_step("Resetting zones");
 	for (ZoneRnum i = 0; i < static_cast<ZoneRnum>(zone_table.size()); i++) {
@@ -1045,11 +1056,6 @@ void BootMudDataBase() {
 		ResetZone(i);
 	}
 	reset_q.head = reset_q.tail = nullptr;
-
-
-	// Assign room triggers AFTER zone reset completes
-	boot_profiler.next_step("Assigning triggers to rooms");
-	world_loader::WorldDataSourceBase::AssignTriggersToLoadedRooms();
 
 
 	// делается после резета зон, см камент к функции


### PR DESCRIPTION
## Суть

В `boot_db` (`db.cpp`) рантайм-триггера комнат подключались **после** первого прохода `ResetZone` по всем зонам. Для YAML/SQLite-загрузчиков это значило, что boot-time `reset_wtrigger` / `random_wtrigger` видели пустой `SCRIPT(room)` и ничего не делали — зоны с WTRIG_RESET (например 974, где мобы лоадятся через триггер 97433) выходили из бута пустыми.

Почему manual `zreset 974` работал — потому что `AssignTriggersToLoadedRooms` к моменту команды уже отработала, `SCRIPT(room)` был заполнен.

## Что меняется

Переставляю `AssignTriggersToLoadedRooms()` ДО цикла `ResetZone`. Тогда триггера попадают в `SCRIPT(room)` до того, как первый раз дёргается reset_wtrigger.

Для legacy дублирования не случится: `TriggersList::add` дедупит по rnum, `dg_read_trigger` уже подключил инстансы во время чтения wld-файла, повторный `assign_triggers` молча скипает.

Альтернативный фикс был — закрывал PR #3216 (подключал инстанс прямо в `AttachTriggerToRoom`). Этот вариант проще: один свап двух вызовов местами.

## Тест

- [x] `make circle` (legacy) проходит.
- [x] `-DHAVE_YAML=ON` сборка: войти в зону 974 сразу после старта — мобы должны быть на месте, без ожидания auto-ресета и без manual zreset.
- [ ] `-DHAVE_SQLITE=ON` сборка: то же самое.
- [ ] Legacy-сборка: проверить что зон-резет работает как раньше (никаких удвоенных триггеров, никаких ошибок).
