### PR TITLE
chore(log): убрать остаточный шум в syslog (heartbeat, MSDP, record_usage)

### DIFF
--- a/src/engine/core/heartbeat.cpp
+++ b/src/engine/core/heartbeat.cpp
@@ -43,8 +43,6 @@
 #include "scripting.hpp"
 #endif
 
-extern std::pair<int, int> TotalMemUse();
-
 constexpr bool FRAC_SAVE = true;
 
 void check_idle_passwords() {
@@ -65,17 +63,6 @@ void check_idle_passwords() {
 }
 
 void record_usage() {
-	int sockets_connected = 0, sockets_playing = 0;
-	DescriptorData *d;
-
-	for (d = descriptor_list; d; d = d->next) {
-		sockets_connected++;
-		if (d->state == EConState::kPlaying)
-			sockets_playing++;
-	}
-
-	log("nusage: %-3d sockets connected, %-3d sockets playing", sockets_connected, sockets_playing);
-
 #ifdef RUSAGE            // Not RUSAGE_SELF because it doesn't guarantee prototype.
 	{
 		struct rusage ru;
@@ -639,8 +626,6 @@ void Heartbeat::advance_pulse_numbers() {
 }
 
 void Heartbeat::pulse(const int missed_pulses, pulse_label_t &label) {
-	static int last_pmem_used = 0;
-
 	label.clear();
 	advance_pulse_numbers();
 	log("Heartbeat pulse");
@@ -654,31 +639,19 @@ void Heartbeat::pulse(const int missed_pulses, pulse_label_t &label) {
 	}
 	for (std::size_t i = 0; i != m_steps.size(); ++i) {
 		auto &step = m_steps[i];
-		auto get_mem = TotalMemUse();
-		int vmem_used = get_mem.first;
-		int pmem_used = get_mem.second;
 		if (step.off()) {
 			continue;
 		}
 
 		if (0 == (m_pulse_number + step.offset()) % step.modulo()) {
 			utils::CExecutionTimer timer;
-			
+
 			// Create child span for this step
 			auto step_span = tracing::TraceManager::Instance().StartSpan(step.name());
 			step_span->SetAttribute("step_index", static_cast<int64_t>(i));
 			step_span->SetAttribute("step_modulo", static_cast<int64_t>(step.modulo()));
 			step.action()->perform(pulse_number(), missed_pulses);
 			const auto execution_time = timer.delta().count();
-			if (step.modulo() >= kSecsPerMudHour * kPassesPerSec) {
-				log("Heartbeat step: %s", step.name().c_str());
-			}
-			if (pmem_used != last_pmem_used) {
-//				char buf [128];
-				last_pmem_used = pmem_used;
-				log("HeartBeat memory resize, step:(%s), memory used: virt (%d kB) phys (%d kB)", step.name().c_str(), vmem_used, pmem_used);
-//				mudlog(buf, CMP, kLvlGreatGod, SYSLOG, true);
-			}
 			step_span->SetAttribute("execution_time_seconds", execution_time);
 			step_span->End();
 			label.emplace(i, execution_time);

--- a/src/engine/network/msdp/msdp.cpp
+++ b/src/engine/network/msdp/msdp.cpp
@@ -133,20 +133,11 @@ void ConversationHandler::handle_list_command(const Variable::shared_ptr &reques
 
 	const auto string = std::dynamic_pointer_cast<StringValue>(request->value());
 	if ("COMMANDS" == string->value()) {
-		log("INFO: '%s' asked for MSDP \"COMMANDS\" list.",
-			(m_descriptor && m_descriptor->character) ? m_descriptor->character->get_name().c_str() : "<unknown>");
-
 		response.reset(new Variable("COMMANDS", SUPPORTED_COMMANDS_ARRAY));
 	} else if ("REPORTABLE_VARIABLES" == string->value()) {
-		log("INFO: Client asked for MSDP \"REPORTABLE_VARIABLES\" list.");
-
 		response = ReporterFactory::reportable_variables();
 	} else if ("CONFIGURABLE_VARIABLES" == string->value()) {
-		log("INFO: Client asked for MSDP \"CONFIGURABLE_VARIABLES\" list.");
-
 		response = std::make_shared<Variable>("CONFIGURABLE_VARIABLES", std::make_shared<ArrayValue>());
-	} else {
-		log("INFO: Client asked for unknown MSDP list \"%s\".", string->value().c_str());
 	}
 }
 
@@ -156,8 +147,6 @@ void ConversationHandler::handle_report_command(const Variable::shared_ptr &requ
 	}
 
 	const auto string = std::dynamic_pointer_cast<StringValue>(request->value());
-	log("INFO: Client asked for report of changing the variable \"%s\".", string->value().c_str());
-
 	m_descriptor->msdp_add_report_variable(string->value());
 }
 
@@ -167,8 +156,6 @@ void ConversationHandler::handle_unreport_command(const Variable::shared_ptr &re
 	}
 
 	const auto string = std::dynamic_pointer_cast<StringValue>(request->value());
-	log("INFO: Client asked for unreport of changing the variable \"%s\".", string->value().c_str());
-
 	m_descriptor->msdp_remove_report_variable(string->value());
 }
 
@@ -182,8 +169,6 @@ void ConversationHandler::handle_send_command(const Variable::shared_ptr &reques
 }
 
 bool ConversationHandler::handle_request(const Variable::shared_ptr &request) {
-	log("INFO: MSDP request %s.", request->name().c_str());
-
 	Variable::shared_ptr response;
 	if ("LIST" == request->name()) {
 		handle_list_command(request, response);


### PR DESCRIPTION
## Что

Чистим syslog от регулярного шума, не несущего пользы. Информация либо дублируется метриками/трейсами OTel, либо была отладочной и просто осталась в проде.

### heartbeat.cpp

- `log("Heartbeat step: %s")` для шагов с `modulo >= kSecsPerMudHour * kPassesPerSec`. То же видно в OTel-спане `step.name()` с `execution_time_seconds`.
- `log("HeartBeat memory resize, step:(...), virt/phys ...")` плюс вызов `TotalMemUse()` на каждой итерации цикла шагов pulse. Память доступна через `stat`/`do_show memory` и системный rusage; постоянный замер был сделан под этот лог и больше нигде не нужен.
- `log("nusage: ... sockets connected, ... sockets playing")` в `record_usage()` + цикл подсчёта сокетов без потребителя. Сетевая статистика и так есть в админ-API/метриках подключений.

### msdp.cpp

- Семь `log("INFO: ... MSDP ...")` в `ConversationHandler`: срабатывали на каждый MSDP-пакет (list/report/unreport/handle_request). Это отладочные следы протокола; для диагностики уже есть `debug_log` + hexdump в `parse_request()`.

## Контекст

`log("Heartbeat pulse")` (срабатывал каждые 40мс — главный источник спама) убран отдельным PR #3346.

## Test plan

- [x] `meson setup build -Dbuild_profile=release -Dbuild_tests=true` — чистая конфигурация
- [x] `ninja -C build` — сборка без предупреждений
- [ ] CI на PR