### PR TITLE
fix: краш при касте kExtraHits (нет heal-экшена) + защита CalcHeal (#3312)

### DIFF
--- a/lib/cfg/spells.xml
+++ b/lib/cfg/spells.xml
@@ -997,13 +997,15 @@ base_stat id - (например "kWis") какой берем параметр,
         <mana max="100" min="85" change="2"/>
         <targets val="kTarCharRoom|kTarFightSelf"/>
         <flags val="kMagPoints|kNpcDummy"/>
-        <action>
+        <talent_actions>
+            <action>
             <heal saving="kCritical" npc_coeff="3">
                 <dices ndice="2" sdice="3" adice="0"/>
                 <base_skill id="kMindMagic" low_skill_bonus="15" hi_skill_bonus="25"/>
                 <base_stat id="kInt" threshold="20" weight="20"/>
             </heal>
-        </action>
+            </action>
+        </talent_actions>
     </spell>
     <spell id="kResurrection" element="kDark" mode="kEnabled">
         <name rus="оживить труп" eng="ressurection"/>

--- a/src/gameplay/abilities/talents_actions.cpp
+++ b/src/gameplay/abilities/talents_actions.cpp
@@ -151,6 +151,10 @@ void Actions::ParseHeal(ActionsRosterPtr &info, parser_wrapper::DataNode &node) 
  *  работы с арекастами, а даже, скорее, переносить ее внутрь эффекта (как сделано с Applies).
  */
 
+bool Actions::Contains(EAction action) const {
+	return actions_->contains(action);
+}
+
 const Damage &Actions::GetDmg() const {
 	if (actions_->contains(EAction::kDamage)) {
 		return *std::static_pointer_cast<Damage>(actions_->find(EAction::kDamage)->second);

--- a/src/gameplay/abilities/talents_actions.h
+++ b/src/gameplay/abilities/talents_actions.h
@@ -97,6 +97,7 @@ class Actions {
 	void Build(parser_wrapper::DataNode &node);
 	void Print(CharData *ch, std::ostringstream &buffer) const;
 
+	[[nodiscard]] bool Contains(EAction action) const;
 	[[nodiscard]] const Damage &GetDmg() const;
 	[[nodiscard]] const Area &GetArea() const;
 	[[nodiscard]] const Heal &GetHeal() const;

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -344,6 +344,16 @@ int CalcBaseDmg(CharData *ch, ESpell spell_id, const talents_actions::Damage &sp
 }
 
 int CalcHeal(CharData *ch, CharData *victim, ESpell spell_id, int level) {
+	// Не у каждого спелла из CastToPoints в данных описан heal-экшен
+	// (напр. свежедобавленные kPatronage/kWarcryOfPower). Без этой проверки
+	// GetHeal() кидает исключение и роняет сервер (#3312). Логируем, какой
+	// спелл недонастроен, и лечим на 0 вместо краша.
+	if (!MUD::Spell(spell_id).actions.Contains(talents_actions::EAction::kHeal)) {
+		mudlog(fmt::format("SYSERR: spell {} ({}) has no 'heal' action, heal skipped",
+				to_underlying(spell_id), MUD::Spell(spell_id).GetCName()),
+			CMP, kLvlImmortal, SYSLOG, true);
+		return 0;
+	}
 	auto spell_heal = MUD::Spell(spell_id).actions.GetHeal();
 	int total_heal{0};
 	double skill_mod;


### PR DESCRIPTION
## Причина

Кордамп, в сислоге `STD exception: Getting heal parameters from talent which has no 'heal' action.`

`CastToPoints` гонит набор спеллов через `CalcHeal`, который безусловно зовёт `MUD::Spell(spell_id).actions.GetHeal()`. `GetHeal()` кидает `std::runtime_error`, если у спелла нет heal-экшена → неперехваченное исключение → краш.

Виновник — спелл **`kExtraHits`** («увеличить жизнь»). В `lib/cfg/spells.xml` его heal-экшен лежал прямо под `<action>` **без внешней обёртки `<talent_actions>`**:

```xml
<action>            <!-- было: нет <talent_actions> -->
    <heal .../>
</action>
```

Загрузчик `SpellInfoBuilder::ParseActions` делает `node.GoToChild("talent_actions")` — секцию без этой обёртки не видит, `actions` остаётся пустым. У всех нормальных heal-спеллов (kHeal, kGroupHeal, …) структура `<talent_actions><action><heal>`. `kExtraHits` был единственным с `<action>` без `<talent_actions>`.

## Что в PR

1. **Данные** (`lib/cfg/spells.xml`): обернул `kExtraHits` в `<talent_actions>` — heal теперь грузится, спелл лечит как задумано.
2. **Код** (защита от повторения): добавил `Actions::Contains(EAction)`. `CalcHeal` проверяет наличие heal-экшена: нет — пишет в SYSLOG `SYSERR: spell <id> (<name>) has no 'heal' action` и лечит на 0 вместо краша. Любая будущая аналогичная ошибка в данных не уронит сервер, а назовёт виновный спелл.

## Test plan
- [x] meson `-Dyaml=builtin` собирается, `meson test` зелёные
- [x] XML well-formed (`xml.etree.parse`)
- [x] в spells.xml не осталось спеллов с `<action>` без `<talent_actions>`
- [ ] прод: каст «увеличить жизнь» лечит и не роняет сервер

Closes #3312

🤖 Generated with [Claude Code](https://claude.com/claude-code)