### PR TITLE
fix(converter): не перехватывать ExtraAttack маркером 'E' (#3223)

### DIFF
--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -22,6 +22,7 @@
 #include "gameplay/affects/affect_contants.h"
 #include "gameplay/skills/skills.h"
 
+#include <algorithm>
 #include <cstring>
 #include <sstream>
 #include <map>
@@ -1370,14 +1371,16 @@ void SqliteWorldDataSource::LoadMobs()
 		mob.set_sex(gender_it != gender_map.end() ?
 			static_cast<EGender>(gender_it->second) : EGender::kMale);
 
-		// Physical attributes
-		GET_SIZE(&mob) = sqlite3_column_int(stmt, 28);
-		GET_HEIGHT(&mob) = sqlite3_column_int(stmt, 29);
-		GET_WEIGHT(&mob) = sqlite3_column_int(stmt, 30);
+		// Physical attributes -- bounds mirror MobileFile::interpret_espec
+		// (boot_data_files.cpp). Без них старые данные расходятся с легаси.
+		GET_SIZE(&mob) = std::clamp<byte>(sqlite3_column_int(stmt, 28), 0, 100);
+		GET_HEIGHT(&mob) = std::clamp(sqlite3_column_int(stmt, 29), 0, 200);
+		GET_WEIGHT(&mob) = std::clamp(sqlite3_column_int(stmt, 30), 0, 200);
 
 		// Class and race
 		mob.set_class(static_cast<ECharClass>(sqlite3_column_int(stmt, 31)));
-		mob.player_data.Race = static_cast<ENpcRace>(sqlite3_column_int(stmt, 32));
+		mob.player_data.Race = std::clamp(static_cast<ENpcRace>(sqlite3_column_int(stmt, 32)),
+										  ENpcRace::kBasic, ENpcRace::kLastNpcRace);
 
 		// Attributes (E-spec)
 		mob.set_str(sqlite3_column_int(stmt, 33));
@@ -1387,23 +1390,24 @@ void SqliteWorldDataSource::LoadMobs()
 		mob.set_con(sqlite3_column_int(stmt, 37));
 		mob.set_cha(sqlite3_column_int(stmt, 38));
 
-		// Enhanced E-spec fields (scalar values)
+		// Enhanced E-spec fields (scalar values).
+		// Clamps mirror interpret_espec; см. PR #3224.
 		mob.set_str_add(sqlite3_column_int(stmt, 39));
-		mob.add_abils.hitreg = sqlite3_column_int(stmt, 40);
-		mob.add_abils.armour = sqlite3_column_int(stmt, 41);
-		mob.add_abils.manareg = sqlite3_column_int(stmt, 42);
-		mob.add_abils.cast_success = sqlite3_column_int(stmt, 43);
-		mob.add_abils.morale = sqlite3_column_int(stmt, 44);
-		mob.add_abils.initiative_add = sqlite3_column_int(stmt, 45);
-		mob.add_abils.absorb = sqlite3_column_int(stmt, 46);
-		mob.add_abils.aresist = sqlite3_column_int(stmt, 47);
-		mob.add_abils.mresist = sqlite3_column_int(stmt, 48);
-		mob.add_abils.presist = sqlite3_column_int(stmt, 49);
-		mob.mob_specials.attack_type = sqlite3_column_int(stmt, 50);
-		mob.mob_specials.like_work = sqlite3_column_int(stmt, 51);
-		mob.mob_specials.MaxFactor = sqlite3_column_int(stmt, 52);
-		mob.mob_specials.extra_attack = sqlite3_column_int(stmt, 53);
-		mob.set_remort(sqlite3_column_int(stmt, 54));
+		mob.add_abils.hitreg = std::clamp(sqlite3_column_int(stmt, 40), -200, 200);
+		mob.add_abils.armour = std::clamp(sqlite3_column_int(stmt, 41), 0, 100);
+		mob.add_abils.manareg = std::clamp(sqlite3_column_int(stmt, 42), -200, 200);
+		mob.add_abils.cast_success = std::clamp(sqlite3_column_int(stmt, 43), -200, 300);
+		mob.add_abils.morale = std::clamp(sqlite3_column_int(stmt, 44), 0, 100);
+		mob.add_abils.initiative_add = std::clamp(sqlite3_column_int(stmt, 45), -200, 200);
+		mob.add_abils.absorb = std::clamp(sqlite3_column_int(stmt, 46), -200, 200);
+		mob.add_abils.aresist = std::clamp(sqlite3_column_int(stmt, 47), 0, 100);
+		mob.add_abils.mresist = std::clamp(sqlite3_column_int(stmt, 48), 0, 100);
+		mob.add_abils.presist = std::clamp(sqlite3_column_int(stmt, 49), 0, 100);
+		mob.mob_specials.attack_type = std::clamp(sqlite3_column_int(stmt, 50), 0, 99);
+		mob.mob_specials.like_work = std::clamp<byte>(sqlite3_column_int(stmt, 51), 0, 100);
+		mob.mob_specials.MaxFactor = std::clamp<byte>(sqlite3_column_int(stmt, 52), 0, 127);
+		mob.mob_specials.extra_attack = std::clamp<byte>(sqlite3_column_int(stmt, 53), 0, 127);
+		mob.set_remort(std::clamp<byte>(sqlite3_column_int(stmt, 54), 0, 100));
 		
 		// special_bitvector (TEXT - FlagData)
 		std::string special_bv = GetText(stmt, 55);
@@ -1629,7 +1633,7 @@ void SqliteWorldDataSource::LoadMobResistances()
 		CharData &mob = mob_proto[it->second];
 		if (resist_type >= 0 && resist_type < static_cast<int>(mob.add_abils.apply_resistance.size()))
 		{
-			mob.add_abils.apply_resistance[resist_type] = value;
+			mob.add_abils.apply_resistance[resist_type] = std::clamp(value, kMinResistance, kMaxNpcResist);
 			resistances_set++;
 		}
 	}
