### PR TITLE
fix: подавить ворнинги при сборке (libfort, yaml emitter, ZCMD)

### DIFF
--- a/src/engine/db/koi8r_yaml_emitter.h
+++ b/src/engine/db/koi8r_yaml_emitter.h
@@ -31,7 +31,7 @@ public:
 
 	void Key(const std::string &key) { out_ << GetIndent() << key << ":"; }
 
-	void Value(const std::string &value, bool literal = false)
+	void Value(const std::string &value, [[maybe_unused]] bool literal = false)
 	{
 		// Any value containing a newline has to go into a literal block --
 		// plain and single-quoted scalars don't survive embedded \n on

--- a/src/engine/olc/redit.cpp
+++ b/src/engine/olc/redit.cpp
@@ -960,4 +960,6 @@ void CleanupRoomData(RoomData *room)
 	room->affected.clear();
 }
 
+#undef ZCMD
+
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/olc/zedit.cpp
+++ b/src/engine/olc/zedit.cpp
@@ -2111,4 +2111,6 @@ void zedit_parse(DescriptorData *d, char *arg) {
 
 // * End of parse_zedit()
 
+#undef ZCMD
+
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/third_party_libs/libfort/meson.build
+++ b/src/third_party_libs/libfort/meson.build
@@ -1,4 +1,4 @@
-fort_args = []
+fort_args = ['-Wno-missing-field-initializers']
 if not get_option('fort_wchar')
     fort_args += '-DFT_CONGIG_DISABLE_WCHAR'
 endif

--- a/src/third_party_libs/libfort/meson.build
+++ b/src/third_party_libs/libfort/meson.build
@@ -1,4 +1,9 @@
-fort_args = ['-Wno-missing-field-initializers']
+fort_args = []
+cpp = meson.get_compiler('cpp')
+if cpp.has_argument('-Wno-missing-field-initializers')
+    fort_args += '-Wno-missing-field-initializers'
+endif
+
 if not get_option('fort_wchar')
     fort_args += '-DFT_CONGIG_DISABLE_WCHAR'
 endif


### PR DESCRIPTION
## Что

Группа независимых ворнингов при сборке, объединённых общим критерием — чистая компиляция:

1. **libfort** — GCC ругался `-Wmissing-field-initializers` на инициализаторы `g_entire_table_properties` и `g_table_properties.entire_table_properties` (в структуре есть поле `border_color_number`, для которого инициализатор не задан). libfort вендорится в дерево, править её source создаст merge-конфликты на upstream-апдейтах, поэтому глушим ворнинг на уровне её собственного `meson.build`.

2. **`Koi8rYamlEmitter::Value`** — параметр `literal` остался в сигнатуре ради самодокументации API, но в теле функции намеренно игнорируется (см. комментарий «Force literal regardless of the caller's `literal` flag»). GCC справедливо ругался `-Wunused-parameter`. Поправлено через `[[maybe_unused]]`.

3. **`redit.cpp` / `zedit.cpp`** — оба файла объявляют макрос `ZCMD` с разными телами (`zone_table[zone].cmd[cmd_no]` и `zone_table[OLC_ZNUM(d)].cmd[subcmd]`) и нигде не делают `#undef` в конце. При unity-сборке, если оба файла попадают в один TU, GCC ругается `"ZCMD" redefined`. У меня локально файлы оказываются в разных unity-блоках (`unity_size=4`), но при любом сдвиге группировки (новый файл, перестановка) они сольются — что и происходит на других конфигурациях (`circle-unity4.cpp` с обоими файлами). `#undef ZCMD` в конце каждого файла гасит ворнинг безусловно.

## Test plan

- [x] `meson compile -C build` (yaml=system) — все три ворнинга ушли, сборка чистая
- [x] `meson compile -C build_no_yaml` (yaml=disabled) — то же самое
- [x] Микро-тест `#define ZCMD ... #undef ZCMD #define ZCMD ...` под `-Wall -Werror` — молчит
- [ ] CI зелёный