### PR TITLE
fix(build): добавить libutf8_range при сборке с otel (#3343)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -237,6 +237,15 @@ if otel_opt != 'disabled'
     endif
     project_args += '-DWITH_OTEL'
     dependencies += [otel_dep, dependency('libcurl', required: true, allow_fallback: false)]
+    # protobuf >= 22 splits utf8_range into a separate library; add it when present.
+    utf8_range_dep = cc.find_library('utf8_range', required: false)
+    if utf8_range_dep.found()
+        dependencies += utf8_range_dep
+    endif
+    utf8_validity_dep = cc.find_library('utf8_validity', required: false)
+    if utf8_validity_dep.found()
+        dependencies += utf8_validity_dep
+    endif
 endif
 
 has_epoll_opt = get_option('has_epoll')

--- a/meson.build
+++ b/meson.build
@@ -238,11 +238,12 @@ if otel_opt != 'disabled'
     project_args += '-DWITH_OTEL'
     dependencies += [otel_dep, dependency('libcurl', required: true, allow_fallback: false)]
     # protobuf >= 22 splits utf8_range into a separate library; add it when present.
-    utf8_range_dep = cc.find_library('utf8_range', required: false)
+    cxx = meson.get_compiler('cpp')
+    utf8_range_dep = cxx.find_library('utf8_range', required: false)
     if utf8_range_dep.found()
         dependencies += utf8_range_dep
     endif
-    utf8_validity_dep = cc.find_library('utf8_validity', required: false)
+    utf8_validity_dep = cxx.find_library('utf8_validity', required: false)
     if utf8_validity_dep.found()
         dependencies += utf8_validity_dep
     endif


### PR DESCRIPTION
## Причина

protobuf ≥ 22 вынес валидацию UTF-8 в отдельную библиотеку `libutf8_range.a` / `libutf8_validity.a`. При system-сборке с OTEL линковщик не находил символы `utf8_range_IsValid` / `utf8_range_ValidPrefix` из `libprotobuf.a`.

## Исправление

В otel-блоке `meson.build` добавлен поиск `utf8_range` и `utf8_validity` через `cc.find_library(..., required: false)` — библиотеки подключаются только если присутствуют, так что старые установки protobuf < 22 не ломаются.

## Test plan

- [ ] Сборка с `-Dotel=system` (protobuf ≥ 22) проходит без ошибок линковки
- [ ] Сборка без otel не затронута

Closes #3343

🤖 Generated with [Claude Code](https://claude.com/claude-code)