### PR TITLE
fix(magic): dispel снимает случайный снимаемый аффект (#3292)

### DIFF
--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -3312,26 +3312,32 @@ int CastUnaffects(int/* level*/, CharData *ch, CharData *victim, ESpell spell_id
 			}
 
 			{
-				const auto affects_count = victim->affected.size();
-				if (0 == affects_count) {
+				// Снимаем случайный аффект из тех, что вообще можно снять.
+				// Раньше брали случайный из всех -- если попадали на
+				// неснимаемый (charm/quest/patronage/...), dispel фейлился,
+				// хотя рядом могли быть снимаемые.
+				int dispellable = 0;
+				for (const auto &aff : victim->affected) {
+					if (!CheckNodispel(aff)) {
+						++dispellable;
+					}
+				}
+				if (dispellable == 0) {
 					SendMsgToChar(NOEFFECT, ch);
 					return 0;
 				}
 
-				auto count = 1;
-				const auto rspell = number(1, static_cast<int>(affects_count));
-				auto affect_i = victim->affected.begin();
-				while (count < rspell) {
-					++affect_i;
-					++count;
+				const auto target = number(1, dispellable);
+				auto seen = 0;
+				for (const auto &aff : victim->affected) {
+					if (CheckNodispel(aff)) {
+						continue;
+					}
+					if (++seen == target) {
+						spell = aff->type;
+						break;
+					}
 				}
-
-				if (CheckNodispel(*affect_i)) {
-					SendMsgToChar(NOEFFECT, ch);
-					return 0;
-				}
-
-				spell = (*affect_i)->type;
 			}
 
 			remove = true;


### PR DESCRIPTION
## Summary

`CastUnaffects` для `kDispellMagic` (`src/gameplay/magic/magic.cpp:3306`) выбирал случайный аффект из **всего** `victim->affected`, а потом проверял `CheckNodispel`. Если жребий падал на неснимаемый (charm / quest / patronage / solobonus / eviless / битвектор kCharmed) — заклинание сразу фейлилось с `NOEFFECT`, хотя в списке могли быть снимаемые аффекты.

Теперь:
1. считаем снимаемые (`CheckNodispel(aff) == false`);
2. если их ноль — `NOEFFECT`;
3. иначе выбираем `number(1, dispellable)` и снимаем именно его.

Два прохода по `affected` (список короткий), без аллокаций и новых include.

Closes #3292

## Test plan
- [x] meson `-Dyaml=builtin` собирается
- [x] `meson test -C build_yaml2` — зелёные
- [ ] на проде: dispel на цели с charm + парой баффов снимает один из баффов, а не фейлится

🤖 Generated with [Claude Code](https://claude.com/claude-code)