### PR TITLE
feat(yaml): инструмент load->save round-trip-теста для yaml-мира

### DIFF
--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -618,6 +618,7 @@ int main_function(int argc, char **argv) {
 	ush_int port;
 	int pos = 1;
 	const char *dir;
+	const char *save_target = nullptr;
 	char cwd[256];
 
 	// Initialize these to check for overruns later.
@@ -653,6 +654,17 @@ int main_function(int argc, char **argv) {
 			case 's': no_specials = 1;
 		puts("Suppressing assignment of special routines.");
 		break;
+	case 'S':
+		if (*(argv[pos] + 2))
+			save_target = argv[pos] + 2;
+		else if (++pos < argc)
+			save_target = argv[pos];
+		else {
+			puts("SYSERR: Output directory arg expected after option -S.");
+			exit(1);
+		}
+		printf("Resave-and-exit mode enabled, target='%s'.\n", save_target);
+		break;
 	case 'W':
 		enable_world_checksum = true;
 		puts("World checksum calculation enabled.");
@@ -675,7 +687,9 @@ int main_function(int argc, char **argv) {
 					   "  -h             Print this command line argument help.\n"
 					   "  -o <file>      Write log to <file> instead of stderr.\n"
 					   "  -r             Restrict MUD -- no new players allowed.\n"
-					   "  -s             Suppress special procedure assignments.\n", argv[0]);
+					   "  -s             Suppress special procedure assignments.\n"
+					   "  -S <out_dir>   Load world, re-emit it via the configured backend\n"
+					   "                 into <out_dir> and exit (round-trip diagnostic).\n", argv[0]);
 				exit(0);
 
 			default: printf("SYSERR: Unknown option -%c in argument string.\n", *(argv[pos] + 1));
@@ -685,7 +699,9 @@ int main_function(int argc, char **argv) {
 					   "  -h             Print this command line argument help.\n"
 					   "  -o <file>      Write log to <file> instead of stderr.\n"
 					   "  -r             Restrict MUD -- no new players allowed.\n"
-					   "  -s             Suppress special procedure assignments.\n", argv[0]);
+					   "  -s             Suppress special procedure assignments.\n"
+					   "  -S <out_dir>   Load world, re-emit it via the configured backend\n"
+					   "                 into <out_dir> and exit (round-trip diagnostic).\n", argv[0]);
 				exit(1);
 			break;
 		}
@@ -730,7 +746,14 @@ int main_function(int argc, char **argv) {
 	}
 	LogBuildInfo();
 	printf("[%s] Code version %s, revision: %s\r\nCompiler: %s\r\nEnabled features: %s\r\n", utils::NowTs().c_str(), build_datetime, revision, build_compiler, build_features);
