### PR TITLE
fix(filter): проверять no_flags вдобавок к anti_flags в фильтре П (#3269)

### DIFF
--- a/src/engine/ui/objects_filter.cpp
+++ b/src/engine/ui/objects_filter.cpp
@@ -68,8 +68,34 @@ EAntiFlag class_specific_anti_flag(ECharClass c) {
 	}
 }
 
-// Заблокирован ли предмет анти-флагами для указанного класса
-// (по логике invalid_anti_class, без учёта специфики персонажа).
+// ENoFlag, соответствующий конкретному классу персонажа.
+// Биты ENoFlag для классов совпадают с EAntiFlag по позиции, но это
+// разные битвекторы (anti_flags и no_flags), поэтому функции отдельные.
+ENoFlag class_specific_no_flag(ECharClass c) {
+	switch (c) {
+		case ECharClass::kSorcerer:    return ENoFlag::kSorcerer;
+		case ECharClass::kConjurer:    return ENoFlag::kConjurer;
+		case ECharClass::kThief:       return ENoFlag::kThief;
+		case ECharClass::kWarrior:     return ENoFlag::kWarrior;
+		case ECharClass::kAssasine:    return ENoFlag::kAssasine;
+		case ECharClass::kGuard:       return ENoFlag::kGuard;
+		case ECharClass::kCharmer:     return ENoFlag::kCharmer;
+		case ECharClass::kWizard:      return ENoFlag::kWizard;
+		case ECharClass::kNecromancer: return ENoFlag::kNecromancer;
+		case ECharClass::kPaladine:    return ENoFlag::kPaladine;
+		case ECharClass::kRanger:      return ENoFlag::kRanger;
+		case ECharClass::kVigilant:    return ENoFlag::kVigilant;
+		case ECharClass::kMerchant:    return ENoFlag::kMerchant;
+		case ECharClass::kMagus:       return ENoFlag::kMagus;
+		default:                       return static_cast<ENoFlag>(0);
+	}
+}
+
+// Заблокирован ли предмет для указанного класса. Проверяет и anti_flags
+// (invalid_anti_class), и no_flags (invalid_no_class): обе системы
+// независимо запрещают использование, и в display даже именованы
+// по-разному -- "Недоступен" / "Неудобен", -- но игроку оба запрещают
+// носить (#3269).
 bool obj_blocked_for_class(const ObjData *obj, ECharClass c) {
 	if (obj->has_anti_flag(EAntiFlag::kMage) && is_magic_class(c)) {
 		return true;
@@ -77,8 +103,19 @@ bool obj_blocked_for_class(const ObjData *obj, ECharClass c) {
 	if (obj->has_anti_flag(EAntiFlag::kFighter) && is_fight_class(c)) {
 		return true;
 	}
-	const auto specific = class_specific_anti_flag(c);
-	if (specific != static_cast<EAntiFlag>(0) && obj->has_anti_flag(specific)) {
+	const auto specific_anti = class_specific_anti_flag(c);
+	if (specific_anti != static_cast<EAntiFlag>(0) && obj->has_anti_flag(specific_anti)) {
+		return true;
+	}
+
+	if (obj->has_no_flag(ENoFlag::kMage) && is_magic_class(c)) {
+		return true;
+	}
+	if (obj->has_no_flag(ENoFlag::kFighter) && is_fight_class(c)) {
+		return true;
+	}
+	const auto specific_no = class_specific_no_flag(c);
+	if (specific_no != static_cast<ENoFlag>(0) && obj->has_no_flag(specific_no)) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Closes #3269.

## Корень

`obj_blocked_for_class` смотрел только `anti_flags` (как `invalid_anti_class`). Но у предметов классовый запрет может стоять во **втором** битвекторе -- `no_flags` (`invalid_no_class`).

В стате это два разных поля:
- `Недоступен:` -- это `anti_flags`
- `Неудобен:` -- это `no_flags`

У большинства предметов классовый запрет идёт именно через `no_flags`. Пример из #3269 -- vnum **97104** "титановый доспех Энея":
```
m0l1 0 e0f0g0h0i0k0l0m0n0o0p0q0r0
^     ^  ^
| affect_flags
|     | anti_flags = 0 (пусто!)
|     |  no_flags  = e0f0g0h0i0k0l0m0n0o0p0q0r0 (13 классов запрещены)
```

Поэтому `Пбогатырь` ничего не отсеивал: `anti_flags` у такого предмета пуст, `has_anti_flag(kWarrior)` возвращает false, `check_profession` пропускает. Игрок видит на бирже/в хране всё подряд, плюс без стака (`list_obj_to_char` не используется в фильтр-пути) -- больше строк чем `х все`.

## Фикс

Добавил параллельный набор проверок `no_flags` к существующим `anti_flags`:
- `kMage` группа,
- `kFighter` группа,
- `class_specific_no_flag(c)`.

Зеркало `invalid_no_class` для классовой части (без религии/пола/PK/чарм -- эти не относятся к "профессии").

## Test plan
- [ ] На проде с PR: `х Пбог` на сундуке с титановым доспехом Энея и подобными -- они должны исчезнуть из выборки.
- [ ] `х Пвитязь` -- должен показать те предметы, в которых нет `!витязи` в `Неудобен:`.
- [ ] Стак: фильтр всё ещё показывает по одной строке на предмет (отдельная проблема, не в скоупе).