### PR TITLE
fix(conf.h): _MSC_VER guard for snprintf _snprintf macro (MinGW)

### DIFF
--- a/src/engine/core/conf.h
+++ b/src/engine/core/conf.h
@@ -59,7 +59,12 @@
 #endif
 #define socklen_t int
 
-#if (_MSC_VER < 1900)
+// _MSC_VER ne opredelyon na MinGW -- usloviye (_MSC_VER < 1900) dayet true,
+// i define snprintf _snprintf lomayet <cstdio>: using std::snprintf
+// prevrashchayetsya v using std::_snprintf (ne sushchestvuyet). Guard
+// defined(_MSC_VER) -- macro nuzhen tolko dlya drevnego MSVC < 2015,
+// MinGW yego ne kasayetsya.
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
 #define snprintf _snprintf
 #endif
 #if _MSC_VER


### PR DESCRIPTION
## Что чинится

`src/engine/core/conf.h:62`:

```c
#if (_MSC_VER < 1900)
#define snprintf _snprintf
#endif
```

`_MSC_VER` не определён на MinGW. По правилам препроцессора undefined
identifier в `#if` раскрывается в `0`, поэтому условие `(0 < 1900) → true`
и макрос определяется на MinGW тоже. Дальше любой `<cstdio>` после
`conf.h` падает:

```
error: '_snprintf' is not a member of 'std'; did you mean 'vsnprintf'?
```

Потому что `<cstdio>` декларирует `using std::snprintf;`, что после
макроса становится `using std::_snprintf;` — а такого символа нет.

Master CI на MinGW проходил случайно — в unity-чанках `<cstdio>` после
`conf.h` не попадал. Любое перетасовывание unity (например, добавление
нового engine-файла, который явно `#include <cstdio>`) вскрывает баг.

## Воспроизведение

`linux / GCC / *` всё проходит (под Linux в `conf.h` другая ветка).
Под MinGW (см. windows / MinGW / Base CI), unity-сборка взрывается
ошибкой выше.

## Фикс

Защищаем `defined(_MSC_VER)` — макрос нужен только для древнего MSVC
< 2015, MinGW (и любой компилятор без `_MSC_VER`) его не касается:

```c
#if defined(_MSC_VER) && (_MSC_VER < 1900)
#define snprintf _snprintf
#endif
```

## Сцена

Найдено при сведении master в PR #3220 (симулятор баланса, #2967):
один из новых engine-файлов (`file_event_sink.cpp`) подключает
`<cstdio>`, что разломало MinGW unity-сборку. Фикс самодостаточный.