### PR TITLE
fix(depot,parcel): чистить pers_online после ObjDecayManager::process_tick (#3239)

### DIFF
--- a/src/gameplay/communication/parcel.cpp
+++ b/src/gameplay/communication/parcel.cpp
@@ -729,7 +729,14 @@ void update_timers() {
 			for (std::list<Node>::iterator it3 = it2->second.begin(); it3 != it2->second.end(); it3 = tmp_it) {
 				tmp_it = it3;
 				++tmp_it;
-				if (it3->obj_->get_timer() == 0) {
+				// После ObjDecayManager::process_tick объекты с истёкшим
+				// дедлайном удаляются из индексов decay_manager, но shared_ptr
+				// здесь продолжает их держать. ObjData::get_timer() в этом
+				// случае возвращает прото-таймер (обычно > 0), и проверка
+				// timer == 0 такие объекты пропускает -- симптоматика ровно
+				// как в #3239 для депо.
+				const bool expired_by_decay = !world_objects.decay_manager().contains(it3->obj_.get());
+				if (expired_by_decay || it3->obj_->get_timer() == 0) {
 					extract_parcel(it2->first, it->first, it3);
 					it2->second.erase(it3);
 				} else {

--- a/src/gameplay/mechanics/depot.cpp
+++ b/src/gameplay/mechanics/depot.cpp
@@ -608,7 +608,17 @@ void save_char_by_uid(int uid) {
 // * Апдейт таймеров в онлайн списках с оповещением о пурже, если чар онлайн и расчетом общей ренты.
 void CharNode::update_online_item() {
 	for (ObjListType::iterator obj_it = pers_online.begin(); obj_it != pers_online.end();) {
-		if ((*obj_it)->get_timer() == 0) {
+		ObjData *obj = obj_it->get();
+		// После ObjDecayManager::process_tick объекты с истёкшим дедлайном
+		// удаляются из индексов decay_manager, но shared_ptr из pers_online
+		// держит их живыми. ObjData::get_timer() в этом случае откатывается
+		// к CObjectPrototype::get_timer() (прото-таймер, обычно > 0), и
+		// проверка timer == 0 такие объекты пропускает. Тогда дальше в
+		// obj_point_update ExtractObjFromWorld(j) удалит их из world_objects,
+		// а pers_online продолжит держать ссылку -- следующий get из сундука
+		// падает в SYSERR в PlaceObjToInventory (issue #3239).
+		const bool expired_by_decay = !world_objects.decay_manager().contains(obj);
+		if (expired_by_decay || obj->get_timer() == 0) {
 			if (ch) {
 				// если чар в лд или еще чего - лучше записать и выдать это ему при след
 				// входе в игру, чтобы уж точно увидел


### PR DESCRIPTION
Закрывает [#3239](https://github.com/bylins/mud/issues/3239).

## Что чинит

`SYSERR: Object at address 0x... is not in the world but we have attempt to put it into character` при попытке `get` из персонального сундука/почты.

## Корень

После #3065 (`dcb04e34f`, 2026-04-05) `read_one_object_new` ставит `kTicktimer` и вставляет загруженные объекты в общий `decay_manager`. Это корректно для депо/почты: kTicktimer на save не сохраняется (особенно у магических компонент в коротком формате), а раз вещи там были в руках игрока, таймер должен продолжать тикать -- именно поэтому он принудительно стартует в `read_one_object_new`.

Когда дедлайн истекает:

1. `ObjDecayManager::process_tick`:
   * удаляет объект из `m_obj_to_deadline`/`m_queue` (теперь `contains() == false`);
   * возвращает в `tick_result.decay_timer`.

2. `obj_point_update` идёт по `tick_result.decay_timer` и для объектов *не* в комнате/инвентаре/контейнере/одежде -- проваливается до строки 1512 и вызывает `ExtractObjFromWorld(j)` -> `world_objects.remove(obj)`.

3. Депо- и почтовые объекты сюда попадают: они хранятся как `shared_ptr` *вне* `world`-структур (`pers_online`, `parcel_list[][].obj_`). `world_objects` теряет связь, но shared_ptr из хранилища продолжает их держать.

4. `Depot::CharNode::update_online_item` и `Parcel::update_timers` параллельно пытаются их почистить:

   ```cpp
   if ((*obj_it)->get_timer() == 0) { erase; }
   ```

   но `ObjData::get_timer()` при отсутствии объекта в `decay_manager` откатывается к `CObjectPrototype::get_timer()` (прото-таймер, обычно > 0). Просроченные объекты пропускаются.

5. Игрок делает `get <obj> chest` -> `PlaceObjToInventory` видит, что `world_objects.get_by_raw_ptr(obj) == nullptr` -> SYSERR.

## Решение

Симметрично в `Depot::CharNode::update_online_item` и `Parcel::update_timers`: помимо `timer == 0` проверяем `!world_objects.decay_manager().contains(obj)`. Объекты, выбывшие из `decay_manager` после истечения дедлайна, считаются просроченными -- удаляются из `pers_online`/`parcel_list`, после чего штатный `ExtractObjFromWorld` в `obj_point_update` корректно убирает их из `world_objects`.

Клан-сундуки этим не страдают: их объекты сидят `in_obj` (в самом сундуке), и `obj_point_update` правильно их `RemoveObjFromObj` -> `ExtractObjFromWorld`. Биржу/обмен также не трогаю -- если там тот же паттерн, придёт следующим PR (нужна проверка).

## История регрессии

* 2026-04-05 #3065 ввёл `decay_manager` -- баг рождается.
* 2026-04-11 первый зафиксированный SYSERR в логах.
* 2026-04-18 #3178 добавил "frozen if !kTicktimer" -- временно скрыл (`read_one_object_new` тогда kTicktimer не ставил, объекты в депо были заморожены).
* 2026-04-21 последний SYSERR (residual).
* 2026-04-24 `afeda413d` ("Удалена лишняя проверка") вернул `set_extra_flag(kTicktimer)` в `read_one_object_new` -- регрессия снова в коде, но не выстреливает в коротких сессиях, поскольку депо-таймеры обычно длинные.

## Test plan

- [x] `cmake -B build -DCMAKE_BUILD_TYPE=Release && make -C build circle` -- собирается.
- [ ] Прогон `tools/run_load_tests.sh --quick`.
- [ ] Локально: подкинуть в депо предмет с коротким таймером (через `oedit` поставить timer=2 и положить через `сложить` в персональный сундук), подождать пока истечёт, попробовать `get`. Должна быть надпись "рассыпался в прах" вместо SYSERR.
- [ ] То же самое для почты: послать на себя сразу с истёкшим таймером (или подождать KEEP_TIMER), убедиться что extract проходит чисто.