### PR TITLE
docs: тесты надо запускать из build_dir (или через meson test)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,12 +94,19 @@ build_debug/
 **NOTE**: Do NOT confuse with repository's `lib/` directory - that is completely separate and used only for production deployments.
 
 ### Running Tests
-```bash
-# Run all tests
-./build/tests/tests
+Тесты используют относительные пути к данным (`data/boards/...`, `misc/grouping`, `data/mob_classes/...`), которые meson копирует в `meson.project_build_root()`. Поэтому запускать тесты надо из самой `build_dir`, иначе `Boards_Changelog`, `FightPenalties` и `MobClassesLoaderTest` упадут с «file not found».
 
-# Run via meson
+```bash
+# Способ 1 — через meson (workdir выставляется автоматически)
 meson test -C build
+
+# Способ 2 — напрямую (cd в build, иначе пути к данным не найдутся)
+cd build && ./tests/tests
+```
+
+Фильтр по подмножеству:
+```bash
+cd build && ./tests/tests --gtest_filter="Boards_Changelog.*:FightPenalties.*"
 ```
 
 ## Code Architecture


### PR DESCRIPTION
## Summary
Тесты используют относительные пути к тестовым данным (`data/boards/changelog.sample`, `misc/grouping`, `data/mob_classes/*.xml`). Meson копирует их в `meson.project_build_root()` и для `meson test` выставляет `workdir` автоматически (`tests/meson.build:104`).

В моём предыдущем PR (#3275) я написал `./build/tests/tests` — это из корня проекта даёт CWD = корень, где `data/` и `misc/grouping` отсутствуют. Из-за этого падают:
- `Boards_Changelog.*` (3 теста)
- `FightPenalties.*` (7 тестов)
- `MobClassesLoaderTest.*` (2 теста)

Подтвердил: `cd build && ./tests/tests` и `meson test -C build` — все 12 проходят.

## Test plan
- [x] `cd build && ./tests/tests --gtest_filter="Boards_Changelog.*:FightPenalties.*:MobClassesLoaderTest.*"` → 12/12 PASS
- [x] `meson test -C build` (если запускать только эти 12 — также проходят)

🤖 Generated with [Claude Code](https://claude.com/claude-code)