### PR TITLE
feat(mob): авто-выставление магии жизни мобам с heal/group_heal (#3267)

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -1069,6 +1069,16 @@ void MobileFile::parse_mobile(const int nr) {
 		}
 	}
 
+	// Авто-выставление "магии жизни" мобам с заклинанием
+	// "исцеление"/"групповое исцеление" -- билдеры часто забывают
+	// прописать Skill: 189, и кастер заваливает каст из-за нулевого
+	// процента. На загрузке выставляем kLifeMagic = level * 10 для
+	// любого моба с одним из этих заклинаний в памяти (#3267).
+	if (GET_SPELL_MEM(mob_proto + i, ESpell::kHeal) > 0
+		|| GET_SPELL_MEM(mob_proto + i, ESpell::kGroupHeal) > 0) {
+		mob_proto[i].set_skill(ESkill::kLifeMagic, mob_proto[i].GetLevel() * 10);
+	}
+
 	top_of_mobt = i++;
 }
 


### PR DESCRIPTION
Closes #3267.

## Что делает

В `MobileFile::parse_mobile` после полной загрузки моба, если в `SplMem` есть `kHeal` (28) или `kGroupHeal` (48), выставляется `kLifeMagic` (189) = `mob.level * 10`.

## Почему

Билдеры часто забывают прописать `Skill: 189 X` мобам, которым раздают исцеление через `Spell:`, и кастер заваливает каст из-за нулевого процента магии жизни. Авто-выставление на загрузке -- защита от человеческого фактора.

## Override

Текст ишью: «установить умение "магия жизни" в уровень моба × 10» -- буквально override любого предыдущего значения. Если это вдруг нежелательно (напр., у босса проставлено 250 вручную, а формула даст 50×10=500 или 5×10=50 -- зависит от уровня), скажи -- сменю на `max(existing, level*10)`.

## Что НЕ покрыто

YAML (`yaml_world_data_source.cpp`) и SQLite (`sqlite_world_data_source.cpp`) загрузчики мобов используют поле `SplKnw` (известно), а не `SplMem` (в памяти). Это, кажется, отдельный баг -- такие мобы вряд ли вообще кастуют (`fight.cpp:983` проверяет `GET_SPELL_MEM`). Если прод сидит на YAML -- сообщи, добавлю аналогичный фикс там же отдельным коммитом.

## Test plan
- [x] Сборка: `meson compile -C build_meson circle:executable` -- чисто.
- [ ] Загрузить mud, у моба-кастера с `Spell: 28` через `mstat <vnum>` посмотреть `kLifeMagic` -- должно быть `level * 10`.
- [ ] Бой против такого моба -- каст исцеления проходит без `Заклинание не удалось`.