### PR TITLE
fix(exchange): на std::string/fmt, убрать truncation-варнинги (#3317)

### DIFF
--- a/src/gameplay/economics/exchange.cpp
+++ b/src/gameplay/economics/exchange.cpp
@@ -10,6 +10,10 @@
 
 #include "exchange.h"
 
+#include <fmt/format.h>
+
+#include <iterator>
+
 #include "engine/db/obj_prototypes.h"
 #include "engine/db/world_characters.h"
 #include "engine/entities/obj_data.h"
@@ -671,35 +675,34 @@ bool correct_filter_length(const CharData *ch, const char *str) {
 
 int exchange_offers(const CharData *ch, const char *arg) {
 //влом байты считать. Если кто хочет оптимизировать, посчитайте точно.
-	char filter[kMaxInputLength] = "";
+	std::string filter;
+	filter.reserve(kMaxInputLength);
 	short int show_type = 0;
 
 	arg = one_argument(arg, arg1);
 	if (utils::IsAbbr(arg1, "все") || utils::IsAbbr(arg1, "all")) {
 		show_type = 2;
-		snprintf(filter, sizeof(filter), "М0+");
+		filter = "М0+";
 	} else if (utils::IsAbbr(arg1, "мои") || utils::IsAbbr(arg1, "mine")) {
 		show_type = 1;
-		snprintf(filter, sizeof(filter), "В%s", GET_NAME(ch));
+		filter = "В";
+		filter += GET_NAME(ch);
 	} else {
 		while (*arg1) {
 			arg1[0] = UPPER(arg1[0]);
-			snprintf(buf, sizeof(buf), "%s ", arg1);
-			strncat(filter, buf, sizeof(filter) - strlen(filter) - 1);
+			filter += arg1;
+			filter += ' ';
 			arg = one_argument(arg, arg1);
 		}
 	}
 	if (show_type == 0 && EXCHANGE_FILTER(ch)) {
-		snprintf(buf, sizeof(buf), "%s %s", EXCHANGE_FILTER(ch), filter);
-		strncpy(filter, buf, sizeof(filter) - strlen(filter) - 1);
+		filter = std::string(EXCHANGE_FILTER(ch)) + " " + filter;
 	}
-	if (!correct_filter_length(ch, filter)) {
+	if (!correct_filter_length(ch, filter.c_str())) {
 		return 0;
 	}
-//	sprintf(buf, "arg=%s, type=%d", filter, show_type);
-//	mudlog(buf, CMP, kLvlGreatGod, SYSLOG, true);
-					
-	show_lots(filter, show_type, ch);
+
+	show_lots(filter.c_str(), show_type, ch);
 	return 1;
 }
 
@@ -1132,19 +1135,29 @@ void show_lots(const char *filter, short int show_type, const CharData *ch) {
 			"Лот      Предмет                                                     Цена  Состояние\r\n"
 			"--------------------------------------------------------------------------------------------\r\n";
 	}
+	// Буферы заводим один раз и переиспользуем (clear сохраняет capacity),
+	// чтобы по совету Квирунда не реаллоцировать на каждой итерации, как
+	// вёл бы себя char[kMaxInputLength].
+	std::string item;
+	item.reserve(kMaxInputLength);
+	std::string aff;
+	aff.reserve(kMaxInputLength);
 	for (ExchangeItem *j = exchange_item_list; j; j = j->next) {
 		if (show_type == 1 && !isname(GET_NAME(ch), GetNameById(GET_EXCHANGE_ITEM_SELLERID(j))))
 			continue;
+		item.clear();
 		// ну идиотизм сидеть статить 5-10 страниц резных
 		// Идиотизм - это тупым хардком по названию предмета вот так проверять.
 		// Использовать флаг или добавить новый - лапки, да?
 		if (utils::IsAbbr("резное запястье", GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str())
 			|| utils::IsAbbr("широкое серебряное обручье", GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str())
 			|| utils::IsAbbr("медное запястье", GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str())) {
-			GET_EXCHANGE_ITEM(j)->get_affect_flags().sprintbits(weapon_affects, buf, sizeof(buf), ",");
+			char affbuf[kMaxStringLength];
+			GET_EXCHANGE_ITEM(j)->get_affect_flags().sprintbits(weapon_affects, affbuf, sizeof(affbuf), ",");
 			// небольшое дублирование кода, чтобы зря не гонять по аффектам всех шмоток
-			if (!strcmp(buf, "ничего")) {
-				bool found = false;
+			aff.assign(affbuf);
+			if (aff == "ничего") {
+				aff.clear();
 				for (int n = 0; n < kMaxObjAffect; n++) {
 					auto drndice = GET_EXCHANGE_ITEM(j)->get_affected(n).location;
 					int drsdice = GET_EXCHANGE_ITEM(j)->get_affected(n).modifier;
@@ -1153,56 +1166,45 @@ void show_lots(const char *filter, short int show_type, const CharData *ch) {
 						if (drsdice < 0)
 							negative = !negative;
 						sprinttype(drndice, apply_types, buf2);
-						snprintf(buf, kMaxStringLength, "%s %s%d", buf2, negative ? "-" : "+", abs(drsdice));
-						found = true;
+						fmt::format_to(std::back_inserter(aff), "{} {}{}", buf2, negative ? "-" : "+", abs(drsdice));
 						break;
 					}
 				}
-
-				if (!found) {
-					snprintf(tmpbuf, sizeof(tmpbuf),
-							"[%4d]   %s",
-							GET_EXCHANGE_ITEM_LOT(j),
-							GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str());
-				} else {
-					snprintf(tmpbuf,
-							 kMaxInputLength,
-							 "[%4d]   %s (%s)",
-							 GET_EXCHANGE_ITEM_LOT(j),
-							 GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str(),
-							 buf);
-				}
-			} else  // end by WorM
-			{
-				snprintf(tmpbuf, kMaxInputLength, "[%4d]   %s (%s)", GET_EXCHANGE_ITEM_LOT(j),
-						 GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str(), buf);
+			}
+			if (aff.empty()) {
+				fmt::format_to(std::back_inserter(item), "[{:4}]   {}",
+						GET_EXCHANGE_ITEM_LOT(j),
+						GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str());
+			} else {
+				fmt::format_to(std::back_inserter(item), "[{:4}]   {} ({})",
+						GET_EXCHANGE_ITEM_LOT(j),
+						GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str(),
+						aff);
 			}
 		} else if (is_dig_stone(GET_EXCHANGE_ITEM(j))
 			&& GET_EXCHANGE_ITEM(j)->get_material() == EObjMaterial::kGlass) {
-			snprintf(tmpbuf, sizeof(tmpbuf),
-					"[%4d]   %s (стекло)",
+			fmt::format_to(std::back_inserter(item), "[{:4}]   {} (стекло)",
 					GET_EXCHANGE_ITEM_LOT(j),
 					GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str());
 		} else {
-			snprintf(tmpbuf, sizeof(tmpbuf),
-					"[%4d]   %s%s",
+			fmt::format_to(std::back_inserter(item), "[{:4}]   {}{}",
 					GET_EXCHANGE_ITEM_LOT(j),
 					GET_EXCHANGE_ITEM(j)->get_PName(ECase::kNom).c_str(),
-					params.show_obj_aff(GET_EXCHANGE_ITEM(j)).c_str());
+					params.show_obj_aff(GET_EXCHANGE_ITEM(j)));
 		}
 		char *tmstr;
 		tmstr = (char *) asctime(localtime(&(j->time)));
 		if (ch->IsGod()) {//asctime добавляет перевод строки лишний
 			snprintf(tmpbuf, sizeof(tmpbuf),
 					"(%5d) %s %9d  %-s %s", GET_EXCHANGE_ITEM(j)->get_vnum(),
-					colored_name(tmpbuf, 63, true),
+					colored_name(item.c_str(), 63, true),
 					GET_EXCHANGE_ITEM_COST(j),
 					diag_obj_timer(GET_EXCHANGE_ITEM(j)),
 					tmstr);
 		} else {
 			snprintf(tmpbuf, sizeof(tmpbuf),
 					"%s %9d  %-s\r\n",
-					colored_name(tmpbuf, 63, true),
+					colored_name(item.c_str(), 63, true),
 					GET_EXCHANGE_ITEM_COST(j),
 					diag_obj_timer(GET_EXCHANGE_ITEM(j)));
 			}


### PR DESCRIPTION
## Summary

Часть #3317 по `exchange.cpp` (do_stat.cpp — отдельным PR позже).

- **`exchange_offers`**: `filter` был `char[kMaxInputLength]` со склейкой `strncat`/`strncpy` → `-Wstringop-truncation` (688/694). Плюс `strncpy` на 694 был багом — `count` считался от длины `filter`, хотя `strncpy` пишет с начала. Перевёл на `std::string`.
- **`show_lots`**: `snprintf("%s")`/`("%s (%s)")` строк неограниченной длины в фиксированные буферы → `-Wformat-truncation` (1154/1168/1175). Строка предмета и описание аффекта теперь строятся через `fmt::format` в `std::string`; `colored_name(const char*, ...)` получает `.c_str()`.

Логика и вывод сохранены (формат строк тот же).

## Test plan
- [x] `-O2 -c` компиляция exchange.cpp → 0 stringop/format-truncation варнингов (раньше: 688/694/1154/1168/1175)
- [x] meson `-Dyaml=builtin` собирается, `meson test` зелёные
- [x] KOI8-R кодировка сохранена
- [ ] на сервере: `базар`/`exchange offers` (все/мои/фильтр) показывает лоты как раньше

Часть #3317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)