### PR TITLE
fix(yaml-world): item affect_flags читать/писать по таблице EWeaponAffect

### DIFF
--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -2179,20 +2179,40 @@ CObjectPrototype* YamlWorldDataSource::ParseObjectFile(const std::string &file_p
 
 			if (root["affect_flags"] && root["affect_flags"].IsSequence())
 			{
+				// affect_flags на предмете -- бит EWeaponAffect (хранится в
+				// m_waffect_flags), не EAffect. Раньше lookup шёл через dm
+				// "affect_flags" (EAffect-нумерация), и kDetectPoison из
+				// YAML попадал в бит 32, который в EWeaponAffect равен
+				// kDisguising -- носитель получал маскировку вместо
+				// определения яда. ITEM_BY_NAME<EWeaponAffect>(name) даёт
+				// корректный EWeaponAffect-бит без посредника.
+				//
+				// Старые YAML, конвертированные ранее через AFFECT_FLAGS-
+				// таблицу, могут содержать имена, которых нет в
+				// EWeaponAffect (kDetectInvisible вместо kDetectInvisibility).
+				// ITEM_BY_NAME .at() бросает out_of_range -- ловим, пишем
+				// syslog, продолжаем. Лучше потерять один сомнительный
+				// флаг, чем уронить boot всего мира.
 				for (const auto &flag_node : root["affect_flags"])
 				{
 					std::string flag_name = flag_node.as<std::string>();
-					long flag_val = dm.Lookup("affect_flags", flag_name, -1);
-					if (flag_val >= 0)
-					{
-						obj_ptr->SetEWeaponAffectFlag(static_cast<EWeaponAffect>(IndexToBitvector(flag_val)));
-					}
-					else if (flag_name.rfind("UNUSED_", 0) == 0)
+					if (flag_name.rfind("UNUSED_", 0) == 0)
 					{
 						int bit = std::stoi(flag_name.substr(7));
 						size_t plane = bit / 30;
 						int bit_in_plane = bit % 30;
 						obj_ptr->toggle_affect_flag(plane, 1 << bit_in_plane);
+						continue;
+					}
+					try
+					{
+						const auto wa = ITEM_BY_NAME<EWeaponAffect>(flag_name);
+						obj_ptr->SetEWeaponAffectFlag(wa);
+					}
+					catch (const std::out_of_range &)
+					{
+						log("SYSERR: unknown EWeaponAffect '%s' on obj vnum %d, skipped",
+							flag_name.c_str(), obj_ptr->get_vnum());
 					}
 				}
 			}
@@ -4051,8 +4071,38 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 			yaml.DecreaseIndent();
 		}
 
