### PR TITLE
fix(handler): убрать ложный SYSERR при экипировке чара с kNowhere (#3338)

### DIFF
--- a/src/engine/core/handler.cpp
+++ b/src/engine/core/handler.cpp
@@ -852,10 +852,6 @@ void EquipObj(CharData *ch, ObjData *obj, int pos, const CharEquipFlags& equip_f
 		}
 	}
 
-	if (ch->in_room == kNowhere) {
-		log("SYSERR: ch->in_room = kNowhere when equipping char %s.", GET_NAME(ch));
-	}
-
 	auto it = ObjData::set_table.begin();
 	if (obj->has_flag(EObjFlag::kSetItem)) {
 		for (; it != ObjData::set_table.end(); it++) {
@@ -1102,8 +1098,7 @@ ObjData *UnequipChar(CharData *ch, int pos, const CharEquipFlags& equip_flags) {
 
 	was_lamp = IsWearingLight(ch);
 
-	if (ch->in_room == kNowhere)
-		log("SYSERR: ch->in_room = kNowhere when unequipping char %s.", GET_NAME(ch));
+
 
 	auto it = ObjData::set_table.begin();
 	if (obj->has_flag(EObjFlag::kSetItem))


### PR DESCRIPTION
## Причина спама

При входе игрока в игру `Crash_load` экипирует сохранённые вещи **до** вызова `char_to_room` (строки 1862 vs 2020 в interpreter.cpp). В этот момент `ch->in_room == kNowhere`, и `EquipObj`/`UnequipObj` логировали SYSERR.

У чаров с сетовыми предметами (`EObjFlag::kSetItem`) `ActivateStuff` делает цикл unequip→equip для пересчёта бонусов сета — каждый вызов давал отдельную строку. Итого десятки записей за один вход.

## Почему это ложный SYSERR

`EquipObj` уже корректно обрабатывает `kNowhere`: ниже по коду есть явная проверка `if (ch->in_room != kNowhere)`, которая пропускает room-зависимые операции (weapon affects, освещение). Поведение правильное — лог вводил в заблуждение.

## Изменения

Удалены два `log("SYSERR: ...")` в `EquipObj` и `UnequipObj` — поведение не меняется.

## Test plan

- [ ] Собирается без ошибок
- [ ] Вход чара с сетовыми вещами не даёт SYSERR в errlog

Closes #3338

🤖 Generated with [Claude Code](https://claude.com/claude-code)