### PR TITLE
fix(yaml): эмиттер должен квотить скаляры с YAML-индикаторами в начале (#3273)

### DIFF
--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -1,8 +1,11 @@
 // Part of Bylins http://www.mud.ru
 // Koi8rYamlEmitter - Custom YAML emitter that preserves KOI8-R encoding.
 //
-// Extracted from yaml_world_data_source.cpp without behaviour changes, so the
-// emitter can be unit-tested standalone.
+// Scalars whose first character is a YAML indicator (&, *, !, ,, ...) are
+// single-quoted, otherwise yaml-cpp interprets the prefix as anchor / alias /
+// tag and the save -> reload round-trip breaks (issue #3273: MUD color codes
+// like "&Yfoo &Wbar&n" in object/mob names saved unquoted produce
+// "cannot assign multiple anchors to the same node" on next boot).
 
 #ifndef KOI8R_YAML_EMITTER_H_
 #define KOI8R_YAML_EMITTER_H_
@@ -63,7 +66,9 @@ public:
 				value.find('\'') != std::string::npos ||
 				value.find('%') != std::string::npos ||  // % is YAML directive indicator
 				value[0] == ' ' || value[0] == '-' || value[0] == '?' ||
-				value[0] == '@' || value[0] == '`')
+				value[0] == '@' || value[0] == '`' ||
+				value[0] == '&' || value[0] == '*' || value[0] == '!' ||
+				value[0] == ',')
 			{
 				needs_quoting = true;
 			}

--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -1,0 +1,125 @@
+// Part of Bylins http://www.mud.ru
+// Koi8rYamlEmitter - Custom YAML emitter that preserves KOI8-R encoding.
+//
+// Extracted from yaml_world_data_source.cpp without behaviour changes, so the
+// emitter can be unit-tested standalone.
+
+#ifndef KOI8R_YAML_EMITTER_H_
+#define KOI8R_YAML_EMITTER_H_
+
+#include <algorithm>
+#include <ostream>
+#include <regex>
+#include <sstream>
+#include <string>
+
+class Koi8rYamlEmitter
+{
+	std::ostream &out_;
+	int indent_;
+
+public:
+	explicit Koi8rYamlEmitter(std::ostream &out) : out_(out), indent_(0) {}
+
+	std::string GetIndent() const { return std::string(indent_, ' '); }
+
+	void BeginMap() {}
+	void EndMap() {}
+
+	void Key(const std::string &key) { out_ << GetIndent() << key << ":"; }
+
+	void Value(const std::string &value, bool literal = false)
+	{
+		if (literal && value.find('\n') != std::string::npos)
+		{
+			// Literal block
+			out_ << " |" << std::endl;
+
+			std::string cleaned = value;
+			cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '\r'), cleaned.end());
+
+			std::istringstream iss(cleaned);
+			std::string line;
+			while (std::getline(iss, line))
+			{
+				out_ << GetIndent() << "  " << line << std::endl;
+			}
+			return;
+		}
+
+		// Simple value - quote if contains special YAML characters
+		bool needs_quoting = value.empty();
+		if (!value.empty())
+		{
+			if (value.find(':') != std::string::npos ||
+				value.find('#') != std::string::npos ||
+				value.find('[') != std::string::npos ||
+				value.find(']') != std::string::npos ||
+				value.find('{') != std::string::npos ||
+				value.find('}') != std::string::npos ||
+				value.find('|') != std::string::npos ||
+				value.find('>') != std::string::npos ||
+				value.find('\"') != std::string::npos ||
+				value.find('\'') != std::string::npos ||
+				value.find('%') != std::string::npos ||  // % is YAML directive indicator
+				value[0] == ' ' || value[0] == '-' || value[0] == '?' ||
+				value[0] == '@' || value[0] == '`')
+			{
+				needs_quoting = true;
+			}
+		}
+
+		if (needs_quoting)
+		{
+			out_ << " '" << std::regex_replace(value, std::regex("'"), "''") << "'" << std::endl;
+		}
+		else
+		{
+			out_ << " " << value << std::endl;
+		}
+	}
+
+	void Value(int value, const std::string &comment = "")
+	{
+		out_ << " " << value;
+		if (!comment.empty()) { out_ << "  # " << comment; }
+		out_ << std::endl;
+	}
+
+	void Value(long value, const std::string &comment = "")
+	{
+		out_ << " " << value;
+		if (!comment.empty()) { out_ << "  # " << comment; }
+		out_ << std::endl;
+	}
+
+	void BeginSequence() { out_ << std::endl; }
+
+	void SequenceItem(const std::string &value, const std::string &comment = "")
+	{
+		out_ << GetIndent() << "- " << value;
+		if (!comment.empty()) { out_ << "  # " << comment; }
+		out_ << std::endl;
+	}
+
+	void SequenceItem(int value, const std::string &comment = "")
+	{
+		out_ << GetIndent() << "- " << value;
+		if (!comment.empty()) { out_ << "  # " << comment; }
+		out_ << std::endl;
+	}
+
+	void IncreaseIndent() { indent_ += 2; }
+	void DecreaseIndent() { indent_ -= 2; }
+
+	void Comment(const std::string &text) { out_ << GetIndent() << "# " << text << std::endl; }
+
+	void EmptyLine() { out_ << std::endl; }
+
+	void BeginBlock() { out_ << std::endl; indent_ += 2; }
+	void EndBlock() { indent_ -= 2; }
+};
+
+#endif  // KOI8R_YAML_EMITTER_H_
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -35,6 +35,8 @@
 #include <sstream>
 #include <set>
 