-		// Affect flags
-		auto affect_flags = ConvertFlagsToNames(obj->get_affect_flags(), "affect_flags");
+		// Affect flags. m_waffect_flags хранит биты EWeaponAffect, имена
+		// берём из EWeaponAffect-таблицы (не EAffect), иначе round-trip
+		// конвертера сломает item-affects: загружено как kDetectPoison,
+		// сохранено как kHorse (бит 27 в EAffect-словаре). Идём по битам
+		// сами и берём имена через NAME_BY_ITEM<EWeaponAffect>.
+		std::vector<std::string> affect_flags;
+		{
+			const auto &fld = obj->get_affect_flags();
+			for (size_t plane = 0; plane < FlagData::kPlanesNumber; ++plane)
+			{
+				Bitvector plane_bits = fld.get_plane(plane);
+				if (plane_bits == 0) continue;
+				for (int bit = 0; bit < 30; ++bit)
+				{
+					if (!(plane_bits & (1u << bit))) continue;
+					const Bitvector v = (plane == 0) ? (1u << bit) :
+						((plane == 1) ? (kIntOne | (1u << bit)) :
+						(plane == 2) ? (kIntTwo | (1u << bit)) :
+						(kIntThree | (1u << bit)));
+					try
+					{
+						const auto &name = NAME_BY_ITEM<EWeaponAffect>(static_cast<EWeaponAffect>(v));
+						if (!name.empty()) affect_flags.push_back(name);
+					}
+					catch (const std::out_of_range &)
+					{
+						const int idx = static_cast<int>(plane) * 30 + bit;
+						affect_flags.push_back("UNUSED_" + std::to_string(idx));
+					}
+				}
+			}
+		}
 		if (!affect_flags.empty())
 		{
 			yaml.Key("affect_flags");

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -2592,10 +2592,15 @@ def parse_obj_file(filepath):
                 idx += 1
 
             # Line 3: affect_flags, anti_flags, no_flags
+            # Для предметов affect_flags -- бит EWeaponAffect (хранится в
+            # m_waffect_flags), а не EAffect. Раньше парсили через
+            # AFFECT_FLAGS -- получали неправильные имена ('kDetectInvisible'
+            # вместо 'kDetectInvisibility'), и носитель шмота получал
+            # совсем не тот эффект.
             if idx < len(lines):
                 parts = lines[idx].split()
                 if len(parts) >= 1:
-                    obj['affect_flags'] = parse_ascii_flags(parts[0], AFFECT_FLAGS) if len(parts) >= 1 else []
+                    obj['affect_flags'] = parse_ascii_flags(parts[0], WEAPON_AFFECT_FLAGS) if len(parts) >= 1 else []
                 if len(parts) >= 2:
                     obj['anti_flags'] = parse_ascii_flags(parts[1], ANTI_FLAGS) if len(parts) >= 2 else []
                 if len(parts) >= 2:


### PR DESCRIPTION
## Что чинится

Закрывает #3242.

YAML-файлы предметов хранят `affect_flags` именами из EAffect-таблицы
(легаси), но поле `m_waffect_flags` на `CObjectPrototype` использует
EWeaponAffect-нумерацию. Имена и биты не совпадают, в результате
носитель шмота получает не тот эффект, который подразумевается в
YAML (например, vnum 106 с YAML `[kDetectPoison]` даёт «маскировку»).

Подробное описание + воспроизведение — в #3242.

## Чем правлю

Три согласованные правки на одной волне:

* `tools/converter/convert_to_yaml.py:2596` — парсер легаси `.obj`
  использует `WEAPON_AFFECT_FLAGS` для предметов (таблица определена
  строкой 655, просто не вызывалась). YAML на диске начинает
  содержать честные EWeaponAffect-имена.
* `src/engine/db/yaml_world_data_source.cpp` (loader) — резолвит имя
  через `ITEM_BY_NAME<EWeaponAffect>(name)`, без посредника. Имена,
  которых нет в EWeaponAffect (эхо старого конвертера —
  `kDetectInvisible` вместо `kDetectInvisibility` и т. п.), ловятся
  try/catch с syslog: пропускаем, чтобы не уронить boot. После
  регенерации мира этих имён в YAML не останется.
* Тот же файл (exporter) — идёт по битам `m_waffect_flags` сам и
  берёт имена через `NAME_BY_ITEM<EWeaponAffect>`. Раньше использовал
  `ConvertFlagsToNames(..., 'affect_flags')` — теряло бы данные на
  round-trip (бит 27 = kDetectPoison в EWeaponAffect → 'kHorse' из
  EAffect-словаря).

## После мерджа

Чтобы старые YAML-имена не выдавали предупреждения в syslog и чтобы
поведение в проде совпадало с тем, что записано в YAML, нужно
перегенерировать YAML-мир свежим конвертером:

```bash
python3 tools/converter/convert_to_yaml.py -i lib.template -o lib --yaml-lib pyyaml
```

или, если ставится на хост из `world.tgz`:

```bash
python3 tools/converter/convert_to_yaml.py -i ~/worlds/world.YYYYMMDD -o lib
```

## Тестирование

* Локально: `mud-sim` с YAML-миром грузится без новых SYSERR-сообщений
  для свежего YAML после регенерации; для старого YAML — корректно
  пропускает неизвестные имена с одним syslog-warning на бит.
* Симулятор `--config scenario.yaml` с `inventory: [106]` после
  регенерации показывает `flags_list = 'маскировка|...'` — ровно как
  в production-движке (новое: имя в YAML теперь честное
  `kDisguising`, а не вводящее в заблуждение `kDetectPoison`).

## Сцена

Найдено при работе над автономным симулятором баланса (#2967), но
фикс самодостаточный.