-	if (scheck) {
+	if (save_target) {
+		GameLoader::BootWorld();
+		// target_dir is interpreted relative to the world data directory
+		// (we chdir'd there above), so callers see the path they passed.
+		int errors = GameLoader::ResaveWorld(save_target);
+		printf("Resave finished, errors=%d\n", errors);
+		return errors == 0 ? 0 : 2;
+	} else if (scheck) {
 		GameLoader::BootWorld();
 		printf("Done.");
 	} else {

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1247,6 +1247,8 @@ void ResetGameWorldTime() {
 }
 
 int GameLoader::ResaveWorld(const std::string &target_dir) {
+#if defined(HAVE_YAML) || defined(HAVE_SQLITE)
+	std::unique_ptr<world_loader::IWorldDataSource> saver;
 #ifdef HAVE_YAML
 	// YamlWorldDataSource's constructor refuses to instantiate without a
 	// readable world_config.yaml under the data root. For a save-only
@@ -1275,13 +1277,9 @@ int GameLoader::ResaveWorld(const std::string &target_dir) {
 	// binary was compiled with. Reads global state (zone_table, world,
 	// obj_proto, ...) and writes paths relative to target_dir; m_world_dir on
 	// the fresh instance is the *write* root.
-	auto saver = world_loader::CreateYamlDataSource(target_dir);
-#elif defined(HAVE_SQLITE)
-	auto saver = world_loader::CreateSqliteDataSource(target_dir);
+	saver = world_loader::CreateYamlDataSource(target_dir);
 #else
-	(void) target_dir;
-	log("ResaveWorld: no save-capable backend compiled in");
-	return 1;
+	saver = world_loader::CreateSqliteDataSource(target_dir);
 #endif
 
 	log("ResaveWorld: target=%s, zones=%zu", target_dir.c_str(), zone_table.size());
@@ -1310,6 +1308,11 @@ int GameLoader::ResaveWorld(const std::string &target_dir) {
 	}
 	log("ResaveWorld: done, errors=%d, skipped_under_construction=%d", errors, skipped);
 	return errors;
+#else
+	(void) target_dir;
+	log("ResaveWorld: no save-capable backend compiled in");
+	return 1;
+#endif
 }
 
 void GameLoader::BootIndex(const EBootType mode) {

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1286,7 +1286,16 @@ int GameLoader::ResaveWorld(const std::string &target_dir) {
 
 	log("ResaveWorld: target=%s, zones=%zu", target_dir.c_str(), zone_table.size());
 	int errors = 0;
+	int skipped = 0;
 	for (size_t z = 0; z < zone_table.size(); ++z) {
+		// Dungeon zones (CreateBlankZoneDungeon, vnum >= kZoneStartDungeons)
+		// exist only in memory and are regenerated per-instance at runtime.
+		// They aren't loaded from disk -- writing them to target_dir would
+		// produce phantom files that have no counterpart in the source tree.
+		if (zone_table[z].under_construction) {
+			++skipped;
+			continue;
+		}
 		try {
 			saver->SaveZone(static_cast<int>(z));
 			saver->SaveRooms(static_cast<int>(z));
@@ -1299,7 +1308,7 @@ int GameLoader::ResaveWorld(const std::string &target_dir) {
 			++errors;
 		}
 	}
-	log("ResaveWorld: done, errors=%d", errors);
+	log("ResaveWorld: done, errors=%d, skipped_under_construction=%d", errors, skipped);
 	return errors;
 }
 

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1252,9 +1252,10 @@ int GameLoader::ResaveWorld(const std::string &target_dir) {
 #ifdef HAVE_YAML
 	// YamlWorldDataSource's constructor refuses to instantiate without a
 	// readable world_config.yaml under the data root. For a save-only
-	// instance, copy the original config (and dictionaries, for completeness)
-	// from the load location -- which BootWorld used at the compile-time
-	// default of "world" -- before constructing.
+	// instance, copy the original config (and dictionaries) from the load
+	// location -- which BootWorld used at the compile-time default of
+	// "world" -- before constructing. SaveZone/Save* rebuild their
+	// index.yaml files themselves now, so we don't mirror any indexes here.
 	namespace fs = std::filesystem;
 	const std::string load_dir = "world";
 	try {
@@ -1287,10 +1288,11 @@ int GameLoader::ResaveWorld(const std::string &target_dir) {
 	int skipped = 0;
 	for (size_t z = 0; z < zone_table.size(); ++z) {
 		// Dungeon zones (CreateBlankZoneDungeon, vnum >= kZoneStartDungeons)
-		// exist only in memory and are regenerated per-instance at runtime.
-		// They aren't loaded from disk -- writing them to target_dir would
-		// produce phantom files that have no counterpart in the source tree.
-		if (zone_table[z].under_construction) {
+		// are generated in-memory and never persisted -- matches legacy's
+		// medit_save_to_disk guard at olc/medit.cpp:532. `under_construction`
+		// alone is not the right filter: ordinary prod zones may carry it as
+		// a "work in progress" marker (zone 73 "Светлый лес" etc.).
+		if (zone_table[z].vnum >= dungeons::kZoneStartDungeons) {
 			++skipped;
 			continue;
 		}
@@ -1306,7 +1308,7 @@ int GameLoader::ResaveWorld(const std::string &target_dir) {
 			++errors;
 		}
 	}
-	log("ResaveWorld: done, errors=%d, skipped_under_construction=%d", errors, skipped);
+	log("ResaveWorld: done, errors=%d, skipped_dungeon=%d", errors, skipped);
 	return errors;
 #else
 	(void) target_dir;

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1,3 +1,5 @@
+#include <filesystem>
+
 #include "third_party_libs/pugixml/pugixml.h"
 
 #include "administration/accounts.h"
@@ -1242,6 +1244,63 @@ void ResetGameWorldTime() {
 		weather_info.sky = kSkyCloudy;
 	else
 		weather_info.sky = kSkyCloudless;
+}
+
+int GameLoader::ResaveWorld(const std::string &target_dir) {
+#ifdef HAVE_YAML
+	// YamlWorldDataSource's constructor refuses to instantiate without a
+	// readable world_config.yaml under the data root. For a save-only
+	// instance, copy the original config (and dictionaries, for completeness)
+	// from the load location -- which BootWorld used at the compile-time
+	// default of "world" -- before constructing.
+	namespace fs = std::filesystem;
+	const std::string load_dir = "world";
+	try {
+		fs::create_directories(target_dir);
+		fs::copy_file(load_dir + "/world_config.yaml",
+					  target_dir + "/world_config.yaml",
+					  fs::copy_options::overwrite_existing);
+		if (fs::exists(load_dir + "/dictionaries")) {
+			fs::copy(load_dir + "/dictionaries",
+					 target_dir + "/dictionaries",
+					 fs::copy_options::recursive
+					 | fs::copy_options::overwrite_existing);
+		}
+	} catch (const std::exception &e) {
+		log("SYSERR: ResaveWorld bootstrap failed: %s", e.what());
+		return 1;
+	}
+
+	// Same backend as BootWorld -- we want round-trip in the same format the
+	// binary was compiled with. Reads global state (zone_table, world,
+	// obj_proto, ...) and writes paths relative to target_dir; m_world_dir on
+	// the fresh instance is the *write* root.
+	auto saver = world_loader::CreateYamlDataSource(target_dir);
+#elif defined(HAVE_SQLITE)
+	auto saver = world_loader::CreateSqliteDataSource(target_dir);
+#else
+	(void) target_dir;
+	log("ResaveWorld: no save-capable backend compiled in");
+	return 1;
+#endif
+
+	log("ResaveWorld: target=%s, zones=%zu", target_dir.c_str(), zone_table.size());
+	int errors = 0;
+	for (size_t z = 0; z < zone_table.size(); ++z) {
+		try {
+			saver->SaveZone(static_cast<int>(z));
+			saver->SaveRooms(static_cast<int>(z));
+			saver->SaveObjects(static_cast<int>(z));
+			saver->SaveMobs(static_cast<int>(z));
+			saver->SaveTriggers(static_cast<int>(z), -1, 0);
+		} catch (const std::exception &e) {
+			log("SYSERR: ResaveWorld failed on zone %d (vnum=%d): %s",
+				static_cast<int>(z), zone_table[z].vnum, e.what());
+			++errors;
+		}
+	}
+	log("ResaveWorld: done, errors=%d", errors);
+	return errors;
 }
 
 void GameLoader::BootIndex(const EBootType mode) {

--- a/src/engine/db/db.h
+++ b/src/engine/db/db.h
@@ -220,6 +220,12 @@ class GameLoader {
 	static void BootWorld(std::unique_ptr<world_loader::IWorldDataSource> data_source = nullptr);
 	static void BootIndex(EBootType mode);
 
+	// Diagnostic: re-emit loaded world via the current backend's Save* APIs
+	// into a fresh directory. Used by `circle -S <out_dir>` for the
+	// load -> save -> diff round-trip test. Returns 0 on success or the
+	// number of save errors encountered.
+	static int ResaveWorld(const std::string &target_dir);
+
  private:
 	static void PrepareGlobalStructures(const EBootType mode, const int rec_count);
 };

--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -1,8 +1,11 @@
 // Part of Bylins http://www.mud.ru
 // Koi8rYamlEmitter - Custom YAML emitter that preserves KOI8-R encoding.
 //
-// Extracted from yaml_world_data_source.cpp without behaviour changes, so the
-// emitter can be unit-tested standalone.
+// Scalars whose first character is a YAML indicator (&, *, !, ,, ...) are
+// single-quoted, otherwise yaml-cpp interprets the prefix as anchor / alias /
+// tag and the save -> reload round-trip breaks (issue #3273: MUD color codes
+// like "&Yfoo &Wbar&n" in object/mob names saved unquoted produce
+// "cannot assign multiple anchors to the same node" on next boot).
 
 #ifndef KOI8R_YAML_EMITTER_H_
 #define KOI8R_YAML_EMITTER_H_
@@ -63,7 +66,9 @@ public:
 				value.find('\'') != std::string::npos ||
 				value.find('%') != std::string::npos ||  // % is YAML directive indicator
 				value[0] == ' ' || value[0] == '-' || value[0] == '?' ||
-				value[0] == '@' || value[0] == '`')
+				value[0] == '@' || value[0] == '`' ||
+				value[0] == '&' || value[0] == '*' || value[0] == '!' ||
+				value[0] == ',')
 			{
 				needs_quoting = true;
 			}

--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -35,11 +35,22 @@ public:
 	{
 		if (literal && value.find('\n') != std::string::npos)
 		{
-			// Literal block
-			out_ << " |" << std::endl;
+			// Literal block with strip chomping ("|-"): no trailing newline.
+			// The Python converter writes "|-" too, so round-trip matches.
+			// With plain "|" yaml-cpp/ruamel parse "a\nb\n" -- with "|-" they
+			// parse "a\nb" -- and our scripts/descriptions don't carry an
+			// expected trailing newline.
+			out_ << " |-" << std::endl;
 
 			std::string cleaned = value;
 			cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '\r'), cleaned.end());
+
+			// Strip a single trailing '\n' so the literal block's content
+			// matches `value` exactly when re-loaded.
+			if (!cleaned.empty() && cleaned.back() == '\n')
+			{
+				cleaned.pop_back();
+			}
 
 			std::istringstream iss(cleaned);
 			std::string line;

--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -37,8 +37,9 @@ public:
 		{
 			// Literal block with explicit indent indicator ("2"): without
 			// it, YAML auto-detects indent from the first non-empty content
-			// line, and leading whitespace there (e.g. "   Вот это да!")
-			// gets folded into indent -- producing parse errors on reload.
+			// line, and leading whitespace there (a description that begins
+			// with extra spaces) gets folded into indent -- producing parse
+			// errors on reload.
 			//
 			// Chomping mode is picked by trailing newline in `value`:
 			//   - clip ("|2") if value ends with '\n', so the parser yields
@@ -87,7 +88,10 @@ public:
 				value[0] == ' ' || value[0] == '-' || value[0] == '?' ||
 				value[0] == '@' || value[0] == '`' ||
 				value[0] == '&' || value[0] == '*' || value[0] == '!' ||
-				value[0] == ',')
+				value[0] == ',' ||
+				// Trailing whitespace would be stripped by the YAML parser
+				// from a plain scalar; quoting preserves it bit-for-bit.
+				value.back() == ' ' || value.back() == '\t')
 			{
 				needs_quoting = true;
 			}

--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -1,0 +1,125 @@
+// Part of Bylins http://www.mud.ru
+// Koi8rYamlEmitter - Custom YAML emitter that preserves KOI8-R encoding.
+//
+// Extracted from yaml_world_data_source.cpp without behaviour changes, so the
+// emitter can be unit-tested standalone.
+
+#ifndef KOI8R_YAML_EMITTER_H_
+#define KOI8R_YAML_EMITTER_H_
+
+#include <algorithm>
+#include <ostream>
+#include <regex>
+#include <sstream>
+#include <string>
+
+class Koi8rYamlEmitter
+{
+	std::ostream &out_;
+	int indent_;
+
+public:
+	explicit Koi8rYamlEmitter(std::ostream &out) : out_(out), indent_(0) {}
+
+	std::string GetIndent() const { return std::string(indent_, ' '); }
+
+	void BeginMap() {}
+	void EndMap() {}
+
+	void Key(const std::string &key) { out_ << GetIndent() << key << ":"; }
+
+	void Value(const std::string &value, bool literal = false)
+	{
+		if (literal && value.find('\n') != std::string::npos)
+		{
+			// Literal block
+			out_ << " |" << std::endl;
+
+			std::string cleaned = value;
+			cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '\r'), cleaned.end());
+
+			std::istringstream iss(cleaned);
+			std::string line;
+			while (std::getline(iss, line))
+			{
+				out_ << GetIndent() << "  " << line << std::endl;
+			}
+			return;
+		}
+
+		// Simple value - quote if contains special YAML characters
+		bool needs_quoting = value.empty();
+		if (!value.empty())
+		{
+			if (value.find(':') != std::string::npos ||
+				value.find('#') != std::string::npos ||
+				value.find('[') != std::string::npos ||
+				value.find(']') != std::string::npos ||
+				value.find('{') != std::string::npos ||
+				value.find('}') != std::string::npos ||
+				value.find('|') != std::string::npos ||
+				value.find('>') != std::string::npos ||
+				value.find('\"') != std::string::npos ||
+				value.find('\'') != std::string::npos ||
+				value.find('%') != std::string::npos ||  // % is YAML directive indicator
+				value[0] == ' ' || value[0] == '-' || value[0] == '?' ||
+				value[0] == '@' || value[0] == '`')
+			{
+				needs_quoting = true;
+			}
+		}
+
+		if (needs_quoting)
+		{
+			out_ << " '" << std::regex_replace(value, std::regex("'"), "''") << "'" << std::endl;
+		}
+		else
+		{
+			out_ << " " << value << std::endl;
+		}
+	}
+
+	void Value(int value, const std::string &comment = "")
+	{
+		out_ << " " << value;
+		if (!comment.empty()) { out_ << "  # " << comment; }
+		out_ << std::endl;
+	}
+
+	void Value(long value, const std::string &comment = "")
+	{
+		out_ << " " << value;
+		if (!comment.empty()) { out_ << "  # " << comment; }
+		out_ << std::endl;
+	}
+
+	void BeginSequence() { out_ << std::endl; }
+
+	void SequenceItem(const std::string &value, const std::string &comment = "")
+	{
+		out_ << GetIndent() << "- " << value;
+		if (!comment.empty()) { out_ << "  # " << comment; }
+		out_ << std::endl;
+	}
+
+	void SequenceItem(int value, const std::string &comment = "")
+	{
+		out_ << GetIndent() << "- " << value;
+		if (!comment.empty()) { out_ << "  # " << comment; }
+		out_ << std::endl;
+	}
+
+	void IncreaseIndent() { indent_ += 2; }
+	void DecreaseIndent() { indent_ -= 2; }
+
+	void Comment(const std::string &text) { out_ << GetIndent() << "# " << text << std::endl; }
+
+	void EmptyLine() { out_ << std::endl; }
+
+	void BeginBlock() { out_ << std::endl; indent_ += 2; }
+	void EndBlock() { indent_ -= 2; }
+};
+
+#endif  // KOI8R_YAML_EMITTER_H_
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -36,11 +36,13 @@ public:
 		if (literal && value.find('\n') != std::string::npos)
 		{
 			// Literal block with strip chomping ("|-"): no trailing newline.
-			// The Python converter writes "|-" too, so round-trip matches.
-			// With plain "|" yaml-cpp/ruamel parse "a\nb\n" -- with "|-" they
-			// parse "a\nb" -- and our scripts/descriptions don't carry an
-			// expected trailing newline.
-			out_ << " |-" << std::endl;
+			// Use an explicit indent indicator ("|-2"): otherwise YAML auto-
+			// detects indent from the first non-empty content line, and any
+			// leading whitespace there (e.g. a description that begins with
+			// "   Вот это да!") gets folded into indent, then a later line
+			// with less leading whitespace looks like the block has ended,
+			// producing parse errors on reload.
+			out_ << " |-2" << std::endl;
 
 			std::string cleaned = value;
 			cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '\r'), cleaned.end());

--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -35,23 +35,29 @@ public:
 	{
 		if (literal && value.find('\n') != std::string::npos)
 		{
-			// Literal block with strip chomping ("|-"): no trailing newline.
-			// Use an explicit indent indicator ("|-2"): otherwise YAML auto-
-			// detects indent from the first non-empty content line, and any
-			// leading whitespace there (e.g. a description that begins with
-			// "   Вот это да!") gets folded into indent, then a later line
-			// with less leading whitespace looks like the block has ended,
-			// producing parse errors on reload.
-			out_ << " |-2" << std::endl;
-
+			// Literal block with explicit indent indicator ("2"): without
+			// it, YAML auto-detects indent from the first non-empty content
+			// line, and leading whitespace there (e.g. "   Вот это да!")
+			// gets folded into indent -- producing parse errors on reload.
+			//
+			// Chomping mode is picked by trailing newline in `value`:
+			//   - clip ("|2") if value ends with '\n', so the parser yields
+			//     the same trailing newline back -- the Python converter
+			//     uses this form for descriptions;
+			//   - strip ("|-2") if value has no trailing newline, matching
+			//     the converter's behaviour for trigger scripts.
 			std::string cleaned = value;
 			cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '\r'), cleaned.end());
 
-			// Strip a single trailing '\n' so the literal block's content
-			// matches `value` exactly when re-loaded.
-			if (!cleaned.empty() && cleaned.back() == '\n')
+			const bool clip = !cleaned.empty() && cleaned.back() == '\n';
+			if (clip)
 			{
-				cleaned.pop_back();
+				cleaned.pop_back();  // we'll add it back via the final std::endl
+				out_ << " |2" << std::endl;
+			}
+			else
+			{
+				out_ << " |-2" << std::endl;
 			}
 
 			std::istringstream iss(cleaned);

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -3298,7 +3298,11 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 		out << std::endl;
 		yaml.IncreaseIndent();
 
-		const std::string &aliases = mob.get_npc_name();
+		// GetCharAliases() returns the full keyword list (name_), matching
+		// what LoadMobs reads via SetCharAliases(GetText(names, "aliases"))
+		// at line 1557. get_npc_name() returns short_descr_ (== nominative),
+		// which would truncate "костяк скелет" -> "скелет" on round-trip.
+		const std::string &aliases = mob.GetCharAliases();
 		if (!aliases.empty())
 		{
 			yaml.Key("aliases");

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -3319,8 +3319,15 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 		yaml.Key("weight");
 		yaml.Value(static_cast<int>(GET_WEIGHT(&mob)));  // ubyte -> int
 
-		// Attributes (only if set)
-		if (mob.get_str() > 0)
+		// Attributes (skip if all six are at default 11). LoadMobs sets every
+		// attribute to 11 unconditionally and then overrides from `attributes`
+		// if present; treating "all 11" as "not specified" matches the Python
+		// converter, which only emits this block when legacy data actually
+		// carried per-attribute values.
+		const bool attributes_set =
+			mob.get_str() != 11 || mob.get_dex() != 11 || mob.get_int() != 11 ||
+			mob.get_wis() != 11 || mob.get_con() != 11 || mob.get_cha() != 11;
+		if (attributes_set)
 		{
 			yaml.Key("attributes");
 			out << std::endl;
@@ -3426,48 +3433,13 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 			yaml.DecreaseIndent();
 		}
 
-		// Enhanced (optional mob stats)
-		if (mob.get_str() > 0)
+		// Enhanced E-spec block. Always emitted because mob_type is always
+		// "E" in this code path and the Python converter writes the block
+		// unconditionally (carrying at least resistances/saves as zero-arrays).
+		char special_buf[kMaxStringLength];
+		mob.mob_specials.npc_flags.tascii(FlagData::kPlanesNumber, special_buf, sizeof(special_buf));
+		std::string role_str = mob.get_role().to_string();
 		{
-			bool has_enhanced = false;
-			
-			// Check if we have any enhanced stats
-			if (mob.get_str_add() != 0 || mob.add_abils.hitreg != 0 || mob.add_abils.armour != 0 ||
-				mob.add_abils.manareg != 0 || mob.add_abils.cast_success != 0 || mob.add_abils.morale != 0 ||
-				mob.add_abils.initiative_add != 0 || mob.add_abils.absorb != 0 || mob.add_abils.aresist != 0 ||
-				mob.add_abils.mresist != 0 || mob.add_abils.presist != 0 || mob.mob_specials.attack_type != 0 ||
-				mob.mob_specials.like_work != 0 || mob.mob_specials.MaxFactor != 0 ||
-				mob.mob_specials.extra_attack != 0 || mob.get_remort() != 0)
-			{
-				has_enhanced = true;
-			}
-
-			// Check special_bitvector
-			char special_buf[kMaxStringLength];
-			mob.mob_specials.npc_flags.tascii(FlagData::kPlanesNumber, special_buf, sizeof(special_buf));
-			if (special_buf[0] != '0' || special_buf[1] != 'a')
-			{
-				has_enhanced = true;
-			}
-
-			// Check role
-			std::string role_str = mob.get_role().to_string();
-			if (!role_str.empty() && role_str != "000000000")
-			{
-				has_enhanced = true;
-			}
-
-			// Check resistances, saves, feats, spells, helpers, destinations
-			for (const auto &val : mob.add_abils.apply_resistance) { if (val != 0) { has_enhanced = true; break; } }
-			for (const auto &val : mob.add_abils.apply_saving_throw) { if (val != 0) { has_enhanced = true; break; } }
-			
-			for (size_t i = 0; i < mob.real_abils.Feats.size(); ++i) { if (mob.real_abils.Feats.test(i)) { has_enhanced = true; break; } }
-			for (size_t i = 0; i < mob.real_abils.SplMem.size(); ++i) { if (mob.real_abils.SplMem[i] > 0) { has_enhanced = true; break; } }
-			
-			if (!mob.summon_helpers.empty()) { has_enhanced = true; }
-			for (int dest : mob.mob_specials.dest) { if (dest != 0) { has_enhanced = true; break; } }
-
-			if (has_enhanced)
 			{
 				yaml.Key("enhanced");
 				out << std::endl;
@@ -3566,45 +3538,28 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 					yaml.Value(role_str);
 				}
 
-				// Resistances
-				bool has_resistances = false;
+				// Resistances. The Python converter always emits this block
+				// (even all-zero), so we mirror that for round-trip parity --
+				// otherwise the diff shows `/enhanced/resistances: missing in
+				// v2` for every mob with default resistances.
+				yaml.Key("resistances");
+				yaml.BeginSequence();
+				yaml.IncreaseIndent();
 				for (const auto &val : mob.add_abils.apply_resistance)
 				{
-					if (val != 0) { has_resistances = true; break; }
+					yaml.SequenceItem(val);
 				}
-				if (has_resistances)
-				{
-					yaml.Key("resistances");
-					yaml.BeginSequence();
-					yaml.IncreaseIndent();
+				yaml.DecreaseIndent();
 
-					for (const auto &val : mob.add_abils.apply_resistance)
-					{
-						yaml.SequenceItem(val);
-					}
-
-					yaml.DecreaseIndent();
-				}
-
-				// Saves
-				bool has_saves = false;
+				// Saves -- same rationale as resistances.
+				yaml.Key("saves");
+				yaml.BeginSequence();
+				yaml.IncreaseIndent();
 				for (const auto &val : mob.add_abils.apply_saving_throw)
 				{
-					if (val != 0) { has_saves = true; break; }
+					yaml.SequenceItem(val);
 				}
-				if (has_saves)
-				{
-					yaml.Key("saves");
-					yaml.BeginSequence();
-					yaml.IncreaseIndent();
-
-					for (const auto &val : mob.add_abils.apply_saving_throw)
-					{
-						yaml.SequenceItem(val);
-					}
-
-					yaml.DecreaseIndent();
-				}
+				yaml.DecreaseIndent();
 
 				// Feats
 				bool has_feats = false;

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -3370,6 +3370,10 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 		yaml.Key("size");
 		yaml.Value(GET_SIZE(&mob));
 
+		// NPC race, between `size` and `height` as the converter writes it.
+		yaml.Key("race");
+		yaml.Value(static_cast<int>(mob.player_data.Race));
+
 		yaml.Key("height");
 		yaml.Value(static_cast<int>(GET_HEIGHT(&mob)));  // ubyte -> int
 

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -35,6 +35,8 @@
 #include <sstream>
 #include <set>
 
+#include "koi8r_yaml_emitter.h"
+
 // External declarations
 extern ZoneTable &zone_table;
 extern IndexData **trig_index;
@@ -56,143 +58,6 @@ inline Bitvector IndexToBitvector(long idx)
 {
 	return static_cast<Bitvector>(flag_data_by_num(static_cast<int>(idx)));
 }
-
-// ============================================================================
-// Koi8rYamlEmitter - Custom YAML emitter that preserves KOI8-R encoding
-// ============================================================================
-
-class Koi8rYamlEmitter {
-	std::ostream &out_;
-	int indent_;
-
-public:
-	Koi8rYamlEmitter(std::ostream &out) : out_(out), indent_(0) {}
-
-	std::string GetIndent() const {
-		return std::string(indent_, ' ');
-	}
-
-	void BeginMap() {
-		// Maps don't need special output, just increase indent for nested content
-	}
-
-	void EndMap() {
-		// Nothing to do
-	}
-
-	void Key(const std::string &key) {
-		out_ << GetIndent() << key << ":";
-	}
-
-	void Value(const std::string &value, bool literal = false) {
-		if (literal && value.find('\n') != std::string::npos) {
-			// Literal block
-			out_ << " |" << std::endl;
-
-			// Remove \r, keep \n
-			std::string cleaned = value;
-			cleaned.erase(std::remove(cleaned.begin(), cleaned.end(), '\r'), cleaned.end());
-
-			std::istringstream iss(cleaned);
-			std::string line;
-			while (std::getline(iss, line)) {
-				out_ << GetIndent() << "  " << line << std::endl;
-			}
-		} else {
-			// Simple value - quote if contains special YAML characters
-			bool needs_quoting = value.empty();
-			
-			if (!value.empty()) {
-				// Check for special YAML characters
-				if (value.find(':') != std::string::npos ||
-					value.find('#') != std::string::npos ||
-					value.find('[') != std::string::npos ||
-					value.find(']') != std::string::npos ||
-					value.find('{') != std::string::npos ||
-					value.find('}') != std::string::npos ||
-					value.find('|') != std::string::npos ||
-					value.find('>') != std::string::npos ||
-					value.find('\"') != std::string::npos ||
-					value.find('\'') != std::string::npos ||
-					value.find('%') != std::string::npos ||  // % is YAML directive indicator
-					value[0] == ' ' || value[0] == '-' || value[0] == '?' ||
-					value[0] == '@' || value[0] == '`') {
-					needs_quoting = true;
-				}
-			}
-			
-			if (needs_quoting) {
-				// Use single quotes, escape single quotes inside by doubling them
-				out_ << " '" << std::regex_replace(value, std::regex("'"), "''") << "'" << std::endl;
-			} else {
-				out_ << " " << value << std::endl;
-			}
-		}
-	}
-
-	void Value(int value, const std::string &comment = "") {
-		out_ << " " << value;
-		if (!comment.empty()) {
-			out_ << "  # " << comment;
-		}
-		out_ << std::endl;
-	}
-
-	void Value(long value, const std::string &comment = "") {
-		out_ << " " << value;
-		if (!comment.empty()) {
-			out_ << "  # " << comment;
-		}
-		out_ << std::endl;
-	}
-
-	void BeginSequence() {
-		out_ << std::endl;
-	}
-
-	void SequenceItem(const std::string &value, const std::string &comment = "") {
-		out_ << GetIndent() << "- " << value;
-		if (!comment.empty()) {
-			out_ << "  # " << comment;
-		}
-		out_ << std::endl;
-	}
-
-	void SequenceItem(int value, const std::string &comment = "") {
-		out_ << GetIndent() << "- " << value;
-		if (!comment.empty()) {
-			out_ << "  # " << comment;
-		}
-		out_ << std::endl;
-	}
-
-	void IncreaseIndent() {
-		indent_ += 2;
-	}
-
-	void DecreaseIndent() {
-		indent_ -= 2;
-	}
-
-	void Comment(const std::string &text) {
-		out_ << GetIndent() << "# " << text << std::endl;
-	}
-
-	void EmptyLine() {
-		out_ << std::endl;
-	}
-
-	// Begin a nested block (for nested maps): outputs newline after key's colon, increases indent
-	void BeginBlock() {
-		out_ << std::endl;
-		indent_ += 2;
-	}
-
-	// End a nested block: decreases indent
-	void EndBlock() {
-		indent_ -= 2;
-	}
-};
 
 // ============================================================================
 // Helper functions for YAML comments

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -3905,9 +3905,12 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 
 		yaml.DecreaseIndent();
 
-		// Short description
+		// Long description ("when in room"). Yaml convention: stored under
+		// `short_desc:` to mirror the legacy file's 8th string, which is the
+		// long-form description. m_short_description is the inventory name
+		// (== nominative) and is already serialised via names/nominative.
 		yaml.Key("short_desc");
-		yaml.Value(obj->get_short_description(), true);  // literal=true
+		yaml.Value(obj->get_description(), true);  // literal=true
 
 		// Action description (optional)
 		if (!obj->get_action_description().empty())

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -2542,6 +2542,27 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 		yaml.BeginSequence();
 		yaml.IncreaseIndent();
 
+		// ResolveZoneCmdVnumArgsToRnums (db.cpp:1626) rewrites cmd.argN from
+		// the on-disk vnums into in-memory rnums during boot. To round-trip
+		// the zonefile we must invert that conversion here.
+		auto mob_v = [](int rnum) -> int {
+			if (rnum < 0 || rnum >= top_of_mobt) return rnum;
+			return mob_index[rnum].vnum;
+		};
+		auto obj_v = [](int rnum) -> int {
+			if (rnum < 0) return rnum;
+			auto obj = obj_proto[rnum];
+			return obj ? obj->get_vnum() : rnum;
+		};
+		auto room_v = [](int rnum) -> int {
+			if (rnum < 0 || rnum > top_of_world || !world[rnum]) return rnum;
+			return world[rnum]->vnum;
+		};
+		auto trig_v = [](int rnum) -> int {
+			if (rnum < 0 || rnum >= top_of_trigt || !trig_index[rnum]) return rnum;
+			return trig_index[rnum]->vnum;
+		};
+
 		for (int i = 0; zone.cmd[i].command != 'S'; ++i)
 		{
 			const struct reset_com &cmd = zone.cmd[i];
@@ -2552,10 +2573,12 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 			{
 			case 'M':
 			{
-				oss << "MOB " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2 << " " << cmd.arg3;
+				int mob_vnum = mob_v(cmd.arg1);
+				int room_vnum = room_v(cmd.arg3);
+				oss << "MOB " << cmd.if_flag << " " << mob_vnum << " " << cmd.arg2 << " " << room_vnum;
 				if (cmd.arg4 != -1) oss << " " << cmd.arg4;
-				std::string mob_name = GetMobNameComment(cmd.arg1);
-				std::string room_name = GetRoomNameByVnum(cmd.arg3);
+				std::string mob_name = GetMobNameComment(mob_vnum);
+				std::string room_name = GetRoomNameByVnum(room_vnum);
 				std::ostringstream coss;
 				if (!mob_name.empty()) coss << mob_name;
 				if (!room_name.empty())
@@ -2573,10 +2596,14 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 			}
 			case 'O':
 			{
-				oss << "OBJECT " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2 << " " << cmd.arg3;
+				int obj_vnum = obj_v(cmd.arg1);
+				// arg3 may legitimately be kNowhere (== -1 in some builds);
+				// in that case ResolveZone... leaves it alone, so do the same.
+				int room_vnum = (cmd.arg3 == kNowhere) ? cmd.arg3 : room_v(cmd.arg3);
+				oss << "OBJECT " << cmd.if_flag << " " << obj_vnum << " " << cmd.arg2 << " " << room_vnum;
 				if (cmd.arg4 != -1) oss << " " << cmd.arg4;
-				std::string obj_name = GetObjNameComment(cmd.arg1);
-				std::string room_name = GetRoomNameByVnum(cmd.arg3);
+				std::string obj_name = GetObjNameComment(obj_vnum);
+				std::string room_name = GetRoomNameByVnum(room_vnum);
 				std::ostringstream coss;
 				if (!obj_name.empty()) coss << obj_name;
 				if (!room_name.empty())
@@ -2588,15 +2615,19 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 				break;
 			}
 			case 'G':
-				oss << "GIVE " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2;
+			{
+				int obj_vnum = obj_v(cmd.arg1);
+				oss << "GIVE " << cmd.if_flag << " " << obj_vnum << " " << cmd.arg2;
 				if (cmd.arg4 != -1) oss << " " << cmd.arg4;
-				comment = GetObjNameComment(cmd.arg1);
+				comment = GetObjNameComment(obj_vnum);
 				break;
+			}
 			case 'E':
 			{
-				oss << "EQUIP " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2 << " " << cmd.arg3;
+				int obj_vnum = obj_v(cmd.arg1);
+				oss << "EQUIP " << cmd.if_flag << " " << obj_vnum << " " << cmd.arg2 << " " << cmd.arg3;
 				if (cmd.arg4 != -1) oss << " " << cmd.arg4;
-				std::string obj_name = GetObjNameComment(cmd.arg1);
+				std::string obj_name = GetObjNameComment(obj_vnum);
 				std::ostringstream coss;
 				if (!obj_name.empty()) coss << obj_name;
 				coss << ", wear: " << cmd.arg3;
@@ -2605,10 +2636,12 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 			}
 			case 'P':
 			{
-				oss << "PUT " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2 << " " << cmd.arg3;
+				int obj_vnum = obj_v(cmd.arg1);
+				int container_vnum = obj_v(cmd.arg3);
+				oss << "PUT " << cmd.if_flag << " " << obj_vnum << " " << cmd.arg2 << " " << container_vnum;
 				if (cmd.arg4 != -1) oss << " " << cmd.arg4;
-				std::string obj_name = GetObjNameComment(cmd.arg1);
-				std::string cont_name = GetObjNameComment(cmd.arg3);
+				std::string obj_name = GetObjNameComment(obj_vnum);
+				std::string cont_name = GetObjNameComment(container_vnum);
 				std::ostringstream coss;
 				if (!obj_name.empty()) coss << obj_name;
 				if (!cont_name.empty())
@@ -2621,8 +2654,9 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 			}
 			case 'D':
 			{
-				oss << "DOOR " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2 << " " << cmd.arg3;
-				std::string room_name = GetRoomNameByVnum(cmd.arg1);
+				int room_vnum = room_v(cmd.arg1);
+				oss << "DOOR " << cmd.if_flag << " " << room_vnum << " " << cmd.arg2 << " " << cmd.arg3;
+				std::string room_name = GetRoomNameByVnum(room_vnum);
 				std::ostringstream coss;
 				if (!room_name.empty()) coss << room_name;
 				coss << ", dir: " << cmd.arg2;
@@ -2631,17 +2665,32 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 			}
 			case 'R':
 			{
-				oss << "REMOVE " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2;
-				comment = GetRoomNameByVnum(cmd.arg1);
+				int room_vnum = room_v(cmd.arg1);
+				int obj_vnum = obj_v(cmd.arg2);
+				oss << "REMOVE " << cmd.if_flag << " " << room_vnum << " " << obj_vnum;
+				comment = GetRoomNameByVnum(room_vnum);
 				break;
 			}
 			case 'T':
-				oss << "TRIGGER " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2;
-				if (cmd.arg3 != -1) oss << " " << cmd.arg3;
-				comment = GetTriggerNameComment(cmd.arg2);
+			{
+				int trig_vnum = trig_v(cmd.arg2);
+				// arg1 is the trigger-class enum (MOB/OBJ/WLD), not an rnum.
+				// arg3 is a room rnum only when arg1 == WLD_TRIGGER.
+				int third = cmd.arg3;
+				if (cmd.arg1 == WLD_TRIGGER && cmd.arg3 != -1)
+				{
+					third = room_v(cmd.arg3);
+				}
+				oss << "TRIGGER " << cmd.if_flag << " " << cmd.arg1 << " " << trig_vnum;
+				if (cmd.arg3 != -1) oss << " " << third;
+				comment = GetTriggerNameComment(trig_vnum);
 				break;
+			}
 			case 'V':
-				oss << "VAR " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2 << " " << cmd.arg3;
+			{
+				int second = cmd.arg2;
+				if (cmd.arg1 == WLD_TRIGGER) second = room_v(cmd.arg2);
+				oss << "VAR " << cmd.if_flag << " " << cmd.arg1 << " " << second << " " << cmd.arg3;
 				if (cmd.sarg1) oss << " " << cmd.sarg1;
 				if (cmd.sarg2) oss << " " << cmd.sarg2;
 				if (cmd.sarg1 && cmd.sarg2)
@@ -2649,16 +2698,23 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 					comment = std::string(cmd.sarg1) + " = " + cmd.sarg2;
 				}
 				break;
+			}
 			case 'Q':
-				oss << "EXTRACT 0 " << cmd.arg1;
-				comment = GetMobNameComment(cmd.arg1);
+			{
+				int mob_vnum = mob_v(cmd.arg1);
+				oss << "EXTRACT 0 " << mob_vnum;
+				comment = GetMobNameComment(mob_vnum);
 				break;
+			}
 			case 'F':
 			{
-				oss << "FOLLOW " << cmd.if_flag << " " << cmd.arg1 << " " << cmd.arg2 << " " << cmd.arg3;
-				std::string leader_name = GetMobNameComment(cmd.arg2);
-				std::string follower_name = GetMobNameComment(cmd.arg3);
-				std::string room_name = GetRoomNameByVnum(cmd.arg1);
+				int room_vnum = room_v(cmd.arg1);
+				int leader_vnum = mob_v(cmd.arg2);
+				int follower_vnum = mob_v(cmd.arg3);
+				oss << "FOLLOW " << cmd.if_flag << " " << room_vnum << " " << leader_vnum << " " << follower_vnum;
+				std::string leader_name = GetMobNameComment(leader_vnum);
+				std::string follower_name = GetMobNameComment(follower_vnum);
+				std::string room_name = GetRoomNameByVnum(room_vnum);
 				std::ostringstream coss;
 				if (!leader_name.empty()) coss << leader_name;
 				if (!follower_name.empty())

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1780,13 +1780,25 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 
 		if (enhanced["spells"] && enhanced["spells"].IsSequence())
 		{
+			// Each occurrence of a spell id in the sequence increments SplMem
+			// (memorized slot count), mirroring the legacy `Spell: N` parser
+			// in boot_data_files.cpp:1393-1405. SplKnw was a yaml/sqlite-only
+			// shortcut that lost the multiplicity and didn't update
+			// caster_level / have_spell, leaving casters effectively spell-less
+			// after a yaml load.
 			for (const auto &spell_node : enhanced["spells"])
 			{
-				int spell_id = spell_node.as<int>();
-				if (spell_id >= 0 && spell_id < static_cast<int>(mob.real_abils.SplKnw.size()))
+				int spell_id_int = spell_node.as<int>();
+				if (spell_id_int < to_underlying(ESpell::kFirst)
+					|| spell_id_int > to_underlying(ESpell::kLast))
 				{
-					mob.real_abils.SplKnw[spell_id] = 1;
+					log("SYSERR: Unknown spell id %d in mob yaml", spell_id_int);
+					continue;
 				}
+				auto spell_id = static_cast<ESpell>(spell_id_int);
+				GET_SPELL_MEM(&mob, spell_id) += 1;
+				mob.caster_level += (MUD::Spell(spell_id).IsFlagged(NPC_CALCULATE) ? 1 : 0);
+				mob.mob_specials.have_spell = true;
 			}
 		}
 
@@ -3577,7 +3589,7 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 			for (const auto &val : mob.add_abils.apply_saving_throw) { if (val != 0) { has_enhanced = true; break; } }
 			
 			for (size_t i = 0; i < mob.real_abils.Feats.size(); ++i) { if (mob.real_abils.Feats.test(i)) { has_enhanced = true; break; } }
-			for (size_t i = 0; i < mob.real_abils.SplKnw.size(); ++i) { if (mob.real_abils.SplKnw[i] > 0) { has_enhanced = true; break; } }
+			for (size_t i = 0; i < mob.real_abils.SplMem.size(); ++i) { if (mob.real_abils.SplMem[i] > 0) { has_enhanced = true; break; } }
 			
 			if (!mob.summon_helpers.empty()) { has_enhanced = true; }
 			for (int dest : mob.mob_specials.dest) { if (dest != 0) { has_enhanced = true; break; } }
@@ -3744,11 +3756,13 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 					yaml.DecreaseIndent();
 				}
 
-				// Spells
+				// Spells (memorized slot counts). Mirror legacy: a spell with
+				// SplMem[id] == N is serialised as N copies of `id`, matching
+				// the load path which increments SplMem on each occurrence.
 				bool has_spells = false;
-				for (size_t i = 0; i < mob.real_abils.SplKnw.size(); ++i)
+				for (size_t i = 0; i < mob.real_abils.SplMem.size(); ++i)
 				{
-					if (mob.real_abils.SplKnw[i] > 0) { has_spells = true; break; }
+					if (mob.real_abils.SplMem[i] > 0) { has_spells = true; break; }
 				}
 				if (has_spells)
 				{
@@ -3756,9 +3770,10 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 					yaml.BeginSequence();
 					yaml.IncreaseIndent();
 
-					for (size_t i = 0; i < mob.real_abils.SplKnw.size(); ++i)
+					for (size_t i = 0; i < mob.real_abils.SplMem.size(); ++i)
 					{
-						if (mob.real_abils.SplKnw[i] > 0)
+						int mem = mob.real_abils.SplMem[i];
+						for (int n = 0; n < mem; ++n)
 						{
 							yaml.SequenceItem(static_cast<int>(i));
 						}

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -2403,9 +2403,107 @@ bool YamlWorldDataSource::WriteYamlAtomic(const std::string &filepath, const YAM
 	catch (const std::exception &e)
 	{
 		log("SYSERR: Failed to write YAML file %s: %s", filepath.c_str(), e.what());
-	
+
 		return false;
 	}
+}
+
+bool YamlWorldDataSource::WriteIndexYaml(const std::string &filepath,
+										 const std::string &top_key,
+										 const std::vector<int> &values) const
+{
+	namespace fs = std::filesystem;
+	try
+	{
+		fs::create_directories(fs::path(filepath).parent_path());
+
+		std::string temp_filepath = filepath + ".tmp";
+		std::ofstream out(temp_filepath);
+		if (!out.is_open())
+		{
+			log("SYSERR: Failed to open temp file for index: %s", temp_filepath.c_str());
+			return false;
+		}
+		// Match the layout the Python converter emits and the loader expects:
+		//   <top_key>:
+		//   - <v>
+		// Or for an empty list, "<top_key>: []".
+		if (values.empty())
+		{
+			out << top_key << ": []\n";
+		}
+		else
+		{
+			out << top_key << ":\n";
+			for (int v : values)
+			{
+				out << "- " << v << "\n";
+			}
+		}
+		out.close();
+		std::rename(temp_filepath.c_str(), filepath.c_str());
+		return true;
+	}
+	catch (const std::exception &e)
+	{
+		log("SYSERR: Failed to write index %s: %s", filepath.c_str(), e.what());
+		return false;
+	}
+}
+
+bool YamlWorldDataSource::RebuildPerZoneIndex(int zone_vnum, const std::string &sub) const
+{
+	// Collect rel-numbers (vnum % 100) of all in-memory prototypes that belong
+	// to this zone. The set guarantees uniqueness + sorted order.
+	std::set<int> rel_nums;
+
+	if (sub == "mobs")
+	{
+		for (MobRnum rnum = 0; rnum < top_of_mobt; ++rnum)
+		{
+			const int v = mob_index[rnum].vnum;
+			if (v / 100 == zone_vnum) rel_nums.insert(v % 100);
+		}
+	}
+	else if (sub == "objects")
+	{
+		for (const auto &[v, rnum] : obj_proto.vnum2index())
+		{
+			if (v / 100 == zone_vnum) rel_nums.insert(v % 100);
+		}
+	}
+	else if (sub == "rooms")
+	{
+		for (RoomRnum rnum = 0; rnum <= top_of_world; ++rnum)
+		{
+			if (!world[rnum]) continue;
+			const int v = world[rnum]->vnum;
+			if (v / 100 != zone_vnum) continue;
+			// rel == 99 is reserved for the runtime-only "virtual room"
+			// (AddVirtualRoomsToAllZones / "неизвестная комната"). SaveRooms
+			// doesn't emit its file, so we mustn't list it in the index either.
+			if (v % 100 == 99) continue;
+			rel_nums.insert(v % 100);
+		}
+	}
+	else if (sub == "triggers")
+	{
+		for (int rnum = 0; rnum < top_of_trigt; ++rnum)
+		{
+			if (!trig_index[rnum]) continue;
+			const int v = trig_index[rnum]->vnum;
+			if (v / 100 == zone_vnum) rel_nums.insert(v % 100);
+		}
+	}
+	else
+	{
+		log("SYSERR: RebuildPerZoneIndex called with unknown sub '%s'", sub.c_str());
+		return false;
+	}
+
+	const std::string filepath = m_world_dir + "/zones/" + std::to_string(zone_vnum)
+		+ "/" + sub + "/index.yaml";
+	return WriteIndexYaml(filepath, sub, {rel_nums.begin(), rel_nums.end()});
 }
 // ============================================================================
 
@@ -2744,6 +2842,22 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 	std::rename(temp_file.c_str(), zone_file.c_str());
 
 	log("Saved zone %d to YAML file", zone.vnum);
+
+	// Top-level zones/index.yaml snapshot. Skip dungeon zones (vnum >=
+	// kZoneStartDungeons) -- they are generated in-memory by
+	// CreateBlankZoneDungeon and never persisted, matching the legacy
+	// medit_save_to_disk guard at olc/medit.cpp:532.
+	std::vector<int> zone_vnums;
+	zone_vnums.reserve(zone_table.size());
+	for (const auto &z : zone_table)
+	{
+		if (z.vnum < dungeons::kZoneStartDungeons)
+		{
+			zone_vnums.push_back(z.vnum);
+		}
+	}
+	std::sort(zone_vnums.begin(), zone_vnums.end());
+	WriteIndexYaml(m_world_dir + "/zones/index.yaml", "zones", zone_vnums);
 }
 
 bool YamlWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int notify_level)
@@ -2764,7 +2878,10 @@ bool YamlWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int not
 	if (first_trig == -1 || last_trig == -1)
 	{
 		log("Zone %d has no triggers to save", zone.vnum);
-		return true; // Not an error - zone just has no triggers
+		// Still write the (empty) index so a subsequent boot sees the zone
+		// has nothing to load instead of failing on a missing file.
+		RebuildPerZoneIndex(zone.vnum, "triggers");
+		return true;
 	}
 
 	namespace fs = std::filesystem;
@@ -2909,6 +3026,8 @@ bool YamlWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int not
 	}
 
 	log("Saved %d triggers for zone %d", saved_count, zone.vnum);
+
+	RebuildPerZoneIndex(zone.vnum, "triggers");
 	return true;
 }
 
@@ -2927,6 +3046,7 @@ void YamlWorldDataSource::SaveRooms(int zone_rnum, int specific_vnum)
 	if (first_room == -1 || last_room == -1)
 	{
 		log("Zone %d has no rooms to save", zone.vnum);
+		RebuildPerZoneIndex(zone.vnum, "rooms");
 		return;
 	}
 
@@ -3058,26 +3178,34 @@ void YamlWorldDataSource::SaveRooms(int zone_rnum, int specific_vnum)
 				}
 				out << std::endl;
 
-				// Description (optional)
+				// Description (optional). Delegate to Koi8rYamlEmitter::Value
+				// for proper clip-vs-strip chomping based on trailing newline
+				// in the source string (otherwise round-trip silently appends
+				// a CR/LF that wasn't in memory).
 				if (!room->dir_option_proto[dir]->general_description.empty())
 				{
-					std::string exit_desc = room->dir_option_proto[dir]->general_description;
-					out << yaml.GetIndent() << "  description: |" << std::endl;
-					
-					exit_desc.erase(std::remove(exit_desc.begin(), exit_desc.end(), '\r'), exit_desc.end());
-					std::istringstream iss(exit_desc);
-					std::string line;
-					while (std::getline(iss, line))
-					{
-						out << yaml.GetIndent() << "    " << line << std::endl;
-					}
+					out << yaml.GetIndent() << "  description:";
+					yaml.IncreaseIndent();
+					yaml.Value(room->dir_option_proto[dir]->general_description, true);
+					yaml.DecreaseIndent();
 				}
 
-				// Keywords (optional)
+				// Keywords (optional). ExitData splits the load value on '|':
+				// keyword = nominative form, vkeyword = accusative. Recombine
+				// them on save with the same delimiter so the next load sees
+				// both forms (otherwise the accusative form is silently lost
+				// and "открыть решетку" no longer matches the door).
 				if (room->dir_option_proto[dir]->keyword)
 				{
-					out << yaml.GetIndent() << "  keywords: ";
-					out << room->dir_option_proto[dir]->keyword << std::endl;
+					std::string kws = room->dir_option_proto[dir]->keyword;
+					const char *vk = room->dir_option_proto[dir]->vkeyword;
+					if (vk && *vk && kws != vk)
+					{
+						kws += "|";
+						kws += vk;
+					}
+					out << yaml.GetIndent() << "  keywords:";
+					yaml.Value(kws);
 				}
 
 				// Exit flags (optional)
@@ -3116,20 +3244,18 @@ void YamlWorldDataSource::SaveRooms(int zone_rnum, int specific_vnum)
 			{
 				if (exdesc->keyword)
 				{
-					out << yaml.GetIndent() << "- keywords: " << exdesc->keyword << std::endl;
+					// keywords may start with '-' (legitimately a single dash), which
+					// the YAML parser would mistake for a sequence indicator unless
+					// quoted. Delegating to Koi8rYamlEmitter::Value applies the
+					// proper leading-indicator-aware quoting.
+					out << yaml.GetIndent() << "- keywords:";
+					yaml.Value(std::string(exdesc->keyword));
 					if (exdesc->description)
 					{
-						out << yaml.GetIndent() << "  description: |" << std::endl;
-						
-						std::string desc_text = exdesc->description;
-						desc_text.erase(std::remove(desc_text.begin(), desc_text.end(), '\r'), desc_text.end());
-						
-						std::istringstream iss(desc_text);
-						std::string line;
-						while (std::getline(iss, line))
-						{
-							out << yaml.GetIndent() << "    " << line << std::endl;
-						}
+						out << yaml.GetIndent() << "  description:";
+						yaml.IncreaseIndent();
+						yaml.Value(std::string(exdesc->description), true);
+						yaml.DecreaseIndent();
 					}
 				}
 			}
@@ -3165,6 +3291,8 @@ void YamlWorldDataSource::SaveRooms(int zone_rnum, int specific_vnum)
 	}
 
 	log("Saved %d rooms for zone %d", saved_count, zone.vnum);
+
+	RebuildPerZoneIndex(zone.vnum, "rooms");
 }
 
 void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
@@ -3182,6 +3310,7 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 	if (first_mob == -1 || last_mob == -1)
 	{
 		log("Zone %d has no mobs to save", zone.vnum);
+		RebuildPerZoneIndex(zone.vnum, "mobs");
 		return;
 	}
 
@@ -3737,6 +3866,8 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 	}
 
 	log("Saved %d mobs for zone %d", saved_count, zone.vnum);
+
+	RebuildPerZoneIndex(zone.vnum, "mobs");
 }
 void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 {
@@ -4091,20 +4222,16 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 			{
 				if (exdesc->keyword)
 				{
-					out << yaml.GetIndent() << "- keywords: " << exdesc->keyword << std::endl;
+					// keywords may start with '-' (legitimately a single dash);
+					// Koi8rYamlEmitter::Value handles leading-indicator quoting.
+					out << yaml.GetIndent() << "- keywords:";
+					yaml.Value(std::string(exdesc->keyword));
 					if (exdesc->description)
 					{
-						out << yaml.GetIndent() << "  description: |" << std::endl;
-
-						std::string desc = exdesc->description;
-						desc.erase(std::remove(desc.begin(), desc.end(), '\r'), desc.end());
-
-						std::istringstream iss(desc);
-						std::string line;
-						while (std::getline(iss, line))
-						{
-							out << yaml.GetIndent() << "    " << line << std::endl;
-						}
+						out << yaml.GetIndent() << "  description:";
+						yaml.IncreaseIndent();
+						yaml.Value(std::string(exdesc->description), true);
+						yaml.DecreaseIndent();
 					}
 				}
 			}
@@ -4172,6 +4299,8 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 	}
 
 	log("Saved %d objects for zone %d", saved_count, zone.vnum);
