### PR TITLE
feat(world): OLC legacy-резев, round-trip тест и фикс dead_load (#3291)

### DIFF
--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -619,6 +619,7 @@ int main_function(int argc, char **argv) {
 	int pos = 1;
 	const char *dir;
 	const char *save_target = nullptr;
+	const char *save_format = nullptr;
 	char cwd[256];
 
 	// Initialize these to check for overruns later.
@@ -665,6 +666,17 @@ int main_function(int argc, char **argv) {
 		}
 		printf("Resave-and-exit mode enabled, target='%s'.\n", save_target);
 		break;
+	case 'T':
+		if (*(argv[pos] + 2))
+			save_format = argv[pos] + 2;
+		else if (++pos < argc)
+			save_format = argv[pos];
+		else {
+			puts("SYSERR: Format arg expected after option -T (legacy|yaml|sqlite).");
+			exit(1);
+		}
+		printf("Resave target format: '%s'.\n", save_format);
+		break;
 	case 'W':
 		enable_world_checksum = true;
 		puts("World checksum calculation enabled.");
@@ -689,7 +701,9 @@ int main_function(int argc, char **argv) {
 					   "  -r             Restrict MUD -- no new players allowed.\n"
 					   "  -s             Suppress special procedure assignments.\n"
 					   "  -S <out_dir>   Load world, re-emit it via the configured backend\n"
-					   "                 into <out_dir> and exit (round-trip diagnostic).\n", argv[0]);
+					   "                 into <out_dir> and exit (round-trip diagnostic).\n"
+					   "  -T <format>   Override -S target format: legacy|yaml|sqlite\n"
+					   "                 (default = compile-time backend).\n", argv[0]);
 				exit(0);
 
 			default: printf("SYSERR: Unknown option -%c in argument string.\n", *(argv[pos] + 1));
@@ -701,7 +715,9 @@ int main_function(int argc, char **argv) {
 					   "  -r             Restrict MUD -- no new players allowed.\n"
 					   "  -s             Suppress special procedure assignments.\n"
 					   "  -S <out_dir>   Load world, re-emit it via the configured backend\n"
-					   "                 into <out_dir> and exit (round-trip diagnostic).\n", argv[0]);
+					   "                 into <out_dir> and exit (round-trip diagnostic).\n"
+					   "  -T <format>   Override -S target format: legacy|yaml|sqlite\n"
+					   "                 (default = compile-time backend).\n", argv[0]);
 				exit(1);
 			break;
 		}
