### PR TITLE
feat: add MsgSheaf/MsgContainer in-game string container (#3294)

### DIFF
--- a/src/engine/structs/msg_container.h
+++ b/src/engine/structs/msg_container.h
@@ -1,0 +1,142 @@
+/**
+\file msg_container.h - a part of the Bylins engine.
+\authors Created by Claude (issue #3294).
+\brief Specialized container for storing in-game player message strings.
+\details Stores message strings for game entities (spells, abilities, affects, ...).
+		 Built on top of info_container: a MsgSheaf is one entity's set of messages
+		 keyed by a per-entity message-type enum, and MsgContainer is an InfoContainer
+		 of MsgSheaf items keyed by an element-id enum (e.g. ESkill).
+*/
+
+#ifndef BYLINS_SRC_STRUCTS_MSG_CONTAINER_H_
+#define BYLINS_SRC_STRUCTS_MSG_CONTAINER_H_
+
+#include "engine/structs/info_container.h"
+#include "engine/structs/meta_enum.h"
+#include "utils/parse.h"
+#include "utils/parser_wrapper.h"
+#include "utils/random.h"
+#include "utils/logger.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace msg_container {
+
+/**
+ * One element's message storage. IdEnum identifies the element (e.g. ESkill);
+ * MsgType is a per-element enum of message kinds (e.g. kCastStart, kCastFail).
+ * A sheaf may hold several strings of the same type; GetMessage() returns a
+ * random one. MsgSheaf is always enabled (it inherits BaseItem only for the id).
+ */
+template<typename IdEnum, typename MsgType>
+class MsgSheaf : public info_container::BaseItem<IdEnum> {
+ public:
+	using info_container::BaseItem<IdEnum>::BaseItem;
+
+	void AddMessage(MsgType type, std::string text) {
+		messages_[type].emplace_back(std::move(text));
+	}
+
+	/**
+	 * Returns a random string of the given type, or an empty string if none.
+	 */
+	[[nodiscard]] const std::string &GetMessage(MsgType type) const {
+		static const std::string kEmpty;
+		const auto it = messages_.find(type);
+		if (it == messages_.end() || it->second.empty()) {
+			return kEmpty;
+		}
+		const auto &variants = it->second;
+		return variants[static_cast<std::size_t>(number(0, static_cast<int>(variants.size()) - 1))];
+	}
+
+	[[nodiscard]] bool HasMessage(MsgType type) const {
+		const auto it = messages_.find(type);
+		return it != messages_.end() && !it->second.empty();
+	}
+
+ private:
+	std::map<MsgType, std::vector<std::string>> messages_;
+};
+
+/**
+ * Builds a single MsgSheaf from one <msg_sheaf id="..."> XML node.
+ * Note: parser_wrapper has no inner-tag-text support, so message text lives in
+ * the "val" attribute: <message type="kCastFail" val="..." />.
+ */
+template<typename IdEnum, typename MsgType>
+class MsgSheafBuilder : public info_container::IItemBuilder<MsgSheaf<IdEnum, MsgType>> {
+ public:
+	using Sheaf = MsgSheaf<IdEnum, MsgType>;
+	using ItemPtr = std::shared_ptr<Sheaf>;
+
+	ItemPtr Build(parser_wrapper::DataNode &node) override {
+		const char *id_str = node.GetValue("id");
+		IdEnum id;
+		try {
+			id = parse::ReadAsConstant<IdEnum>(id_str);
+		} catch (const std::exception &) {
+			err_log("MsgSheafBuilder: msg_sheaf has unknown or missing 'id' attribute ('%s').", id_str);
+			return nullptr;
+		}
+
+		auto sheaf = std::make_shared<Sheaf>(id, EItemMode::kEnabled);
+		for (auto &message : node.Children("message")) {
+			const char *type_str = message.GetValue("type");
+			try {
+				const MsgType type = parse::ReadAsConstant<MsgType>(type_str);
+				sheaf->AddMessage(type, message.GetValue("val"));
+			} catch (const std::exception &) {
+				err_log("MsgSheafBuilder: message has unknown 'type' ('%s') in msg_sheaf '%s'.", type_str, id_str);
+			}
+		}
+		return sheaf;
+	}
+};
+
+/**
+ * A container of MsgSheaf items keyed by element id. Reuses InfoContainer for
+ * Init/Reload/operator[]/iteration. The default sheaf is the kUndefined slot
+ * (XML id "kDefault" should map to IdEnum::kUndefined).
+ */
+template<typename IdEnum, typename MsgType>
+class MsgContainer
+	: public info_container::InfoContainer<IdEnum, MsgSheaf<IdEnum, MsgType>, MsgSheafBuilder<IdEnum, MsgType>> {
+ public:
+	using Sheaf = MsgSheaf<IdEnum, MsgType>;
+
+	/**
+	 * Returns a message string for the element id and message type.
+	 * Fallback: unknown id or empty message -> default sheaf -> literal error string.
+	 */
+	[[nodiscard]] const std::string &GetMessage(IdEnum id, MsgType type) const {
+		static const std::string fallback{kFallbackErrorMsg};
+		if (this->IsKnown(id)) {
+			const auto &message = (*this)[id].GetMessage(type);
+			if (!message.empty()) {
+				return message;
+			}
+		} else {
+			err_log("MsgContainer: unknown element id '%s', falling back to default messages.",
+					NAME_BY_ITEM<IdEnum>(id).c_str());
+		}
+
+		const auto &default_message = (*this)[IdEnum::kUndefined].GetMessage(type);
+		if (!default_message.empty()) {
+			return default_message;
+		}
+		return fallback;
+	}
+
+ private:
+	static constexpr const char *kFallbackErrorMsg = "ERROR: message not found";
+};
+
+} // namespace msg_container
+
+#endif // BYLINS_SRC_STRUCTS_MSG_CONTAINER_H_
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/data/msg_container/test_messages.xml
+++ b/tests/data/msg_container/test_messages.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Minimal msg_container XML for unit tests (issue #3294).
+     ASCII placeholder values are used on purpose; the container stores strings
+     opaquely, so message content is irrelevant to the logic under test.
+     Real game data stores Russian player messages in KOI8-R. -->
+<msg_container>
+    <msg_sheaf id="kFireball">
+        <message type="kStart"   val="fireball-start" />
+        <message type="kSuccess" val="fireball-hit-a" />
+        <message type="kSuccess" val="fireball-hit-b" />
+        <message type="kFail"    val="fireball-fail" />
+    </msg_sheaf>
+
+    <!-- Default sheaf: its id maps to EMsgTestElem::kUndefined. -->
+    <msg_sheaf id="kDefault">
+        <message type="kFail" val="default-fail" />
+        <message type="kTick" val="default-tick" />
+    </msg_sheaf>
+</msg_container>

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -49,7 +49,8 @@ test_sources = files(
     'world_load_order.cpp',
     'obj_decay_manager.cpp',
     'char.utilities.cpp',
-    'exit_is_empty.cpp'
+    'exit_is_empty.cpp',
+    'msg_container.cpp'
 )
 
 fs = import('fs')
@@ -60,6 +61,7 @@ files_to_copy = [
     ['data/boards/news.sample',       'data/boards/news.sample'],
     ['data/mob_classes/test_initial.xml', 'data/mob_classes/test_initial.xml'],
     ['data/mob_classes/test_updated.xml', 'data/mob_classes/test_updated.xml'],
+    ['data/msg_container/test_messages.xml', 'data/msg_container/test_messages.xml'],
 ]
 
 copied_targets = []

--- a/tests/msg_container.cpp
+++ b/tests/msg_container.cpp
@@ -1,0 +1,151 @@
+// Part of Bylins http://www.mud.ru
+// Unit tests for msg_container: MsgSheaf / MsgSheafBuilder / MsgContainer (issue #3294).
+//
+// The container stores message strings opaquely, so ASCII placeholder values are
+// used here. Real game data stores Russian player messages (KOI8-R).
+//
+// Names are deliberately unique (EMsgTest*, MsgTest*) so they do not collide
+// with other test sources under a unity build.
+
+#include "engine/structs/msg_container.h"
+
+#include "utils/parser_wrapper.h"
+
+#include <gtest/gtest.h>
+#include <map>
+#include <set>
+#include <string>
+
+// Throwaway element-id enum (must provide kUndefined for the default slot).
+enum class EMsgTestElem {
+	kUndefined,
+	kFireball,
+	kHeal
+};
+
+// Throwaway per-element message-type enum.
+enum class EMsgTestKind {
+	kStart,
+	kSuccess,
+	kFail,
+	kTick
+};
+
+// --- enum <-> name specializations required by the meta_enum mechanism ---
+// The XML "id" of the default sheaf ("kDefault") maps to EMsgTestElem::kUndefined.
+
+template<>
+EMsgTestElem ITEM_BY_NAME<EMsgTestElem>(const std::string &name) {
+	static const std::map<std::string, EMsgTestElem> kMap{
+		{"kDefault", EMsgTestElem::kUndefined},
+		{"kFireball", EMsgTestElem::kFireball},
+		{"kHeal", EMsgTestElem::kHeal},
+	};
+	return kMap.at(name); // throws std::out_of_range on unknown name
+}
+
+template<>
+const std::string &NAME_BY_ITEM<EMsgTestElem>(const EMsgTestElem item) {
+	static const std::map<EMsgTestElem, std::string> kMap{
+		{EMsgTestElem::kUndefined, "kDefault"},
+		{EMsgTestElem::kFireball, "kFireball"},
+		{EMsgTestElem::kHeal, "kHeal"},
+	};
+	return kMap.at(item);
+}
+
+template<>
+EMsgTestKind ITEM_BY_NAME<EMsgTestKind>(const std::string &name) {
+	static const std::map<std::string, EMsgTestKind> kMap{
+		{"kStart", EMsgTestKind::kStart},
+		{"kSuccess", EMsgTestKind::kSuccess},
+		{"kFail", EMsgTestKind::kFail},
+		{"kTick", EMsgTestKind::kTick},
+	};
+	return kMap.at(name);
+}
+
+template<>
+const std::string &NAME_BY_ITEM<EMsgTestKind>(const EMsgTestKind item) {
+	static const std::map<EMsgTestKind, std::string> kMap{
+		{EMsgTestKind::kStart, "kStart"},
+		{EMsgTestKind::kSuccess, "kSuccess"},
+		{EMsgTestKind::kFail, "kFail"},
+		{EMsgTestKind::kTick, "kTick"},
+	};
+	return kMap.at(item);
+}
+
+using MsgTestSheaf = msg_container::MsgSheaf<EMsgTestElem, EMsgTestKind>;
+using MsgTestContainer = msg_container::MsgContainer<EMsgTestElem, EMsgTestKind>;
+
+static constexpr const char *kMsgTestXmlPath = "data/msg_container/test_messages.xml";
+
+// --- MsgSheaf ---
+
+TEST(MsgSheaf, AddAndGetMessage) {
+	MsgTestSheaf sheaf(EMsgTestElem::kFireball, EItemMode::kEnabled);
+	sheaf.AddMessage(EMsgTestKind::kStart, "boom");
+	EXPECT_EQ("boom", sheaf.GetMessage(EMsgTestKind::kStart));
+	EXPECT_TRUE(sheaf.HasMessage(EMsgTestKind::kStart));
+	EXPECT_EQ(EMsgTestElem::kFireball, sheaf.GetId());
+}
+
+TEST(MsgSheaf, MissingTypeReturnsEmpty) {
+	MsgTestSheaf sheaf(EMsgTestElem::kFireball, EItemMode::kEnabled);
+	EXPECT_TRUE(sheaf.GetMessage(EMsgTestKind::kFail).empty());
+	EXPECT_FALSE(sheaf.HasMessage(EMsgTestKind::kFail));
+}
+
+TEST(MsgSheaf, GetMessagePicksAmongAllVariants) {
+	MsgTestSheaf sheaf(EMsgTestElem::kFireball, EItemMode::kEnabled);
+	sheaf.AddMessage(EMsgTestKind::kSuccess, "a");
+	sheaf.AddMessage(EMsgTestKind::kSuccess, "b");
+
+	std::set<std::string> seen;
+	for (int i = 0; i < 1000; ++i) {
+		const auto &message = sheaf.GetMessage(EMsgTestKind::kSuccess);
+		ASSERT_TRUE(message == "a" || message == "b");
+		seen.insert(message);
+	}
+	EXPECT_EQ(2u, seen.size()); // both variants appear over 1000 random draws
+}
+
+// --- MsgContainer (full XML parse via parser_wrapper) ---
+
+TEST(MsgContainer, LoadsAndReturnsMessages) {
+	parser_wrapper::DataNode data(kMsgTestXmlPath);
+	ASSERT_TRUE(static_cast<bool>(data));
+
+	MsgTestContainer container;
+	container.Init(data.Children());
+
+	EXPECT_EQ("fireball-start", container.GetMessage(EMsgTestElem::kFireball, EMsgTestKind::kStart));
+	EXPECT_EQ("fireball-fail", container.GetMessage(EMsgTestElem::kFireball, EMsgTestKind::kFail));
+
+	const auto &hit = container.GetMessage(EMsgTestElem::kFireball, EMsgTestKind::kSuccess);
+	EXPECT_TRUE(hit == "fireball-hit-a" || hit == "fireball-hit-b");
+}
+
+TEST(MsgContainer, FallsBackToDefaultSheaf) {
+	parser_wrapper::DataNode data(kMsgTestXmlPath);
+	MsgTestContainer container;
+	container.Init(data.Children());
+
+	// kFireball has no kTick message -> default sheaf supplies it.
+	EXPECT_EQ("default-tick", container.GetMessage(EMsgTestElem::kFireball, EMsgTestKind::kTick));
+	// Unknown element kHeal -> default sheaf supplies kFail.
+	EXPECT_EQ("default-fail", container.GetMessage(EMsgTestElem::kHeal, EMsgTestKind::kFail));
+}
+
+TEST(MsgContainer, ReturnsLiteralFallbackWhenNothingMatches) {
+	parser_wrapper::DataNode data(kMsgTestXmlPath);
+	MsgTestContainer container;
+	container.Init(data.Children());
+
+	// Unknown element + a type the default sheaf lacks (kStart) -> literal error string.
+	EXPECT_EQ("ERROR: message not found",
+			  container.GetMessage(EMsgTestElem::kHeal, EMsgTestKind::kStart));
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
New string-message storage subsystem in src/engine/structs/msg_container.h, built on the existing info_container classes:

- MsgSheaf<IdEnum, MsgType> (inherits BaseItem): stores messages keyed by message type, returns a random variant or an empty string when absent.
- MsgSheafBuilder: parses <msg_sheaf id="..."> nodes with <message type="..." val="..."/> attributes (parser_wrapper has no inner-tag-text support).
- MsgContainer<IdEnum, MsgType> (inherits InfoContainer): sheaves keyed by an element-id enum, with fallback to the default (kUndefined) sheaf and a literal error string.

Adds unit tests + fixture and wires them into tests/meson.build. Header-only; no existing consumers, no player-facing strings changed.