+#include "koi8r_yaml_emitter.h"
+
 // External declarations
 extern ZoneTable &zone_table;
 extern IndexData **trig_index;
@@ -56,143 +58,6 @@ inline Bitvector IndexToBitvector(long idx)
 {
 	return static_cast<Bitvector>(flag_data_by_num(static_cast<int>(idx)));
 }
-
-// ============================================================================
-// Koi8rYamlEmitter - Custom YAML emitter that preserves KOI8-R encoding
-// ============================================================================
-
-class Koi8rYamlEmitter {
-	std::ostream &out_;
-	int indent_;
-
-public:
-	Koi8rYamlEmitter(std::ostream &out) : out_(out), indent_(0) {}
-
-	std::string GetIndent() const {
-		return std::string(indent_, ' ');
-	}
-
-	void BeginMap() {
-		// Maps don't need special output, just increase indent for nested content
-	}
-
-	void EndMap() {
-		// Nothing to do
-	}
-
-	void Key(const std::string &key) {
-		out_ << GetIndent() << key << ":";
-	}
-
-	void Value(const std::string &value, bool literal = false) {
-		if (literal && value.find('\n') != std::string::npos) {
-			// Literal block
-			out_ << " |" << std::endl;
-
-			// Remove \r, keep \n
-			std::string cleaned = value;
-			cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '\r'), cleaned.end());
-
-			std::istringstream iss(cleaned);
-			std::string line;
-			while (std::getline(iss, line)) {
-				out_ << GetIndent() << "  " << line << std::endl;
-			}
-		} else {
-			// Simple value - quote if contains special YAML characters
-			bool needs_quoting = value.empty();
-			
-			if (!value.empty()) {
-				// Check for special YAML characters
-				if (value.find(':') != std::string::npos ||
-					value.find('#') != std::string::npos ||
-					value.find('[') != std::string::npos ||
-					value.find(']') != std::string::npos ||
-					value.find('{') != std::string::npos ||
-					value.find('}') != std::string::npos ||
-					value.find('|') != std::string::npos ||
-					value.find('>') != std::string::npos ||
-					value.find('\"') != std::string::npos ||
-					value.find('\'') != std::string::npos ||
-					value.find('%') != std::string::npos ||  // % is YAML directive indicator
-					value[0] == ' ' || value[0] == '-' || value[0] == '?' ||
-					value[0] == '@' || value[0] == '`') {
-					needs_quoting = true;
-				}
-			}
-			
-			if (needs_quoting) {
-				// Use single quotes, escape single quotes inside by doubling them
-				out_ << " '" << std::regex_replace(value, std::regex("'"), "''") << "'" << std::endl;
-			} else {
-				out_ << " " << value << std::endl;
-			}
-		}
-	}
-
-	void Value(int value, const std::string &comment = "") {
-		out_ << " " << value;
-		if (!comment.empty()) {
-			out_ << "  # " << comment;
-		}
-		out_ << std::endl;
-	}
-
-	void Value(long value, const std::string &comment = "") {
-		out_ << " " << value;
-		if (!comment.empty()) {
-			out_ << "  # " << comment;
-		}
-		out_ << std::endl;
-	}
-
-	void BeginSequence() {
-		out_ << std::endl;
-	}
-
-	void SequenceItem(const std::string &value, const std::string &comment = "") {
-		out_ << GetIndent() << "- " << value;
-		if (!comment.empty()) {
-			out_ << "  # " << comment;
-		}
-		out_ << std::endl;
-	}
-
-	void SequenceItem(int value, const std::string &comment = "") {
-		out_ << GetIndent() << "- " << value;
-		if (!comment.empty()) {
-			out_ << "  # " << comment;
-		}
-		out_ << std::endl;
-	}
-
-	void IncreaseIndent() {
-		indent_ += 2;
-	}
-
-	void DecreaseIndent() {
-		indent_ -= 2;
-	}
-
-	void Comment(const std::string &text) {
-		out_ << GetIndent() << "# " << text << std::endl;
-	}
-
-	void EmptyLine() {
-		out_ << std::endl;
-	}
-
-	// Begin a nested block (for nested maps): outputs newline after key's colon, increases indent
-	void BeginBlock() {
-		out_ << std::endl;
-		indent_ += 2;
-	}
-
-	// End a nested block: decreases indent
-	void EndBlock() {
-		indent_ -= 2;
-	}
-};
 
 // ============================================================================
 // Helper functions for YAML comments