@@ -750,7 +766,8 @@ int main_function(int argc, char **argv) {
 		GameLoader::BootWorld();
 		// target_dir is interpreted relative to the world data directory
 		// (we chdir'd there above), so callers see the path they passed.
-		int errors = GameLoader::ResaveWorld(save_target);
+		int errors = GameLoader::ResaveWorld(save_target,
+			save_format ? std::string(save_format) : std::string());
 		printf("Resave finished, errors=%d\n", errors);
 		return errors == 0 ? 0 : 2;
 	} else if (scheck) {

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1270,7 +1270,6 @@ int GameLoader::ResaveWorld(const std::string &target_dir, const std::string &ta
 	}
 
 	std::unique_ptr<world_loader::IWorldDataSource> saver;
-	world_loader::LegacyWorldDataSource *legacy_saver = nullptr;
 
 	if (fmt == "yaml") {
 #ifdef HAVE_YAML
@@ -1309,19 +1308,12 @@ int GameLoader::ResaveWorld(const std::string &target_dir, const std::string &ta
 		return 1;
 #endif
 	} else if (fmt == "legacy") {
-		// Legacy save uses OLC functions that write to fixed WLD_PREFIX paths
-		// ("world/wld/<vnum>.wld", ...) relative to cwd. LegacyWorldDataSource
-		// chdir's into target_dir for each Save* call, so the saved tree
-		// mirrors the boot layout under <target_dir>/world/.
-		try {
-			fs::create_directories(target_dir);
-		} catch (const std::exception &e) {
-			log("SYSERR: ResaveWorld bootstrap failed: %s", e.what());
-			return 1;
-		}
-		auto legacy = std::make_unique<world_loader::LegacyWorldDataSource>(target_dir);
-		legacy_saver = legacy.get();
-		saver = std::move(legacy);
+		// Legacy save uses OLC functions that write to "world/{wld,mob,...}/"
+		// relative to cwd. LegacyWorldDataSource owns its world_dir and
+		// chdir's into it for each Save* call (creating the layout first), so
+		// the saved tree lands under <target_dir>/world/. Symmetric with the
+		// YAML/SQLite factories below.
+		saver = world_loader::CreateLegacyDataSource(target_dir);
 	} else {
 		log("SYSERR: ResaveWorld: unknown target format '%s'", fmt.c_str());
 		return 1;
@@ -1354,16 +1346,13 @@ int GameLoader::ResaveWorld(const std::string &target_dir, const std::string &ta
 		}
 	}
 
-	// OLC save_to_disk routines write individual <vnum>.<ext> files but do
-	// not maintain the boot indexes -- regenerate them so the resulting
-	// tree is bootable by a legacy build.
-	if (legacy_saver != nullptr) {
-		try {
-			legacy_saver->RebuildIndexes();
-		} catch (const std::exception &e) {
-			log("SYSERR: ResaveWorld: index rebuild failed: %s", e.what());
-			++errors;
-		}
+	// Let the backend finalize after the full resave: legacy rebuilds its
+	// boot indexes here (YAML/SQLite already maintain them inside Save*).
+	try {
+		saver->FinalizeResave();
+	} catch (const std::exception &e) {
+		log("SYSERR: ResaveWorld: finalize failed: %s", e.what());
+		++errors;
 	}
 
 	log("ResaveWorld: done, errors=%d, skipped_dungeon=%d", errors, skipped);

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1254,44 +1254,81 @@ void ResetGameWorldTime() {
 		weather_info.sky = kSkyCloudless;
 }
 
-int GameLoader::ResaveWorld(const std::string &target_dir) {
-#if defined(HAVE_YAML) || defined(HAVE_SQLITE)
-	std::unique_ptr<world_loader::IWorldDataSource> saver;
-#ifdef HAVE_YAML
-	// YamlWorldDataSource's constructor refuses to instantiate without a
-	// readable world_config.yaml under the data root. For a save-only
-	// instance, copy the original config (and dictionaries) from the load
-	// location -- which BootWorld used at the compile-time default of
-	// "world" -- before constructing. SaveZone/Save* rebuild their
-	// index.yaml files themselves now, so we don't mirror any indexes here.
+int GameLoader::ResaveWorld(const std::string &target_dir, const std::string &target_format) {
 	namespace fs = std::filesystem;
-	const std::string load_dir = "world";
-	try {
-		fs::create_directories(target_dir);
-		fs::copy_file(load_dir + "/world_config.yaml",
-					  target_dir + "/world_config.yaml",
-					  fs::copy_options::overwrite_existing);
-		if (fs::exists(load_dir + "/dictionaries")) {
-			fs::copy(load_dir + "/dictionaries",
-					 target_dir + "/dictionaries",
-					 fs::copy_options::recursive
-					 | fs::copy_options::overwrite_existing);
+
+	// Resolve target_format: empty / "auto" -> compile-time default.
+	std::string fmt = target_format;
+	if (fmt.empty() || fmt == "auto") {
+#if defined(HAVE_YAML)
+		fmt = "yaml";
+#elif defined(HAVE_SQLITE)
+		fmt = "sqlite";
+#else
+		fmt = "legacy";
+#endif
+	}
+
+	std::unique_ptr<world_loader::IWorldDataSource> saver;
+	world_loader::LegacyWorldDataSource *legacy_saver = nullptr;
+
+	if (fmt == "yaml") {
+#ifdef HAVE_YAML
+		// YamlWorldDataSource's constructor refuses to instantiate without a
+		// readable world_config.yaml under the data root. For a save-only
+		// instance, copy the original config (and dictionaries) from the load
+		// location -- which BootWorld used at the compile-time default of
+		// "world" -- before constructing. SaveZone/Save* rebuild their
+		// index.yaml files themselves now, so we don't mirror any indexes here.
+		const std::string load_dir = "world";
+		try {
+			fs::create_directories(target_dir);
+			fs::copy_file(load_dir + "/world_config.yaml",
+						  target_dir + "/world_config.yaml",
+						  fs::copy_options::overwrite_existing);
+			if (fs::exists(load_dir + "/dictionaries")) {
+				fs::copy(load_dir + "/dictionaries",
+						 target_dir + "/dictionaries",
+						 fs::copy_options::recursive
+						 | fs::copy_options::overwrite_existing);
+			}
+		} catch (const std::exception &e) {
+			log("SYSERR: ResaveWorld bootstrap failed: %s", e.what());
+			return 1;
 		}
-	} catch (const std::exception &e) {
-		log("SYSERR: ResaveWorld bootstrap failed: %s", e.what());
+		saver = world_loader::CreateYamlDataSource(target_dir);
+#else
+		log("SYSERR: ResaveWorld: yaml backend requested but not compiled in");
+		return 1;
+#endif
+	} else if (fmt == "sqlite") {
+#ifdef HAVE_SQLITE
+		saver = world_loader::CreateSqliteDataSource(target_dir);
+#else
+		log("SYSERR: ResaveWorld: sqlite backend requested but not compiled in");
+		return 1;
+#endif
+	} else if (fmt == "legacy") {
+		// Legacy save uses OLC functions that write to fixed WLD_PREFIX paths
+		// ("world/wld/<vnum>.wld", ...) relative to cwd. LegacyWorldDataSource
+		// chdir's into target_dir for each Save* call, so the saved tree
+		// mirrors the boot layout under <target_dir>/world/.
+		try {
+			fs::create_directories(target_dir);
+		} catch (const std::exception &e) {
+			log("SYSERR: ResaveWorld bootstrap failed: %s", e.what());
+			return 1;
+		}
+		auto legacy = std::make_unique<world_loader::LegacyWorldDataSource>(target_dir);
+		legacy_saver = legacy.get();
+		saver = std::move(legacy);
+	} else {
+		log("SYSERR: ResaveWorld: unknown target format '%s'", fmt.c_str());
 		return 1;
 	}
 
-	// Same backend as BootWorld -- we want round-trip in the same format the
-	// binary was compiled with. Reads global state (zone_table, world,
-	// obj_proto, ...) and writes paths relative to target_dir; m_world_dir on
-	// the fresh instance is the *write* root.
-	saver = world_loader::CreateYamlDataSource(target_dir);
-#else
-	saver = world_loader::CreateSqliteDataSource(target_dir);
-#endif
-
-	log("ResaveWorld: target=%s, zones=%zu", target_dir.c_str(), zone_table.size());
+	log("ResaveWorld: target=%s, format=%s, zones=%zu",
+		target_dir.c_str(), fmt.c_str(), zone_table.size());
 	int errors = 0;
 	int skipped = 0;
 	for (size_t z = 0; z < zone_table.size(); ++z) {
@@ -1316,13 +1353,21 @@ int GameLoader::ResaveWorld(const std::string &target_dir) {
 			++errors;
 		}
 	}
+
+	// OLC save_to_disk routines write individual <vnum>.<ext> files but do
+	// not maintain the boot indexes -- regenerate them so the resulting
+	// tree is bootable by a legacy build.
+	if (legacy_saver != nullptr) {
+		try {
+			legacy_saver->RebuildIndexes();
+		} catch (const std::exception &e) {
+			log("SYSERR: ResaveWorld: index rebuild failed: %s", e.what());
+			++errors;
+		}
+	}
+
 	log("ResaveWorld: done, errors=%d, skipped_dungeon=%d", errors, skipped);
 	return errors;
-#else
-	(void) target_dir;
-	log("ResaveWorld: no save-capable backend compiled in");
-	return 1;
-#endif
 }
 
 void GameLoader::BootIndex(const EBootType mode) {

--- a/src/engine/db/db.h
+++ b/src/engine/db/db.h
@@ -224,7 +224,15 @@ class GameLoader {
 	// into a fresh directory. Used by `circle -S <out_dir>` for the
 	// load -> save -> diff round-trip test. Returns 0 on success or the
 	// number of save errors encountered.
-	static int ResaveWorld(const std::string &target_dir);
+	//
+	// target_format selects the saver explicitly: "", "auto" or nullptr
+	// keeps the compile-time default (YAML when HAVE_YAML, SQLite when
+	// HAVE_SQLITE, otherwise legacy). Explicit values: "legacy", "yaml",
+	// "sqlite". Selecting a backend not compiled in returns a non-zero
+	// error count. The legacy target also regenerates per-subdir index
+	// files so the resulting tree is bootable.
+	static int ResaveWorld(const std::string &target_dir,
+		const std::string &target_format = std::string());
 
  private:
 	static void PrepareGlobalStructures(const EBootType mode, const int rec_count);

--- a/src/engine/db/legacy_world_data_source.cpp
+++ b/src/engine/db/legacy_world_data_source.cpp
@@ -217,11 +217,6 @@ std::unique_ptr<IWorldDataSource> CreateLegacyDataSource()
 	return std::make_unique<LegacyWorldDataSource>();
 }
 
-std::unique_ptr<IWorldDataSource> CreateLegacyDataSource(std::string target_dir)
-{
-	return std::make_unique<LegacyWorldDataSource>(std::move(target_dir));
-}
-
 } // namespace world_loader
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/db/legacy_world_data_source.cpp
+++ b/src/engine/db/legacy_world_data_source.cpp
@@ -6,6 +6,15 @@
 #include "obj_prototypes.h"
 #include "utils/logger.h"
 
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <system_error>
+#include <utility>
+#include <vector>
+
 // Forward declarations for OLC save functions
 void zedit_save_to_disk(int zone_rnum);
 void redit_save_to_disk(int zone_rnum);
@@ -15,6 +24,92 @@ bool trigedit_save_to_disk(int zone_rnum, int notify_level);
 
 namespace world_loader
 {
+
+namespace
+{
+
+// RAII helper: chdir into target on construction, restore on destruction.
+// Used to redirect WLD_PREFIX-relative paths inside OLC save_to_disk
+// routines to a caller-supplied output directory without modifying the
+// macros or save routines themselves.
+class ScopedChdir
+{
+public:
+	explicit ScopedChdir(const std::filesystem::path &target)
+		: m_saved(std::filesystem::current_path())
+	{
+		std::filesystem::current_path(target);
+	}
+	~ScopedChdir() noexcept
+	{
+		std::error_code ec;
+		std::filesystem::current_path(m_saved, ec);
+	}
+	ScopedChdir(const ScopedChdir &) = delete;
+	ScopedChdir &operator=(const ScopedChdir &) = delete;
+
+private:
+	std::filesystem::path m_saved;
+};
+
+// Ensure <target_dir>/world/{wld,mob,obj,zon,trg}/ exist. OLC save routines
+// fopen() into these directories without creating them.
+void EnsureLegacyWorldLayout(const std::filesystem::path &target_dir)
+{
+	static const char *const kSubdirs[] = {"wld", "mob", "obj", "zon", "trg"};
+	const auto world_root = target_dir / "world";
+	std::filesystem::create_directories(world_root);
+	for (const auto *sub : kSubdirs) {
+		std::filesystem::create_directories(world_root / sub);
+	}
+}
+
+void WriteIndexFile(const std::filesystem::path &dir, const std::string &extension)
+{
+	if (!std::filesystem::is_directory(dir)) {
+		return;
+	}
+	std::vector<std::string> names;
+	for (const auto &entry : std::filesystem::directory_iterator(dir)) {
+		if (!entry.is_regular_file()) {
+			continue;
+		}
+		const auto &path = entry.path();
+		if (path.extension() != extension) {
+			continue;
+		}
+		names.push_back(path.filename().string());
+	}
+	// Sort numerically by leading vnum, falling back to lexicographic.
+	std::sort(names.begin(), names.end(),
+		[](const std::string &a, const std::string &b) {
+			const long va = std::strtol(a.c_str(), nullptr, 10);
+			const long vb = std::strtol(b.c_str(), nullptr, 10);
+			if (va != vb) {
+				return va < vb;
+			}
+			return a < b;
+		});
+	const auto tmp = dir / "index.new";
+	{
+		std::ofstream os(tmp, std::ios::trunc);
+		if (!os) {
+			throw std::runtime_error("cannot open " + tmp.string());
+		}
+		for (const auto &n : names) {
+			os << n << "\n";
+		}
+		os << "$\n";
+	}
+	std::filesystem::rename(tmp, dir / "index");
+}
+
+} // namespace
+
+LegacyWorldDataSource::LegacyWorldDataSource(std::string target_dir)
+	: m_target_dir(std::move(target_dir))
+{
+}
 
 void LegacyWorldDataSource::LoadZones()
 {
@@ -48,36 +143,83 @@ void LegacyWorldDataSource::LoadObjects()
 
 void LegacyWorldDataSource::SaveZone(int zone_rnum)
 {
+	if (m_target_dir.empty()) {
+		zedit_save_to_disk(zone_rnum);
+		return;
+	}
+	EnsureLegacyWorldLayout(m_target_dir);
+	ScopedChdir guard(m_target_dir);
 	zedit_save_to_disk(zone_rnum);
 }
 
 bool LegacyWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int notify_level)
 {
 	(void)specific_vnum; // Legacy format always saves entire zone
+	if (m_target_dir.empty()) {
+		return trigedit_save_to_disk(zone_rnum, notify_level);
+	}
+	EnsureLegacyWorldLayout(m_target_dir);
+	ScopedChdir guard(m_target_dir);
 	return trigedit_save_to_disk(zone_rnum, notify_level);
 }
 
 void LegacyWorldDataSource::SaveRooms(int zone_rnum, int specific_vnum)
 {
 	(void)specific_vnum; // Legacy format always saves entire zone
+	if (m_target_dir.empty()) {
+		redit_save_to_disk(zone_rnum);
+		return;
+	}
+	EnsureLegacyWorldLayout(m_target_dir);
+	ScopedChdir guard(m_target_dir);
 	redit_save_to_disk(zone_rnum);
 }
 
 void LegacyWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 {
 	(void)specific_vnum; // Legacy format always saves entire zone
+	if (m_target_dir.empty()) {
+		medit_save_to_disk(zone_rnum);
+		return;
+	}
+	EnsureLegacyWorldLayout(m_target_dir);
+	ScopedChdir guard(m_target_dir);
 	medit_save_to_disk(zone_rnum);
 }
 
 void LegacyWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 {
 	(void)specific_vnum; // Legacy format always saves entire zone
+	if (m_target_dir.empty()) {
+		oedit_save_to_disk(zone_rnum);
+		return;
+	}
+	EnsureLegacyWorldLayout(m_target_dir);
+	ScopedChdir guard(m_target_dir);
 	oedit_save_to_disk(zone_rnum);
+}
+
+void LegacyWorldDataSource::RebuildIndexes()
+{
+	if (m_target_dir.empty()) {
+		return;
+	}
+	const std::filesystem::path world_root = std::filesystem::path(m_target_dir) / "world";
+	WriteIndexFile(world_root / "wld", ".wld");
+	WriteIndexFile(world_root / "mob", ".mob");
+	WriteIndexFile(world_root / "obj", ".obj");
+	WriteIndexFile(world_root / "zon", ".zon");
+	WriteIndexFile(world_root / "trg", ".trg");
 }
 
 std::unique_ptr<IWorldDataSource> CreateLegacyDataSource()
 {
 	return std::make_unique<LegacyWorldDataSource>();
+}
+
+std::unique_ptr<IWorldDataSource> CreateLegacyDataSource(std::string target_dir)
+{
+	return std::make_unique<LegacyWorldDataSource>(std::move(target_dir));
 }
 
 } // namespace world_loader

--- a/src/engine/db/legacy_world_data_source.cpp
+++ b/src/engine/db/legacy_world_data_source.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <stdexcept>
 #include <system_error>
 #include <utility>
@@ -104,107 +105,120 @@ void WriteIndexFile(const std::filesystem::path &dir, const std::string &extensi
 	std::filesystem::rename(tmp, dir / "index");
 }
 
+// Enter m_world_dir for the duration of a load/save call so the OLC and
+// BootIndex routines, which use paths relative to cwd ("world/wld/" etc.),
+// operate on this source's world directory. An empty world_dir means "the
+// current working directory" -- the running server's mode (cwd is the data
+// dir after the main chdir(-d)) -- and yields no chdir at all.
+std::optional<ScopedChdir> EnterWorldDir(const std::string &world_dir)
+{
+	if (world_dir.empty()) {
+		return std::nullopt;
+	}
+	return std::optional<ScopedChdir>(std::in_place, world_dir);
+}
+
 } // namespace
 
-LegacyWorldDataSource::LegacyWorldDataSource(std::string target_dir)
-	: m_target_dir(std::move(target_dir))
+LegacyWorldDataSource::LegacyWorldDataSource(std::string world_dir)
+	: m_world_dir(std::move(world_dir))
 {
 }
 
 void LegacyWorldDataSource::LoadZones()
 {
 	log("Loading zone table.");
+	auto guard = EnterWorldDir(m_world_dir);
 	GameLoader::BootIndex(DB_BOOT_ZON);
 }
 
 void LegacyWorldDataSource::LoadTriggers()
 {
 	log("Loading triggers and generating index.");
+	auto guard = EnterWorldDir(m_world_dir);
 	GameLoader::BootIndex(DB_BOOT_TRG);
 }
 
 void LegacyWorldDataSource::LoadRooms()
 {
 	log("Loading rooms.");
+	auto guard = EnterWorldDir(m_world_dir);
 	GameLoader::BootIndex(DB_BOOT_WLD);
 }
 
 void LegacyWorldDataSource::LoadMobs()
 {
 	log("Loading mobs and generating index.");
+	auto guard = EnterWorldDir(m_world_dir);
 	GameLoader::BootIndex(DB_BOOT_MOB);
 }
 
 void LegacyWorldDataSource::LoadObjects()
 {
 	log("Loading objs and generating index.");
+	auto guard = EnterWorldDir(m_world_dir);
 	GameLoader::BootIndex(DB_BOOT_OBJ);
 }
 
 void LegacyWorldDataSource::SaveZone(int zone_rnum)
 {
-	if (m_target_dir.empty()) {
-		zedit_save_to_disk(zone_rnum);
-		return;
+	if (!m_world_dir.empty()) {
+		EnsureLegacyWorldLayout(m_world_dir);
 	}
-	EnsureLegacyWorldLayout(m_target_dir);
-	ScopedChdir guard(m_target_dir);
+	auto guard = EnterWorldDir(m_world_dir);
 	zedit_save_to_disk(zone_rnum);
 }
 
 bool LegacyWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int notify_level)
 {
 	(void)specific_vnum; // Legacy format always saves entire zone
-	if (m_target_dir.empty()) {
-		return trigedit_save_to_disk(zone_rnum, notify_level);
+	if (!m_world_dir.empty()) {
+		EnsureLegacyWorldLayout(m_world_dir);
 	}
-	EnsureLegacyWorldLayout(m_target_dir);
-	ScopedChdir guard(m_target_dir);
+	auto guard = EnterWorldDir(m_world_dir);
 	return trigedit_save_to_disk(zone_rnum, notify_level);
 }
 
 void LegacyWorldDataSource::SaveRooms(int zone_rnum, int specific_vnum)
 {
 	(void)specific_vnum; // Legacy format always saves entire zone
-	if (m_target_dir.empty()) {
-		redit_save_to_disk(zone_rnum);
-		return;
+	if (!m_world_dir.empty()) {
+		EnsureLegacyWorldLayout(m_world_dir);
 	}
-	EnsureLegacyWorldLayout(m_target_dir);
-	ScopedChdir guard(m_target_dir);
+	auto guard = EnterWorldDir(m_world_dir);
 	redit_save_to_disk(zone_rnum);
 }
 
 void LegacyWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 {
 	(void)specific_vnum; // Legacy format always saves entire zone
-	if (m_target_dir.empty()) {
-		medit_save_to_disk(zone_rnum);
-		return;
+	if (!m_world_dir.empty()) {
+		EnsureLegacyWorldLayout(m_world_dir);
 	}
-	EnsureLegacyWorldLayout(m_target_dir);
-	ScopedChdir guard(m_target_dir);
+	auto guard = EnterWorldDir(m_world_dir);
 	medit_save_to_disk(zone_rnum);
 }
 
 void LegacyWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 {
 	(void)specific_vnum; // Legacy format always saves entire zone
-	if (m_target_dir.empty()) {
-		oedit_save_to_disk(zone_rnum);
-		return;
+	if (!m_world_dir.empty()) {
+		EnsureLegacyWorldLayout(m_world_dir);
 	}
-	EnsureLegacyWorldLayout(m_target_dir);
-	ScopedChdir guard(m_target_dir);
+	auto guard = EnterWorldDir(m_world_dir);
 	oedit_save_to_disk(zone_rnum);
 }
 
-void LegacyWorldDataSource::RebuildIndexes()
+void LegacyWorldDataSource::FinalizeResave()
 {
-	if (m_target_dir.empty()) {
+	// The OLC save_to_disk routines write individual <vnum>.<ext> files but
+	// do not maintain the boot indexes. After a full resave regenerate them
+	// so the resulting tree is bootable. In-place (empty world_dir) server
+	// saves don't rebuild the whole index, so this is a no-op there.
+	if (m_world_dir.empty()) {
 		return;
 	}
-	const std::filesystem::path world_root = std::filesystem::path(m_target_dir) / "world";
+	const std::filesystem::path world_root = std::filesystem::path(m_world_dir) / "world";
 	WriteIndexFile(world_root / "wld", ".wld");
 	WriteIndexFile(world_root / "mob", ".mob");
 	WriteIndexFile(world_root / "obj", ".obj");
@@ -212,9 +226,9 @@ void LegacyWorldDataSource::RebuildIndexes()
 	WriteIndexFile(world_root / "trg", ".trg");
 }
 
-std::unique_ptr<IWorldDataSource> CreateLegacyDataSource()
+std::unique_ptr<IWorldDataSource> CreateLegacyDataSource(std::string world_dir)
 {
-	return std::make_unique<LegacyWorldDataSource>();
+	return std::make_unique<LegacyWorldDataSource>(std::move(world_dir));
 }
 
 } // namespace world_loader

--- a/src/engine/db/legacy_world_data_source.h
+++ b/src/engine/db/legacy_world_data_source.h
@@ -15,6 +15,11 @@ class LegacyWorldDataSource : public IWorldDataSource
 {
 public:
 	LegacyWorldDataSource() = default;
+	// target_dir, if non-empty, redirects Save* methods to write under
+	// <target_dir>/world/{wld,mob,obj,zon,trg}/ instead of the default
+	// "world/..." paths relative to cwd. Used by GameLoader::ResaveWorld
+	// for cross-format round-trip diagnostics.
+	explicit LegacyWorldDataSource(std::string target_dir);
 	~LegacyWorldDataSource() override = default;
 
 	std::string GetName() const override { return "Legacy file-based loader"; }
@@ -30,10 +35,21 @@ public:
 	void SaveRooms(int zone_rnum, int specific_vnum = -1) override;
 	void SaveMobs(int zone_rnum, int specific_vnum = -1) override;
 	void SaveObjects(int zone_rnum, int specific_vnum = -1) override;
+
+	// Scan <target_dir>/world/{wld,mob,obj,zon,trg}/ and regenerate the
+	// per-subdir "index" files. The OLC save_to_disk routines write
+	// individual <vnum>.<ext> files but do not maintain the boot indexes,
+	// so a freshly resaved world is not bootable without this step.
+	// No-op when target_dir is empty (in-place edits keep existing indexes).
+	void RebuildIndexes();
+
+private:
+	std::string m_target_dir;
 };
 
 // Factory function for creating legacy data source
 std::unique_ptr<IWorldDataSource> CreateLegacyDataSource();
+std::unique_ptr<IWorldDataSource> CreateLegacyDataSource(std::string target_dir);
 
 } // namespace world_loader
 

--- a/src/engine/db/legacy_world_data_source.h
+++ b/src/engine/db/legacy_world_data_source.h
@@ -14,12 +14,13 @@ namespace world_loader
 class LegacyWorldDataSource : public IWorldDataSource
 {
 public:
-	// target_dir, if non-empty, redirects Save* methods to write under
-	// <target_dir>/world/{wld,mob,obj,zon,trg}/ instead of the default
-	// "world/..." paths relative to cwd. Used by GameLoader::ResaveWorld
-	// for cross-format round-trip diagnostics; empty (the default) keeps
-	// the in-place behaviour the running server relies on.
-	explicit LegacyWorldDataSource(std::string target_dir = "");
+	// world_dir is the directory the world lives in: Load* read from it and
+	// Save* write to it (both via "world/{wld,mob,obj,zon,trg}/" relative to
+	// it). Empty (the default) means the current working directory -- the
+	// running server's mode, where cwd is the data dir after the main
+	// chdir(-d). A non-empty value is used by GameLoader::ResaveWorld to
+	// point a save-only instance at an export directory.
+	explicit LegacyWorldDataSource(std::string world_dir = "");
 	~LegacyWorldDataSource() override = default;
 
 	std::string GetName() const override { return "Legacy file-based loader"; }
@@ -36,21 +37,21 @@ public:
 	void SaveMobs(int zone_rnum, int specific_vnum = -1) override;
 	void SaveObjects(int zone_rnum, int specific_vnum = -1) override;
 
-	// Scan <target_dir>/world/{wld,mob,obj,zon,trg}/ and regenerate the
-	// per-subdir "index" files. The OLC save_to_disk routines write
-	// individual <vnum>.<ext> files but do not maintain the boot indexes,
-	// so a freshly resaved world is not bootable without this step.
-	// No-op when target_dir is empty (in-place edits keep existing indexes).
-	void RebuildIndexes();
+	// Regenerate the per-subdir "index" files under world_dir/world/*. The
+	// OLC save_to_disk routines write individual <vnum>.<ext> files but do
+	// not maintain the boot indexes, so a freshly resaved tree is not
+	// bootable without this step. No-op for the in-place (empty world_dir)
+	// server mode.
+	void FinalizeResave() override;
 
 private:
-	std::string m_target_dir;
+	std::string m_world_dir;
 };
 
-// Factory function for creating legacy data source (in-place, no redirect).
-// ResaveWorld constructs LegacyWorldDataSource directly because it needs the
-// concrete type for RebuildIndexes(), so no target_dir factory is needed.
-std::unique_ptr<IWorldDataSource> CreateLegacyDataSource();
+// Factory for the legacy data source. world_dir defaults to the current
+// working directory (the running server's mode); ResaveWorld passes an
+// explicit export directory, symmetric with the YAML/SQLite factories.
+std::unique_ptr<IWorldDataSource> CreateLegacyDataSource(std::string world_dir = "");
 
 } // namespace world_loader
 

--- a/src/engine/db/legacy_world_data_source.h
+++ b/src/engine/db/legacy_world_data_source.h
@@ -14,12 +14,12 @@ namespace world_loader
 class LegacyWorldDataSource : public IWorldDataSource
 {
 public:
-	LegacyWorldDataSource() = default;
 	// target_dir, if non-empty, redirects Save* methods to write under
 	// <target_dir>/world/{wld,mob,obj,zon,trg}/ instead of the default
 	// "world/..." paths relative to cwd. Used by GameLoader::ResaveWorld
-	// for cross-format round-trip diagnostics.
-	explicit LegacyWorldDataSource(std::string target_dir);
+	// for cross-format round-trip diagnostics; empty (the default) keeps
+	// the in-place behaviour the running server relies on.
+	explicit LegacyWorldDataSource(std::string target_dir = "");
 	~LegacyWorldDataSource() override = default;
 
 	std::string GetName() const override { return "Legacy file-based loader"; }
@@ -47,9 +47,10 @@ private:
 	std::string m_target_dir;
 };
 
-// Factory function for creating legacy data source
+// Factory function for creating legacy data source (in-place, no redirect).
+// ResaveWorld constructs LegacyWorldDataSource directly because it needs the
+// concrete type for RebuildIndexes(), so no target_dir factory is needed.
 std::unique_ptr<IWorldDataSource> CreateLegacyDataSource();
-std::unique_ptr<IWorldDataSource> CreateLegacyDataSource(std::string target_dir);
 
 } // namespace world_loader
 

--- a/src/engine/db/world_checksum.cpp
+++ b/src/engine/db/world_checksum.cpp
@@ -9,7 +9,10 @@
 #include "engine/entities/zone.h"
 #include "engine/entities/room_data.h"
 #include "engine/entities/char_data.h"
+#include "engine/entities/obj_data.h"
+#include "gameplay/mechanics/dead_load.h"
 #include "utils/logger.h"
+#include "utils/utils.h"
 #include "utils/utils_string.h"
 #include "engine/structs/extra_description.h"
 
@@ -192,6 +195,23 @@ std::string SerializeRoom(const RoomData *room)
 			oss << trig_vnum << ",";
 		}
 	}
+	oss << "|";
+
+	// Extra descriptions (E-blocks in the legacy room file). Without these
+	// the checksum is blind to a yaml/sqlite converter that silently drops
+	// the room's ex_description list (see boot_data_files.cpp:463-475).
+	for (auto ed = room->ex_description; ed; ed = ed->next)
+	{
+		if (ed->keyword)
+		{
+			oss << ed->keyword << ":";
+		}
+		if (ed->description)
+		{
+			oss << ed->description;
+		}
+		oss << ";";
+	}
 
 	return oss.str();
 }
@@ -283,6 +303,107 @@ std::string SerializeMob(int vnum, const CharData &mob)
 	oss << mob.add_abils.aresist << "|";
 	oss << mob.add_abils.mresist << "|";
 	oss << mob.add_abils.presist << "|";
+
+	// Basic numeric block fields parsed by parse_simple_mob() that were
+	// previously absent -- their loss in the yaml/sqlite pipeline would slip
+	// past the round-trip test before this PR.
+	oss << GET_ALIGNMENT(&mob) << "|";
+	oss << mob.real_abils.hitroll << "|";
+	oss << static_cast<int>(mob.real_abils.armor) << "|";
+	oss << mob.real_abils.damroll << "|";
+	oss << static_cast<int>(mob.real_abils.size) << "|";
+	oss << mob.mem_queue.total << "," << mob.mem_queue.stored << "|";
+	oss << mob.get_gold() << "|";
+	oss << GET_GOLD_NoDs(&mob) << "," << GET_GOLD_SiDs(&mob) << "|";
+	oss << mob.get_exp() << "|";
+	oss << static_cast<int>(mob.GetPosition()) << "|";
+	oss << static_cast<int>(mob.mob_specials.default_pos) << "|";
+	oss << static_cast<int>(mob.get_sex()) << "|";
+	oss << mob.mob_specials.speed << "|";
+	oss << static_cast<int>(mob.get_race()) << "|";
+	oss << static_cast<int>(mob.get_height()) << "|";
+	oss << static_cast<int>(mob.get_weight()) << "|";
+
+	// E-spec arrays (Resistances, Saves, Destination).
+	for (int r = 0; r <= EResist::kLastResist; ++r)
+	{
+		oss << GET_RESIST(&mob, r) << ",";
+	}
+	oss << "|";
+	for (auto save = ESaving::kFirst; save <= ESaving::kLast; ++save)
+	{
+		oss << GetSave(const_cast<CharData *>(&mob), save) << ",";
+	}
+	oss << "|";
+	oss << mob.mob_specials.dest_count << ":";
+	for (int d = 0; d < mob.mob_specials.dest_count && d < kMaxDest; ++d)
+	{
+		oss << mob.mob_specials.dest[d] << ",";
+	}
+	oss << "|";
+
+	// Feats (bitset over EFeat). Iterate over the whole bitset width so the
+	// serialisation length is stable across mobs.
+	for (size_t f = 0; f < mob.real_abils.Feats.size(); ++f)
+	{
+		if (mob.real_abils.Feats.test(f))
+		{
+			oss << f << ",";
+		}
+	}
+	oss << "|";
+
+	// Skills: sort by ESkill id for determinism.
+	{
+		std::vector<std::pair<int, int>> sk;
+		for (const auto &kv : mob.GetCharSkills())
+		{
+			sk.emplace_back(static_cast<int>(kv.first), kv.second.skillLevel);
+		}
+		std::sort(sk.begin(), sk.end());
+		for (const auto &kv : sk)
+		{
+			oss << kv.first << ":" << kv.second << ",";
+		}
+	}
+	oss << "|";
+
+	// Spell memory (Spell: lines parsed into SplMem[]).
+	for (int s = static_cast<int>(ESpell::kFirst); s <= static_cast<int>(ESpell::kLast); ++s)
+	{
+		const auto val = mob.real_abils.SplMem[s];
+		if (val != 0)
+		{
+			oss << s << ":" << static_cast<int>(val) << ",";
+		}
+	}
+	oss << "|";
+
+	// Helper: lines -> summon_helpers list.
+	for (const auto &h : mob.summon_helpers)
+	{
+		oss << h << ",";
+	}
+	oss << "|";
+
+	// Role bits.
+	{
+		const auto &role = mob.get_role();
+		for (size_t i = 0; i < role.size(); ++i)
+		{
+			oss << (role.test(i) ? '1' : '0');
+		}
+	}
+	oss << "|";
+
+	// L-lines -> dead-load list (issue #3291). The yaml/sqlite pipeline
+	// silently drops these without this entry in the checksum.
+	for (const auto &dl : mob.dl_list)
+	{
+		oss << dl.obj_vnum << ":" << dl.load_prob << ":"
+		    << dl.load_type << ":" << dl.spec_param << ",";
+	}
+	oss << "|";
 
 	// Proto script
 	if (mob.proto_script)
@@ -416,7 +537,22 @@ std::string SerializeObject(const CObjectPrototype::shared_ptr &obj)
 	{
 		oss << trig_vnum << ",";
 	}
+	oss << "|";
 
+	// Skill bindings (S-line in the legacy obj file, boot_data_files.cpp:802).
+	// Iterate the prototype's skill map sorted by skill id.
+	{
+		std::vector<std::pair<int, int>> sk;
+		for (const auto &kv : obj->get_skills())
+		{
+			sk.emplace_back(static_cast<int>(kv.first), kv.second);
+		}
+		std::sort(sk.begin(), sk.end());
+		for (const auto &kv : sk)
+		{
+			oss << kv.first << ":" << kv.second << ",";
+		}
+	}
 
 	return oss.str();
 }

--- a/src/engine/db/world_data_source.h
+++ b/src/engine/db/world_data_source.h
@@ -39,6 +39,13 @@ public:
 	virtual void SaveRooms(int zone_rnum, int specific_vnum = -1) = 0;
 	virtual void SaveMobs(int zone_rnum, int specific_vnum = -1) = 0;
 	virtual void SaveObjects(int zone_rnum, int specific_vnum = -1) = 0;
+
+	// Called once after a full-world resave (GameLoader::ResaveWorld) so a
+	// backend can finalize global structures that aren't maintained
+	// incrementally by per-zone Save*. YAML/SQLite rebuild their indexes
+	// inside Save* and need nothing here; the legacy backend regenerates its
+	// per-subdir boot "index" files. Default: no-op.
+	virtual void FinalizeResave() {}
 };
 
 // Factory function type for creating data sources

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1451,8 +1451,14 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 	if (stats)
 	{
 		mob.set_level(GetInt(stats, "level", 1));
-		GET_HR(&mob) = GetInt(stats, "hitroll_penalty", 20);
-		GET_AC(&mob) = GetInt(stats, "armor", 100);
+		// hitroll_penalty and armor are stored in the YAML in legacy file
+		// units (i.e. before parse_simple_mob's `20 - x` and `10 * x`
+		// transformations), matching what convert_to_yaml.py emits. Applying
+		// the same conversions here is required for round-trip: otherwise
+		// legacy -> yaml -> legacy oscillates the on-disk hitroll value
+		// (e.g. 5 -> 15 -> 5 -> 15) every pass.
+		GET_HR(&mob) = 20 - GetInt(stats, "hitroll_penalty", 20);
+		GET_AC(&mob) = 10 * GetInt(stats, "armor", 10);
 
 		YAML::Node hp = stats["hp"];
 		if (hp)
@@ -3465,11 +3471,14 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 		yaml.Key("level");
 		yaml.Value(mob.GetLevel());
 
+		// Write in legacy file units to stay symmetric with LoadMob() and
+		// matching convert_to_yaml.py output -- otherwise yaml -> legacy
+		// -> yaml round-trip flips the on-disk hitroll value every pass.
 		yaml.Key("hitroll_penalty");
-		yaml.Value(GET_HR(&mob));
+		yaml.Value(20 - GET_HR(&mob));
 
 		yaml.Key("armor");
-		yaml.Value(GET_AC(&mob));
+		yaml.Value(GET_AC(&mob) / 10);
 
 		// HP
 		yaml.Key("hp");

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -20,6 +20,7 @@
 #include "engine/db/description.h"
 #include "engine/structs/extra_description.h"
 #include "engine/structs/flag_data.h"
+#include "gameplay/mechanics/dead_load.h"
 #include "gameplay/mechanics/dungeons.h"
 #include "engine/scripting/dg_olc.h"
 #include "gameplay/affects/affect_contants.h"
@@ -1693,6 +1694,22 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 				}
 				idx++;
 			}