+
+	RebuildPerZoneIndex(zone.vnum, "objects");
 }
 
 // ============================================================================

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -28,6 +28,7 @@
 
 #include <yaml-cpp/yaml.h>
 #include <algorithm>
+#include <cstring>
 #include <iomanip>
 #include <regex>
 #include <filesystem>
@@ -3436,7 +3437,13 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 		// Enhanced E-spec block. Always emitted because mob_type is always
 		// "E" in this code path and the Python converter writes the block
 		// unconditionally (carrying at least resistances/saves as zero-arrays).
+		// `tascii` appends into the buffer (uses strlen(ascii) + strncat) and
+		// does NOT clear it -- callers must zero-init or its output becomes
+		// the concatenation of whatever was in stack memory from prior mob
+		// iterations. That's the root cause of the "special_bitvector accretes
+		// across mobs" diff: 'f1 0' on mob 1, 'f1 0 0 0' on mob 2, etc.
 		char special_buf[kMaxStringLength];
+		special_buf[0] = '\0';
 		mob.mob_specials.npc_flags.tascii(FlagData::kPlanesNumber, special_buf, sizeof(special_buf));
 		std::string role_str = mob.get_role().to_string();
 		{
@@ -3526,10 +3533,19 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 					yaml.Value(mob.get_remort());
 				}
 
