### PR TITLE
fix(rent): сохранять локацию ингредиентов в контейнере (#3221)

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -559,8 +559,13 @@ inline bool proto_has_descr(const ExtraDescription::shared_ptr &odesc, const Ext
 	return false;
 }
 
-void WriteMagicComponentItem(std::stringstream &out, ObjData *object) {
+void WriteMagicComponentItem(std::stringstream &out, ObjData *object, int location) {
 	out << "#" << object->get_vnum() << "\n";
+	// Положение в экипировке/контейнере: без него ингредиент из сумки
+	// при загрузке оказывается в инвентаре (issue #3221).
+	if (location) {
+		out << "Lctn: " << location << "~\n";
+	}
 	out << "Ouid: " << object->get_unique_id() << "~\n";
 	out << "Tmer: " << object->CObjectPrototype::get_timer() << "~\n";
 	out << "Val1: " << GET_OBJ_VAL(object, 1) << "~\n";
@@ -579,7 +584,7 @@ void WriteMagicComponentItem(std::stringstream &out, ObjData *object) {
 // [ ИСПОЛЬЗУЕТСЯ В НОВОМ ФОРМАТЕ ВЕЩЕЙ ПЕРСОНАЖА ОТ 10.12.04 ]
 void write_one_object(std::stringstream &out, ObjData *object, int location) {
 	if (object->get_type() == EObjType::kMagicComponent) {
-		WriteMagicComponentItem(out, object);
+		WriteMagicComponentItem(out, object, location);
 		return;
 	}
 	ObjRnum orn = object->get_rnum();


### PR DESCRIPTION
## Что исправлено

После перепостоя ингредиенты, которые лежали в сумке, оказывались в инвентаре.

## Причина

Короткий формат сохранения `WriteMagicComponentItem`, добавленный в #3194/#3195, не выводил поле `Lctn:`. При чтении `read_one_object_new` поле `worn_on` оставалось со значением по умолчанию (`kNowhere = 0`), поэтому `Crash_load` относил такой предмет к ветке "Equipped or in inventory" и клал его в инвентарь, а не в открытый сверху контейнер.

Обычный `write_one_object` пишет `Lctn:` ровно когда `location != 0` - этого хватает, чтобы отличить "лежит в инвентаре" (location = 0, поле не пишется) от "вложен в N-й контейнер сверху" (location < 0).

## Решение

Передаём `location` в `WriteMagicComponentItem` и эмитируем `Lctn:` по тому же правилу. Никаких новых полей в формате не появляется, на старые сохранения не повлияет: там, где `Lctn` отсутствовало, по-прежнему будет считаться location = 0 (инвентарь), что соответствует прежнему поведению.

Closes #3221

## План тестирования

- [x] Сборка чистая.
- [ ] Зайти, положить ингредиенты в сумку, выйти/зайти - ингредиенты должны остаться в сумке.
- [ ] Старые рент-файлы без `Lctn` у `kMagicComponent` остаются загружаемыми (location = 0 = инвентарь).

🤖 Generated with [Claude Code](https://claude.com/claude-code)