+		}
+	}
+
+	// Dead-load entries (legacy `L` lines, issue #3291). At top level of the
+	// mob document, not under `enhanced`, so the YAML matches the legacy
+	// position-after-E-section semantics.
+	if (root["dead_load"] && root["dead_load"].IsSequence())
+	{
+		for (const auto &node : root["dead_load"])
+		{
+			dead_load::LoadingItem item;
+			item.obj_vnum = GetInt(node, "obj_vnum", 0);
+			item.load_prob = GetInt(node, "load_prob", 0);
+			item.load_type = GetInt(node, "load_type", 0);
+			item.spec_param = GetInt(node, "spec_param", 0);
+			mob.dl_list.push_back(item);
 		}
 	}
 
@@ -3881,6 +3898,26 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 
 				yaml.DecreaseIndent();  // enhanced
 			}
+		}
+
+		// Dead-load list (legacy L-lines, issue #3291). Top-level, after the
+		// enhanced block so the document layout matches the converter output.
+		// Emitted as raw "- key: value" sequence-of-maps because the
+		// Koi8rYamlEmitter has no Begin/EndMappingItem helpers (the same
+		// pattern is used by the skills block above).
+		if (!mob.dl_list.empty())
+		{
+			yaml.Key("dead_load");
+			yaml.BeginSequence();
+			yaml.IncreaseIndent();
+			for (const auto &dl : mob.dl_list)
+			{
+				out << yaml.GetIndent() << "- obj_vnum: " << dl.obj_vnum << std::endl;
+				out << yaml.GetIndent() << "  load_prob: " << dl.load_prob << std::endl;
+				out << yaml.GetIndent() << "  load_type: " << dl.load_type << std::endl;
+				out << yaml.GetIndent() << "  spec_param: " << dl.spec_param << std::endl;
+			}
+			yaml.DecreaseIndent();
 		}
 
 		// Close file and rename atomically