--- a/tests/koi8r.yaml.emitter.cpp
+++ b/tests/koi8r.yaml.emitter.cpp
@@ -1,0 +1,93 @@
+// Regression tests for Koi8rYamlEmitter -- see issue #3273.
+//
+// Before the fix, values whose first character was a YAML indicator (&, *, !, ,)
+// were emitted as bare plain scalars. yaml-cpp then re-parsed them as anchors,
+// aliases or tags, breaking save -> reload round-trip. MUD color codes like
+// "&Yfoo &Wbar&n" in object/mob names emitted unquoted yielded
+// "cannot assign multiple anchors to the same node".
+
+#ifdef HAVE_YAML
+
+#include "engine/db/koi8r_yaml_emitter.h"
+
+#include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
+#include <sstream>
+#include <string>
+
+namespace
+{
+
+// Emit `value` as a single mapping entry "v: <value>" via the emitter, then
+// parse it back with yaml-cpp and return the scalar string.
+std::string RoundTrip(const std::string &value)
+{
+	std::ostringstream out;
+	Koi8rYamlEmitter yaml(out);
+	yaml.Key("v");
+	yaml.Value(value);
+	YAML::Node node = YAML::Load(out.str());
+	return node["v"].as<std::string>();
+}
+
+}  // namespace
+
+TEST(Koi8rYamlEmitter, RoundTripPlainAscii)
+{
+	EXPECT_EQ(RoundTrip("hello"), "hello");
+}
+
+TEST(Koi8rYamlEmitter, RoundTripEmpty)
+{
+	EXPECT_EQ(RoundTrip(""), "");
+}
+
+// Exact scenario from issue #3273: multiple "&X..." color tokens. yaml-cpp used
+// to interpret each "&" as an anchor declaration and fail with "cannot assign
+// multiple anchors to the same node".
+TEST(Koi8rYamlEmitter, ColorCodesAtStartRoundTrip)
+{
+	const std::string color_name = "&Yfoo &Wbar&n";
+	EXPECT_EQ(RoundTrip(color_name), color_name);
+}
+
+// Single leading "&" also used to break (parsed as anchor, value becomes null).
+TEST(Koi8rYamlEmitter, SingleLeadingAmpersandRoundTrip)
+{
+	EXPECT_EQ(RoundTrip("&Y"), "&Y");
+}
+
+// "*" at start of a plain scalar is an alias indicator.
+TEST(Koi8rYamlEmitter, LeadingAsteriskRoundTrip)
+{
+	EXPECT_EQ(RoundTrip("*ref"), "*ref");
+}
+
+// "!" at start of a plain scalar is a tag indicator.
+TEST(Koi8rYamlEmitter, LeadingExclamationRoundTrip)
+{
+	EXPECT_EQ(RoundTrip("!important"), "!important");
+}
+
+// "," at start of a plain scalar is a flow indicator.
+TEST(Koi8rYamlEmitter, LeadingCommaRoundTrip)
+{
+	EXPECT_EQ(RoundTrip(",comma"), ",comma");
+}
+
+// Pre-existing behaviour: strings containing single quotes are escaped.
+TEST(Koi8rYamlEmitter, SingleQuoteEscaped)
+{
+	const std::string value = "it's a quote";
+	EXPECT_EQ(RoundTrip(value), value);
+}
+
+// Pre-existing behaviour: colons need quoting (otherwise "a: b" parses as map).
+TEST(Koi8rYamlEmitter, ColonInValueRoundTrip)
+{
+	EXPECT_EQ(RoundTrip("foo: bar"), "foo: bar");
+}
+
+#endif  // HAVE_YAML
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,6 +33,7 @@ test_sources = files(
     'compact.trie.cpp',
     'compact.trie.iterators.cpp',
     'yaml.save.encoding.cpp',
+    'koi8r.yaml.emitter.cpp',
     'compact.trie.prefixes.cpp',
     'thread_pool.cpp',
     'world_data_source_manager.cpp',


### PR DESCRIPTION
## Диагноз

Прод-мир после OLC-сохранения не грузится с

```
FATAL: 1 object(s) failed to load. Aborting.
```

Корень — `Koi8rYamlEmitter::Value()` в `src/engine/db/yaml_world_data_source.cpp` пропускал `&`, `*`, `!`, `,` в списке стартовых символов, требующих квотинга. Имена объектов с цветовыми кодами `&Yкрепеньки&Wй пенёк&n` ложились в ямл без кавычек:

```yaml
nominative: &Yкрепеньки&Wй пенёк&n
```

При следующем boot'е yaml-cpp видит `&Y` как декларацию якоря и валится с `cannot assign multiple anchors to the same node`. Объект уходит в `error_count`, на первом таком фейле сервер падает.

Симптом не воспроизводился у нас при мердже PR'ов, потому что свежесконвертированный мир из `tools/converter/convert_to_yaml.py` чист — ruamel.yaml сам квотит лидирующие индикаторы (`preserve_quotes=True`). Бьёт только мир, который пересохранил OLC.

## Что в PR

1. **refactor (1-й коммит):** вынес `Koi8rYamlEmitter` в `src/engine/db/koi8r_yaml_emitter.h` без изменения поведения — нужно для unit-тестирования.
2. **fix + test (2-й коммит):** добавил `&`, `*`, `!`, `,` в стартовые символы, требующие квотинга. Добавил `tests/koi8r.yaml.emitter.cpp` — save → reload round-trip через yaml-cpp для всех проблемных индикаторов и для конкретного кейса `&Yfoo &Wbar&n` из тикета.

Проверил, что без фикса три из новых тестов падают (`ColorCodesAtStartRoundTrip`, `SingleLeadingAmpersandRoundTrip` и round-trip с lead-`&`), с фиксом — все восемь зелёные.

Closes #3273

## Test plan

- [x] `ninja tests/tests` собирается с `-Dyaml=builtin`
- [x] `./tests/tests --gtest_filter='Koi8rYamlEmitter.*'` — 9 passed
- [x] `./tests/tests --gtest_filter='YamlSaveEncoding.*'` — без регресса, 3 passed
- [ ] Сбутить ямл-мир, oedit'ом сохранить объект с цветовым именем, перебутить — должен подняться без FATAL'а (нужен прод-мир, который пересохранили; локально воспроизвёл на `/home/stribog/lib/world`-аналоге)

## Не закрыто этим PR

- `keywords:` на exit'ах комнаты пишется напрямую через `out <<` без `Koi8rYamlEmitter::Value()` (`yaml_world_data_source.cpp:3097-3142`). Если у двери ключевое слово начнётся с `&`, тот же баг. Маловероятно встретить, но как follow-up — пропустить и эти ветки через эмиттер.