-				if (special_buf[0] != '0' || special_buf[1] != 'a')
+				// tascii leaves a trailing " " (or "0 " for empty) -- strip it
+				// to match the Python converter, which emits "f1" not "f1 ".
+				{
+					size_t len = std::strlen(special_buf);
+					while (len > 0 && special_buf[len - 1] == ' ')
+					{
+						special_buf[--len] = '\0';
+					}
+				}
+				if (special_buf[0] != '0' || special_buf[1] != '\0')
 				{
 					yaml.Key("special_bitvector");
-					yaml.Value(special_buf);
+					yaml.Value(std::string(special_buf));
 				}
 
 				if (!role_str.empty() && role_str != "000000000")

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -2765,6 +2765,10 @@ bool YamlWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int not
 		yaml.Comment("Trigger #" + std::to_string(trig_vnum));
 		yaml.EmptyLine();
 
+		// Vnum (matches Python converter output and SaveRooms convention).
+		yaml.Key("vnum");
+		yaml.Value(trig_vnum);
+
 		// Name
 		yaml.Key("name");
 		yaml.Value(GET_TRIG_NAME(trig));
@@ -3169,6 +3173,10 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 		// Header comment
 		yaml.Comment("Mob #" + std::to_string(mob_vnum));
 		yaml.EmptyLine();
