### PR TITLE
fix(vnum): команда vnum f находит флаги с точкой/пробелом в имени (#3235)

### DIFF
--- a/src/engine/ui/cmd_god/do_tabulate.cpp
+++ b/src/engine/ui/cmd_god/do_tabulate.cpp
@@ -115,7 +115,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			plane_offset = 0;
 			continue;
 		}
-		if (utils::IsAbbr(searchname, extra_bits[counter])) {
+		if (utils::IsEqual(searchname, utils::FixDot(extra_bits[counter]))) {
 			f = true;
 			break;
 		}
@@ -135,7 +135,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 // --------------------- apply_types
 	f = false;
 	for (counter = 0; *apply_types[counter] != '\n'; counter++) {
-		if (utils::IsAbbr(searchname, apply_types[counter])) {
+		if (utils::IsEqual(searchname, utils::FixDot(apply_types[counter]))) {
 			f = true;
 			break;
 		}
@@ -162,7 +162,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			plane_offset = 0;
 			continue;
 		}
-		if (utils::IsAbbr(searchname, weapon_affects[counter])) {
+		if (utils::IsEqual(searchname, utils::FixDot(weapon_affects[counter]))) {
 			f = true;
 			break;
 		}
@@ -187,7 +187,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			plane_offset = 0;
 			continue;
 		}
-		if (utils::IsAbbr(searchname, anti_bits[counter])) {
+		if (utils::IsEqual(searchname, utils::FixDot(anti_bits[counter]))) {
 			f = true;
 			break;
 		}
@@ -212,7 +212,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			plane_offset = 0;
 			continue;
 		}
-		if (utils::IsAbbr(searchname, no_bits[counter])) {
+		if (utils::IsEqual(searchname, utils::FixDot(no_bits[counter]))) {
 			f = true;
 			break;
 		}


### PR DESCRIPTION
Закрывает [#3235](https://github.com/bylins/mud/issues/3235).

## Что было

```
> vnum f кам.рук
Нет объектов с таким флагом.

> vnum f кам рук
Нет объектов с таким флагом.

> vnum f кам
  1. [   1081]                          шкатулка Пандоры : каменная.рука
  ...
```

## Корень

В `TabulateObjsByFlagName` (`do_tabulate.cpp`) для всех типов флагов используется `utils::IsAbbr` — простой посимвольный prefix-чек. Для составных имён вроде `каменная.рука` он ломается:

```
IsAbbr("кам.рук", "каменная.рука")
→ к=к, а=а, м=м, "."=е → false

IsAbbr("кам рук", "каменная.рука")
→ к=к, а=а, м=м, " "=е → false
```

## Фикс

В проекте уже есть `utils::IsEqual`, который Split-ит abbrev по пробелам (после `FixDot` переводит `.` и `_` в пробелы) и сравнивает каждое слово как abbr через `IsAbbr`. Чтобы и flag-name тоже разбился на слова, `FixDot` применяется на обеих сторонах:

```cpp
IsEqual("кам.рук", FixDot("каменная.рука"))
= IsEqual("кам.рук", "каменная рука")
abbr_list  = ["кам", "рук"]
words_list = ["каменная", "рука"]
IsAbbr("кам", "каменная") → true
IsAbbr("рук", "рука")     → true
→ true
```

Аналогично для `extra_bits`, `apply_types`, `weapon_affects`, `anti_bits`, `no_bits`. Старый кейс `vnum f кам` остаётся рабочим: `abbr_list = ["кам"]`, матчит первое слово `words_list`. Поведение для односложных флагов (`!рента`, `светится`) не меняется.

## Test plan

- [x] `make -C build circle` — собирается чисто.
- [ ] `vnum f кам.рук` → находит "каменная.рука".
- [ ] `vnum f кам рук` → то же самое.
- [ ] `vnum f кам` → как раньше, находит всё с "кам..." в первом слове.
- [ ] `vnum f сопр.магии.тьмы` / `vnum f сопр магии тьмы` / `vnum f сопр` → должны находить "сопротивление.магии.тьмы".
- [ ] `vnum f благ` → как раньше, находит "благословлен" (single-word).
- [ ] `vnum f !рент` → как раньше, находит "!рента".