### PR TITLE
fix(zone): читаемый формат "Time reset" в логе (#3302)

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -2161,7 +2161,7 @@ void ZoneUpdate() {
 				}
 			}
 			mudlog(ss.str(), LGH, kLvlGod, SYSLOG, true);
-			out << " ]\r\n[ Time reset: " << timer_count.delta().count();
+			out << " ]\r\n[ Time reset: " << fmt::format("{:.3f} ms", timer_count.delta().count() * 1000.0);
 			mudlog(out.str(), LGH, kLvlGod, SYSLOG, true);
 			if (update_u == reset_q.head) {
 				reset_q.head = reset_q.head->next;


### PR DESCRIPTION
## Summary

`Time reset: 9.4223e-05` — это `timer_count.delta().count()` (`double`, секунды), который дефолтный `operator<<` для мелких значений печатал в научной нотации.

Вывожу миллисекунды с фиксированной точностью через `fmt` (уже подключён в db.cpp):

```
[ Time reset: 0.094 ms ]
```

Одна строка в `ZoneUpdate` (`src/engine/db/db.cpp`).

Closes #3302

## Test plan
- [x] meson `-Dyaml=builtin` собирается
- [x] `meson test -C build_yaml2` — зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)