### PR TITLE
refactor(sysdep): вынести сетевые системные заголовки в sysdep_net.h (#3228)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -681,6 +681,7 @@ set(HEADERS
 		src/engine/structs/structs.h
 		src/gameplay/mechanics/stuff.h
 		src/engine/core/sysdep.h
+		src/engine/core/sysdep_net.h
 		src/engine/network/telnet.h
 		src/utils/utils_time.h
 		src/utils/tracing/trace_sender.h

--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -27,7 +27,7 @@
  * if it is a client or server problem.
  */
 
-#define __COMM_C__
+#include "engine/core/sysdep_net.h"
 
 #include "comm.h"
 

--- a/src/engine/core/sysdep.h
+++ b/src/engine/core/sysdep.h
@@ -194,55 +194,10 @@ extern void abort(), exit();
 #include <zlib.h>
 #endif
 
-// Header files only used in comm.cpp and some of the utils
+// Сетевые системные заголовки (sys/socket.h, netinet/in.h, signal.h и т.д.)
+// вынесены в sysdep_net.h. Файлы, которым нужна сетевая часть, инклудят
+// его явно. Остальные TU не платят за эти заголовки в препроцессинге.
 
-#if defined(__COMM_C__) || defined(CIRCLE_UTIL)
-
-#ifndef HAVE_STRUCT_IN_ADDR
-struct in_addr
-{
-	unsigned long int s_addr;	// for inet_addr, etc.
-}
-#endif
-#ifdef HAVE_SYS_SELECT_H
-#include <sys/select.h>
-#endif
-#if defined(HAVE_FCNTL_H)
-#include <fcntl.h>
-#elif defined(HAVE_SYS_FCNTL_H)
-#include <sys/fcntl.h>
-#endif
-#ifdef HAVE_SYS_SOCKET_H
-# include <sys/socket.h>
-#endif
-#ifdef HAVE_SYS_RESOURCE_H
-# include <sys/resource.h>
-#endif
-#ifdef HAVE_SYS_WAIT_H
-# include <sys/wait.h>
-#endif
-#ifdef HAVE_NETINET_IN_H
-# include <netinet/in.h>
-#endif
-#ifdef HAVE_ARPA_INET_H
-# include <arpa/inet.h>
-#endif
-#ifdef HAVE_NETDB_H
-# include <netdb.h>
-#endif
-#ifdef HAVE_SIGNAL_H
-# ifndef _POSIX_C_SOURCE
-#  define _POSIX_C_SOURCE 2
-#  include <signal.h>
-#  undef _POSIX_C_SOURCE
-# else
-#  include <signal.h>		// GNU libc 6 already defines _POSIX_C_SOURCE.
-# endif
-#endif
-#ifdef HAVE_SYS_UIO_H
-# include <sys/uio.h>
-#endif
-#endif                // __COMM_C__ && CIRCLE_UNIX
 // Basic system dependencies ******************************************
 #if !defined(__GNUC__)
 #define __attribute__(x)	// nothing //
@@ -453,111 +408,8 @@ int unlink(const char *path);
 int remove(const char *path);
 #endif
 
-// Function prototypes that are only used in comm.cpp and some of the utils
-
-#if defined(__COMM_C__) || defined(CIRCLE_UTIL)
-
-#ifdef NEED_ACCEPT_PROTO
-int accept(socket_t s, struct sockaddr *addr, int *addrlen);
-#endif
-
-#ifdef NEED_BIND_PROTO
-int bind(socket_t s, const struct sockaddr *name, int namelen);
-#endif
-
-#ifdef NEED_CHDIR_PROTO
-int chdir(const char *path);
-#endif
-
-#ifdef NEED_CLOSE_PROTO
-int close(int fildes);
-#endif
-
-#ifdef NEED_FCNTL_PROTO
-int fcntl(int fildes, int cmd, /* arg */ ...);
-#endif
-
-#ifdef NEED_FPUTC_PROTO
-int fputc(char c, FILE * stream);
-#endif
-
-#ifdef NEED_FPUTS_PROTO
-int fputs(const char *s, FILE * stream);
-#endif
-
-#ifdef NEED_GETPEERNAME_PROTO
-int getpeername(socket_t s, struct sockaddr *name, int *namelen);
-#endif
-
-#if defined(HAS_RLIMIT) && defined(NEED_GETRLIMIT_PROTO)
-int getrlimit(int resource, struct rlimit *rlp);
-#endif
-
-#ifdef NEED_GETSOCKNAME_PROTO
-int getsockname(socket_t s, struct sockaddr *name, int *namelen);
-#endif
-
-#ifdef NEED_HTONL_PROTO
-ulong htonl(u_long hostlong);
-#endif
-
-#ifdef NEED_HTONS_PROTO
-u_short htons(u_short hostshort);
-#endif
-
-#if defined(HAVE_INET_ADDR) && defined(NEED_INET_ADDR_PROTO)
-unsigned long int inet_addr(const char *cp);
-#endif
-
-#if defined(HAVE_INET_ATON) && defined(NEED_INET_ATON_PROTO)
-int inet_aton(const char *cp, struct in_addr *inp);
-#endif
-
-#ifdef NEED_INET_NTOA_PROTO
-char *inet_ntoa(const struct in_addr in);
-#endif
-
-#ifdef NEED_LISTEN_PROTO
-int listen(socket_t s, int backlog);
-#endif
-
-#ifdef NEED_NTOHL_PROTO
-u_long ntohl(u_long netlong);
-#endif
-
-#ifdef NEED_PRINTF_PROTO
-int printf(char *format, ...);
-#endif
-
-#ifdef NEED_READ_PROTO
-ssize_t read(int fildes, void *buf, size_t nbyte);
-#endif
-
-#ifdef NEED_SELECT_PROTO
-int select(int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, struct timeval *timeout);
-#endif
-
-#ifdef NEED_SETITIMER_PROTO
-int setitimer(int which, const struct itimerval *value, struct itimerval *ovalue);
-#endif
-
-#if defined(HAS_RLIMIT) && defined(NEED_SETRLIMIT_PROTO)
-int setrlimit(int resource, const struct rlimit *rlp);
-#endif
-
-#ifdef NEED_SETSOCKOPT_PROTO
-int setsockopt(socket_t s, int level, int optname, const char *optval, int optlen);
-#endif
-
-#ifdef NEED_SOCKET_PROTO
-int socket(int domain, int type, int protocol);
-#endif
-
-#ifdef NEED_WRITE_PROTO
-ssize_t write(int fildes, const void *buf, size_t nbyte);
-#endif
-
-#endif                // __COMM_C__
+// Прототипы сетевых функций (accept, bind, htonl, inet_addr и т.д.)
+// перенесены в sysdep_net.h.
 
 #endif                // NO_LIBRARY_PROTOTYPES
 

--- a/src/engine/core/sysdep_net.h
+++ b/src/engine/core/sysdep_net.h
@@ -1,0 +1,171 @@
+/* ************************************************************************
+*   File: sysdep_net.h                                  Part of Bylins MUD *
+*  Usage: socket-related system headers and prototypes                     *
+*                                                                          *
+*  Вынесено из sysdep.h (где было под #if defined(__COMM_C__)). Включается *
+*  файлами, которым реально нужна сетевая часть (comm.cpp, утилиты).       *
+*  Остальные TU не платят цену <sys/socket.h>, <netinet/in.h>, <signal.h>  *
+*  и пр.                                                                   *
+************************************************************************ */
+
+#ifndef _SYSDEP_NET_H_
+#define _SYSDEP_NET_H_
+
+#include "sysdep.h"
+
+// Header files only used in comm.cpp and some of the utils
+
+#ifndef HAVE_STRUCT_IN_ADDR
+struct in_addr
+{
+	unsigned long int s_addr;	// for inet_addr, etc.
+};
+#endif
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+#if defined(HAVE_FCNTL_H)
+#include <fcntl.h>
+#elif defined(HAVE_SYS_FCNTL_H)
+#include <sys/fcntl.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
+# include <sys/socket.h>
+#endif
+#ifdef HAVE_SYS_RESOURCE_H
+# include <sys/resource.h>
+#endif
+#ifdef HAVE_SYS_WAIT_H
+# include <sys/wait.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+# include <netinet/in.h>
+#endif
+#ifdef HAVE_ARPA_INET_H
+# include <arpa/inet.h>
+#endif
+#ifdef HAVE_NETDB_H
+# include <netdb.h>
+#endif
+#ifdef HAVE_SIGNAL_H
+# ifndef _POSIX_C_SOURCE
+#  define _POSIX_C_SOURCE 2
+#  include <signal.h>
+#  undef _POSIX_C_SOURCE
+# else
+#  include <signal.h>		// GNU libc 6 already defines _POSIX_C_SOURCE.
+# endif
+#endif
+#ifdef HAVE_SYS_UIO_H
+# include <sys/uio.h>
+#endif
+
+// Function prototypes that are only used in comm.cpp and some of the utils
+
+#ifndef NO_LIBRARY_PROTOTYPES
+
+#ifdef NEED_ACCEPT_PROTO
+int accept(socket_t s, struct sockaddr *addr, int *addrlen);
+#endif
+
+#ifdef NEED_BIND_PROTO
+int bind(socket_t s, const struct sockaddr *name, int namelen);
+#endif
+
+#ifdef NEED_CHDIR_PROTO
+int chdir(const char *path);
+#endif
+
+#ifdef NEED_CLOSE_PROTO
+int close(int fildes);
+#endif
+
+#ifdef NEED_FCNTL_PROTO
+int fcntl(int fildes, int cmd, /* arg */ ...);
+#endif
+
+#ifdef NEED_FPUTC_PROTO
+int fputc(char c, FILE * stream);
+#endif
+
+#ifdef NEED_FPUTS_PROTO
+int fputs(const char *s, FILE * stream);
+#endif
+
+#ifdef NEED_GETPEERNAME_PROTO
+int getpeername(socket_t s, struct sockaddr *name, int *namelen);
+#endif
+
+#if defined(HAS_RLIMIT) && defined(NEED_GETRLIMIT_PROTO)
+int getrlimit(int resource, struct rlimit *rlp);
+#endif
+
+#ifdef NEED_GETSOCKNAME_PROTO
+int getsockname(socket_t s, struct sockaddr *name, int *namelen);
+#endif
+
+#ifdef NEED_HTONL_PROTO
+ulong htonl(u_long hostlong);
+#endif
+
+#ifdef NEED_HTONS_PROTO
+u_short htons(u_short hostshort);
+#endif
+
+#if defined(HAVE_INET_ADDR) && defined(NEED_INET_ADDR_PROTO)
+unsigned long int inet_addr(const char *cp);
+#endif
+
+#if defined(HAVE_INET_ATON) && defined(NEED_INET_ATON_PROTO)
+int inet_aton(const char *cp, struct in_addr *inp);
+#endif
+
+#ifdef NEED_INET_NTOA_PROTO
+char *inet_ntoa(const struct in_addr in);
+#endif
+
+#ifdef NEED_LISTEN_PROTO
+int listen(socket_t s, int backlog);
+#endif
+
+#ifdef NEED_NTOHL_PROTO
+u_long ntohl(u_long netlong);
+#endif
+
+#ifdef NEED_PRINTF_PROTO
+int printf(char *format, ...);
+#endif
+
+#ifdef NEED_READ_PROTO
+ssize_t read(int fildes, void *buf, size_t nbyte);
+#endif
+
+#ifdef NEED_SELECT_PROTO
+int select(int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, struct timeval *timeout);
+#endif
+
+#ifdef NEED_SETITIMER_PROTO
+int setitimer(int which, const struct itimerval *value, struct itimerval *ovalue);
+#endif
+
+#if defined(HAS_RLIMIT) && defined(NEED_SETRLIMIT_PROTO)
+int setrlimit(int resource, const struct rlimit *rlp);
+#endif
+
+#ifdef NEED_SETSOCKOPT_PROTO
+int setsockopt(socket_t s, int level, int optname, const char *optval, int optlen);
+#endif
+
+#ifdef NEED_SOCKET_PROTO
+int socket(int domain, int type, int protocol);
+#endif
+
+#ifdef NEED_WRITE_PROTO
+ssize_t write(int fildes, const void *buf, size_t nbyte);
+#endif
+
+#endif  // NO_LIBRARY_PROTOTYPES
+
+#endif  // _SYSDEP_NET_H_
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
Quick win B.4 по issue #3228 -- расщепление `sysdep.h`.

## Зачем

В `sysdep.h` было два больших блока, защищённых `#if defined(__COMM_C__)`:

1. Системные заголовки: `<sys/socket.h>`, `<netinet/in.h>`, `<arpa/inet.h>`, `<netdb.h>`, `<signal.h>`, `<sys/select.h>`, `<sys/wait.h>`, `<sys/uio.h>`, `<sys/resource.h>`, `<fcntl.h>`, fallback `struct in_addr`.
2. Прототипы сетевых функций: `accept`/`bind`/`listen`/`socket`/`htonl`/`inet_addr` и т.п.

Макрос `__COMM_C__` определялся только в `comm.cpp` *перед* `#include "comm.h"`, после чего `sysdep.h` раскрывал эти блоки ровно для одного TU. Конструкция работала, но:

* непрозрачна: чтобы понять, какой набор заголовков получит TU, нужно знать про скрытый макрос;
* **блокирует `sysdep.h` в precompiled headers** -- PCH компилируется без TU-локальных `#define`, поэтому эти блоки в PCH теряются и `comm.cpp` потом перестаёт находить `sockaddr_in`. Это всплыло при работе над PCH (#3230, см. `sysdep.h` намеренно не положен).

## Что сделано

* Создан `src/engine/core/sysdep_net.h` -- содержит оба `__COMM_C__`-блока в чистом виде (без макро-гейта).
* В `sysdep.h` оба блока удалены, оставлено общее системное ядро (stdio/stdlib/errno/time/zlib/limits/...). LOC: 587 → 439.
* `comm.cpp`: заменил `#define __COMM_C__` на явный `#include "engine/core/sysdep_net.h"`.
* `CMakeLists.txt`: зарегистрирован новый заголовок.

Никакие другие файлы трогать не пришлось -- остальные потребители сокетов (`iosystem.cpp`, `interpreter.cpp`, `admin_api.cpp`, `char_player.cpp`) и так инклудят системные заголовки явно.

## Эффект

* По препроцессингу: ноль для всех TU, кроме `comm.cpp` (там заголовков теперь столько же). Сама по себе B.4 wallclock не меняет (проверял).
* **Разблокирует** добавление `sysdep.h` в PCH, что даст дополнительные проценты к B.6 (#3230). После мержа этого PR можно либо обновить #3230, либо открыть отдельный PR на расширение PCH.

## Test plan

- [x] `cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF && make circle` -- собирается чисто.
- [ ] `tools/run_load_tests.sh --quick` перед мержем.
- [ ] Проверить, что сервер слушает порт и принимает соединение (smoke-тест на тестовом мире).