### PR TITLE
fix(yaml): сохранять и загружать V-строки объектов (#3218)

### DIFF
--- a/src/engine/db/world_checksum.cpp
+++ b/src/engine/db/world_checksum.cpp
@@ -13,7 +13,9 @@
 #include "utils/utils_string.h"
 #include "engine/structs/extra_description.h"
 
+#include <algorithm>
 #include <sstream>
+#include <utility>
 #include <vector>
 #include <filesystem>
 
@@ -333,6 +335,24 @@ std::string SerializeObject(const CObjectPrototype::shared_ptr &obj)
 	for (int i = 0; i < CObjectPrototype::VALS_COUNT; ++i)
 	{
 		oss << obj->get_val(i) << ",";
+	}
+	oss << "|";
+
+	// Extra values (V-lines: potion spells/levels, refilled-potion proto vnum,
+	// etc.). Without this the round-trip fix for issue #3218 would not be
+	// observable in checksums and a converter regression could slip through
+	// run_load_tests.sh again.
+	{
+		std::vector<std::pair<int, int>> sorted_extra;
+		for (const auto &kv : obj->get_all_values())
+		{
+			sorted_extra.emplace_back(static_cast<int>(kv.first), kv.second);
+		}
+		std::sort(sorted_extra.begin(), sorted_extra.end());
+		for (const auto &kv : sorted_extra)
+		{
+			oss << kv.first << ":" << kv.second << ",";
+		}
 	}
 	oss << "|";
 

--- a/src/engine/db/world_checksum.h
+++ b/src/engine/db/world_checksum.h
@@ -9,8 +9,11 @@
 #include <string>
 #include <map>
 
+#include <memory>
+
 class CharData;
 class RoomData;
+class CObjectPrototype;
 
 namespace WorldChecksum
 {
@@ -20,6 +23,7 @@ namespace WorldChecksum
 // through the global mob_proto[] / world[] arrays.
 std::string SerializeMob(int vnum, const CharData &mob);
 std::string SerializeRoom(const RoomData *room);
+std::string SerializeObject(const std::shared_ptr<CObjectPrototype> &obj);
 
 
 struct ChecksumResult

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -11,6 +11,7 @@
 #include "utils/logger.h"
 #include "utils/utils.h"
 #include "utils/utils_string.h"
+#include "utils/parse.h"
 #include "engine/entities/zone.h"
 #include "engine/entities/room_data.h"
 #include "engine/entities/char_data.h"
@@ -2215,6 +2216,19 @@ CObjectPrototype* YamlWorldDataSource::ParseObjectFile(const std::string &file_p
 				}
 			}
 
+			// Extra values (V-строки): данные зелий и контейнеров с жидкостью.
+			// Без чтения этой секции зелья в YAML-мире выходят без заклинаний (issue #3218).
+			if (root["extra_values"] && root["extra_values"].IsMap())
+			{
+				for (const auto &kv : root["extra_values"])
+				{
+					std::string key = kv.first.as<std::string>();
+					int value = kv.second.as<int>(0);
+					std::string line = key + " " + std::to_string(value);
+					obj_ptr->init_values_from_zone(line.c_str());
+				}
+			}
+
 			// Extra descriptions
 			if (root["extra_descriptions"] && root["extra_descriptions"].IsSequence())
 			{
@@ -4097,10 +4111,10 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 					if (exdesc->description)
 					{
 						out << yaml.GetIndent() << "  description: |" << std::endl;
-						
+
 						std::string desc = exdesc->description;
 						desc.erase(std::remove(desc.begin(), desc.end(), '\r'), desc.end());
-						
+
 						std::istringstream iss(desc);
 						std::string line;
 						while (std::getline(iss, line))
@@ -4112,6 +4126,38 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 			}
 
 			yaml.DecreaseIndent();
+		}
+
+		// Extra values (V-строки): данные зелий и прочих контейнеров с жидкостью.
+		// Без сохранения этой секции данные о заклинаниях зелий пропадут (issue #3218).
+		if (!obj->get_all_values().empty())
+		{
+			std::vector<std::pair<std::string, int>> sorted_vals;
+			for (const auto &kv : obj->get_all_values())
+			{
+				std::string key_str = text_id::ToStr(text_id::kObjVals, to_underlying(kv.first));
+				if (!key_str.empty())
+				{
+					sorted_vals.emplace_back(std::move(key_str), kv.second);
+				}
+			}
+
+			if (!sorted_vals.empty())
+			{
+				std::sort(sorted_vals.begin(), sorted_vals.end(),
+					[](const std::pair<std::string, int> &a, const std::pair<std::string, int> &b) {
+						return a.first < b.first;
+					});
+
+				yaml.Key("extra_values");
+				yaml.BeginBlock();
+				for (const auto &kv : sorted_vals)
+				{
+					yaml.Key(kv.first);
+					yaml.Value(kv.second);
+				}
+				yaml.EndBlock();
+			}
 		}
 
 		// Triggers (with comments)

--- a/tests/world_checksum_serialization.cpp
+++ b/tests/world_checksum_serialization.cpp
@@ -13,10 +13,12 @@
 #include "engine/db/world_checksum.h"
 #include "engine/entities/char_data.h"
 #include "engine/entities/entities_constants.h"
+#include "engine/entities/obj_data.h"
 #include "engine/entities/room_data.h"
 #include "engine/structs/flag_data.h"
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -121,6 +123,43 @@ TEST(SerializeRoom, UndefFlagsAreNotMaskedFromChecksum) {
 	const std::string sb = WorldChecksum::SerializeRoom(&b);
 	EXPECT_NE(sa, sb)
 		<< "Rooms with different UNDEF high-plane flags must hash differently";
+}
+
+// Issue #3218: V-lines on objects (potion spells, refilled-potion proto vnum,
+// etc.) live in CObjectPrototype::get_all_values() rather than the four-slot
+// values array. Until this commit SerializeObject did not include them, so
+// a converter or loader regression that dropped the V-block could pass
+// run_load_tests.sh unnoticed. These tests pin the new behaviour down.
+//
+// Note: we set values via SetPotionValueKey() instead of
+// init_values_from_zone() because the latter goes through the text_id
+// dictionary, which only gets populated during full-server boot.
+TEST(SerializeObject, IncludesExtraValuesFromObjVal) {
+	auto obj = std::make_shared<CObjectPrototype>(42);
+	obj->set_type(EObjType::kPotion);
+	obj->SetPotionValueKey(ObjVal::EValueKey::POTION_SPELL1_NUM, 17);
+	obj->SetPotionValueKey(ObjVal::EValueKey::POTION_SPELL1_LVL, 23);
+
+	const std::string out = WorldChecksum::SerializeObject(obj);
+	EXPECT_NE(std::string::npos, out.find("0:17"))
+		<< "POTION_SPELL1_NUM (key 0) must appear in checksum input; got: " << out;
+	EXPECT_NE(std::string::npos, out.find("1:23"))
+		<< "POTION_SPELL1_LVL (key 1) must appear in checksum input; got: " << out;
+}
+
+TEST(SerializeObject, ObjectsDifferingOnlyByExtraValuesSerializeDifferently) {
+	auto a = std::make_shared<CObjectPrototype>(42);
+	auto b = std::make_shared<CObjectPrototype>(42);
+	a->set_type(EObjType::kPotion);
+	b->set_type(EObjType::kPotion);
+
+	// Same base values, same flags, same descriptions -- only ObjVal map differs.
+	a->SetPotionValueKey(ObjVal::EValueKey::POTION_SPELL1_NUM, 17);
+
+	const std::string sa = WorldChecksum::SerializeObject(a);
+	const std::string sb = WorldChecksum::SerializeObject(b);
+	EXPECT_NE(sa, sb)
+		<< "Potions with different POTION_SPELL* must hash differently";
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -2693,6 +2693,15 @@ def parse_obj_file(filepath):
                     obj['minimum_remorts'] = int(line[2:].strip())
                 elif line.startswith('T '):
                     obj['triggers'].append(int(line[2:].strip()))
+                elif line.startswith('V '):
+                    # Extra values (V-lines): potion/drink container metadata.
+                    # Format: "V <KEY_NAME> <int_value>" (issue #3218).
+                    parts = line[2:].split()
+                    if len(parts) >= 2:
+                        try:
+                            obj.setdefault('extra_values', {})[parts[0]] = int(parts[1])
+                        except ValueError:
+                            log_error(f"Bad V-line value: {line}", vnum=obj.get('vnum'))
 
                 idx += 1
 
@@ -2809,6 +2818,13 @@ def obj_to_yaml(obj):
             e['description'] = to_literal_block(ed['description'])
             eds.append(e)
         data['extra_descriptions'] = eds
+
+    # Extra values (V-lines): potion / drink container metadata (issue #3218).
+    if obj.get('extra_values'):
+        ev = CommentedMap()
+        for key in sorted(obj['extra_values'].keys()):
+            ev[key] = obj['extra_values'][key]
+        data['extra_values'] = ev
 
     # Max in world
     if 'max_in_world' in obj:


### PR DESCRIPTION
## Что исправлено

В мире, собранном из YAML, зелья выходили без заклинаний - при попытке выпить выдавалось `у данного зелья отсутствуют заклинания`. Причина: ключи `POTION_*` (V-строки legacy формата) терялись при конвертации и не обрабатывались YAML-загрузчиком/сохранятелем.

## Изменения

- **tools/converter/convert_to_yaml.py**: разбираем строки `V <KEY> <val>` в obj-файлах и выводим карту `extra_values` в YAML.
- **src/engine/db/yaml_world_data_source.cpp**:
  - на загрузке читаем секцию `extra_values` и переливаем её через `init_values_from_zone` (тот же путь, что и legacy `case 'V':` в `boot_data_files.cpp`);
  - на сохранении выводим `extra_values` отсортированной по ключу - как в `ObjVal::print_to_zone`.

Closes #3218

## План тестирования

- [x] Сборка: `cmake -DHAVE_YAML=ON` и `make circle` собираются чисто.
- [x] Конвертация `lib/world` -> YAML: в `zones/776/objects/45.yaml` появилась карта `extra_values:` с `POTION_PROTO_VNUM/POTION_SPELL1_LVL/POTION_SPELL1_NUM`.
- [x] Прогон `tools/compare_load_checksums.sh` на полном мире `world.20260427`: 17031/17031 объектов, 13776/13776 мобов, 40988/40988 комнат, 11839/11839 триггеров — `OK: no unexpected differences`.
- [x] Ручная проверка в игре на сборке `build/circle` со свежесконвертированным `world.20260427` (порт 4000):
  1. Зайти иммортал-персонажем.
  2. `vstat obj 153` — это «пузатый бочонок с синим колдовским зельем» из issue #3218. В блоке `Script information` / описания жидкости должна быть строка с заклинанием (объект конвертится в YAML с `extra_values: POTION_SPELL1_NUM: 103, POTION_SPELL1_LVL: 25`). До фикса YAML-сборка показывала «ВНИМАНИЕ: у данного зелья отсутствуют заклинания».
  3. `load obj 153` → бочонок появится в инвентаре. `vstat <бочонок>` — у инстанса видны те же заклинания.
  4. (опционально) Налить из бочонка во флягу: `налить из бочонок во фляга` и `выпить фляга` — заклинание должно сработать.
  5. Параллельно сравнить с любым другим зельем, отображающимся в YAML (например, обычная склянка с полём `extra_values: POTION_SPELL*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

