### PR TITLE
Issue.3308.fixmagic

### DIFF
--- a/lib/cfg/spells.xml
+++ b/lib/cfg/spells.xml
@@ -515,6 +515,15 @@ base_stat id - (например "kWis") какой берем параметр,
         <mana max="85" min="70" change="2"/>
         <targets val="kTarSelfOnly|kTarCharRoom"/>
         <flags val="kMagPoints|kMagAffects"/>
+        <talent_actions>
+            <action>
+                <heal saving="kCritical" npc_coeff="3">
+                    <dices ndice="0" sdice="0" adice="1"/>
+                    <base_skill id="kLifeMagic" low_skill_bonus="30" hi_skill_bonus="200"/>
+                    <base_stat id="kWis" threshold="20" weight="150"/>
+                </heal>
+            </action>
+        </talent_actions>
     </spell>
     <spell id="kWorldOfRecall" element="kMind" mode="kEnabled">
         <name rus="слово возврата" eng="recall"/>

--- a/lib/cfg/spells.xml
+++ b/lib/cfg/spells.xml
@@ -997,6 +997,13 @@ base_stat id - (например "kWis") какой берем параметр,
         <mana max="100" min="85" change="2"/>
         <targets val="kTarCharRoom|kTarFightSelf"/>
         <flags val="kMagPoints|kNpcDummy"/>
+        <action>
+            <heal saving="kCritical" npc_coeff="3">
+                <dices ndice="2" sdice="3" adice="0"/>
+                <base_skill id="kMindMagic" low_skill_bonus="15" hi_skill_bonus="25"/>
+                <base_stat id="kInt" threshold="20" weight="20"/>
+            </heal>
+        </action>
     </spell>
     <spell id="kResurrection" element="kDark" mode="kEnabled">
         <name rus="оживить труп" eng="ressurection"/>
@@ -1563,6 +1570,11 @@ base_stat id - (например "kWis") какой берем параметр,
         <flags val="kMagGroups|kMagAffects|kMagPoints"/>
         <talent_actions>
             <action>
+                <heal saving="kCritical" npc_coeff="3">
+                    <dices ndice="15" sdice="15" adice="15"/>
+                    <base_skill id="kDarkMagic" low_skill_bonus="20" hi_skill_bonus="100"/>
+                    <base_stat id="kInt" threshold="20" weight="50"/>
+                </heal>
                 <area>
                     <decay cast="0.0" level="0" free_targets="3"/>
                     <victims skill_divisor="20" dice_size="2" min_targets="1" max_targets="20"/>
@@ -2129,6 +2141,11 @@ base_stat id - (например "kWis") какой берем параметр,
         <flags val="kMagWarcry|kMagGroups|kMagPoints|kMagAffects|kNpcDummy|kNpcAffectNpc"/>
         <talent_actions>
             <action>
+                <heal saving="kCritical" npc_coeff="3">
+                    <dices ndice="0" sdice="1" adice="1"/>
+                    <base_skill id="kWarcry" low_skill_bonus="40" hi_skill_bonus="60"/>
+                    <base_stat id="kCon" threshold="20" weight="200"/>
+                </heal>
                 <area>
                     <decay cast="0.0" level="0" free_targets="3"/>
                     <victims skill_divisor="20" dice_size="2" min_targets="5" max_targets="20"/>

--- a/lib/cfg/spells.xml
+++ b/lib/cfg/spells.xml
@@ -599,6 +599,11 @@ base_stat id - (например "kWis") какой берем параметр,
         <flags val="kMagGroups|kMagPoints|kNpcDummy"/>
         <talent_actions>
             <action>
