### PR TITLE
fix(merc): сбрасывать isFavorite=1 при повторном найме (#3263)

### DIFF
--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -2198,6 +2198,13 @@ void Player::updateCharmee(int vnum, int gold) {
 		++it->second.CharmedCount;
 		it->second.spentGold += gold;
 		it->second.currRemortAvail = 1;
+		// Сброс isFavorite в 1 при повторном найме: после
+		// "наемник фаворит N" запись попадает в опалу
+		// (isFavorite=0) и пропадает из краткого списка.
+		// Повторный найм -- явный сигнал, что игрок снова с
+		// мобом работает, иначе моб теряется в кратком
+		// списке навсегда (#3263).
+		it->second.isFavorite = 1;
 	}
 }
 


### PR DESCRIPTION
Closes #3263.

## Корень

`Player::updateCharmee` при повторном найме (запись уже есть в `charmeeHistory`) обновлял `CharmedCount`, `spentGold`, `currRemortAvail`, но **не** трогал `isFavorite`. Если игрок раньше делал `наемник фаворит N` и моб попадал в опалу (`isFavorite=0`), запись исчезала из краткого списка (`наемник список`) навсегда -- даже после повторного найма. Полный список (`наемник список полный`) её показывает, но многие об этом не знают.

## Фикс

В ветке "запись уже есть" сбрасываю `isFavorite = 1`. Поведение для нового entry не меняется -- инициализация `MERCDATA md = {1, gold, 0, 1, 1}` и так ставит `isFavorite=1`.

Применяется ко всем местам, где вызывается `updateCharmee`:
- `do_hire.cpp:352` -- найм через `do_hire` (плата гольдой найму).
- `spells.cpp:1440` -- charm spell успешно зачаровал моба.

## Сценарий из репорта

1. Игрок нанимает `удалого наемничка`, делает `наемник фаворит N` -> опала.
2. Нанимает повторно (в т.ч. через charm spell).
3. Моб не появляется в кратком списке `наемник список` -- хотя только что был чармлен.

После фикса: после любого повторного найма моб снова в кратком списке.

## Test plan
- [ ] Локально: создать игрока с фитом kEmployer, нанять моба (без `kNoMercList`), сделать `наемник фаворит <N>`, проверить отсутствие в `наемник список`. Нанять повторно, проверить наличие.
- [ ] То же самое через charm spell.