### PR TITLE
fix(fight): точный стиль всегда наносит минимум 1 дамаги (#3352)

### DIFF
--- a/src/gameplay/fight/fight_hit.cpp
+++ b/src/gameplay/fight/fight_hit.cpp
@@ -1008,6 +1008,7 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 		return;
 	}
 	//Рассчёт шанса точного стиля:
+	bool paladine_inspiration = false;
 	if (!IS_CHARMICE(ch) && ch->battle_affects.get(kEafPunctual) && ch->punctual_wait <= 0 && ch->get_wait() <= 0
 		&& (hit_params.diceroll >= 18 - AFF_FLAGGED(victim, EAffect::kHold))) {
 		SkillRollResult result = MakeSkillTest(ch, ESkill::kPunctual, victim);
@@ -1025,7 +1026,7 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 			if (!ch->IsImmortal()) {
 				PUNCTUAL_WAIT_STATE(ch, 2 * kBattleRound);
 			}
-			CallMagic(ch, victim, nullptr, nullptr, ESpell::kPaladineInspiration, GetRealLevel(ch));
+			paladine_inspiration = true;
 		}
 	}
 
@@ -1037,6 +1038,11 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 
 	// обработка защитных скилов (захват, уклон, парир, веер, блок)
 	hit_params.ProcessDefensiveAbilities(ch, victim);
+
+	// kPaladineInspiration - только если удар не заблокирован полностью
+	if (paladine_inspiration && hit_params.dam > 0) {
+		CallMagic(ch, victim, nullptr, nullptr, ESpell::kPaladineInspiration, GetRealLevel(ch));
+	}
 
 	// итоговый дамаг
 	ch->send_to_TC(false, true, true, "&CНанёс: Регуляр дамаг = %d&n\r\n", hit_params.dam);

--- a/src/gameplay/fight/fight_hit.cpp
+++ b/src/gameplay/fight/fight_hit.cpp
@@ -1039,6 +1039,11 @@ void hit(CharData *ch, CharData *victim, ESkill type, fight::AttackType weapon) 
 	// обработка защитных скилов (захват, уклон, парир, веер, блок)
 	hit_params.ProcessDefensiveAbilities(ch, victim);
 
+	// точный стиль: если точка сработала, дамаг не может быть нулевым
+	if (hit_params.GetFlags()[fight::kCritHit] && hit_params.dam_critic && hit_params.dam <= 0) {
+		hit_params.dam = 1;
+	}
+
 	// kPaladineInspiration - только если удар не заблокирован полностью
 	if (paladine_inspiration && hit_params.dam > 0) {
 		CallMagic(ch, victim, nullptr, nullptr, ESpell::kPaladineInspiration, GetRealLevel(ch));


### PR DESCRIPTION
## Проблема

`ProcessPunctualStyle` проверяет `hit_data.dam > 0` прежде чем применить эффекты точки. Если защитные механики (броня, поглощение, частичное уклонение/парирование) обнуляли дамаг после того как точка уже сработала — эффект точки не применялся, а игрок видел сообщение «ваш удар не достиг цели», хотя анонс о точном ударе уже был.

## Решение

После `ProcessDefensiveAbilities`: если точка сработала (`kCritHit` + `dam_critic`) и `dam <= 0` — выставляем `dam = 1`.

```cpp
// точный стиль: если точка сработала, дамаг не может быть нулевым
if (hit_params.GetFlags()[fight::kCritHit] && hit_params.dam_critic && hit_params.dam <= 0) {
    hit_params.dam = 1;
}
```

Дополнительно: `kPaladineInspiration` теперь тоже корректно срабатывает в этом случае (см. PR #3351).

## Тест-план
- [ ] Точный удар с нормальным дамагом — эффект точки применяется, дамаг не изменён
- [ ] Точный удар, дамаг обнулён защитой — эффект точки всё равно применяется, дамаг = 1
- [ ] Обычный удар (не точка) — поведение не изменилось