### PR TITLE
chore(top): убрать диагностический лог из RefreshAll (#3284)

### DIFF
--- a/src/gameplay/statistics/top.cpp
+++ b/src/gameplay/statistics/top.cpp
@@ -1,7 +1,5 @@
 #include "top.h"
 
-#include <fmt/format.h>
-
 #include "gameplay/classes/pc_classes.h"
 #include "engine/ui/color.h"
 #include "gameplay/mechanics/glory_const.h"
@@ -10,7 +8,6 @@
 #include "engine/network/descriptor_data.h"
 #include "engine/db/global_objects.h"
 #include "engine/ui/table_wrapper.h"
-#include "utils/logger.h"
 #include "utils/utils_time.h"
 
 
@@ -83,11 +80,8 @@ void TopPlayer::Refresh(CharData *short_ch, bool reboot) {
 // изменениями. Оффлайн-игроки остаются на боковых записях с буткового
 // прохода (их состояние всё равно не меняется, пока они не в игре).
 void TopPlayer::RefreshAll() {
-	utils::CExecutionTimer timer;
-
 	// Phase 1: snapshot online players.
 	std::unordered_map<long, std::pair<long, int>> online;
-	int considered = 0;
 	for (DescriptorData *d = descriptor_list; d; d = d->next) {
 		if (d->state != EConState::kPlaying || !d->character) {
 			continue;
@@ -100,26 +94,18 @@ void TopPlayer::RefreshAll() {
 			continue;
 		}
 		online[ch->get_uid()] = {ch->get_exp(), GetRealRemort(ch)};
-		++considered;
 	}
-	const auto snapshot_ms = timer.delta().count() * 1000.0;
 
 	// Early exit: пустой snapshot значит обновлять нечего, нет смысла
 	// перебирать весь chart_ (десятки тысяч записей в std::list -- куча
 	// кэш-промахов).
 	if (online.empty()) {
-		log(fmt::format("TopPlayer::RefreshAll: онлайн 0, пропуск (snapshot {:.3f} мс)",
-			snapshot_ms));
 		return;
 	}
 
 	// Phase 2: walk chart_, update in place, mark dirty classes.
-	std::size_t chart_total = 0;
-	int updated = 0;
-	int dirty_classes = 0;
 	for (auto &class_entry : chart_) {
 		auto &list = class_entry.second;
-		chart_total += list.size();
 		bool dirty = false;
 		for (auto &entry : list) {
 			auto it = online.find(entry.unique_);
@@ -132,7 +118,6 @@ void TopPlayer::RefreshAll() {
 				entry.exp_ = new_exp;
 				entry.remort_ = new_remort;
 				dirty = true;
-				++updated;
 			}
 		}
 		if (dirty) {
@@ -140,14 +125,8 @@ void TopPlayer::RefreshAll() {
 				if (a.remort_ != b.remort_) return a.remort_ > b.remort_;
 				return a.exp_ > b.exp_;
 			});
-			++dirty_classes;
 		}
 	}
-
-	log(fmt::format("TopPlayer::RefreshAll: онлайн {}, обновлено {} в {} классах, "
-			"chart={} записей, итого {:.3f} мс (snapshot {:.3f} мс)",
-		considered, updated, dirty_classes, chart_total,
-		timer.delta().count() * 1000.0, snapshot_ms));
 }
 
 const PlayerChart &TopPlayer::Chart() {


### PR DESCRIPTION
## Summary

Перф `RefreshAll` подтверждён на проде (`chart=8599`, онлайн ~95 → ~2 мс, ранний выход при 0 онлайн). Диагностический лог, который добавляли для замера, больше не нужен — убираю.

Снято: `CExecutionTimer`, счётчики (`considered`/`updated`/`dirty_classes`/`chart_total`), обе `log(fmt::format(...))`-строки, и ставшие ненужными `#include <fmt/format.h>` / `utils/logger.h`. Логика без изменений: snapshot из `descriptor_list` → early-exit при пустом онлайне → in-place правка `chart_` → сортировка грязных классов.

## Test plan
- [x] meson `-Dyaml=builtin` собирается
- [x] `meson test -C build_yaml2` — зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)