+
+		// Vnum (matches Python converter output and SaveRooms convention).
+		yaml.Key("vnum");
+		yaml.Value(mob_vnum);
 
 		// Names
 		yaml.Key("names");
@@ -3760,6 +3768,10 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 		// Header comment
 		yaml.Comment("Object #" + std::to_string(obj_vnum));
 		yaml.EmptyLine();
+
+		// Vnum (matches Python converter output and SaveRooms convention).
+		yaml.Key("vnum");
+		yaml.Value(obj_vnum);
 
 		// Names
 		yaml.Key("names");

--- a/src/engine/db/yaml_world_data_source.h
+++ b/src/engine/db/yaml_world_data_source.h
@@ -105,6 +105,22 @@ private:
 	std::string ReverseLookupEnum(const std::string &dict_name, int value) const;
 	bool WriteYamlAtomic(const std::string &filepath, const YAML::Node &node) const;
 
+	// Rewrite an `index.yaml` file as a snapshot of the current in-memory
+	// state. `top_key` is the YAML root key ("zones"/"mobs"/"objects"/...);
+	// `values` is the sorted list of vnums or rel-numbers. Save* methods call
+	// these after writing entity files so the on-disk index stays consistent
+	// with what loader will see on next boot (no stale rnums, new entities
+	// from OLC visible, no leftover deletions).
+	bool WriteIndexYaml(const std::string &filepath,
+						const std::string &top_key,
+						const std::vector<int> &values) const;
+
+	// Rebuild the per-zone index for one of the entity sub-directories
+	// ("mobs"/"objects"/"rooms"/"triggers"). Iterates the corresponding
+	// global prototype table, collects entries whose vnum/100 == zone_vnum,
+	// writes the rel-numbers (vnum % 100) into <m_world_dir>/zones/<zone>/<sub>/index.yaml.
+	bool RebuildPerZoneIndex(int zone_vnum, const std::string &sub) const;
+
 	// Parallel loading methods (only used when m_num_threads > 1)
 	void LoadZonesParallel();
 	void LoadTriggersParallel();

