### PR TITLE
fix(obj-save-sync): не считать ошибкой сохранение оффлайн-игрока

### DIFF
--- a/src/gameplay/mechanics/obj_save_ext.cpp
+++ b/src/gameplay/mechanics/obj_save_ext.cpp
@@ -6,7 +6,6 @@
 #include "depot.h"
 #include "gameplay/communication/parcel.h"
 #include "engine/db/world_characters.h"
-#include "utils/backtrace.h"
 
 namespace ObjSaveSync {
 
@@ -45,11 +44,9 @@ void write_file(long uid, int type) {
 		CharData *ch = find_char(uid);
 		if (ch) {
 			Crash_crashsave(ch);
-			return;
-		} else {
-			mudlog(fmt::format("Запрошена запись в файл неизвестного игрока, uid {} Создан coredump", uid));
-			debug::backtrace(runtime_config.logs(SYSLOG).handle());
 		}
+		// Игрок ушёл оффлайн до срабатывания зависимости -
+		// сохранение уже произошло при выходе.
 	} else if (type == CLAN_SAVE) {
 		for (const auto &i : Clan::ClanList) {
 			if (i->GetRent() == uid) {


### PR DESCRIPTION
## Проблема

Когда игрок взаимодействовал с ладанкой клана (брал/клал предмет),
`ObjSaveSync::add(player_uid, clan_rent, CLAN_SAVE)` добавляла запись
в `save_list`. Если игрок уходил оффлайн до периодического вызова
`Clan::SaveChestAll()`, зависимость оставалась в `save_list`.

При следующем вызове `save_chest()` -> `ObjSaveSync::check(clan_rent, CLAN_SAVE)`
-> `fill_force_list` находил запись и вызывал `write_file(player_uid, CHAR_SAVE)`,
но `find_char(uid)` возвращал `nullptr` - игрок оффлайн. Это вызывало
backtrace в лог ("Создан coredump").

## Фикс

Игрок, ушедший оффлайн, уже сохранился при выходе - никаких действий
не требуется. Убрали ложный backtrace и неиспользуемый `#include`.

Fixes #3319 #3320

## Test plan
- [ ] Игрок берёт предмет из ладанки клана и уходит оффлайн
- [ ] При следующем срабатывании `SaveChestAll` ошибок в syslog нет

Generated with [Claude Code](https://claude.com/claude-code)