### PR TITLE
chore(log): убрать спам "Heartbeat pulse" из syslog

### DIFF
--- a/src/engine/core/heartbeat.cpp
+++ b/src/engine/core/heartbeat.cpp
@@ -643,7 +643,6 @@ void Heartbeat::pulse(const int missed_pulses, pulse_label_t &label) {
 
 	label.clear();
 	advance_pulse_numbers();
-	log("Heartbeat pulse");
 	{
 		auto span = tracing::TraceManager::Instance().StartSpan("Characters::PurgeExtractedList");
 		character_list.PurgeExtractedList();

--- a/src/engine/db/legacy_world_data_source.cpp
+++ b/src/engine/db/legacy_world_data_source.cpp
@@ -33,6 +33,12 @@ namespace
 // Used to redirect WLD_PREFIX-relative paths inside OLC save_to_disk
 // routines to a caller-supplied output directory without modifying the
 // macros or save routines themselves.
+//
+// TODO(#3301): this chdir dance exists only because the OLC *_save_to_disk
+// routines and the legacy loaders hardcode the "world/{wld,mob,...}/" paths
+// via compile-time *_PREFIX macros. Teaching them to take a base path would
+// let LegacyWorldDataSource carry m_world_dir as a plain path prefix (like
+// YAML/SQLite) and drop the global-cwd manipulation entirely.
 class ScopedChdir
 {
 public:


### PR DESCRIPTION
## Что

В `Heartbeat::pulse()` каждый тик (25Hz) писалось в syslog сообщение `Heartbeat pulse` — это чистый шум:
- ~1.5M строк в час на ровном месте
- никакой полезной нагрузки: ни тика-номера, ни тайминга
- в продовом логе мешает находить реальные ошибки

## Почему безопасно убирать

Полезная информация о pulse уже доступна через OTel:
- трейс `heartbeat.total` со всеми step-спанами и таймингами
- метрика-гистограмма `heartbeat.total.duration`

В крайнем случае всегда можно вернуть `git revert`'ом.

## Test plan

- [x] `meson setup build -Dbuild_profile=release -Dbuild_tests=true`
- [x] `ninja -C build` — сборка чистая
- [ ] CI на PR