--- a/src/engine/entities/char_data.h
+++ b/src/engine/entities/char_data.h
@@ -361,6 +361,7 @@ class CharData : public ProtectedCharData {
 	int GetSkill(ESkill skill_id) const;
 	int GetSkillWithoutEquip(ESkill skill_id) const;
 	int get_skills_count() const;
+	const CharSkillsType &GetCharSkills() const { return skills; }
 	int GetEquippedSkill(ESkill skill_id) const;
 	int get_skill_bonus() const;
 	void set_skill_bonus(int);

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -2116,12 +2116,18 @@ def parse_mob_file(filepath):
                         mob['experience'] = int(parts[1]) if parts[1].isdigit() else 0
                 idx += 1
 
-            # Position and sex line
+            # Position and sex line.
+            # Legacy file layout (parse_simple_mob:1156-1158): first field
+            # is the current/start position, second is default_pos. Earlier
+            # this code put parts[0] under 'default' and parts[1] under
+            # 'start', i.e. swapped relative to the C++ YAML loader's
+            # semantics (default_pos = pos["default"], current = pos["start"]),
+            # so every legacy<->yaml<->legacy hop oscillated the two values.
             if idx < len(lines):
                 parts = lines[idx].split()
                 if len(parts) >= 2:
-                    pos_default = int(parts[0]) if parts[0].isdigit() else 8
-                    pos_start = int(parts[1]) if parts[1].isdigit() else 8
+                    pos_start = int(parts[0]) if parts[0].isdigit() else 8
+                    pos_default = int(parts[1]) if parts[1].isdigit() else 8
                     sex = int(parts[2]) if parts[2].isdigit() else 0
 
                     mob['position'] = {

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -2283,6 +2283,20 @@ def parse_mob_file(filepath):
                             'skill_id': int(parts[0]),
                             'value': int(parts[1])
                         })