--- a/tests/koi8r.yaml.emitter.cpp
+++ b/tests/koi8r.yaml.emitter.cpp
@@ -1,0 +1,93 @@
+// Regression tests for Koi8rYamlEmitter -- see issue #3273.
+//
+// Before the fix, values whose first character was a YAML indicator (&, *, !, ,)
+// were emitted as bare plain scalars. yaml-cpp then re-parsed them as anchors,
+// aliases or tags, breaking save -> reload round-trip. MUD color codes like
+// "&Yfoo &Wbar&n" in object/mob names emitted unquoted yielded
+// "cannot assign multiple anchors to the same node".
+
+#ifdef HAVE_YAML
+
+#include "engine/db/koi8r_yaml_emitter.h"
+
+#include <gtest/gtest.h>
+#include <yaml-cpp/yaml.h>
+#include <sstream>
+#include <string>
+
+namespace
+{
+
+// Emit `value` as a single mapping entry "v: <value>" via the emitter, then
+// parse it back with yaml-cpp and return the scalar string.
+std::string RoundTrip(const std::string &value)
+{
+	std::ostringstream out;
+	Koi8rYamlEmitter yaml(out);
+	yaml.Key("v");
+	yaml.Value(value);
+	YAML::Node node = YAML::Load(out.str());
+	return node["v"].as<std::string>();
+}
+
+}  // namespace
+
+TEST(Koi8rYamlEmitter, RoundTripPlainAscii)
+{
+	EXPECT_EQ(RoundTrip("hello"), "hello");
+}
+
+TEST(Koi8rYamlEmitter, RoundTripEmpty)
+{
+	EXPECT_EQ(RoundTrip(""), "");
+}
+
+// Exact scenario from issue #3273: multiple "&X..." color tokens. yaml-cpp used
+// to interpret each "&" as an anchor declaration and fail with "cannot assign
+// multiple anchors to the same node".
+TEST(Koi8rYamlEmitter, ColorCodesAtStartRoundTrip)
+{
+	const std::string color_name = "&Yfoo &Wbar&n";
+	EXPECT_EQ(RoundTrip(color_name), color_name);
+}
+
+// Single leading "&" also used to break (parsed as anchor, value becomes null).
+TEST(Koi8rYamlEmitter, SingleLeadingAmpersandRoundTrip)
+{
+	EXPECT_EQ(RoundTrip("&Y"), "&Y");
+}
+
+// "*" at start of a plain scalar is an alias indicator.
+TEST(Koi8rYamlEmitter, LeadingAsteriskRoundTrip)
+{
+	EXPECT_EQ(RoundTrip("*ref"), "*ref");
+}
+
+// "!" at start of a plain scalar is a tag indicator.
+TEST(Koi8rYamlEmitter, LeadingExclamationRoundTrip)
+{
+	EXPECT_EQ(RoundTrip("!important"), "!important");
+}
+
+// "," at start of a plain scalar is a flow indicator.
+TEST(Koi8rYamlEmitter, LeadingCommaRoundTrip)
+{
+	EXPECT_EQ(RoundTrip(",comma"), ",comma");
+}
+
+// Pre-existing behaviour: strings containing single quotes are escaped.
+TEST(Koi8rYamlEmitter, SingleQuoteEscaped)
+{
+	const std::string value = "it's a quote";
+	EXPECT_EQ(RoundTrip(value), value);
+}
+
+// Pre-existing behaviour: colons need quoting (otherwise "a: b" parses as map).
+TEST(Koi8rYamlEmitter, ColonInValueRoundTrip)
+{
+	EXPECT_EQ(RoundTrip("foo: bar"), "foo: bar");
+}
+
+#endif  // HAVE_YAML
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -33,6 +33,7 @@ test_sources = files(
     'compact.trie.cpp',
     'compact.trie.iterators.cpp',
     'yaml.save.encoding.cpp',
+    'koi8r.yaml.emitter.cpp',
     'compact.trie.prefixes.cpp',
     'thread_pool.cpp',
     'world_data_source_manager.cpp',

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -3232,12 +3232,15 @@ def _lowercase_first_token(line):
 
 
 def _normalize_script(script):
-    """Apply _lowercase_first_token + rstrip to every line of a multi-line script.
+    """Apply _lowercase_first_token to every line of a multi-line script.
 
-    rstrip mirrors utils::TrimRight(line) in the C++ loaders
-    (world_data_source_base.cpp:48 and boot_data_files.cpp:324); without it,
-    legacy files with trailing whitespace on a line produce a save-vs-load
-    round-trip diff ("set dmsg  " vs "set dmsg").
+    NOTE: rstrip()'ing each line *would* mirror utils::TrimRight(line) at the
+    line-content level in the C++ loaders, but it also drops lines that
+    consist of nothing but whitespace -- which ParseTriggerScript /
+    boot_data_files.cpp KEEP (their empty-line check runs *before* the trim).
+    Stripping changes the in-memory cmdlist (a different number of nodes),
+    so the world checksum shifts. We deliberately do NOT rstrip here -- it
+    is the loader's job to normalise per-line whitespace at load time.
     """
     if not script:
         return script
@@ -3246,7 +3249,7 @@ def _normalize_script(script):
         sep = '\r\n'
     else:
         sep = '\n'
-    return sep.join(_lowercase_first_token(line.rstrip()) for line in script.split(sep))
+    return sep.join(_lowercase_first_token(line) for line in script.split(sep))
 
 
 def trg_to_yaml(trigger):

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -3198,7 +3198,9 @@ def parse_trg_file(filepath):
                 last_line = lines[idx].rstrip('~')
                 if last_line:
                     script_parts.append(last_line)
-            trigger['script'] = '\r\n'.join(script_parts).replace('~~', '~')
+            trigger['script'] = _normalize_script(
+                '\r\n'.join(script_parts).replace('~~', '~')
+            )
 
             triggers.append(trigger)
 
@@ -3207,6 +3209,38 @@ def parse_trg_file(filepath):
             continue
 
     return triggers
+
+
+def _lowercase_first_token(line):
+    """Lowercase the first whitespace-delimited token of a script line.
+
+    Mirrors the load-time normalisation in
+    src/engine/db/world_data_source_base.cpp (ParseTriggerScript) and the
+    legacy loader in src/engine/boot/boot_data_files.cpp -- both rewrite the
+    first word of each command via LOWER() so the DG-script runtime can use
+    strncmp() for dispatch. Doing the same here keeps the YAML on disk in the
+    canonical form and removes a spurious round-trip diff
+    ("DgAffect" -> "dgaffect" after one save).
+    """
+    i = 0
+    while i < len(line) and line[i] in ' \t':
+        i += 1
+    j = i
+    while j < len(line) and line[j] not in ' \t':
+        j += 1
+    return line[:i] + line[i:j].lower() + line[j:]
+
+
+def _normalize_script(script):
+    """Apply _lowercase_first_token to every line of a multi-line script."""
+    if not script:
+        return script
+    # Preserve the original line separator (\r\n vs \n) by detecting first.
+    if '\r\n' in script:
+        sep = '\r\n'
+    else:
+        sep = '\n'
+    return sep.join(_lowercase_first_token(line) for line in script.split(sep))
 
 
 def trg_to_yaml(trigger):

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -3232,7 +3232,13 @@ def _lowercase_first_token(line):
 
 
 def _normalize_script(script):
-    """Apply _lowercase_first_token to every line of a multi-line script."""
+    """Apply _lowercase_first_token + rstrip to every line of a multi-line script.
+
+    rstrip mirrors utils::TrimRight(line) in the C++ loaders
+    (world_data_source_base.cpp:48 and boot_data_files.cpp:324); without it,
+    legacy files with trailing whitespace on a line produce a save-vs-load
+    round-trip diff ("set dmsg  " vs "set dmsg").
+    """
     if not script:
         return script
     # Preserve the original line separator (\r\n vs \n) by detecting first.
@@ -3240,7 +3246,7 @@ def _normalize_script(script):
         sep = '\r\n'
     else:
         sep = '\n'
-    return sep.join(_lowercase_first_token(line) for line in script.split(sep))
+    return sep.join(_lowercase_first_token(line.rstrip()) for line in script.split(sep))
 
 
 def trg_to_yaml(trigger):
@@ -3264,7 +3270,9 @@ def trg_to_yaml(trigger):
     if 'narg' in trigger:
         data['narg'] = trigger['narg']
 
-    if 'arglist' in trigger:
+    # Match C++ SaveTriggers: emit arglist only when non-empty. Otherwise
+    # converter writes `arglist: ''` and a round-trip save drops the key.
+    if trigger.get('arglist'):
         data['arglist'] = trigger['arglist']
 
     if 'script' in trigger:

--- a/tools/run_load_tests.sh
+++ b/tools/run_load_tests.sh
@@ -100,11 +100,16 @@ for arg in "$@"; do
     esac
 done
 
-# Quick mode: only Small_Legacy_checksums and Small_YAML_checksums
+# Quick mode: only Small_Legacy_checksums and Small_YAML_checksums.
+# Skip sqlite explicitly -- the project ships no sqlite3.wrap and the test box
+# may not have libsqlite3-dev installed, in which case `meson setup
+# -Dsqlite=auto` would error out.
+QUICK_SKIP_SQLITE=0
 if [ $QUICK_MODE -eq 1 ]; then
     FILTER_LOADER=""  # Will run both legacy and yaml
     FILTER_WORLD="small"
     FILTER_CHECKSUMS="yes"
+    QUICK_SKIP_SQLITE=1
     echo "Quick mode: Running Small_Legacy_checksums and Small_YAML_checksums"
     echo ""
 fi
@@ -435,6 +440,9 @@ fi
 if [ -z "$FILTER_LOADER" ] || [ "$FILTER_LOADER" = "sqlite" ]; then
     NEED_SQLITE=1
 fi
+if [ $QUICK_SKIP_SQLITE -eq 1 ]; then
+    NEED_SQLITE=0
+fi
 if [ -z "$FILTER_LOADER" ] || [ "$FILTER_LOADER" = "yaml" ]; then
     NEED_YAML=1
 fi
@@ -454,7 +462,10 @@ fi
 
 if [ $NEED_SQLITE -eq 1 ]; then
 
-    build_binary "$MUD_DIR/build_sqlite" "-Dadmin_api=true -Dsqlite=builtin -Dbuild_profile=debug" "sqlite" || exit 1
+    # sqlite=auto: prefer system libsqlite3, fall back to the meson subproject
+    # (which requires a checked-in subprojects/sqlite3.wrap that we currently
+    # don't ship).
+    build_binary "$MUD_DIR/build_sqlite" "-Dadmin_api=true -Dsqlite=auto -Dbuild_profile=debug" "sqlite" || exit 1
 fi
 if [ $NEED_YAML -eq 1 ]; then
 

--- a/tools/run_load_tests.sh
+++ b/tools/run_load_tests.sh
@@ -39,8 +39,8 @@
 #   --checksums       Run only tests WITH checksum calculation
 #   --no-checksums    Run only tests WITHOUT checksum calculation
 #   --quick           Run quick comparison: Small_Legacy_checksums vs Small_YAML_checksums
-#   --rebuild         Force full rebuild (make clean && make)
-#   --build-type=TYPE Set CMAKE_BUILD_TYPE (Release|Debug|Test|FastTest)
+#   --rebuild         Force full rebuild (ninja -t clean && ninja)
+#   --build-type=TYPE Set meson build_profile (release|debug|dev|fasttest|custom)
 #   --recreate-builds Delete and recreate all build directories (implies world recreation)
 #   --help            Show this help
 #
@@ -112,103 +112,126 @@ fi
 # Default location of full world archive
 FULL_WORLD_ARCHIVE="${FULL_WORLD_ARCHIVE:-$HOME/repos/world.tgz}"
 
-# Function to build a specific binary variant
+# Map a CMake-style build type ("Debug"/"Release"/"Test"/"FastTest") to the
+# corresponding meson profile. Pass through anything we don't recognise.
+map_build_type_to_meson_profile() {
+    case "$1" in
+        Debug|debug)        echo "debug" ;;
+        Release|release)    echo "release" ;;
+        Test|test|Dev|dev)  echo "dev" ;;
+        FastTest|fasttest)  echo "fasttest" ;;
+        Custom|custom)      echo "custom" ;;
+        "")                 echo "" ;;
+        *)                  echo "$1" ;;
+    esac
+}
+
+# Function to build a specific binary variant.
+# Uses meson + ninja (the project's current build system).
+#
+# Args:
+#   $1 = build_dir (out-of-source directory to set up)
+#   $2 = meson_opts (space-separated -Doption=value flags)
+#   $3 = binary_name (label for log files, e.g. "legacy"/"yaml")
 build_binary() {
     local build_dir="$1"
-    local cmake_opts="$2"
+    local meson_opts="$2"
     local binary_name="$3"
-    local needs_reconfigure=0
-    
+    local needs_setup=0
+
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo "Building: $binary_name"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    
-    # Check if we need to recreate or reconfigure
-    if [ ! -d "$build_dir" ]; then
+
+    # Detect meson + ninja; allow ~/.local/bin fallback for pip --user installs.
+    local meson_bin
+    if command -v meson >/dev/null 2>&1; then
+        meson_bin=meson
+    elif [ -x "$HOME/.local/bin/meson" ]; then
+        meson_bin="$HOME/.local/bin/meson"
+    else
+        echo "X ERROR: meson not found. Install with: pip install --user meson ninja"
+        return 1
+    fi
+
+    local ninja_bin
+    if command -v ninja >/dev/null 2>&1; then
+        ninja_bin=ninja
+    elif [ -x "$HOME/.local/bin/ninja" ]; then
+        ninja_bin="$HOME/.local/bin/ninja"
+    else
+        echo "X ERROR: ninja not found. Install with: pip install --user meson ninja"
+        return 1
+    fi
+
+    # Decide if we need a fresh `meson setup`.
+    if [ ! -d "$build_dir" ] || [ ! -f "$build_dir/build.ninja" ]; then
         mkdir -p "$build_dir"
-        needs_reconfigure=1
+        needs_setup=1
     elif [ $RECREATE_BUILDS -eq 1 ]; then
         echo "Recreating build directory (--recreate-builds)..."
         rm -rf "$build_dir"
         mkdir -p "$build_dir"
-        needs_reconfigure=1
-    elif [ -n "$BUILD_TYPE" ] && [ -f "$build_dir/CMakeCache.txt" ]; then
-        # Check if BUILD_TYPE changed
-        local current_type=$(grep "CMAKE_BUILD_TYPE:" "$build_dir/CMakeCache.txt" 2>/dev/null | cut -d= -f2)
-        if [ "$current_type" != "$BUILD_TYPE" ]; then
-            echo "Build type changed ($current_type -> $BUILD_TYPE), reconfiguring..."
-            needs_reconfigure=1
-        fi
-    elif [ ! -f "$build_dir/CMakeCache.txt" ]; then
-        needs_reconfigure=1
+        needs_setup=1
     fi
-    
-    cd "$build_dir"
-    
-    # Apply BUILD_TYPE override if specified
-    local final_cmake_opts="$cmake_opts"
+
+    # Translate optional BUILD_TYPE into a meson profile flag.
+    local effective_opts="$meson_opts"
     if [ -n "$BUILD_TYPE" ]; then
-        # Replace existing -DCMAKE_BUILD_TYPE or add if missing
-        if echo "$cmake_opts" | grep -q "CMAKE_BUILD_TYPE"; then
-            final_cmake_opts=$(echo "$cmake_opts" | sed "s/-DCMAKE_BUILD_TYPE=[^ ]*/-DCMAKE_BUILD_TYPE=$BUILD_TYPE/")
-        else
-            final_cmake_opts="$cmake_opts -DCMAKE_BUILD_TYPE=$BUILD_TYPE"
-        fi
+        local profile
+        profile=$(map_build_type_to_meson_profile "$BUILD_TYPE")
+        # Strip any existing -Dbuild_profile=... so we don't end up with two.
+        effective_opts=$(echo "$effective_opts" | sed -E 's/-Dbuild_profile=[^ ]*//g')
+        effective_opts="$effective_opts -Dbuild_profile=$profile"
     fi
-    
-    # Run cmake if needed
-    if [ $needs_reconfigure -eq 1 ]; then
-        echo "[1/2] Configuring with CMake..."
-        echo "      Options: $final_cmake_opts"
-        cmake $final_cmake_opts .. > /tmp/build_${binary_name}_cmake.log 2>&1 || {
-            echo "X ERROR: CMake configuration failed"
-            echo "  Log: /tmp/build_${binary_name}_cmake.log"
-            cd "$MUD_DIR"
+
+    if [ $needs_setup -eq 1 ]; then
+        echo "[1/2] Configuring with meson..."
+        echo "      Options: $effective_opts"
+        "$meson_bin" setup "$build_dir" $effective_opts > /tmp/build_${binary_name}_meson.log 2>&1 || {
+            echo "X ERROR: meson setup failed"
+            echo "  Log: /tmp/build_${binary_name}_meson.log"
+            echo "  Last 20 lines:"
+            tail -20 /tmp/build_${binary_name}_meson.log
             return 1
         }
-        echo " CMake configuration complete"
+        echo " meson configuration complete"
     else
-        echo "[1/2] Using cached CMake configuration"
+        echo "[1/2] Using existing meson configuration"
+        # Allow `meson configure` to absorb an updated BUILD_TYPE override.
+        if [ -n "$BUILD_TYPE" ]; then
+            "$meson_bin" configure "$build_dir" -Dbuild_profile="$(map_build_type_to_meson_profile "$BUILD_TYPE")" \
+                >> /tmp/build_${binary_name}_meson.log 2>&1 || true
+        fi
     fi
-    
-    # Build
+
+    # Build (parallel; use half of cores to keep the box responsive).
     echo "[2/2] Compiling (this may take a while)..."
     echo "      Log: /tmp/build_${binary_name}.log"
     echo "      Tip: Run 'tail -f /tmp/build_${binary_name}.log' in another terminal to watch progress"
     echo ""
-    # Clean if rebuild requested
+
+    local nprocs=$(($(nproc)/2))
+    if [ "$nprocs" -lt 1 ]; then nprocs=1; fi
+
     if [ $REBUILD_MODE -eq 1 ]; then
-        echo "      Running make clean (rebuild mode)..."
-        make clean > /tmp/build_${binary_name}.log 2>&1
-        make circle -j$(nproc) >> /tmp/build_${binary_name}.log 2>&1 || {
-            echo "X ERROR: Build failed"
-            echo "  Log: /tmp/build_${binary_name}.log"
-            echo "  Last 20 lines:"
-            tail -20 /tmp/build_${binary_name}.log
-            cd "$MUD_DIR"
-            return 1
-        }
-    else
-        make circle -j$(nproc) > /tmp/build_${binary_name}.log 2>&1 || {
-            echo "X ERROR: Build failed"
-            echo "  Log: /tmp/build_${binary_name}.log"
-            echo "  Last 20 lines:"
-            tail -20 /tmp/build_${binary_name}.log
-            cd "$MUD_DIR"
-            return 1
-        }
+        echo "      Cleaning previous build..."
+        "$ninja_bin" -C "$build_dir" -t clean > /tmp/build_${binary_name}.log 2>&1 || true
     fi
-    
-    cd "$MUD_DIR"
-    
-    # Verify binary was created
-    if [ ! -x "$build_dir/circle" ]; then
-        echo "X ERROR: Binary not created despite successful make"
+
+    "$ninja_bin" -C "$build_dir" circle "-j$nprocs" >> /tmp/build_${binary_name}.log 2>&1 || {
+        echo "X ERROR: Build failed"
         echo "  Log: /tmp/build_${binary_name}.log"
         echo "  Last 20 lines:"
         tail -20 /tmp/build_${binary_name}.log
-        cd "$MUD_DIR"
+        return 1
+    }
+
+    if [ ! -x "$build_dir/circle" ]; then
+        echo "X ERROR: Binary not created despite successful build"
+        echo "  Log: /tmp/build_${binary_name}.log"
+        tail -20 /tmp/build_${binary_name}.log
         return 1
     fi
     echo " Successfully built $build_dir/circle"
@@ -240,34 +263,18 @@ setup_small_world() {
 
     rm -rf "$dest_dir"
 
-    # Reconfigure CMake to recreate small directory with symlinks
-    echo "Reconfiguring CMake to create small world structure..."
-
-    cd "$build_dir"
-    if [ "$loader" = "legacy" ]; then
-        cmake -DCMAKE_BUILD_TYPE=Debug .. > /tmp/cmake_small_legacy.log 2>&1 || {
-            echo "X ERROR: CMake reconfiguration failed"
-            echo "  Log: /tmp/cmake_small_legacy.log"
-            cd "$MUD_DIR"
-            return 1
-        }
-    elif [ "$loader" = "sqlite" ]; then
-        cmake -DHAVE_SQLITE=ON -DCMAKE_BUILD_TYPE=Debug .. > /tmp/cmake_small_sqlite.log 2>&1 || {
-            echo "X ERROR: CMake reconfiguration failed"
-            echo "  Log: /tmp/cmake_small_sqlite.log"
-            cd "$MUD_DIR"
-            return 1
-        }
-    elif [ "$loader" = "yaml" ]; then
-        cmake -DHAVE_YAML=ON -DCMAKE_BUILD_TYPE=Debug .. > /tmp/cmake_small_yaml.log 2>&1 || {
-            echo "X ERROR: CMake reconfiguration failed"
-            echo "  Log: /tmp/cmake_small_yaml.log"
-            cd "$MUD_DIR"
-            return 1
-        }
-    fi
-    cd "$MUD_DIR"
-    echo " CMake created $dest_dir (copied lib + lib.template)"
+    # Materialise the small world via the meson helper (the same one that
+    # `-Dsmall_world=true` triggers during configure). It copies lib/ -> small/
+    # and overlays lib.template/.
+    echo "Running tools/meson/setup_world.py to create small world structure..."
+    python3 "$MUD_DIR/tools/meson/setup_world.py" \
+        "$build_dir" "$MUD_DIR" "" > /tmp/setup_small_${loader}.log 2>&1 || {
+        echo "X ERROR: small world setup failed"
+        echo "  Log: /tmp/setup_small_${loader}.log"
+        cat /tmp/setup_small_${loader}.log
+        return 1
+    }
+    echo " Small world created at $dest_dir (lib + lib.template)"
 
     if [ "$loader" = "legacy" ]; then
         echo " Legacy world ready (using lib.template/world)"
@@ -442,17 +449,17 @@ fi
 # Build binaries if needed (with Admin API enabled for testing)
 if [ $NEED_LEGACY -eq 1 ]; then
 
-    build_binary "$MUD_DIR/build_test" "-DENABLE_ADMIN_API=ON -DCMAKE_BUILD_TYPE=Debug" "legacy" || exit 1
+    build_binary "$MUD_DIR/build_test" "-Dadmin_api=true -Dbuild_profile=debug" "legacy" || exit 1
 fi
 
 if [ $NEED_SQLITE -eq 1 ]; then
 
-    build_binary "$MUD_DIR/build_sqlite" "-DENABLE_ADMIN_API=ON -DHAVE_SQLITE=ON -DCMAKE_BUILD_TYPE=Debug" "sqlite" || exit 1
+    build_binary "$MUD_DIR/build_sqlite" "-Dadmin_api=true -Dsqlite=builtin -Dbuild_profile=debug" "sqlite" || exit 1
 fi
 if [ $NEED_YAML -eq 1 ]; then
 
 
-    build_binary "$MUD_DIR/build_yaml" "-DENABLE_ADMIN_API=ON -DHAVE_YAML=ON -DCMAKE_BUILD_TYPE=Debug" "yaml" || exit 1
+    build_binary "$MUD_DIR/build_yaml" "-Dadmin_api=true -Dyaml=builtin -Dbuild_profile=debug" "yaml" || exit 1
 fi
 # Setup worlds
 if [ $NEED_SMALL -eq 1 ]; then

--- a/tools/yaml_roundtrip_test.sh
+++ b/tools/yaml_roundtrip_test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# YAML world round-trip diagnostic.
+#
+# Loads the YAML world from <data_dir>/world, re-emits it via the C++
+# Koi8rYamlEmitter into <data_dir>/world_v2, then runs a structural diff
+# (tools/yaml_world_diff.py) between v1 and v2. Used to catch save -> reload
+# inconsistencies in YamlWorldDataSource::Save* methods.
+#
+# Usage:
+#   ./tools/yaml_roundtrip_test.sh [<data_dir>] [<circle_binary>]
+#
+# Defaults:
+#   data_dir = build_yaml/full
+#   circle_binary = build_yaml_meson/circle  (must be built with -Dyaml=...)
+#
+# Pre-requisites:
+#   - <data_dir>/world contains a valid YAML world (world_config.yaml,
+#     dictionaries/, zones/index.yaml + per-zone trees).
+#   - <data_dir>/misc/configuration.xml exists (circle needs it on boot).
+#
+# Exit codes:
+#   0  resave succeeded and v1 ~= v2 (no structural diffs);
+#   1  parse errors or structural diffs (real findings);
+#   2  resave itself failed (circle exit code != 0).
+#
+
+set -euo pipefail
+
+DATA_DIR=${1:-build_yaml/full}
+CIRCLE_BIN=${2:-build_yaml_meson/circle}
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ ! -d "$DATA_DIR/world" ]]; then
+    echo "ERROR: $DATA_DIR/world not found." >&2
+    exit 2
+fi
+if [[ ! -x "$CIRCLE_BIN" ]]; then
+    echo "ERROR: $CIRCLE_BIN not found or not executable." >&2
+    exit 2
+fi
+
+# Resolve to absolute paths before any cd.
+CIRCLE_BIN_ABS="$(cd "$(dirname "$CIRCLE_BIN")" && pwd)/$(basename "$CIRCLE_BIN")"
+DATA_DIR_ABS="$(cd "$DATA_DIR" && pwd)"
+
+echo "== Round-trip: load $DATA_DIR_ABS/world -> save world_v2 =="
+rm -rf "$DATA_DIR_ABS/world_v2"
+
+# circle does chdir(data_dir); target path is interpreted relative to that.
+(
+    cd "$DATA_DIR_ABS"
+    "$CIRCLE_BIN_ABS" -d . -S world_v2 4001
+)
+rc=$?
+if [[ $rc -ne 0 ]]; then
+    echo "ERROR: circle -S exited with code $rc" >&2
+    exit 2
+fi
+
+echo
+echo "== Diff: $DATA_DIR_ABS/world vs $DATA_DIR_ABS/world_v2 =="
+python3 "$REPO_ROOT/tools/yaml_world_diff.py" \
+    "$DATA_DIR_ABS/world" "$DATA_DIR_ABS/world_v2"

--- a/tools/yaml_world_diff.py
+++ b/tools/yaml_world_diff.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Structural diff for two YAML world trees.
+
+Used by tools/yaml_roundtrip_test.sh to compare an original YAML world (v1,
+produced by the Python converter) against its resave by `circle -S` (v2). Both
+files are expected to be in KOI8-R and parseable as YAML mappings.
+
+Comparison is per-entity (mob/object/room/trigger/zone) and ignores:
+- key order inside mappings;
+- string-vs-int scalar form for values that look like integers (the Python
+  converter emits `'8'`, the C++ emitter emits `8`; semantically equal);
+- comments and blank lines (yaml-cpp/ruamel both strip them on parse).
+
+Files present in one tree but not the other are reported. Per-zone index.yaml
+files and the top-level zones/index.yaml are skipped -- they are never written
+by SaveZone/SaveObjects/etc., so the C++ side legitimately doesn't produce them.
+
+Exit code: 0 if the trees are equivalent, non-zero on any difference.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    from ruamel.yaml import YAML
+except ImportError:
+    sys.stderr.write("ruamel.yaml not installed. pip install ruamel.yaml\n")
+    sys.exit(2)
+
+
+_yaml = YAML(typ="safe")
+
+
+# Files that the C++ Save* code path never writes -- skip them on comparison.
+SKIP_NAMES = {"index.yaml"}
+
+
+def load_yaml(path: Path):
+    with path.open("rb") as f:
+        raw = f.read()
+    text = raw.decode("koi8-r", errors="replace")
+    return _yaml.load(text)
+
+
+def normalize_scalar(v):
+    """Treat string-form integers as integers; leave everything else as-is."""
+    if isinstance(v, str):
+        stripped = v.strip()
+        # Conservative: only normalize unambiguous decimal integers.
+        if stripped and (stripped.lstrip("-").isdigit()):
+            try:
+                return int(stripped)
+            except ValueError:
+                pass
+    return v
+
+
+def compare(a, b, path: str, diffs: list[str]):
+    a = normalize_scalar(a)
+    b = normalize_scalar(b)
+    if type(a) is not type(b):
+        diffs.append(f"{path}: type {type(a).__name__} != {type(b).__name__}: {a!r} vs {b!r}")
+        return
+    if isinstance(a, dict):
+        all_keys = sorted(set(a.keys()) | set(b.keys()))
+        for k in all_keys:
+            if k not in a:
+                diffs.append(f"{path}/{k}: missing in v1, v2={b[k]!r}")
+            elif k not in b:
+                diffs.append(f"{path}/{k}: missing in v2, v1={a[k]!r}")
+            else:
+                compare(a[k], b[k], f"{path}/{k}", diffs)
+    elif isinstance(a, list):
+        if len(a) != len(b):
+            diffs.append(f"{path}: list len {len(a)} != {len(b)}: v1={a!r}, v2={b!r}")
+            return
+        for i, (x, y) in enumerate(zip(a, b)):
+            compare(x, y, f"{path}[{i}]", diffs)
+    else:
+        if a != b:
+            diffs.append(f"{path}: {a!r} != {b!r}")
+
+
+def collect_files(root: Path):
+    """Yield relative paths of yaml files we care about under root."""
+    for p in root.rglob("*.yaml"):
+        if p.name in SKIP_NAMES:
+            continue
+        yield p.relative_to(root)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("v1", type=Path, help="reference yaml world (e.g. python-converted)")
+    ap.add_argument("v2", type=Path, help="re-emitted yaml world (e.g. circle -S output)")
+    ap.add_argument("--max-diffs-per-file", type=int, default=10,
+                    help="cap differences printed per file (default 10)")
+    ap.add_argument("--max-files", type=int, default=0,
+                    help="stop after this many files with diffs (0 = unlimited)")
+    args = ap.parse_args()
+
+    v1_files = set(collect_files(args.v1))
+    v2_files = set(collect_files(args.v2))
+
+    only_v1 = sorted(v1_files - v2_files)
+    only_v2 = sorted(v2_files - v1_files)
+    shared = sorted(v1_files & v2_files)
+
+    n_diff_files = 0
+    n_total_diffs = 0
+    bad_files = 0
+
+    if only_v1:
+        print(f"== {len(only_v1)} file(s) only in v1 ==")
+        for p in only_v1[:20]:
+            print(f"  - {p}")
+        if len(only_v1) > 20:
+            print(f"  ... and {len(only_v1) - 20} more")
+    if only_v2:
+        print(f"== {len(only_v2)} file(s) only in v2 ==")
+        for p in only_v2[:20]:
+            print(f"  + {p}")
+        if len(only_v2) > 20:
+            print(f"  ... and {len(only_v2) - 20} more")
+
+    for rel in shared:
+        try:
+            a = load_yaml(args.v1 / rel)
+            b = load_yaml(args.v2 / rel)
+        except Exception as e:
+            print(f"!! {rel}: parse error: {e}")
+            bad_files += 1
+            continue
+        diffs: list[str] = []
+        compare(a, b, "", diffs)
+        if diffs:
+            n_diff_files += 1
+            n_total_diffs += len(diffs)
+            print(f"== {rel}: {len(diffs)} diff(s) ==")
+            for d in diffs[:args.max_diffs_per_file]:
+                print(f"  {d}")
+            if len(diffs) > args.max_diffs_per_file:
+                print(f"  ... and {len(diffs) - args.max_diffs_per_file} more")
+            if args.max_files and n_diff_files >= args.max_files:
+                print(f"\n(stopped after {args.max_files} files with diffs)")
+                break
+
+    print()
+    print(f"Summary: {n_diff_files} file(s) with diffs ({n_total_diffs} total), "
+          f"{bad_files} parse error(s), {len(only_v1)} only in v1, "
+          f"{len(only_v2)} only in v2.")
+    return 0 if (n_diff_files == 0 and bad_files == 0 and not only_v1 and not only_v2) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Что и зачем

Добавляет диагностический CLI-флаг `circle -S <out_dir>` и обвязку для проверки save→reload-целостности yaml-мира.

Мотивация (выросло из обсуждения #3273 и PR #3277): эмиттер `Koi8rYamlEmitter` и save-методы `YamlWorldDataSource` пишут yaml, который потом сам же сервер должен уметь читать. Без round-trip-теста любая регрессия в save-коде не ловится — баг проявляется только когда кто-то отредактировал зону через OLC и сервер при следующем boot'е падает.

## Что в PR

1. **`circle -S <out_dir>`** (`src/engine/core/comm.cpp` + `src/engine/db/db.{cpp,h}`)
   - Грузит мир штатным бэкендом (yaml/sqlite), вызывает `Save*` для каждой зоны в `zone_table` через свежий экземпляр того же бэкенда, указанный на `out_dir`, и выходит.
   - Save-экземпляр создаётся через ту же фабрику `CreateYamlDataSource(out_dir)`, без расширения `IWorldDataSource` — `Save*` уже виртуальные.
   - `ResaveWorld` предварительно копирует `world_config.yaml` и `dictionaries/` из `world/` в `out_dir`: конструктор `YamlWorldDataSource` валится без `world_config.yaml`, а словари нужны для `ReverseLookupEnum` на save (через глобальный `DictionaryManager`).
   - Без `-S` поведение бинаря не меняется.

2. **`tools/yaml_world_diff.py`**
   - Structural diff двух yaml-миров через ruamel.yaml. Сравнивает per-entity файлы как древо данных, игнорируя порядок ключей, комменты, string-vs-int форму чисел.
   - `index.yaml` пропускает — `Save*` их не пишет.

3. **`tools/yaml_roundtrip_test.sh`**
   - `circle -S world_v2` → `yaml_world_diff world world_v2`.
   - Дефолты: `data_dir=build_yaml/full`, `binary=build_yaml_meson/circle`.

## Что инструмент уже нашёл

Прогон на текущем full-world (`build_yaml/full/world`):

```
Summary: 45180 file(s) with diffs (255593 total), 39046 parse error(s),
         45123 only in v1, 20000 only in v2.
```

Известные баги, на которые этот инструмент даёт повторяемое воспроизведение и которые надо чинить отдельными PR'ами:

- **yaml-cpp parse errors на 39 046 файлах** — `Koi8rYamlEmitter` пишет `&Yfoo` без кавычек. Уже фиксится в **#3277**.
- **`vnum:` не записывается в SaveObjects/SaveMobs/SaveTriggers.** Конвертер пишет; save опирается на имя файла. Не data loss, но расхождение.
- **`short_desc` подменяется на `nominative` на load** (`yaml_world_data_source.cpp:2022`). Поле `short_desc:` из yaml-файла не используется при загрузке — реальный data loss.
- **Zone-команды сохраняются с rnum вместо vnum.** `MOB 0 99990 1 99990 1` → `MOB 0 12912 1 39347 1`. Тоже data loss: после save→load зональные ресеты ссылаются на другие сущности.
- **`aliases` обрезается** на load: `'костяк скелет'` → `'скелет'`.
- **`enhanced/spells` дедуплицируется** на load: `[78,78,78,78,78]` → `[78]`.
- **`enhanced/resistances`, `race`, `skills`, `mob_type`** не пишутся обратно `SaveMobs` — после save→load теряются.
- **Trailing `\n` в literal block-скриптах** триггеров — конвертер не пишет, эмиттер пишет (минорное косметическое).
- **`DgAffect` ↔ `dgaffect`** — case в командах триггеров разъезжается между конвертером и save.
- **45 123 файла «только в v1»** — каталоги зон, не упомянутых в `zones/index.yaml` (мусор от старого формата). + **20 000 файлов «только в v2»** — `zones/30000+/...`, dungeon-зоны, которые `BootWorld` создаёт в памяти после load. Можно потом отфильтровать опцией скрипта.

## Test plan

- [x] `ninja circle` собирается с `-Dyaml=builtin -Dbuild_tests=true`
- [x] `circle -S world_v2 -d <data_dir>` отрабатывает без ошибок (`errors=0` в логе), exit 0
- [x] `tools/yaml_roundtrip_test.sh build_yaml/full build_yaml_meson/circle` выдаёт ожидаемый Summary с расхождениями
- [x] Без `-S` старые сценарии (`-c`, обычный запуск) не задеты
- [ ] CI: тесты, прогон под ASAN — оставляю на CI

## Дальнейшие шаги (вне этого PR)

После мерджа #3277:
- открыть отдельные PR'ы на пункты 2–9 из списка выше; каждое расхождение в диффе становится регрессионным тестом, который мы добавляем как unit-тест по мере фиксов
- опционально: добавить опции скрипта `--only-shared-zones` / `--ignore-dungeons` для уменьшения шума на full world