### PR TITLE
fix(mob): не бросать пустой узелок сезонного моба (#3297)

### DIFF
--- a/src/gameplay/ai/mobact.cpp
+++ b/src/gameplay/ai/mobact.cpp
@@ -1326,6 +1326,15 @@ bool drop_mob_objects_to_box(CharData *ch)
 		PlaceObjIntoObj(object, charmice_box);
 	}
 
+	// Вещи могли испариться при снятии (триггеры на remove, временные/
+	// декейные предметы) -- тогда узелок пустой. Пустышку не бросаем и не
+	// логируем, незачем плодить мусор на полу.
+	if (!charmice_box->get_contains())
+	{
+		ExtractObjFromWorld(charmice_box);
+		return false;
+	}
+
 	DropObjOnZoneReset(ch, charmice_box, true, false);
 
 	return true;

--- a/src/gameplay/ai/mobact.cpp
+++ b/src/gameplay/ai/mobact.cpp
@@ -1323,12 +1323,22 @@ bool drop_mob_objects_to_box(CharData *ch)
 	ObjData *charmice_box = create_charmice_box(ch);
 	for (auto &object : objects)
 	{
-		PlaceObjIntoObj(object, charmice_box);
+		// kTicktimer выставляется в PlaceObjToInventory (handler.cpp), когда
+		// вещь поднял игрок или его чармис -- "таймер запущен" = вещь игрока.
+		// Такое сохраняем в узелок. Интринзик-экипировка моба (флага нет) --
+		// уничтожаем, незачем плодить дубли при каждом межсезонье.
+		if (object->has_flag(EObjFlag::kTicktimer))
+		{
+			PlaceObjIntoObj(object, charmice_box);
+		}
+		else
+		{
+			ExtractObjFromWorld(object);
+		}
 	}
 
-	// Вещи могли испариться при снятии (триггеры на remove, временные/
-	// декейные предметы) -- тогда узелок пустой. Пустышку не бросаем и не
-	// логируем, незачем плодить мусор на полу.
+	// Если игроцких вещей не было (только мобовский шмот) -- узелок пустой.
+	// Пустышку не бросаем и не логируем.
 	if (!charmice_box->get_contains())
 	{
 		ExtractObjFromWorld(charmice_box);


### PR DESCRIPTION
## Summary

При уходе сезонного моба в виртуальную комнату `drop_mob_objects_to_box` (`src/gameplay/ai/mobact.cpp:1294`) собирает его вещи в «узелок» и бросает на пол. По уточнению из тикета:

- **вещи игроков** (моб мог быть зачармлен и налутить) — у них запущен таймер — кладём в узелок, бросаем на пол, пишем в SYSLOG;
- **интринзик-экипировка моба** (таймер не запущен) — уничтожаем молча, иначе каждое межсезонье плодит дубли мобовского шмота на полу;
- **узелок пуст** (игроцких вещей не было / всё испарилось при снятии) — не бросаем и не логируем.

Разделение по `EObjFlag::kTicktimer`: флаг выставляется в `PlaceObjToInventory` (`handler.cpp:460`) ровно когда вещь поднимает игрок или его чармис → "вещь прошла через руки игрока / таймер запущен". Мобовская зонная экипировка флаг не получает.

Механику узелка НЕ убираем (см. #3286) — она нужна для возврата налученного игроцкого шмота.

Closes #3297

## Test plan
- [x] meson `-Dyaml=builtin` собирается
- [x] `meson test -C build_yaml2` — зелёные
- [ ] прод: сезонный моб с игроцким шмотом — узелок с этим шмотом на полу + лог; моб только со своей экипировкой — ничего на полу, лог молчит

🤖 Generated with [Claude Code](https://claude.com/claude-code)