+                elif line.startswith('L '):
+                    # Dead-load entry (issue #3291): `L obj_vnum prob type spec_param`.
+                    # Without this branch the loot list silently disappears in YAML,
+                    # then in SQLite, and finally on every player who kills the mob.
+                    dl_parts = line[2:].strip().split()
+                    if len(dl_parts) >= 4:
+                        if 'dead_load' not in mob:
+                            mob['dead_load'] = []
+                        mob['dead_load'].append({
+                            'obj_vnum': int(dl_parts[0]),
+                            'load_prob': int(dl_parts[1]),
+                            'load_type': int(dl_parts[2]),
+                            'spec_param': int(dl_parts[3]),
+                        })
                 elif line.startswith('T '):
                     trig_vnum = int(line[2:].strip())
                     mob['triggers'].append(trig_vnum)
@@ -2413,6 +2427,18 @@ def mob_to_yaml(mob):
             s['value'] = skill['value']
             skills.append(s)
         data['skills'] = skills
+
+    # Dead-load list (L lines in legacy mob file). Issue #3291.
+    if mob.get('dead_load'):
+        dl = CommentedSeq()
+        for entry in mob['dead_load']:
+            item = CommentedMap()
+            item['obj_vnum'] = entry['obj_vnum']
+            item['load_prob'] = entry['load_prob']
+            item['load_type'] = entry['load_type']
+            item['spec_param'] = entry['spec_param']
+            dl.append(item)
+        data['dead_load'] = dl
 
     # Triggers with name comments
     if mob.get('triggers'):

