### PR TITLE
fix(rent): кламп испорченного таймера в бинарном таймер-файле (#3225)

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -1494,8 +1494,18 @@ int Crash_load(CharData *ch) {
 		// вычтем таймер оффлайна
 		if (!(stable_objs::IsTimerUnlimited(obj.get()) || obj->has_flag(EObjFlag::kNoRentTimer))) {
 			const SaveInfo *si = SAVEINFO(index);
-			obj->set_timer(si->time[fsize].timer);
-			obj->dec_timer(timer_dec);
+			const int saved_timer = si->time[fsize].timer;
+			// Защита от мусорных значений в бинарном таймер-файле
+			// (UNLIMITED_TIMER и близкие следы старых багов decay_manager
+			// в otransform/oedit - см. #3213, #3225). Текстовый Tmer уже
+			// клампится в read_one_object_new по тому же порогу 99999.
+			// Если значение бракованное, не переписываем m_timer, иначе
+			// dec_timer ниже разгонит UNLIMITED-N*timer_dec в дрейфующий
+			// таймер, который медленно сходит к нулю.
+			if (saved_timer <= 99999) {
+				obj->set_timer(saved_timer);
+				obj->dec_timer(timer_dec);
+			}
 		}
 
 		std::string cap = obj->get_PName(ECase::kNom);


### PR DESCRIPTION
## Что исправлено

Вторая дыра по тому же сценарию #3213/#3215. У белого браслета мага (vnum 37715) после релога таймер становился `2147480588` = `UNLIMITED_TIMER - N*timer_dec`. Правка в #3215 (кламп `Tmer:` в obj-файле игрока) не помогла, потому что то же значение лежит ещё в бинарном таймер-файле и читается оттуда без защиты.

## Корень

`Crash_save` пишет два таймера на каждый предмет:
- текстовый `Tmer:` в obj-файле через `obj->get_timer()`;
- бинарный `SaveTimeInfo.timer` в таймер-файле через тот же `obj->get_timer()`.

Если в момент сохранения у объекта в `decay_manager` стоял `deadline = UINT64_MAX` (последствие старого бага в otransform/oedit/swap до #3186/#3214), `get_timer()` возвращает `UNLIMITED_TIMER` (2147483647). В таймер-файл это и попадает.

При загрузке `read_one_object_new` теперь клампит `Tmer > 99999` (#3215), но в `Crash_load` идёт ещё одна перезапись:

```cpp
if (!(stable_objs::IsTimerUnlimited(obj) || obj->has_flag(kNoRentTimer))) {
    obj->set_timer(si->time[fsize].timer);  // 2147483647
    obj->dec_timer(timer_dec);
}
```

`IsTimerUnlimited` для kLimitedTimer-предмета даёт false. `dec_timer` внутри проверяет ту же `IsTimerUnlimited` (тоже false) и зовёт `set_timer(UNLIMITED - timer_dec)`. Таймер становится реальным, `decay_manager` пересчитывает `deadline` и предмет начинает медленно протухать. Каждый цикл рент/логин - ещё минус `timer_dec`.

## Решение

Тот же кламп `> 99999`, что и в `read_one_object_new` (#3215). Если `saveinfo.timer` бракованный, не переписываем `m_timer` и не зовём `dec_timer`. `m_timer` тогда останется тем, что прокинуто из прототипа в `create_from_prototype_by_vnum`.

Closes #3225

## План тестирования

- [x] Сборка чистая.
- [ ] Игроку с уже испорченным предметом (timer > 100k) полезть в рент/логин - предмет должен прийти с таймером прототипа, а не с дрейфующим UNLIMITED-N.
- [ ] Обычные предметы продолжают корректно вычитать `timer_dec` за оффлайн.

🤖 Generated with [Claude Code](https://claude.com/claude-code)