### PR TITLE
fix(map): крайние правые клетки не отрисовывались в большом режиме богов

### DIFF
--- a/src/engine/ui/mapsystem.cpp
+++ b/src/engine/ui/mapsystem.cpp
@@ -642,9 +642,14 @@ void print_map(CharData *ch, CharData *imm) {
 					break;
 				}
 			}
-			for (unsigned k = left_margin; k < MAX_LENGTH; ++k) {
-				if (screen[i][k] != -1 && k > right_margin) {
-					right_margin = k;
+			// Сканируем справа -- ищем именно самую правую непустую клетку
+			// строки, а не первую после текущего right_margin (иначе клетки
+			// дальше теряются).
+			for (unsigned k = MAX_LENGTH; k-- > 0; ) {
+				if (screen[i][k] != -1) {
+					if (k > right_margin) {
+						right_margin = k;
+					}
 					break;
 				}
 			}


### PR DESCRIPTION
## Проблема

В `MAP_MODE_GOD_BIG` (большая карта для богов) крайние правые клетки не выводились.

## Корень

В `mapsystem.cpp::print_map` для расчёта `right_margin` (правой границы рисования) был такой цикл:

```cpp
for (unsigned k = left_margin; k < MAX_LENGTH; ++k) {
    if (screen[i][k] != -1 && k > right_margin) {
        right_margin = k;
        break;     // ← останавливаемся на первой непустой справа от
                   //   текущего right_margin, а не на самой правой
    }
}
```

При клетках в позициях 5 и 10 на одной строке и текущем `right_margin=0`:
- `k=5`: `screen[i][5] != -1 && 5 > 0` → `right_margin = 5`, **break**.
- Клетка в позиции 10 теряется. Дальше при отрисовке всё что `> 5` не выводится.

Левая граница искалась корректно (скан слева, break на первой непустой — это и есть leftmost), а правая — зеркально, должна сканить справа налево.

## Фикс

```cpp
for (unsigned k = MAX_LENGTH; k-- > 0; ) {
    if (screen[i][k] != -1) {
        if (k > right_margin) {
            right_margin = k;
        }
        break;
    }
}
```

Сканируем справа налево, break на первой непустой — это самая правая клетка строки. Если она дальше уже накопленного `right_margin` — расширяем.

## Test plan

- [x] `make -C build circle` — собирается чисто.
- [ ] Бог с включенным режимом большой карты заходит в локацию с клетками у правого края — крайние клетки видны.
- [ ] Обычный игрок (не immortal) — карта рисуется как раньше (этот if вообще не входит).