--- a/tools/legacy_yaml_legacy_roundtrip.sh
+++ b/tools/legacy_yaml_legacy_roundtrip.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+#
+# Legacy <-> YAML <-> Legacy round-trip checksum test (5-stage).
+#
+# Pipeline:
+#
+#                  convert_to_yaml.py   yaml-build -S -T legacy
+#   v1 (legacy) ─────────────────────► v2 (YAML) ──────────────────► v3 (legacy)
+#                                                                         │
+#                                          convert_to_yaml.py             │
+#                       v4 (YAML) ◄──────────────────────────────────────┘
+#                            │
+#                            ▼  yaml-build -S -T legacy
+#                       v5 (legacy)
+#
+# Checksum probes (legacy-build -W -c):
+#   checksum(v1) -- baseline
+#   checksum(v3) -- after one legacy-save normalization pass
+#   checksum(v5) -- after a second pass
+#
+# Theory: if the v1 != v3 drift is just OLC normalization (whitespace,
+# stripped flag bits, etc. -- `redit_save_to_disk` / `trigedit_save_to_disk`
+# rewrites format), then v3 is already in canonical form, so a second
+# round-trip is a fixed point: checksum(v3) == checksum(v5). A v3 vs v5
+# mismatch instead would indicate a semantic loss across the pipeline.
+#
+# Pre-requisites:
+#   - A legacy world data_dir at <v1_dir> with world/{wld,mob,obj,zon,trg}/
+#     index + per-zone files and misc/configuration.xml.
+#   - convert_to_yaml.py deps installed
+#     (pip install -r tools/converter/requirements.txt).
+#   - YAML build: -Dyaml=builtin or =system.
+#   - Legacy build: -Dyaml=disabled -Dsqlite=disabled.
+#
+# Usage:
+#   tools/legacy_yaml_legacy_roundtrip.sh \
+#       --v1-dir <path> \
+#       [--legacy-bin <path>] \
+#       [--yaml-bin <path>] \
+#       [--workdir <path>] \
+#       [--keep]
+#
+# Defaults:
+#   --legacy-bin = build_legacy/circle
+#   --yaml-bin   = build/circle           (must be YAML build)
+#   --workdir    = /tmp/legacy-yaml-roundtrip
+#
+# Exit codes:
+#   0  v3 == v5 (round-trip is a fixed point after the first normalization)
+#   1  v3 != v5 (round-trip is not idempotent -- real semantic loss)
+#   2  pipeline failure
+#
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LEGACY_BIN="$REPO_ROOT/build_legacy/circle"
+YAML_BIN="$REPO_ROOT/build/circle"
+WORKDIR="/tmp/legacy-yaml-roundtrip"
+V1_DIR=""
+KEEP=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --v1-dir) V1_DIR="$2"; shift 2 ;;
+        --legacy-bin) LEGACY_BIN="$2"; shift 2 ;;
+        --yaml-bin) YAML_BIN="$2"; shift 2 ;;
+        --workdir) WORKDIR="$2"; shift 2 ;;
+        --keep) KEEP=1; shift ;;
+        -h|--help) sed -n '/^# /,/^$/p' "$0" | head -80; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$V1_DIR" ]]; then
+    echo "ERROR: --v1-dir is required (path to a legacy world data dir)." >&2
+    exit 2
+fi
+for f in "$V1_DIR" "$LEGACY_BIN" "$YAML_BIN"; do
+    if [[ ! -e "$f" ]]; then
+        echo "ERROR: $f not found." >&2
+        exit 2
+    fi
+done
+if [[ ! -d "$V1_DIR/world/wld" ]]; then
+    echo "ERROR: $V1_DIR is not a legacy data dir (no world/wld/)." >&2
+    exit 2
+fi
+if [[ ! -x "$LEGACY_BIN" || ! -x "$YAML_BIN" ]]; then
+    echo "ERROR: binaries must be executable." >&2
+    exit 2
+fi
+
+V1_ABS="$(cd "$V1_DIR" && pwd)"
+LEGACY_BIN_ABS="$(cd "$(dirname "$LEGACY_BIN")" && pwd)/$(basename "$LEGACY_BIN")"
+YAML_BIN_ABS="$(cd "$(dirname "$YAML_BIN")" && pwd)/$(basename "$YAML_BIN")"
+
+V2_DIR="$WORKDIR/v2"
+V3_DIR="$WORKDIR/v3"
+V4_DIR="$WORKDIR/v4"
+V5_DIR="$WORKDIR/v5"
+CHECKSUM_LOG_V1="$WORKDIR/checksum-v1.log"
+CHECKSUM_LOG_V3="$WORKDIR/checksum-v3.log"
+CHECKSUM_LOG_V5="$WORKDIR/checksum-v5.log"
+
+mkdir -p "$WORKDIR"
+rm -rf "$V2_DIR" "$V3_DIR" "$V4_DIR" "$V5_DIR"
+rm -f "$CHECKSUM_LOG_V1" "$CHECKSUM_LOG_V3" "$CHECKSUM_LOG_V5"
+
+# circle writes syslog into its launch cwd (configuration.xml controls the
+# filename; -o is wired into a dead LOGNAME global), so we truncate
+# <bin_dir>/syslog before the run and then snapshot it to log_path.
+# Returns the combined checksum on stdout; non-zero exit on failure.
+compute_checksum() {
+    local label="$1" bin="$2" data_dir="$3" log_path="$4"
+    local bin_dir
+    bin_dir="$(dirname "$bin")"
+    echo "[$label] $bin -W -c -d $data_dir" >&2
+    : > "$bin_dir/syslog"
+    (
+        cd "$bin_dir"
+        "$bin" -W -c -d "$data_dir" 4001 >/dev/null
+    )
+    cp "$bin_dir/syslog" "$log_path"
+    local combined
+    combined="$(grep -E ':: Combined: [0-9A-F]+' "$log_path" | tail -1 | awk '{print $5}')"
+    if [[ -z "$combined" ]]; then
+        echo "ERROR: no 'Combined:' line in $log_path" >&2
+        return 1
+    fi
+    echo "$combined"
+}
+
+# Copy non-world artifacts from src to dst so legacy/yaml builds can boot it.
+copy_data_dir_skeleton() {
+    local src="$1" dst="$2"
+    for sub in misc cfg etc text plrs plrobjs plralias plrstuff plrvars stat; do
+        if [[ -e "$src/$sub" ]]; then
+            cp -r "$src/$sub" "$dst/"
+        fi
+    done
+}
+
+# legacy data_dir -> YAML data_dir via convert_to_yaml.py
+convert_legacy_to_yaml() {
+    local src_legacy="$1" dst_yaml="$2"
+    mkdir -p "$dst_yaml/world"
+    python3 "$REPO_ROOT/tools/converter/convert_to_yaml.py" \
+        -i "$src_legacy" -o "$dst_yaml" -t all -f yaml >/dev/null
+    copy_data_dir_skeleton "$src_legacy" "$dst_yaml"
+}
+
+# YAML data_dir -> legacy data_dir via yaml build's -S -T legacy
+yaml_resave_to_legacy() {
+    local src_yaml="$1" dst_legacy="$2"
+    (
+        cd "$(dirname "$YAML_BIN_ABS")"
+        "$YAML_BIN_ABS" -d "$src_yaml" -S "$dst_legacy" -T legacy 4001 >/dev/null
+    )
+    if [[ ! -d "$dst_legacy/world/wld" ]]; then
+        echo "ERROR: $dst_legacy/world/wld not produced" >&2
+        return 1
+    fi
+    copy_data_dir_skeleton "$src_yaml" "$dst_legacy"
+}
+
+echo "== Stage 1/5: checksum(v1) =="
+SUM_V1="$(compute_checksum v1 "$LEGACY_BIN_ABS" "$V1_ABS" "$CHECKSUM_LOG_V1")"
+echo "checksum(v1) = $SUM_V1"
+
+echo
+echo "== Stage 2/5: v1 (legacy) -> v2 (YAML) =="
+convert_legacy_to_yaml "$V1_ABS" "$V2_DIR"
+echo "v2 at $V2_DIR"
+
+echo
+echo "== Stage 3/5: v2 (YAML) -> v3 (legacy) =="
+yaml_resave_to_legacy "$V2_DIR" "$V3_DIR"
+SUM_V3="$(compute_checksum v3 "$LEGACY_BIN_ABS" "$V3_DIR" "$CHECKSUM_LOG_V3")"
+echo "checksum(v3) = $SUM_V3"
+
+echo
+echo "== Stage 4/5: v3 (legacy) -> v4 (YAML) =="
+convert_legacy_to_yaml "$V3_DIR" "$V4_DIR"
+echo "v4 at $V4_DIR"
+
+echo
+echo "== Stage 5/5: v4 (YAML) -> v5 (legacy) =="
+yaml_resave_to_legacy "$V4_DIR" "$V5_DIR"
+SUM_V5="$(compute_checksum v5 "$LEGACY_BIN_ABS" "$V5_DIR" "$CHECKSUM_LOG_V5")"
+echo "checksum(v5) = $SUM_V5"
+
+echo
+echo "== Round-trip result =="
+echo "  v1 = $SUM_V1   (baseline)"
+echo "  v3 = $SUM_V3   (after one yaml<->legacy hop)"
+echo "  v5 = $SUM_V5   (after two yaml<->legacy hops)"
+echo
+if [[ "$SUM_V3" == "$SUM_V5" ]]; then
+    if [[ "$SUM_V1" == "$SUM_V3" ]]; then
+        echo "MATCH (v1 == v3 == v5)  ←  Round-trip is fully byte-stable."
+    else
+        echo "FIXED-POINT (v1 != v3, v3 == v5)  ←  First pass normalizes, subsequent passes are idempotent (OLC formatting drift only)."
+    fi
+    if [[ "$KEEP" -eq 0 ]]; then
+        rm -rf "$V2_DIR" "$V3_DIR" "$V4_DIR" "$V5_DIR"
+    fi
+    exit 0
+fi
+
+echo "MISMATCH (v3 != v5)  ←  Round-trip is NOT idempotent. Real semantic loss across the pipeline."
+echo
+echo "Per-section v1 / v3 / v5:"
+for key in Zones Rooms Mobs Objects Triggers Combined; do
+    v1_line="$(grep -E ":: $key:" "$CHECKSUM_LOG_V1" | tail -1 | awk -F':: ' '{print $2}')"
+    v3_line="$(grep -E ":: $key:" "$CHECKSUM_LOG_V3" | tail -1 | awk -F':: ' '{print $2}')"
+    v5_line="$(grep -E ":: $key:" "$CHECKSUM_LOG_V5" | tail -1 | awk -F':: ' '{print $2}')"
+    printf "  %-9s v1=%s\n            v3=%s\n            v5=%s\n" "$key" "$v1_line" "$v3_line" "$v5_line"
+done
+exit 1


