### PR TITLE
build(cmake): CMAKE_EXPORT_COMPILE_COMMANDS=ON по умолчанию (#3228)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ if (NOT ${CMAKE_VERSION} VERSION_LESS "3.12.0")
 	cmake_policy(SET CMP0074 NEW)
 endif ()
 
+# Экспортируем compile_commands.json из коробки -- нужен clangd, IWYU,
+# include-graph-аудиту и любым внешним статическим анализаторам.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(SOURCES


### PR DESCRIPTION
Quick win A.3 по issue #3228.

Включает `CMAKE_EXPORT_COMPILE_COMMANDS` на уровне `CMakeLists.txt`, чтобы `compile_commands.json` генерировался во всех директориях сборки без необходимости передавать флаг каждый раз.

## Зачем

* `clangd`, `clang-tidy`, IWYU, include-graph-аудиты и любые внешние статические анализаторы используют `compile_commands.json` как источник истины о флагах компиляции.
* Без этого флага каждый разработчик вручную добавляет `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, либо инструменты не работают.
* Генерируемый файл попадает в `build/`, который уже в `.gitignore`.

## Test plan

- [x] `cmake -S . -B build_test -DCMAKE_BUILD_TYPE=Release` создаёт `build_test/compile_commands.json` без дополнительных флагов.
- [x] Smoke-сборка `make circle` проходит чисто.