@@ -1671,7 +1675,7 @@ void SqliteWorldDataSource::LoadMobSaves()
 		CharData &mob = mob_proto[it->second];
 		if (save_type >= 0 && save_type < static_cast<int>(mob.add_abils.apply_saving_throw.size()))
 		{
-			mob.add_abils.apply_saving_throw[save_type] = value;
+			mob.add_abils.apply_saving_throw[save_type] = std::clamp(value, kMinSaving, kMaxSaving);
 			saves_set++;
 		}
 	}

--- a/src/engine/db/world_checksum.cpp
+++ b/src/engine/db/world_checksum.cpp
@@ -262,6 +262,28 @@ std::string SerializeMob(int vnum, const CharData &mob)
 	oss << npc.get_plane(0) << "," << npc.get_plane(1) << ","
 	    << npc.get_plane(2) << "," << npc.get_plane(3) << "|";
 
+	// Enhanced E-spec fields. Without these, the checksum is blind to
+	// loader/converter regressions on the "E"-section (see PR #3224 -
+	// ExtraAttack silently lost in YAML conversion).
+	oss << static_cast<int>(mob.mob_specials.extra_attack) << "|";
+	oss << mob.mob_specials.attack_type << "|";
+	oss << static_cast<int>(mob.mob_specials.like_work) << "|";
+	oss << mob.mob_specials.MaxFactor << "|";
+	oss << mob.get_remort() << "|";
+	oss << static_cast<int>(mob.mob_specials.damnodice) << "|";
+	oss << static_cast<int>(mob.mob_specials.damsizedice) << "|";
+	oss << mob.get_str_add() << "|";
+	oss << mob.add_abils.hitreg << "|";
+	oss << mob.add_abils.armour << "|";
+	oss << mob.add_abils.manareg << "|";
+	oss << mob.add_abils.cast_success << "|";
+	oss << mob.add_abils.morale << "|";
+	oss << mob.add_abils.initiative_add << "|";
+	oss << mob.add_abils.absorb << "|";
+	oss << mob.add_abils.aresist << "|";
+	oss << mob.add_abils.mresist << "|";
+	oss << mob.add_abils.presist << "|";
+
 	// Proto script
 	if (mob.proto_script)
 	{

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1630,13 +1630,14 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 	// Sex
 	mob.set_sex(static_cast<EGender>(ParseGender(root["sex"])));
 
-	// Race
-	mob.player_data.Race = static_cast<ENpcRace>(GetInt(root, "race", ENpcRace::kBasic));
+	// Race -- legacy clamps to [kBasic, kLastNpcRace] (boot_data_files.cpp).
+	mob.player_data.Race = std::clamp(static_cast<ENpcRace>(GetInt(root, "race", ENpcRace::kBasic)),
+									  ENpcRace::kBasic, ENpcRace::kLastNpcRace);
 
-	// Physical attributes
-	GET_SIZE(&mob) = GetInt(root, "size", 0);
-	GET_HEIGHT(&mob) = GetInt(root, "height", 0);
-	GET_WEIGHT(&mob) = GetInt(root, "weight", 0);
+	// Physical attributes -- bounds mirror legacy interpret_espec.
+	GET_SIZE(&mob) = std::clamp<byte>(GetInt(root, "size", 0), 0, 100);
+	GET_HEIGHT(&mob) = std::clamp(GetInt(root, "height", 0), 0, 200);
+	GET_WEIGHT(&mob) = std::clamp(GetInt(root, "weight", 0), 0, 200);
 
 	// E-spec attributes - set defaults, then override
 	mob.set_str(11);
@@ -1704,22 +1705,25 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 	{
 		YAML::Node enhanced = root["enhanced"];
 
+		// Clamps mirror MobileFile::interpret_espec in boot_data_files.cpp.
+		// Без них старые данные (например, MaxFactor: 1000 у моба 200300)
+		// попадали в YAML/SQLite как сырые значения и расходились с легаси.
 		mob.set_str_add(GetInt(enhanced, "str_add", 0));
-		mob.add_abils.hitreg = GetInt(enhanced, "hp_regen", 0);
-		mob.add_abils.armour = GetInt(enhanced, "armour_bonus", 0);
-		mob.add_abils.manareg = GetInt(enhanced, "mana_regen", 0);
-		mob.add_abils.cast_success = GetInt(enhanced, "cast_success", 0);
-		mob.add_abils.morale = GetInt(enhanced, "morale", 0);
-		mob.add_abils.initiative_add = GetInt(enhanced, "initiative_add", 0);
-		mob.add_abils.absorb = GetInt(enhanced, "absorb", 0);
-		mob.add_abils.aresist = GetInt(enhanced, "aresist", 0);
-		mob.add_abils.mresist = GetInt(enhanced, "mresist", 0);
-		mob.add_abils.presist = GetInt(enhanced, "presist", 0);
-		mob.mob_specials.attack_type = GetInt(enhanced, "bare_hand_attack", 0);
-		mob.mob_specials.like_work = GetInt(enhanced, "like_work", 0);
-		mob.mob_specials.MaxFactor = GetInt(enhanced, "max_factor", 0);
-		mob.mob_specials.extra_attack = GetInt(enhanced, "extra_attack", 0);
-		mob.set_remort(GetInt(enhanced, "mob_remort", 0));
+		mob.add_abils.hitreg = std::clamp(GetInt(enhanced, "hp_regen", 0), -200, 200);
+		mob.add_abils.armour = std::clamp(GetInt(enhanced, "armour_bonus", 0), 0, 100);
+		mob.add_abils.manareg = std::clamp(GetInt(enhanced, "mana_regen", 0), -200, 200);
+		mob.add_abils.cast_success = std::clamp(GetInt(enhanced, "cast_success", 0), -200, 300);
+		mob.add_abils.morale = std::clamp(GetInt(enhanced, "morale", 0), 0, 100);
+		mob.add_abils.initiative_add = std::clamp(GetInt(enhanced, "initiative_add", 0), -200, 200);
+		mob.add_abils.absorb = std::clamp(GetInt(enhanced, "absorb", 0), -200, 200);
+		mob.add_abils.aresist = std::clamp(GetInt(enhanced, "aresist", 0), 0, 100);
+		mob.add_abils.mresist = std::clamp(GetInt(enhanced, "mresist", 0), 0, 100);
+		mob.add_abils.presist = std::clamp(GetInt(enhanced, "presist", 0), 0, 100);
+		mob.mob_specials.attack_type = std::clamp(GetInt(enhanced, "bare_hand_attack", 0), 0, 99);
+		mob.mob_specials.like_work = std::clamp<byte>(GetInt(enhanced, "like_work", 0), 0, 100);
+		mob.mob_specials.MaxFactor = std::clamp<byte>(GetInt(enhanced, "max_factor", 0), 0, 127);
+		mob.mob_specials.extra_attack = std::clamp<byte>(GetInt(enhanced, "extra_attack", 0), 0, 127);
+		mob.set_remort(std::clamp<byte>(GetInt(enhanced, "mob_remort", 0), 0, 100));
 
 		if (enhanced["special_bitvector"])
 		{
@@ -1739,7 +1743,7 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 			int idx = 0;
 			for (const auto &val_node : enhanced["resistances"])
 			{
-				int value = val_node.as<int>();
+				int value = std::clamp(val_node.as<int>(), kMinResistance, kMaxNpcResist);
 				if (idx < static_cast<int>(mob.add_abils.apply_resistance.size()))
 				{
 					mob.add_abils.apply_resistance[idx] = value;
@@ -1753,7 +1757,7 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 			int idx = 0;
 			for (const auto &val_node : enhanced["saves"])
 			{
-				int value = val_node.as<int>();
+				int value = std::clamp(val_node.as<int>(), kMinSaving, kMaxSaving);
 				if (idx < static_cast<int>(mob.add_abils.apply_saving_throw.size()))
 				{
 					mob.add_abils.apply_saving_throw[idx] = value;

--- a/tests/world_checksum_serialization.cpp
+++ b/tests/world_checksum_serialization.cpp
@@ -76,6 +76,36 @@ TEST(SerializeMob, IncludesNpcFlagPlanes) {
 		<< "SerializeMob must embed npc_flags planes; got: " << out;
 }
 
+// Issue #3223 / PR #3224: the converter silently dropped `ExtraAttack:`
+// because the section-marker check matched the field name. The bug went
+// unnoticed because SerializeMob did not include any "E"-section fields,
+// so Legacy and YAML checksums still agreed despite the data divergence.
+// Pin the enhanced-section scalars into the checksum so this class of
+// regression cannot hide again.
+TEST(SerializeMob, MobsDifferingOnlyByExtraAttackSerializeDifferently) {
+	CharData a, b;
+	a.SetNpcAttribute(true);
+	b.SetNpcAttribute(true);
+	a.mob_specials.extra_attack = 1;
+
+	const std::string sa = WorldChecksum::SerializeMob(42, a);
+	const std::string sb = WorldChecksum::SerializeMob(42, b);
+	EXPECT_NE(sa, sb)
+		<< "Mobs with different extra_attack must hash differently";
+}
+
+TEST(SerializeMob, MobsDifferingOnlyByAddAbilSerializeDifferently) {
+	CharData a, b;
+	a.SetNpcAttribute(true);
+	b.SetNpcAttribute(true);
+	a.add_abils.morale = 7;
+
+	const std::string sa = WorldChecksum::SerializeMob(42, a);
+	const std::string sb = WorldChecksum::SerializeMob(42, b);
+	EXPECT_NE(sa, sb)
+		<< "Mobs with different add_abils.morale must hash differently";
+}
+
 // Distinct mobs whose ONLY difference is a high-plane action flag must produce
 // different checksum-input strings. Before the fix, missing flag-plane fields
 // made these collide.

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -2084,7 +2084,7 @@ def parse_mob_file(filepath):
                         'armor': int(parts[2]) if parts[2].lstrip('-').isdigit() else 100
                     }
                     # Parse HP dice (format: XdY+Z)
-                    hp_match = re.match(r'(-?\d+)d(\d+)([+-]\d+)?', parts[3])
+                    hp_match = re.match(r'(-?\d+)d(-?\d+)([+-]\d+)?', parts[3])
                     if hp_match:
                         mob['stats']['hp'] = {
                             'dice_count': int(hp_match.group(1)),
@@ -2092,7 +2092,7 @@ def parse_mob_file(filepath):
                             'bonus': int(hp_match.group(3)) if hp_match.group(3) else 0
                         }
                     # Parse damage dice
-                    dmg_match = re.match(r'(-?\d+)d(\d+)([+-]\d+)?', parts[4])
+                    dmg_match = re.match(r'(-?\d+)d(-?\d+)([+-]\d+)?', parts[4])
                     if dmg_match:
                         mob['stats']['damage'] = {
                             'dice_count': int(dmg_match.group(1)),
@@ -2105,7 +2105,7 @@ def parse_mob_file(filepath):
             if idx < len(lines):
                 parts = lines[idx].split()
                 if parts:
-                    gold_match = re.match(r'(-?\d+)d(\d+)([+-]\d+)?', parts[0])
+                    gold_match = re.match(r'(-?\d+)d(-?\d+)([+-]\d+)?', parts[0])
                     if gold_match:
                         mob['gold'] = {
                             'dice_count': int(gold_match.group(1)),

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -2142,8 +2142,10 @@ def parse_mob_file(filepath):
                     idx += 1
                     continue
 
-                if line.startswith('E'):
-                    # Enhanced mob marker - continue parsing
+                if line == 'E':
+                    # Enhanced mob marker - continue parsing.
+                    # Точное равенство, иначе перехватываем ExtraAttack: и
+                    # другие поля, начинающиеся с 'E' (issue #3223).
                     idx += 1
                     continue
                 elif line.startswith('Str:'):


### PR DESCRIPTION
## Что исправлено

Наёмники-чармисы в YAML-мире били один раз вместо положенного количества атак: ферстах и другие мобы с `ExtraAttack: 1` приходили из YAML с `extra_attack = 0`.

## Причина

В `tools/converter/convert_to_yaml.py` (parse_mob_file) проверка маркера секции `E` стояла как `line.startswith('E')` ДО проверки `line.startswith('ExtraAttack:')`. Для строки `ExtraAttack: 1` истинно и то и другое, но первая ветка побеждала и `idx += 1; continue` пропускал поле без записи. На загрузке `mob.mob_specials.extra_attack` оставался по умолчанию = 0, и в `do_hire` `num_attacks = 1 + extra_attack` давал 1.

## Решение

Сравнение точным равенством: `if line == 'E'`. Маркер секции - это всегда отдельная строка из одной буквы; никакого риска не отстрелить настоящие маркеры.

Closes #3223

## План тестирования

- [x] `parse_mob_file('lib/world/mob/1000.mob')` теперь возвращает `extra_attack: 1` для всех мобов с `ExtraAttack: 1`.
- [ ] Конвертация всего мира + загрузка YAML, проверить `do_stat` на ферстахе или другом моба с `ExtraAttack`.
- [ ] Нанять чармиса в YAML-мире, убедиться что бьёт несколько раз.

🤖 Generated with [Claude Code](https://claude.com/claude-code)