### PR DESCRIPTION
Closes #3291

## Summary

- `circle -S <dir>` получил флаг `-T <format>` (`legacy`/`yaml`/`sqlite`/auto). Дефолт — compile-time backend.
- `LegacyWorldDataSource` теперь умеет писать в произвольный target_dir: `Save*` временно chdir-ит туда (RAII), OLC `*_save_to_disk` пишут в `<target>/world/{wld,mob,obj,zon,trg}/` без правок макросов `WLD_PREFIX`. После прохода зон `RebuildIndexes()` сканит подпапки и регенерирует `index` файлы.
- `tools/legacy_yaml_legacy_roundtrip.sh` — 5-этапный round-trip: `legacy → yaml → legacy → yaml → legacy`, сверяет `checksum(v3) == checksum(v5)`.
- `WorldChecksum::Serialize*` расширены на все парс-поля mob/obj/room — без этого round-trip-тест был слеп к большинству регрессий yaml/sqlite пайплайна.
- Починены три потери в legacy↔yaml пайплайне, найденные расширенным тестом: dead_load (issue #3291), hitroll/armor flip, position vs default_pos swap.

## Что сделано

**Round-trip инфраструктура** (коммит `24302bd5e`):

- `src/engine/db/legacy_world_data_source.{h,cpp}` — `LegacyWorldDataSource` принимает опциональный `target_dir`; `Save*` через RAII-обёртку `ScopedChdir` временно меняют cwd, существующие OLC `*_save_to_disk` пишут в `<target>/world/{wld,mob,obj,zon,trg}/` без изменения макросов `WLD_PREFIX`. Добавлен `RebuildIndexes()` — сканит подпапки и регенерирует `index` файлы (OLC их не трогает).
- `src/engine/db/db.{h,cpp}` — `GameLoader::ResaveWorld(target_dir, target_format)` диспатчит сохранение по формату.
- `src/engine/core/comm.cpp` — CLI флаг `-T <format>` рядом с `-S`.

**Тест round-trip** (коммит `9aa2a0b3a`):

- `tools/legacy_yaml_legacy_roundtrip.sh` — 5-этапный пайплайн `v1 → v2 (yaml) → v3 (legacy) → v4 (yaml) → v5 (legacy)`. Сверяет `checksum(v3) == checksum(v5)`. Несовпадение означает реальную семантическую потерю.

**Расширение checksum** (коммит `d65a5c055`):

`WorldChecksum::Serialize*` дополнены всеми полями, которые легаси-парсер кладёт в `mob_proto`/`obj_proto`/`world`:

- **Mob**: `alignment`, `hitroll`, `armor` (real), `damroll`, `real_abils.size`, `mem_queue.{total,stored}`, `gold` (с dice NoDs/SiDs), `exp`, `position`, `default_pos`, `sex`, `speed`, `race`, `height`, `weight`, Resistances (8), Saves (4), Destination (по `dest_count`), Feats (bitset), Skills map, SplMem, summon_helpers, role bits, **dl_list (#3291)**.
- **Object**: `set_skill` proto map (S-строка `boot_data_files.cpp:802` ранее в чексумме не учитывалась).
- **Room**: `ex_description` (E-блоки парсятся, но в чексумму не попадали).

Добавлен публичный `CharData::GetCharSkills()` для итерации skill-карты — сам контейнер `skills` остаётся private.

**Фиксы потерь, найденных расширенным тестом:**

1. **dead_load (issue #3291)** — коммит `c463da372`. L-строки мобов (`L obj_vnum prob type spec_param`) при конвертации legacy→yaml полностью пропадали: ни Python конвертер их не парсил, ни `YamlWorldDataSource::ParseMobFile` не искал, ни `SaveMobs` не выписывал. Добавил parse+emit в обе стороны.

2. **hitroll_penalty / armor** — коммит `2e98d5e21`. `YamlWorldDataSource::ParseMobFile` / `SaveMobs` хранили `GET_HR`/`GET_AC` напрямую, тогда как `convert_to_yaml.py` копировал значения *до* преобразований `parse_simple_mob` (`20 - t[1]` и `10 * t[2]`). Из-за конфликта семантик каждый legacy↔yaml↔legacy hop переворачивал hitroll на on-disk форме (5 → 15 → 5 → 15) и обрезал armor целочисленным делением. Починено: YAML loader/saver теперь применяют те же преобразования, что `parse_simple_mob` и `medit_save_to_disk`.

3. **position vs default_pos swap** — коммит `5c0aa1df4`. Python конвертер вешал `parts[0]` (current position) на `mob['position']['default']`, а `parts[1]` (default_pos) — на `'start'`. C++ YAML loader использовал поля по семантике имён. Каждый round-trip свопил два значения. Починено: Python теперь даёт `start=parts[0]`, `default=parts[1]`.

## Результаты round-trip

Small world (`lib/` + `lib.template/`) — **fixed-point по всем секциям**:

| section | v1 | v3 | v5 |
|---|---|---|---|
| Zones | `A856938C` | `A856938C` | `A856938C` |
| Rooms | `BDC96834` | `752B73C1` | `752B73C1` |
| Mobs | `66220773` | `2087FECD` | `2087FECD` |
| Objects | `AB86A971` | `9421E78E` | `9421E78E` |
| Triggers | `816C858D` | `61775C3C` | `61775C3C` |
| Combined | `A8950AF4` | `F8AD77D1` | `F8AD77D1` |

`v1 ≠ v3, v3 == v5` — фиксированная точка после первого нормализующего прохода OLC. Дрифт `v1 → v3` чисто косметический (whitespace strip в `redit_save_to_disk`, `REMOVE_BIT(kBrokenLock)`, форматирование). Семантической потери нигде нет.

## Тесты

- C++ unit: 409/409 ✅ (`meson test -C build`).
- Python конвертер: 14/14 ✅ (`python3 tools/converter/test_convert_to_yaml.py`).
- Round-trip: exit 0 (FIXED-POINT) на `lib/` + `lib.template/`.

## Test plan

- [ ] `meson setup build_legacy -Dbuild_profile=release -Dyaml=disabled -Dsqlite=disabled && ninja -C build_legacy`
- [ ] `meson setup build -Dbuild_profile=release -Dyaml=builtin && ninja -C build` (или `yaml=system`)
- [ ] `mkdir -p /tmp/v1_legacy && cp -r lib/* lib.template/* /tmp/v1_legacy/`
- [ ] `tools/legacy_yaml_legacy_roundtrip.sh --v1-dir /tmp/v1_legacy` → exit 0, печатает `FIXED-POINT (v1 != v3, v3 == v5)`
- [ ] `meson test -C build` — все 409 unit-тестов проходят.
- [ ] Smoke: `build/circle -d <yaml_world_dir> -S /tmp/out -T legacy 4001` пишет `/tmp/out/world/{wld,mob,obj,zon,trg}/` + index файлы, `build_legacy/circle -W -c -d /tmp/out 4001` грузит без структурных ошибок и считает чексумму.