+                <heal saving="kCritical" npc_coeff="3">
+                    <dices ndice="12" sdice="12" adice="12"/>
+                    <base_skill id="kPunctual" low_skill_bonus="10" hi_skill_bonus="5"/>
+                    <base_stat id="kInt" threshold="16" weight="6"/>
+                </heal>
                 <area>
                     <decay cast="0.01" level="0" free_targets="3"/>
                     <victims skill_divisor="20" dice_size="2" min_targets="5" max_targets="20"/>

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -3088,20 +3088,19 @@ int CastToPoints(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 
 	switch (spell_id) {
 		case ESpell::kCureLight:
-			hit = CalcHeal(ch, victim, ESpell::kCureLight, level);
+			hit = CalcHeal(ch, victim, spell_id, level);
 			break;
 		case ESpell::kCureSerious:
-			hit = CalcHeal(ch, victim, ESpell::kCureSerious, level);
+			hit = CalcHeal(ch, victim, spell_id, level);
 			break;
 		case ESpell::kCureCritic:
-			hit = CalcHeal(ch, victim, ESpell::kCureCritic, level);
+			hit = CalcHeal(ch, victim, spell_id, level);
 			break;
-		case ESpell::kHeal: hit = CalcHeal(ch, victim, ESpell::kHeal, level);
+		case ESpell::kHeal: hit = CalcHeal(ch, victim, spell_id, level);
 			break;
-		case ESpell::kGroupHeal: hit = CalcHeal(ch, victim, ESpell::kGroupHeal, level);
+		case ESpell::kGroupHeal: hit = CalcHeal(ch, victim, spell_id, level);
 			break;
-		case ESpell::kGreatHeal:
-			hit = victim->get_real_max_hit() - victim->get_hit();
+		case ESpell::kGreatHeal: hit = CalcHeal(ch, victim, spell_id, level);
 			break;
 		case ESpell::kPatronage: hit = (GetRealLevel(victim) + GetRealRemort(victim)) * 2;
 			break;

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -278,51 +278,6 @@ float CalcDurationCoef(ESpell spell_id, int skill_percent) {
 	}
 }
 
-// зависимость модификации спелла от скила магии
-float CalcModCoef(ESpell spell_id, int percent) {
-	switch (spell_id) {
-		case ESpell::kStrength:
-		case ESpell::kDexterity:
-			if (percent > 100)
-				return 1;
-			return 0;
-			break;
-		case ESpell::kMassSlow:
-		case ESpell::kSlowdown: {
-			if (percent >= 80) {
-				return (percent - 80) / 20.00 + 1.00;
-			}
-		}
-			break;
-		case ESpell::kSonicWave:
-			if (percent > 100) {
-				return (percent - 80) / 20.00; // после 100% идет прибавка
-			}
-			return 1;
-			break;
-		case ESpell::kFascination:
-		case ESpell::kHypnoticPattern:
-			if (percent >= 80) {
-				return (percent - 80) / 20.00 + 1.00;
-			}
-			return 1;
-			break;
-		case ESpell::kWhirlwind:
-			if (percent > 80) {
-				return (percent) / 80; // 160 -2 вихря, 240 - 3 вихря и т.д.
-			}
-			return 1;
-			break;
-		case ESpell::kLightingBolt:
-			if (percent > 100) {
-				return (percent - 70) / 30; // 130 - 2 молнии, 160 -3, 190 -4
-			}
-			return 1;
-			break;
-		default: return 1;
-	}
-	return 0;
-}
 bool IsBreath(ESpell spell_id) {
 	static const std::set<ESpell> magic_breath {
 	 	ESpell::kFireBreath,
@@ -557,14 +512,12 @@ int CastDamage(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 			break;
 		}
 		case ESpell::kLightingBolt: {
-				count = CalcModCoef(spell_id, ch->GetSkill(GetMagicSkillId(spell_id)));
-				count += number(1, 5)==1?1:0;
+				count += ((number(1, 5) == 1) ? 1 : 0);
 				count = std::min(count, 4);
 			break;
 		}
 		case ESpell::kWhirlwind: {
-				count = CalcModCoef(spell_id, ch->GetSkill(GetMagicSkillId(spell_id)));
-				count += number(1, 7)==1?1:0;
+				count += ((number(1, 7) == 1) ? 1 : 0);
 				count = std::min(count, 4);
 			break;
 		}
@@ -1014,7 +967,6 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 	}
 
 	const auto koef_duration = CalcDurationCoef(spell_id, ch->GetSkill(GetMagicSkillId(spell_id)));
-	const auto koef_modifier = CalcModCoef(spell_id, ch->GetSkill(GetMagicSkillId(spell_id)));
 
 	auto savetype{ESaving::kStability};
 	switch (spell_id) {
@@ -1221,9 +1173,9 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 			af[0].duration =
 				CalcDuration(victim, 20, kSecsPerPlayerAffect * GetRealRemort(ch), 1, 0, 0) * koef_duration;
 			if (ch == victim)
-				af[0].modifier = (level + 9) / 10 + 0.7 * koef_modifier;
+				af[0].modifier = (level + 9) / 10;
 			else
-				af[0].modifier = (level + 14) / 15 + 0.7 * koef_modifier;
+				af[0].modifier = (level + 14) / 15;
 			accum_duration = true;
 			accum_affect = true;
 			to_room =
@@ -1588,7 +1540,7 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 				ApplyResist(victim, GetResistType(spell_id), CalcDuration(victim, 9, 0, 0, 0, 0))
 					* koef_duration;
 			af[1].location = EApply::kDex;
-			af[1].modifier = -koef_modifier;
+			af[1].modifier = -1 - GetRealRemort(ch) / 5;
 			to_room = "Движения $n1 заметно замедлились.";
 			to_vict = "Ваши движения заметно замедлились.";
 			spell_id = ESpell::kSlowdown;
@@ -1813,9 +1765,9 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 			af[0].location = EApply::kStr;
 			af[0].duration = CalcDuration(victim, 20, kSecsPerPlayerAffect * GetRealRemort(ch), 1, 0, 0) * koef_duration;
 			if (ch == victim)
-				af[0].modifier = (level + 9) / 10 + koef_modifier + GetRealRemort(ch) / 5;
+				af[0].modifier = (level + 9) / 10 + GetRealRemort(ch) / 5;
 			else
-				af[0].modifier = (level + 14) / 15 + koef_modifier + GetRealRemort(ch) / 5;
+				af[0].modifier = (level + 14) / 15 + GetRealRemort(ch) / 5;
 			accum_duration = true;
 			accum_affect = true;
 			to_vict = "Вы почувствовали себя сильнее.";
@@ -1833,9 +1785,9 @@ int CastAffect(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 			af[0].duration =
 					CalcDuration(victim, 20, kSecsPerPlayerAffect * GetRealRemort(ch), 1, 0, 0) * koef_duration;
 			if (ch == victim)
-				af[0].modifier = (level + 9) / 10 + koef_modifier + GetRealRemort(ch) / 5;
+				af[0].modifier = (level + 9) / 10 + GetRealRemort(ch) / 5;
 			else
-				af[0].modifier = (level + 14) / 15 + koef_modifier + GetRealRemort(ch) / 5;
+				af[0].modifier = (level + 14) / 15 + GetRealRemort(ch) / 5;
 			accum_duration = true;
 			accum_affect = true;
 			to_vict = "Вы почувствовали себя более шустрым.";

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -3091,25 +3091,22 @@ int CastToPoints(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 		case ESpell::kCureSerious:
 		case ESpell::kCureCritic:
 		case ESpell::kHeal:
-		case ESpell::kGroupHeal: [[fallthrough]];
+		case ESpell::kGroupHeal:
 		case ESpell::kGreatHeal:
-        case ESpell::kPatronage:
+        case ESpell::kPatronage: [[fallthrough]];
+        case ESpell::kWarcryOfPower:
             hit = CalcHeal(ch, victim, spell_id, level);
-//		hit = (GetRealLevel(victim) + GetRealRemort(victim)) * 2;
-			break;
-		case ESpell::kWarcryOfPower: hit = std::min(200, (4 * ch->get_con() + ch->GetSkill(ESkill::kWarcry)) / 2);
 			break;
 		case ESpell::kExtraHits: extraHealing = true;
-			hit = RollDices(10, abs(level) / 3) + level;
+			hit = CalcHeal(ch, victim, spell_id, level);
 			break;
 		case ESpell::kEviless:
-			//лечим только умертвия-чармисы
-			if (!victim->IsNpc() || victim->get_master() != ch || !victim->IsFlagged(EMobFlag::kCorpse))
-				return 1;
-			//при рекасте - не лечим
+			if (!victim->IsNpc() || victim->get_master() != ch || !victim->IsFlagged(EMobFlag::kCorpse)) {
+                return 1;
+            }
 			if (AFF_FLAGGED(ch, EAffect::kForcesOfEvil)) {
-				hit = victim->get_real_max_hit() - victim->get_hit();
-				RemoveAffectFromCharAndRecalculate(ch, ESpell::kEviless); //сбрасываем аффект с хозяина
+				hit = CalcHeal(ch, victim, spell_id, level);
+				RemoveAffectFromCharAndRecalculate(ch, ESpell::kEviless);
 			}
 			break;
 		case ESpell::kResfresh:

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -355,9 +355,9 @@ int CalcHeal(CharData *ch, CharData *victim, ESpell spell_id, int level) {
 		skill_mod = base_heal * abs(level) / 0.25;
 	}
 //	mudlog(fmt::format("Хиляем level = {}, skill_mod = {}", level, skill_mod));
-	double wis_mod = base_heal * spell_heal.CalcBaseStatCoeff(ch);
+	double stat_mod = base_heal * spell_heal.CalcBaseStatCoeff(ch);
 	double bonus_mod = ch->add_abils.percent_spellpower_add / 100.0;
-	total_heal = static_cast<int>(base_heal + skill_mod + wis_mod);
+	total_heal = static_cast<int>(base_heal + skill_mod + stat_mod);
 	total_heal += static_cast<int>(total_heal * bonus_mod);
 	double npc_heal = spell_heal.GetNpcCoeff();
 	if (ch->IsNpc()) {
@@ -369,7 +369,7 @@ int CalcHeal(CharData *ch, CharData *victim, ESpell spell_id, int level) {
 		GET_NAME(victim),
 		base_heal,
 		skill_mod,
-		wis_mod,
+		stat_mod,
 		1 + bonus_mod,
 		npc_heal,
 		total_heal);
@@ -379,7 +379,7 @@ int CalcHeal(CharData *ch, CharData *victim, ESpell spell_id, int level) {
 			GET_NAME(ch),
 			base_heal,
 			skill_mod,
-			wis_mod,
+			stat_mod,
 			bonus_mod,
 			npc_heal,
 			total_heal);
@@ -3093,9 +3093,9 @@ int CastToPoints(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 		case ESpell::kHeal:
 		case ESpell::kGroupHeal: [[fallthrough]];
 		case ESpell::kGreatHeal:
+        case ESpell::kPatronage:
             hit = CalcHeal(ch, victim, spell_id, level);
-			break;
-		case ESpell::kPatronage: hit = (GetRealLevel(victim) + GetRealRemort(victim)) * 2;
+//		hit = (GetRealLevel(victim) + GetRealRemort(victim)) * 2;
 			break;
 		case ESpell::kWarcryOfPower: hit = std::min(200, (4 * ch->get_con() + ch->GetSkill(ESkill::kWarcry)) / 2);
 			break;

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -3088,19 +3088,12 @@ int CastToPoints(int level, CharData *ch, CharData *victim, ESpell spell_id) {
 
 	switch (spell_id) {
 		case ESpell::kCureLight:
-			hit = CalcHeal(ch, victim, spell_id, level);
-			break;
 		case ESpell::kCureSerious:
-			hit = CalcHeal(ch, victim, spell_id, level);
-			break;
 		case ESpell::kCureCritic:
-			hit = CalcHeal(ch, victim, spell_id, level);
-			break;
-		case ESpell::kHeal: hit = CalcHeal(ch, victim, spell_id, level);
-			break;
-		case ESpell::kGroupHeal: hit = CalcHeal(ch, victim, spell_id, level);
-			break;
-		case ESpell::kGreatHeal: hit = CalcHeal(ch, victim, spell_id, level);
+		case ESpell::kHeal:
+		case ESpell::kGroupHeal: [[fallthrough]];
+		case ESpell::kGreatHeal:
+            hit = CalcHeal(ch, victim, spell_id, level);
 			break;
 		case ESpell::kPatronage: hit = (GetRealLevel(victim) + GetRealRemort(victim)) * 2;
 			break;

--- a/src/gameplay/magic/magic.h
+++ b/src/gameplay/magic/magic.h
@@ -66,7 +66,6 @@ int CalcGeneralSaving(CharData *killer, CharData *victim, ESaving type, int ext_
 int GetBasicSave(CharData *ch, ESaving saving, bool log = false);
 bool ProcessMatComponents(CharData *caster, CharData *victim, ESpell spell_id);
 int CalcClassAntiSavingsMod(CharData *ch, ESpell spell_id);
-float CalcModCoef(ESpell spell_id, int percent);
 
 #endif // MAGIC_H_
 

--- a/src/gameplay/magic/magic_rooms.cpp
+++ b/src/gameplay/magic/magic_rooms.cpp
@@ -700,9 +700,7 @@ void ProcessRoomAffectsOnEntry(CharData *ch, RoomRnum room) {
 			// если вошел игрок - ПвП - делаем проверку на шанс в зависимости от % магии кастующего
 			// без магии и ниже 80%: шанс 25%, на 100% - 27%, на 200% - 37% ,при 300% - 47%
 			// иначе пве, и просто кастим сон на входящего
-			float mkof = CalcModCoef(ESpell::kHypnoticPattern,
-									 caster->GetSkill(GetMagicSkillId(ESpell::kHypnoticPattern)));
-			if (!ch->IsNpc() && (number (1, 100) > (23 + 2*mkof))) {
+			if (!ch->IsNpc() && (number (1, 100) > (25))) {
 				return;
 			}
 			SendMsgToChar("Вы уставились на огненный узор, как баран на новые ворота.", ch);


### PR DESCRIPTION
Вырезал из magic.cpp костыльное начисление умения магии некоторым заклинаниям. Заодно перевел "великое исцеление", "клич мощи", "покровительство" и "силы зла" на стандартную формулу лечения. Коэффициенты несложно подкрутить прямо на сервере и релоадннуть.