### PR TITLE
refactor(includes): убрать pugixml.h из широких заголовков (birthplaces, parser_wrapper, parse) (#3228)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -550,6 +550,7 @@ set(HEADERS
 		src/utils/backtrace.h
 		src/administration/ban.h
 		src/gameplay/mechanics/birthplaces.h
+		src/gameplay/mechanics/birthplaces_constants.h
         src/gameplay/communication/boards/boards_changelog_loaders.h
         src/gameplay/communication/boards/boards_constants.h
         src/gameplay/communication/boards/boards_formatters.h

--- a/src/engine/core/config.cpp
+++ b/src/engine/core/config.cpp
@@ -17,6 +17,7 @@
 #include "config.h"
 #include "utils/timestamp.h"
 
+#include "gameplay/mechanics/birthplaces.h"
 #include "gameplay/communication/boards/boards_changelog_loaders.h"
 #include "gameplay/communication/boards/boards_constants.h"
 #include "engine/entities/char_data.h"

--- a/src/engine/core/config.cpp
+++ b/src/engine/core/config.cpp
@@ -17,6 +17,8 @@
 #include "config.h"
 #include "utils/timestamp.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
+
 #include "gameplay/mechanics/birthplaces.h"
 #include "gameplay/communication/boards/boards_changelog_loaders.h"
 #include "gameplay/communication/boards/boards_constants.h"

--- a/src/engine/core/config.h
+++ b/src/engine/core/config.h
@@ -2,7 +2,7 @@
 #define __CONFIG_HPP__
 
 #include "engine/structs/blocking_queue.h"
-#include "gameplay/mechanics/birthplaces.h"
+#include "gameplay/mechanics/birthplaces_constants.h"
 #include "engine/structs/structs.h"
 #include "engine/structs/meta_enum.h"
 

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -9,6 +9,7 @@
 #include "gameplay/communication/social.h"
 #include "gameplay/crafting/jewelry.h"
 #include "gameplay/crafting/mining.h"
+#include "gameplay/mechanics/birthplaces.h"
 #include "gameplay/mechanics/player_races.h"
 #include "gameplay/mechanics/corpse.h"
 #include "gameplay/mechanics/celebrates.h"

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1,5 +1,7 @@
 #define DB_CPP_
 
+#include "third_party_libs/pugixml/pugixml.h"
+
 #include "administration/accounts.h"
 #include "administration/ban.h"
 #include "administration/karma.h"

--- a/src/engine/ui/cmd/do_remort.cpp
+++ b/src/engine/ui/cmd/do_remort.cpp
@@ -5,6 +5,7 @@
 #include "administration/karma.h"
 #include "do_follow.h"
 #include "engine/entities/char_data.h"
+#include "gameplay/mechanics/birthplaces.h"
 #include "gameplay/mechanics/player_races.h"
 #include "gameplay/mechanics/sight.h"
 #include "engine/core/handler.h"

--- a/src/gameplay/core/reset_stats.cpp
+++ b/src/gameplay/core/reset_stats.cpp
@@ -6,6 +6,7 @@
 #include "engine/ui/color.h"
 #include "engine/entities/char_data.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
 #include <third_party_libs/fmt/include/fmt/format.h>
 
 extern bool ValidateStats(DescriptorData *d);

--- a/src/gameplay/economics/shop_ext.cpp
+++ b/src/gameplay/economics/shop_ext.cpp
@@ -4,6 +4,8 @@
 
 #include "shop_ext.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
+
 #include "engine/db/global_objects.h"
 #include "engine/db/obj_prototypes.h"
 #include "engine/core/handler.h"

--- a/src/gameplay/mechanics/birthplaces.cpp
+++ b/src/gameplay/mechanics/birthplaces.cpp
@@ -1,6 +1,8 @@
 // $RCSfile$     $Date$     $Revision$
 // Part of Bylins http://www.mud.ru
 
+#include "birthplaces.h"
+
 #include "utils/utils.h"
 #include "third_party_libs/pugixml/pugixml.h"
 

--- a/src/gameplay/mechanics/birthplaces.h
+++ b/src/gameplay/mechanics/birthplaces.h
@@ -5,20 +5,20 @@
 #ifndef BIRTH_PLACES_HPP_INCLUDED
 #define BIRTH_PLACES_HPP_INCLUDED
 
-//Для тех, у кого нет нормального файла рас, и нет зон.
-const int kDefaultLoadroom = 4056;
-const int kBirthplaceUndefined = -1;
+#include "birthplaces_constants.h"
+
 #define BIRTH_PLACES_FILE "birthplaces.xml"
 #define BIRTH_PLACE_NAME_UNDEFINED "Undefined: у кодера какие-то проблемы"
 #define BIRTH_PLACE_MAIN_TAG "birthplaces"
 #define BIRTH_PLACE_ERROR_STR "...birth places reading fail"
 
-#include "engine/core/conf.h"
-#include "engine/core/sysdep.h"
-#include "engine/structs/structs.h"
-#include "third_party_libs/pugixml/pugixml.h"
-
+#include <memory>
+#include <string>
 #include <vector>
+
+namespace pugi {
+class xml_node;
+}
 
 class Birthplaces;
 

--- a/src/gameplay/mechanics/birthplaces_constants.h
+++ b/src/gameplay/mechanics/birthplaces_constants.h
@@ -1,0 +1,14 @@
+//  Part of Bylins http://www.mud.ru
+// Лёгкий хедер с константами для точек входа в игру.
+// Вынесен из birthplaces.h, чтобы config.h не тащил pugixml в каждый TU.
+
+#ifndef BIRTH_PLACES_CONSTANTS_HPP_INCLUDED
+#define BIRTH_PLACES_CONSTANTS_HPP_INCLUDED
+
+// Для тех, у кого нет нормального файла рас, и нет зон.
+const int kDefaultLoadroom = 4056;
+const int kBirthplaceUndefined = -1;
+
+#endif // BIRTH_PLACES_CONSTANTS_HPP_INCLUDED
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/gameplay/mechanics/city_guards.cpp
+++ b/src/gameplay/mechanics/city_guards.cpp
@@ -3,6 +3,8 @@
 //
 #include "city_guards.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
+
 #include "engine/boot/boot_constants.h"
 #include "engine/entities/char_data.h"
 #include "engine/entities/entities_constants.h"

--- a/src/gameplay/mechanics/mob_races.cpp
+++ b/src/gameplay/mechanics/mob_races.cpp
@@ -4,6 +4,8 @@
 
 #include "mob_races.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
+
 #include "engine/boot/boot_constants.h"
 #include "engine/entities/char_data.h"
 

--- a/src/gameplay/mechanics/noob.cpp
+++ b/src/gameplay/mechanics/noob.cpp
@@ -4,6 +4,7 @@
 #include "noob.h"
 
 #include "engine/entities/char_data.h"
+#include "gameplay/mechanics/birthplaces.h"
 #include "third_party_libs/pugixml/pugixml.h"
 #include "utils/parse.h"
 #include "engine/core/handler.h"

--- a/src/gameplay/mechanics/stable_objs.cpp
+++ b/src/gameplay/mechanics/stable_objs.cpp
@@ -4,6 +4,8 @@
 
 #include "stable_objs.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
+
 #include "engine/boot/boot_constants.h"
 #include "engine/entities/obj_data.h"
 #include "gameplay/core/constants.h"

--- a/src/gameplay/quests/daily_quest.cpp
+++ b/src/gameplay/quests/daily_quest.cpp
@@ -1,5 +1,7 @@
 #include "daily_quest.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
+
 #include "engine/entities/char_data.h"
 #include "engine/entities/char_player.h"
 #include "engine/db/global_objects.h"

--- a/src/utils/parse.cpp
+++ b/src/utils/parse.cpp
@@ -3,6 +3,8 @@
 
 #include "parse.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
+
 #include "engine/db/obj_prototypes.h"
 #include "engine/db/db.h"
 

--- a/src/utils/parse.h
+++ b/src/utils/parse.h
@@ -8,11 +8,15 @@
 #include <set>
 
 #include "engine/core/conf.h"
-#include "third_party_libs/pugixml/pugixml.h"
 #include "engine/core/sysdep.h"
 #include "engine/structs/structs.h"
 #include "engine/core/comm.h"
 #include "utils/logger.h"
+
+namespace pugi {
+class xml_node;
+class xml_document;
+}
 
 namespace text_id {
 

--- a/src/utils/parser_wrapper.cpp
+++ b/src/utils/parser_wrapper.cpp
@@ -2,92 +2,113 @@
 
 #include "utils/logger.h"
 
+#include "third_party_libs/pugixml/pugixml.h"
+
+#include <sstream>
+
 namespace parser_wrapper {
+
+struct DataNode::Impl {
+	std::shared_ptr<pugi::xml_document> xml_doc{std::make_shared<pugi::xml_document>()};
+	pugi::xml_node curren_xml_node{};
+	std::string filter_name{};
+};
+
+DataNode::DataNode() :
+	impl_{std::make_unique<Impl>()} {}
 
 DataNode::DataNode(const std::filesystem::path &file_name) :
 	DataNode()
 {
-	if (auto result = xml_doc_->load_file(file_name.c_str()); !result) {
+	if (auto result = impl_->xml_doc->load_file(file_name.c_str()); !result) {
 		std::ostringstream buffer;
 		buffer << "..." << result.description() << "\r\n" << " (file: " << file_name << ")" << "\r\n";
 		err_log("%s", buffer.str().c_str());
 	}
-	curren_xml_node_ = xml_doc_->document_element();
+	impl_->curren_xml_node = impl_->xml_doc->document_element();
 }
 
 DataNode::DataNode(const DataNode &d) :
-	DataNode()
-{
-	xml_doc_ = d.xml_doc_;
-	curren_xml_node_ = d.curren_xml_node_;
-	filter_name_ = d.filter_name_;
+	impl_{std::make_unique<Impl>(*d.impl_)} {}
+
+DataNode::DataNode(DataNode &&d) noexcept = default;
+
+DataNode::~DataNode() = default;
+
+DataNode &DataNode::operator=(const DataNode &d) {
+	if (this != &d) {
+		*impl_ = *d.impl_;
+	}
+	return *this;
 }
 
+DataNode &DataNode::operator=(DataNode &&d) noexcept = default;
+
 bool DataNode::IsEmpty() const {
-	return curren_xml_node_.empty();
+	return impl_->curren_xml_node.empty();
 }
 
 const char *DataNode::GetName() const {
-	return curren_xml_node_.name();
+	return impl_->curren_xml_node.name();
 }
 
 const char *DataNode::GetValue(const std::string &key) const {
 	if (key.empty()) {
-		return curren_xml_node_.child_value();
+		return impl_->curren_xml_node.child_value();
 	}
-	return curren_xml_node_.attribute(key.c_str()).value();
+	return impl_->curren_xml_node.attribute(key.c_str()).value();
 }
 
 void DataNode::GoToRadix() {
-	curren_xml_node_ = xml_doc_->document_element();
+	impl_->curren_xml_node = impl_->xml_doc->document_element();
 }
 
 void DataNode::GoToParent() {
-	curren_xml_node_ = curren_xml_node_.parent();
+	impl_->curren_xml_node = impl_->curren_xml_node.parent();
 }
 
 bool DataNode::HaveChild(const std::string &key) {
-	return curren_xml_node_.child(key.c_str());
+	return impl_->curren_xml_node.child(key.c_str());
 }
 
 bool DataNode::GoToChild(const std::string &key) {
-	if (curren_xml_node_.child(key.c_str())) {
-		curren_xml_node_ = curren_xml_node_.child(key.c_str());
+	if (impl_->curren_xml_node.child(key.c_str())) {
+		impl_->curren_xml_node = impl_->curren_xml_node.child(key.c_str());
 		return true;
 	}
 	return false;
 }
 
 bool DataNode::GoToSibling(const std::string &key) {
-	if (curren_xml_node_.parent().child(key.c_str())) {
-		curren_xml_node_ = curren_xml_node_.parent().child(key.c_str());
+	if (impl_->curren_xml_node.parent().child(key.c_str())) {
+		impl_->curren_xml_node = impl_->curren_xml_node.parent().child(key.c_str());
 		return true;
 	}
 	return false;
 }
 
 bool DataNode::HavePrevious() {
-	return curren_xml_node_.previous_sibling();
+	return impl_->curren_xml_node.previous_sibling();
 }
 
 void DataNode::GoToPrevious() {
-	curren_xml_node_ = curren_xml_node_.previous_sibling();
+	impl_->curren_xml_node = impl_->curren_xml_node.previous_sibling();
 }
 
 bool DataNode::HaveNext() {
-	return curren_xml_node_.next_sibling();
+	return impl_->curren_xml_node.next_sibling();
 }
 
 void DataNode::GoToNext() {
-	curren_xml_node_ = curren_xml_node_.next_sibling();
+	impl_->curren_xml_node = impl_->curren_xml_node.next_sibling();
 }
 
 DataNode::operator bool() const {
-	return !curren_xml_node_.empty();
+	return !impl_->curren_xml_node.empty();
 }
 
 bool DataNode::operator==(const DataNode &d) const {
-	return curren_xml_node_ == d.curren_xml_node_;
+	return impl_->curren_xml_node == d.impl_->curren_xml_node;
 }
 
 bool DataNode::operator!=(const DataNode &other) const {
@@ -103,10 +124,10 @@ DataNode::pointer DataNode::operator->() {
 }
 
 DataNode &DataNode::operator++() {
-	if (filter_name_.empty()) {
-		curren_xml_node_ = curren_xml_node_.next_sibling();
+	if (impl_->filter_name.empty()) {
+		impl_->curren_xml_node = impl_->curren_xml_node.next_sibling();
 	} else {
-		curren_xml_node_ = curren_xml_node_.next_sibling(filter_name_.c_str());
+		impl_->curren_xml_node = impl_->curren_xml_node.next_sibling(impl_->filter_name.c_str());
 	}
 	return *this;
 }
@@ -118,7 +139,7 @@ const DataNode DataNode::operator++(int) {
 }
 
 DataNode &DataNode::operator--() {
-	curren_xml_node_ = curren_xml_node_.previous_sibling();
+	impl_->curren_xml_node = impl_->curren_xml_node.previous_sibling();
 	return *this;
 }
 
@@ -130,14 +151,14 @@ const DataNode DataNode::operator--(int) {
 
 [[nodiscard]] iterators::Range<DataNode> DataNode::Children() {
 	auto node = *this;
-	node->curren_xml_node_ = node->curren_xml_node_.first_child();
+	node.impl_->curren_xml_node = node.impl_->curren_xml_node.first_child();
 	return iterators::Range(node);
 }
 
 [[nodiscard]] iterators::Range<DataNode> DataNode::Children(const std::string &key) {
 	auto node = *this;
-	node.filter_name_ = key;
-	node.curren_xml_node_ = node.curren_xml_node_.child(key.c_str());
+	node.impl_->filter_name = key;
+	node.impl_->curren_xml_node = node.impl_->curren_xml_node.child(key.c_str());
 	return iterators::Range(node);
 }
 

--- a/src/utils/parser_wrapper.h
+++ b/src/utils/parser_wrapper.h
@@ -17,39 +17,34 @@
 
 #ifndef PARSER_WRAPPER
 #define PARSER_WRAPPER
-#include <sstream>
+
 #include <filesystem>
 #include <memory>
+#include <string>
 
-#include "third_party_libs/pugixml/pugixml.h"
 #include "engine/structs/iterators.h"
 
 namespace parser_wrapper {
 
 class DataNode {
-  using value_type        = DataNode;
-  using pointer           = DataNode*;
-  using reference         = DataNode&;
- protected:
-	using DocPtr = std::shared_ptr<pugi::xml_document>;
-
-	DocPtr xml_doc_;
-	// Получить указатель на ноду непосредственно штатными средстваим нельзя.
-	pugi::xml_node curren_xml_node_;
-	std::string filter_name_;
-
  public:
-	DataNode() :
-		xml_doc_{std::make_shared<pugi::xml_document>()},
-		curren_xml_node_{pugi::xml_node()} {};
+	using value_type        = DataNode;
+	using pointer           = DataNode*;
+	using reference         = DataNode&;
+
+	DataNode();
 
 	explicit DataNode(const std::filesystem::path &file_name);
 
 	DataNode(const DataNode &d);
 
-	~DataNode() = default;
+	DataNode(DataNode &&d) noexcept;
 
-	DataNode &operator=(const DataNode &d) = default;
+	~DataNode();
+
+	DataNode &operator=(const DataNode &d);
+
+	DataNode &operator=(DataNode &&d) noexcept;
 
 	explicit operator bool() const;
 
@@ -145,6 +140,9 @@ class DataNode {
 	 */
 	[[nodiscard]] iterators::Range<DataNode> Children(const std::string &key);
 
+ private:
+	struct Impl;
+	std::unique_ptr<Impl> impl_;
 };
 
 } //parcer_wrapper


### PR DESCRIPTION
Quick wins по issue #3228: разрыв цепочки `pugixml.h` в широких заголовках.

## Что сделано

### Коммит 1: A.1 -- разорвать `config.h -> birthplaces.h -> pugixml.h`

`config.h` инклудил `birthplaces.h` ради единственной константы `kBirthplaceUndefined` в дефолтном аргументе `calc_loadroom`. `birthplaces.h`, в свою очередь, тащил `pugixml.h` ради двух функций `Load(pugi::xml_node)` и `LoadBirthPlace(pugi::xml_node)`.

* Вынесены `kBirthplaceUndefined` и `kDefaultLoadroom` в `birthplaces_constants.h`.
* В `birthplaces.h` -- forward-declare `namespace pugi { class xml_node; }`.
* Файлам, получавшим класс `Birthplaces` транзитивно через `config.h`, добавлены явные `#include "birthplaces.h"`.

### Коммит 2: PIMPL `parser_wrapper` + forward-decl pugi в `parse.h`

После A.1 `pugixml` всё ещё дотягивался до 397 TU через две оставшиеся цепочки:

```
char_data.h -> obj_sets.h -> feats.h -> talents_effects.h -> parser_wrapper.h -> pugixml.h
char_data.h -> ... -> info_container.h -> parse.h -> pugixml.h
```

* `parser_wrapper.h`: класс `DataNode` хранил `pugi::xml_node` и `std::shared_ptr<pugi::xml_document>` по значению, поэтому forward-declare не работал. Введён скрытый `struct DataNode::Impl` (PIMPL): unique_ptr на impl, операции копирования/перемещения и деструктор -- в `.cpp`. Полный pugixml видит только `parser_wrapper.cpp`.
* `parse.h`: функции принимают `pugi::xml_node` по ссылке и возвращают по значению. Для деклараций достаточно `namespace pugi { class xml_node; class xml_document; }`. Полный pugixml видит только `parse.cpp`.
* Файлам, ранее получавшим pugi-типы транзитивно через `parse.h`, добавлены явные `#include`: `config.cpp`, `db.cpp`, `reset_stats.cpp`, `mob_races.cpp`, `city_guards.cpp`, `daily_quest.cpp`, `stable_objs.cpp`, `shop_ext.cpp`.

## Замер совокупного эффекта

`g++ -E -P` на 461 TU (Release, без тестов).

| Метрика | До | После A.1 | После PIMPL+parse | Δ от мастера |
|---|---|---|---|---|
| reach `pugixml.h` (TU) | 433 | 397 | **54** | **-379** |
| Препроцессировано строк | 46 799 106 | 46 740 250 | **46 511 372** | **-287 734** |

`pugixml.h` теперь видят только те 54 TU, которые реально работают с XML.

## Test plan

- [x] `cmake -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release && make circle` -- собирается чисто.
- [ ] `tools/run_load_tests.sh --quick` -- прогнать перед мержем.
- [ ] Смок-тест на тестовом мире: вход в игру, рематинг, чтение abilities/feats из xml, чтение currencies/shops.