### PR TITLE
fix(yaml): опечатка в имени EWeaponAffect::kProtectFromMind (#3273)

### DIFF
--- a/src/gameplay/affects/affect_contants.cpp
+++ b/src/gameplay/affects/affect_contants.cpp
@@ -242,7 +242,7 @@ void init_EWeaponAffectFlag_ITEM_NAMES() {
 	EWeaponAffectFlag_name_by_value[EWeaponAffect::kInfravision] = "kInfravision";
 	EWeaponAffectFlag_name_by_value[EWeaponAffect::kPoison] = "kPoison";
 	EWeaponAffectFlag_name_by_value[EWeaponAffect::kProtectFromDark] = "kProtectFromDark";
-	EWeaponAffectFlag_name_by_value[EWeaponAffect::kProtectFromMind] = "kProtectFromEvil";
+	EWeaponAffectFlag_name_by_value[EWeaponAffect::kProtectFromMind] = "kProtectFromMind";
 	EWeaponAffectFlag_name_by_value[EWeaponAffect::kSleep] = "kSleep";
 	EWeaponAffectFlag_name_by_value[EWeaponAffect::kNoTrack] = "kNoTrack";
 	EWeaponAffectFlag_name_by_value[EWeaponAffect::kBless] = "kBless";


### PR DESCRIPTION
## Summary
- В `src/gameplay/affects/affect_contants.cpp:245` enum `EWeaponAffect::kProtectFromMind` был промаплен на строку `"kProtectFromEvil"`. `init_EWeaponAffectFlag_ITEM_NAMES()` строит из этой таблицы обратный `value_by_name`, поэтому `ITEM_BY_NAME<EWeaponAffect>("kProtectFromMind")` кидал `std::out_of_range`.
- Ямл-загрузчик при boot ловил исключение и писал `SYSERR: unknown EWeaponAffect 'kProtectFromMind' on obj vnum N, skipped` для каждого предмета с этим флагом — флаг при загрузке терялся.
- Опечатка с #1764 (2022-09-23), на легаси не проявлялась — флаги пишутся по битам, имена не используются.

Fixes часть симптомов #3273 (SYSERR-ы по `kProtectFromMind` на vnum 201508/201510/201520/...). Фатальная остановка boot — отдельный баг (yaml-cpp анкера на цветовых кодах `&Y...` в начале значений `names`), её этот PR не трогает.

## Test plan
- [x] meson-сборка с `-Dyaml=builtin` проходит
- [ ] ямл-сервер бутается без `SYSERR: unknown EWeaponAffect 'kProtectFromMind'` (зависит от отдельного фикса фатального объекта)
- [ ] предметы 201508/201510/.../201526 на ямл-сервере имеют флаг `kProtectFromMind` после boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)