### PR TITLE
ci(coverage): switch coverage-html artifact to ReportGenerator

### DIFF
--- a/.github/workflows/_linux.yml
+++ b/.github/workflows/_linux.yml
@@ -131,7 +131,7 @@ jobs:
   coverage:
     name: GCC / Coverage
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/world-load-refactoring' || github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
+    if: github.ref == 'refs/heads/world-load-refactoring' || github.ref == 'refs/heads/master' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/_linux.yml
+++ b/.github/workflows/_linux.yml
@@ -171,9 +171,20 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Generate ReportGenerator HTML
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.5.9
+        with:
+          reports: build/meson-logs/coverage.xml
+          targetdir: build/meson-logs/coverage-html
+          reporttypes: 'Html;HtmlSummary;Badges'
+          sourcedirs: ${{ github.workspace }}
+          title: 'bylins-mud coverage'
+          tag: '${{ github.run_number }}_${{ github.run_id }}'
+          toolpath: 'reportgeneratortool'
+
       - name: Upload HTML report as artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
-          path: build/meson-logs/coveragereport/
+          path: build/meson-logs/coverage-html/
           retention-days: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master, world-load-refactoring ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Что
Два связанных мелких изменения в CI (по одному коммиту на каждый):

1. **`ci(coverage): switch coverage-html artifact to ReportGenerator`** — заменить дефолтный gcovr-HTML отчёт на отчёт [ReportGenerator](https://github.com/danielpalme/ReportGenerator) в job `linux / GCC / Coverage`.
2. **`ci: add workflow_dispatch trigger to Build workflow`** — добавить ручной триггер «Run workflow» в Build, чтобы maintainers могли проверять CI на любой ветке без необходимости открывать PR в master.

## Зачем

### ReportGenerator
Текущий `coverage-html` артефакт (генерится `ninja -C build coverage` ⇒ gcovr `--html-details`) — это плоский список из 559 файлов в одном уровне с именами `index.<filename>.cpp.<hash>.html`. Корневой `index.html` буквально теряется в этом списке. Сортировки колонок нет, поиска нет, file-tree нет. Стилистика середины 2000-х.

ReportGenerator (Apache-2.0, активно поддерживается) ест ту самую cobertura `coverage.xml`, что meson уже генерит в `build/meson-logs/coverage.xml` (мы её и так скармливаем Codecov), и строит SPA-отчёт:
- сортируемые колонки во всех таблицах
- глобальный поиск по файлам/функциям
- file-tree-навигация слева
- treemap по покрытию
- light/dark тема
- badges/summary

Cobertura-input не трогаем — Codecov-step остаётся прежним. Меняется только содержимое `coverage-html` артефакта.

### workflow_dispatch
До этого коммита `Build` workflow триггерился **только** на `push` в `master`/`world-load-refactoring` или на `pull_request: branches: [master]`. PR в любую другую ветку (например, в `meson_compatibility` — что и понадобилось ровно для этого PR) запускал только `quick-check`, без полноценной матрицы и без coverage. Чтобы maintainerу не приходилось открывать throwaway-PR в master ради CI, добавлена кнопка `Run workflow` в UI Actions. Заодно условие coverage-job расширено на `workflow_dispatch`, иначе ручные запуски всё равно бы coverage пропускали.

## Test plan
Сразу после пуша воспользовался новым `workflow_dispatch` чтобы запустить полный `Build` на этой ветке:

```bash
gh workflow run build.yml --repo bylins/mud --ref chore/meson-coverage-reportgenerator
```

→ Run [#25285748923](https://github.com/bylins/mud/actions/runs/25285748923).

- [ ] Дождаться зелёных Linux/Windows/macOS-jobs (логика самой сборки не менялась).
- [ ] Убедиться, что job `linux / GCC / Coverage` отработал, скачать артефакт `coverage-html`, открыть `index.html` в браузере: главная страница с summary, кликабельный file-tree слева, поле поиска работает, в таблицах сортировка по колонкам.

## Заметки
- Версия экшена пиннована на текущий стабильный релиз `5.5.9` (опубликован 2026-05-02).
- `ninja -C build coverage` всё ещё генерит и gcovr-HTML тоже — он уходит в `build/meson-logs/coveragereport/` и просто не выкладывается. Если хочется сэкономить ~10 секунд, можно заменить шаг `ninja -C build coverage` на `ninja -C build coverage-text coverage-xml` — оставил на отдельный PR, чтобы не размазывать изменения.
- `sourcedirs: ${{ github.workspace }}` нужен, чтобы ReportGenerator корректно резолвил пути к исходникам и встраивал per-line annotations. KOI8-R-исходники корректно отображаются (action их трогает только как метаданные путей).
