### PR TITLE
fix(world): дропать полностью пустые D-блоки при загрузке (#3272)

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -540,6 +540,13 @@ void WorldFile::setup_dir(int room, unsigned dir) {
 
 	world[room]->dir_option_proto[dir]->key = t[1];
 	world[room]->dir_option_proto[dir]->to_room(t[2]);
+
+	// Полностью пустые D-блоки - мусор из старых редакторов, на рантайм не
+	// влияют и без причины засоряют show errors. Дропаем их сразу при загрузке
+	// (симметрично в YAML- и SQLite-загрузчиках), см. issue #3272.
+	if (world[room]->dir_option_proto[dir]->is_empty()) {
+		world[room]->dir_option_proto[dir].reset();
+	}
 }
 
 bool WorldFile::load() {

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -1182,6 +1182,10 @@ void SqliteWorldDataSource::LoadRoomExits(const std::map<int, int> &vnum_to_rnum
 		// Set exit flags (stored as string in database, parse as integer)
 		exit_data->exit_info = exit_flags;
 
+		// Дропаем полностью пустые D-блоки (симметрично с legacy/yaml),
+		// см. issue #3272.
+		if (exit_data->is_empty()) continue;
+
 		room->dir_option_proto[dir] = exit_data;
 		exits_loaded++;
 	}

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1507,6 +1507,10 @@ void YamlWorldDataSource::LoadRoomExits(RoomData *room, const YAML::Node &exits_
 
 		exit_data->exit_info = GetInt(exit_node, "exit_flags", 0);
 
+		// Дропаем полностью пустые D-блоки (симметрично с legacy/sqlite),
+		// см. issue #3272.
+		if (exit_data->is_empty()) continue;
+
 		room->dir_option_proto[dir] = exit_data;
 	}
 }

--- a/src/engine/entities/room_data.cpp
+++ b/src/engine/entities/room_data.cpp
@@ -65,6 +65,16 @@ void ExitData::to_room(const RoomRnum _) {
 	to_room_ = _;
 }
 
+bool ExitData::is_empty() const {
+	return to_room_ == kNowhere
+		&& general_description.empty()
+		&& keyword == nullptr
+		&& vkeyword == nullptr
+		&& exit_info == 0
+		&& key <= 0
+		&& lock_complexity == 0;
+}
+
 RoomData::RoomData() : vnum(0),
 					   zone_rn(0),
 					   sector_type(0),

--- a/src/engine/entities/room_data.h
+++ b/src/engine/entities/room_data.h
@@ -25,6 +25,11 @@ class ExitData {
 	RoomRnum to_room() const;
 	void to_room(const RoomRnum _);
 
+	// Полностью пустой D-блок из .wld/yaml/sqlite (мусор из старых редакторов).
+	// На рантайм не влияет и фильтруется загрузчиком, чтобы не засорять
+	// отчёт show errors и зря не держать ExitData в памяти.
+	bool is_empty() const;
+
 	std::string general_description;    // When look DIR.         //
 
 	char *keyword;        // for open/close       //

--- a/tests/exit_is_empty.cpp
+++ b/tests/exit_is_empty.cpp
@@ -1,0 +1,69 @@
+// Part of Bylins http://www.mud.ru
+// Regression tests for ExitData::is_empty (issue #3272).
+//
+// Background: пустые D-блоки в .wld/yaml/sqlite (всё нулевое: to_room=0,
+// нет keyword/vkeyword/description, exit_info=0, key<=0, lock_complexity=0)
+// раньше доходили до рантайма и палились в `show errors`. Все три загрузчика
+// теперь дропают такие блоки на этапе загрузки; эта функция фиксирует, что
+// считать "полностью пустым", чтобы фильтр случайно не съел осмысленный выход.
+
+#include "engine/entities/room_data.h"
+#include "engine/structs/structs.h"
+
+#include <gtest/gtest.h>
+
+TEST(ExitDataIsEmpty, DefaultConstructedIsEmpty) {
+	ExitData e;
+	EXPECT_TRUE(e.is_empty());
+}
+
+TEST(ExitDataIsEmpty, ToRoomSetMakesNonEmpty) {
+	ExitData e;
+	e.to_room(42);
+	EXPECT_FALSE(e.is_empty());
+}
+
+TEST(ExitDataIsEmpty, ExitInfoFlagMakesNonEmpty) {
+	// Случай вроде [15000] D0: 8 0 0 0 -- декоративная скрытая дверь без to_room.
+	// Фильтр не должен её схлопывать.
+	ExitData e;
+	e.exit_info = 8;
+	EXPECT_FALSE(e.is_empty());
+}
+
+TEST(ExitDataIsEmpty, DescriptionMakesNonEmpty) {
+	ExitData e;
+	e.general_description = "look-only door description";
+	EXPECT_FALSE(e.is_empty());
+}
+
+TEST(ExitDataIsEmpty, KeywordMakesNonEmpty) {
+	ExitData e;
+	e.set_keyword("дверь");
+	EXPECT_FALSE(e.is_empty());
+}
+
+TEST(ExitDataIsEmpty, VkeywordMakesNonEmpty) {
+	ExitData e;
+	e.set_vkeyword("дверь");
+	EXPECT_FALSE(e.is_empty());
+}
+
+TEST(ExitDataIsEmpty, KeyMakesNonEmpty) {
+	ExitData e;
+	e.key = 1234;
+	EXPECT_FALSE(e.is_empty());
+}
+
+TEST(ExitDataIsEmpty, NegativeKeyIsStillEmpty) {
+	// key = -1 это "нет ключа", такой блок считается мусором.
+	ExitData e;
+	e.key = -1;
+	EXPECT_TRUE(e.is_empty());
+}
+
+TEST(ExitDataIsEmpty, LockComplexityMakesNonEmpty) {
+	ExitData e;
+	e.lock_complexity = 5;
+	EXPECT_FALSE(e.is_empty());
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -47,7 +47,8 @@ test_sources = files(
     'mob_classes.loader.cpp',
     'world_load_order.cpp',
     'obj_decay_manager.cpp',
-    'char.utilities.cpp'
+    'char.utilities.cpp',
+    'exit_is_empty.cpp'
 )
 
 fs = import('fs')


### PR DESCRIPTION
Closes #3272

## Что было

`show errors` в legacy-сборке показывал ~120 «пустых выходов» (легаси
prod-мир) и около 117 в ямл. Расхождение объясняется тем, что в исходных
`.wld` лежат полностью нулевые `D`-блоки (`to_room=0`, нет описания/keyword,
`exit_info=0`, `key<=0`, `lock_complexity=0`) -- мусор из старых
редакторов. Они не влияют на рантайм, но висят в `dir_option[]` и без
причины засоряют отчёт.

## Что делает PR

Все три загрузчика (`WorldFile::setup_dir`, `YamlWorldDataSource` и
`SqliteWorldDataSource::LoadRoomExits`) теперь отбрасывают такой
`ExitData` сразу после парсинга. Условие пустого блока вынесено в
`ExitData::is_empty()` и накрыто юнит-тестом
`tests/exit_is_empty.cpp` (9 кейсов).

Декоративные двери вида `[15000] D0: 8 0 0 0` (`exit_info=8`, `kHidden`,
без `to_room`) под условие не попадают и остаются в мире -- ровно как
просил Стрибог в обсуждении.

## Проверка

- `meson compile` в `build_yaml_meson` -- зелёный.
- Полный набор тестов: `400 tests from 43 test suites -- PASSED`.
- На распакованном prod-мире (приложенном в комментариях к #3272) скрипт
  параллельно по форматам считает 128 пустых `D`-блоков в 114 комнатах и
  в `.wld`, и в `zones/*/rooms/*.yaml` (diff пустой), включая 25063 south
  и 77089 south из отчёта Стрибога. После патча все они уйдут из
  `show errors`.
- Чексумм-сравнение Legacy↔YAML↔SQLite через `tools/compare_load_checksums.sh`
  должно остаться MATCH: фильтр срабатывает на каждой стороне симметрично,
  обе пишут пустой `dir_option_proto[dir]` -> сериализатор в
  `world_checksum.cpp:160` пропускает их одинаково.