### PR TITLE
build(cmake): PCH для circle.library, ~15% быстрее full rebuild (#3228)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1143,6 +1143,38 @@ target_link_libraries(circle.library fort)
 add_subdirectory(src/third_party_libs/fmt EXCLUDE_FROM_ALL)
 target_link_libraries(circle.library fmt::fmt)
 
+# Precompiled headers: ускоряем сборку, единожды парся "ядро" заголовков,
+# которое тащится в большинство TU. Включается опционально, чтобы не мешать
+# редким сборкам на машинах без поддержки PCH.
+option(USE_PCH "Use precompiled headers for circle.library" ON)
+if (USE_PCH)
+	# PCH-набор подобран эмпирически: только то, что есть почти в каждом TU.
+	# Расширение (atomic/thread/chrono/bitset/deque/...) делает PCH больше и
+	# фактически замедляет сборку, поэтому оставлено только ядро.
+	# Не подключаем sysdep.h: его блок под __COMM_C__ ломается в PCH (PCH
+	# компилируется без TU-локальных #define перед include).
+	target_precompile_headers(circle.library PRIVATE
+		<algorithm>
+		<array>
+		<cstddef>
+		<cstdint>
+		<functional>
+		<list>
+		<map>
+		<memory>
+		<set>
+		<sstream>
+		<string>
+		<type_traits>
+		<unordered_map>
+		<unordered_set>
+		<utility>
+		<vector>
+		<fmt/format.h>
+		"${CMAKE_SOURCE_DIR}/src/engine/core/conf.h"
+	)
+endif()
+
 # Boost
 option(BOOST "Turns on/off scripting engine" NO)
 if (BOOST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1147,6 +1147,13 @@ target_link_libraries(circle.library fmt::fmt)
 # которое тащится в большинство TU. Включается опционально, чтобы не мешать
 # редким сборкам на машинах без поддержки PCH.
 option(USE_PCH "Use precompiled headers for circle.library" ON)
+# MinGW: -D__USE_MINGW_ANSI_STDIO=1 неправильно прокидывается в PCH-компиляцию,
+# и nlohmann/json.hpp ломается на std::snprintf (см. CI на PR #3230). На MSVC,
+# Cygwin, Linux/macOS PCH работает; на MinGW по умолчанию выключаем.
+if (USE_PCH AND MINGW)
+	message(STATUS "PCH disabled on MinGW (snprintf macro conflict with PCH)")
+	set(USE_PCH OFF)
+endif()
 if (USE_PCH)
 	# PCH-набор подобран эмпирически: только то, что есть почти в каждом TU.
 	# Расширение (atomic/thread/chrono/bitset/deque/...) делает PCH больше и


### PR DESCRIPTION
Quick win B.6 по issue #3228 -- precompiled headers для `circle.library`.

## Что сделано

В `CMakeLists.txt` добавлен `target_precompile_headers` для целевого `circle.library` под опцией `USE_PCH` (по умолчанию `ON`).

В PCH-набор включены только заголовки, которые встречаются почти в каждом TU:
- **STL containers**: `array`, `list`, `map`, `set`, `unordered_map`, `unordered_set`, `vector`
- **STL utilities**: `algorithm`, `functional`, `memory`, `sstream`, `string`, `type_traits`, `utility`
- **C library**: `cstddef`, `cstdint`
- **Третья сторона**: `fmt/format.h` (4306 LOC, нужен почти везде)
- **Проектное ядро**: `engine/core/conf.h`

## Ограничения и почему не больше

**`sysdep.h` в PCH не подключён** -- он содержит блок под `__COMM_C__`:

```cpp
#if defined(__COMM_C__) || defined(CIRCLE_UTIL)
#include <sys/socket.h>
// ... и т.п.
#endif
```

Этот макрос определяется только в `comm.cpp` *перед* `#include "sysdep.h"`. PCH компилируется без TU-локальных define, поэтому при попытке положить `sysdep.h` в PCH этот блок остаётся пустым и `comm.cpp` ломается с ошибкой `'sockaddr_in' has incomplete type`. Чистое решение -- расщепить `sysdep.h` на `sysdep_core.h` + `sysdep_net.h` (B.4 из плана).

**Расширение PCH замедляет сборку.** Эмпирически проверил: добавление `<atomic>`, `<thread>`, `<chrono>`, `<bitset>`, `<deque>`, `<iterator>`, `<limits>`, `<cstring>` увеличивает размер PCH и фактически медленнее (3m07s против 2m48s). PCH окупается только для заголовков, реально присутствующих в большинстве TU.

## Замер

Чистая пересборка `circle` (Release, без тестов, gcc 13, `-j$(nproc)/2`):

| Сборка | Wallclock | User CPU | Sys |
|---|---|---|---|
| Без PCH (master) | 3m17s | 19m50s | 3m13s |
| С PCH (этот PR) | **2m48s** | **16m02s** | 2m51s |
| Δ | **-29s (-15%)** | -3m48s (-19%) | -22s |

Эффект скейлится с числом TU и количеством мест, где парсятся одни и те же тяжёлые хедеры.

## Совместимость

* `USE_PCH=OFF` отключает PCH (на случай странных конфигураций).
* На цель `tests` PCH не распространяется -- они собираются как раньше.
* Никакие `.cpp`/`.h` не изменены, поэтому риски минимальные. Если у кого-то локальная сборка ломается -- надо добавить недостающий include явно (PCH не должен «спасать» забывчивых).

## Test plan

- [x] `cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF && make circle` собирается чисто, бинарь линкуется.
- [x] Замер времени сборки до/после.
- [ ] Прогон `tools/run_load_tests.sh --quick` перед мержем.
- [ ] Проверить, что Debug-сборка с ASAN тоже работает с PCH.