### PR TITLE
fix(scripting): не сканировать мир по чисто-цифровому имени в get_char/get_obj (#3232)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -446,14 +446,11 @@ int find_room_uid(long n) {
  ************************************************************/
 
 // Чисто-цифровая строка (без UID-префикса) -- это vnum, а не имя/UID.
-// В get_char/get_obj по таким строкам нечего искать через isname(), но они
-// проваливаются туда и устраивают O(N) скан по character_list / object_list.
-// Самый громкий случай -- триггер вида "detach 97137 %vnum%", где %vnum%
-// это число; см. issue #3232 (488мс на одну зону вместо 4мс).
-//
-// get_room такие строки трактует как vnum намеренно, поэтому он не
-// затронут -- продолжаем туда отдавать управление дальше по цепочке.
-static bool is_plain_vnum_string(const char *name) {
+// Используется в process_attach/detach/run для предупреждения билдеров
+// о паттернах вида "detach <trig> %vnum%" -- они проваливаются в O(N)
+// сканы по character_list / object_list, прежде чем дойти до get_room.
+// См. issue #3232 (488мс на одну зону вместо 4мс).
+bool is_plain_vnum_string(const char *name) {
 	if (!name || !*name) {
 		return false;
 	}
@@ -471,11 +468,6 @@ CharData *get_char(const char *name) {
 
 	// Отсекаем поиск левых UID-ов.
 	if ((*name == UID_OBJ) || (*name == UID_ROOM))
-		return nullptr;
-
-	// Чистый vnum -- не char-id, не имя; искать его isname-ом по миру
-	// бессмысленно и стоит O(N). См. #3232.
-	if (is_plain_vnum_string(name))
 		return nullptr;
 
 	if (*name == UID_CHAR || *name == UID_CHAR_ALL) {
@@ -502,10 +494,6 @@ ObjData *get_obj(const char *name, int/* vnum*/) {
 	long id;
 
 	if ((*name == UID_CHAR) || (*name == UID_ROOM) || (*name == UID_CHAR_ALL))
-		return nullptr;
-
-	// Чистый vnum -- не obj-id, не алиас; isname-скан бессмыслен (#3232).
-	if (is_plain_vnum_string(name))
 		return nullptr;
 
 	if (*name == UID_OBJ) {
@@ -4637,6 +4625,17 @@ void process_attach(void *go, Script *sc, Trigger *trig, int type, char *cmd) {
 	// parse and locate the id specified
 	eval_expr(id_p, result, sizeof(result), go, sc, trig, type);
 
+	// Сырой vnum как ID (без UID-обёртки) проваливается в O(N)-сканы по
+	// character_list и object_list прежде чем дойти до get_room. См. #3232.
+	// Чинится в .trg: использовать %world.room(<vnum>)% / %world.mob(<vnum>)%
+	// или calcuid <var> <vnum> room/mob/obj.
+	if (is_plain_vnum_string(id_p)) {
+		snprintf(buf2, sizeof(buf2),
+				 "attach: argument '%s' is plain vnum, use %%world.room/mob/obj(...)%% or calcuid (#3232). cmd: '%s'",
+				 id_p, cmd);
+		trig_log(trig, buf2);
+	}
+
 	c = get_char(id_p);
 	if (!c) {
 		o = get_obj(id_p);
@@ -4731,6 +4730,14 @@ Trigger *process_detach(void *go, Script *sc, Trigger *trig, int type, char *cmd
 
 	// parse and locate the id specified
 	eval_expr(id_p, result, sizeof(result), go, sc, trig, type);
+
+	// Сырой vnum как ID (см. process_attach выше и #3232).
+	if (is_plain_vnum_string(id_p)) {
+		snprintf(buf2, sizeof(buf2),
+				 "detach: argument '%s' is plain vnum, use %%world.room/mob/obj(...)%% or calcuid (#3232). cmd: '%s'",
+				 id_p, cmd);
+		trig_log(trig, buf2);
+	}
 
 	c = get_char(id_p);
 	if (!c) {
@@ -4859,6 +4866,14 @@ int process_run(void *go, Script **sc, Trigger **trig, int type, char *cmd, int 
 
 	// parse and locate the id specified
 	eval_expr(id_p, result, sizeof(result), go, *sc, *trig, type);
+
+	// Сырой vnum как ID (см. process_attach выше и #3232).
+	if (is_plain_vnum_string(id_p)) {
+		snprintf(buf2, sizeof(buf2),
+				 "run: argument '%s' is plain vnum, use %%world.room/mob/obj(...)%% or calcuid (#3232). cmd: '%s'",
+				 id_p, cmd);
+		trig_log(*trig, buf2);
+	}
 
 	c = get_char(id_p);
 	if (!c) {

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -4625,15 +4625,12 @@ void process_attach(void *go, Script *sc, Trigger *trig, int type, char *cmd) {
 	// parse and locate the id specified
 	eval_expr(id_p, result, sizeof(result), go, sc, trig, type);
 
-	// Сырой vnum как ID (без UID-обёртки) проваливается в O(N)-сканы по
-	// character_list и object_list прежде чем дойти до get_room. См. #3232.
-	// Чинится в .trg: использовать %world.room(<vnum>)% / %world.mob(<vnum>)%
-	// или calcuid <var> <vnum> room/mob/obj.
 	if (is_plain_vnum_string(id_p)) {
 		snprintf(buf2, sizeof(buf2),
-				 "attach: argument '%s' is plain vnum, use %%world.room/mob/obj(...)%% or calcuid (#3232). cmd: '%s'",
+				 "attach: 2-й аргумент '%s' -- голый vnum, используйте UID, строка отменена. Команда: '%s'",
 				 id_p, cmd);
 		trig_log(trig, buf2);
+		return;
 	}
 
 	c = get_char(id_p);
@@ -4731,12 +4728,12 @@ Trigger *process_detach(void *go, Script *sc, Trigger *trig, int type, char *cmd
 	// parse and locate the id specified
 	eval_expr(id_p, result, sizeof(result), go, sc, trig, type);
 
-	// Сырой vnum как ID (см. process_attach выше и #3232).
 	if (is_plain_vnum_string(id_p)) {
 		snprintf(buf2, sizeof(buf2),
-				 "detach: argument '%s' is plain vnum, use %%world.room/mob/obj(...)%% or calcuid (#3232). cmd: '%s'",
+				 "detach: 2-й аргумент '%s' -- голый vnum, используйте UID, строка отменена. Команда: '%s'",
 				 id_p, cmd);
 		trig_log(trig, buf2);
+		return retval;
 	}
 
 	c = get_char(id_p);
@@ -4867,12 +4864,12 @@ int process_run(void *go, Script **sc, Trigger **trig, int type, char *cmd, int 
 	// parse and locate the id specified
 	eval_expr(id_p, result, sizeof(result), go, *sc, *trig, type);
 
-	// Сырой vnum как ID (см. process_attach выше и #3232).
 	if (is_plain_vnum_string(id_p)) {
 		snprintf(buf2, sizeof(buf2),
-				 "run: argument '%s' is plain vnum, use %%world.room/mob/obj(...)%% or calcuid (#3232). cmd: '%s'",
+				 "run: 2-й аргумент '%s' -- голый vnum, используйте UID, строка отменена. Команда: '%s'",
 				 id_p, cmd);
 		trig_log(*trig, buf2);
+		return false;
 	}
 
 	c = get_char(id_p);

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -445,12 +445,37 @@ int find_room_uid(long n) {
  * generic searches based only on name
  ************************************************************/
 
+// Чисто-цифровая строка (без UID-префикса) -- это vnum, а не имя/UID.
+// В get_char/get_obj по таким строкам нечего искать через isname(), но они
+// проваливаются туда и устраивают O(N) скан по character_list / object_list.
+// Самый громкий случай -- триггер вида "detach 97137 %vnum%", где %vnum%
+// это число; см. issue #3232 (488мс на одну зону вместо 4мс).
+//
+// get_room такие строки трактует как vnum намеренно, поэтому он не
+// затронут -- продолжаем туда отдавать управление дальше по цепочке.
+static bool is_plain_vnum_string(const char *name) {
+	if (!name || !*name) {
+		return false;
+	}
+	for (const char *p = name; *p; ++p) {
+		if (*p < '0' || *p > '9') {
+			return false;
+		}
+	}
+	return true;
+}
+
 // search the entire world for a char, and return a pointer
 CharData *get_char(const char *name) {
 	CharData *i;
 
 	// Отсекаем поиск левых UID-ов.
 	if ((*name == UID_OBJ) || (*name == UID_ROOM))
+		return nullptr;
+
+	// Чистый vnum -- не char-id, не имя; искать его isname-ом по миру
+	// бессмысленно и стоит O(N). См. #3232.
+	if (is_plain_vnum_string(name))
 		return nullptr;
 
 	if (*name == UID_CHAR || *name == UID_CHAR_ALL) {
@@ -477,6 +502,10 @@ ObjData *get_obj(const char *name, int/* vnum*/) {
 	long id;
 
 	if ((*name == UID_CHAR) || (*name == UID_ROOM) || (*name == UID_CHAR_ALL))
+		return nullptr;
+
+	// Чистый vnum -- не obj-id, не алиас; isname-скан бессмыслен (#3232).
+	if (is_plain_vnum_string(name))
 		return nullptr;
 
 	if (*name == UID_OBJ) {


### PR DESCRIPTION
Закрывает [#3232](https://github.com/bylins/mud/issues/3232).

## Что чинит

`get_char` и `get_obj` (`src/engine/scripting/dg_scripts.cpp`) принимают имя цели для команд триггера (`attach`, `detach`, `run`, `exec`, `force` и т.п.). Если строка начинается с UID-маркера (`UID_CHAR`/`UID_OBJ`/`UID_ROOM`, control-байты `\x1c..\x1f`) -- идём корректно по индексам. Если же приходит **плоский номер** вроде `"97114"`, оба сваливаются в:

```cpp
// get_char
for (const auto &character : character_list) {
    if (isname(name, i->GetCharAliases()) && ...)
        return i;
}

// get_obj
return world_objects.find_by_name(name).get();   // тоже isname по всем objs
```

Полный обход мира на каждый вызов.

## Воспроизведение (issue #3232)

Триггер 97135 в `bylins/world` после переписывания на while-цикл:

```
set vnum 97114
while %vnum% <= 97168
  detach 97137 %vnum%   # %vnum% это число, а не UID
  eval vnum %vnum% + 1
done
```

55 итераций * N мобов в мире * `isname()` -> **488мс на одной зоне** против 4мс до изменения мира.

## Решение

Ранний выход в `get_char`/`get_obj`, если имя -- чистая цифровая строка. `get_room` оставляем как есть: там плоский vnum используется по назначению (`GetRoomRnum`, O(1)), и в `process_attach`/`process_detach` он зовётся последним по цепочке -- так что после нашего раннего выхода управление дойдёт до него и комната корректно найдётся.

```cpp
static bool is_plain_vnum_string(const char *name) {
    if (!name || !*name) return false;
    for (const char *p = name; *p; ++p)
        if (*p < '0' || *p > '9') return false;
    return true;
}
```

## Аудит мира (#3232)

Прогнал [бытлиновский world](https://github.com/bylins/world) HEAD: **7018** строк `attach/detach <vnum> %var%`, **2 точно сломанных места**:

* `trg/971.trg` #97135 -- тот, что породил issue.
* `trg/220.trg` #22000 -- `attach 22009 %loadroom%` и `run 22009 %loadroom%`. Автор сделал `calcuid rm %loadroom% room` рядом, но забыл подставить `%rm%` дальше.

Оба теперь не лагают независимо от того, починят ли мир. Авторы триггеров получают возможность писать `detach <trig> %numeric_var%` без скрытого штрафа.

## Совместимость

Триггеры, которые опираются на алиасы вида `"97114"` у мобов/объектов (если такие где-то существуют), перестанут находиться через `attach <trig> %vnum%`. Это анти-паттерн -- правильный путь:

```
calcuid v %vnum% mob   # или obj/room
attach <trig> %v%
```

или

```
attach <trig> %world.mob(%vnum%)%
```

Если кто-то так делал намеренно -- предупреждаем заранее.

## Test plan

- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Release && make -C build circle` -- собирается чисто.
- [ ] Прогнать `tools/run_load_tests.sh --quick`.
- [ ] На тестовом мире: `attach <trig> %vnum%` теперь возвращает null fast (можно проверить через `attach 97137 97114` god-командой и убедиться, что время отклика микросекундное).
- [ ] Проверить, что нормальные пути (`attach 97137 %self%`, `detach <trig> %world.room(...)%`, `run <trig> %actor%`) продолжают работать как раньше.