### PR TITLE
chore(log): убрать спам в Purge/extract, affect_update и script-триггерах

### DIFF
--- a/src/engine/db/world_characters.cpp
+++ b/src/engine/db/world_characters.cpp
@@ -97,7 +97,6 @@ void Characters::AddToExtractedList(CharData *ch) {
 	if (ch->IsNpc()) {
 		mobs_by_vnum_remove(ch, mob_index[(ch)->get_rnum()].vnum);
 	}
-	log("add mob to extracted list %s %d", GET_NAME(ch), GET_MOB_VNUM(ch));
 	ch->set_purged(true);
 	DropEquipment(ch, false);
 	DropInventory(ch, false);
@@ -109,7 +108,6 @@ void Characters::PurgeExtractedList() {
 	if (!m_extracted_list.empty()) {
 		auto extracted_list_copy = m_extracted_list;  // чистится в Characters::remove
 
-		log("Start mob PurgeExtractedList");
 		for (auto &it : extracted_list_copy) {
 			it->set_purged(false);  // игрок может остаться в игре
 			ExtractCharFromWorld(it, false);

--- a/src/engine/db/world_objects.cpp
+++ b/src/engine/db/world_objects.cpp
@@ -380,10 +380,6 @@ void WorldObjects::AddToExtractedList(ObjData *obj) {
 
 	object_ptr->unsubscribe_from_rnum_changes(m_rnum_change_observer);
 	m_rnum_to_object_ptr[object_ptr->get_rnum()].erase(object_ptr);
-	log("add obj to extracted list %s %d", obj->get_PName(ECase::kNom).c_str(), GET_OBJ_VNUM(obj));
-//	if (obj->get_vnum() == 33516) {
-//		debug::backtrace(runtime_config.logs(SYSLOG).handle());
-//	}
 	obj->set_extracted_list(true);
 //	obj->get_script()->set_purged(true);
 	m_extracted_list.insert(obj);
@@ -391,7 +387,6 @@ void WorldObjects::AddToExtractedList(ObjData *obj) {
 
 void WorldObjects::PurgeExtractedList() {
 	if (!m_extracted_list.empty()) {
-		log("Start obj PurgeExtractedList");
 		for (auto it : m_extracted_list) {
 			ExtractObjFromWorld(it, false);
 		}

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -727,8 +727,6 @@ static const char *trigger_type_name(int mode) {
 
 // checks every PLUSE_SCRIPT for random triggers
 void script_trigger_check(int mode) {
-	utils::CExecutionTimer timer;
-
 	auto trigger_span = tracing::TraceManager::Instance().StartSpan("Script Trigger Check");
 	observability::ScopedMetric trigger_metric("script.trigger.duration");
 
@@ -775,8 +773,6 @@ void script_trigger_check(int mode) {
 		default:
 		break;
 	}
-	
-	log("script_trigger_check() mode %d всего: %f ms.", mode, timer.delta().count());
 }
 
 // проверка каждый час на триги изменении времени
@@ -5605,10 +5601,6 @@ void process_context(Script * /*sc*/, Trigger *trig, char *cmd) {
 		trig_log(trig, buf2);
 		return;
 	}
-	if (trig_index[trig->get_rnum()]->vnum / 100 == 2) {
-		log("dungeon смена контекста с %ld на %ld номер триггера %d строка %d", trig->context, atol(var), trig_index[trig->get_rnum()]->vnum, trig->curr_line->line_num);
-	}
-
 	trig->context = atol(var);
 }
 

--- a/src/gameplay/affects/affect_data.cpp
+++ b/src/gameplay/affects/affect_data.cpp
@@ -231,8 +231,6 @@ void player_affect_update() {
 
 	RunStats profile;
 	utils::CExecutionTimer total_timer;
-	int count = 0, c_all = 0, recalc = 0;
-//	character_list.foreach_on_copy([&count](const CharData::shared_ptr &i) {
 	for (auto d = descriptor_list; d; d = d->next) {
 		if (d->state != EConState::kPlaying)
 			continue;
@@ -259,10 +257,8 @@ void player_affect_update() {
 		}
 
 		if (!i->affected.empty()) {
-			++count;
 			++profile.counters[static_cast<std::size_t>(Counter::kAffectedPlayers)];
 		}
-		++c_all;
 		bool was_purged = false;
 		bool set_abstinent = false;
 		bool need_recalc = false;
@@ -363,15 +359,12 @@ void player_affect_update() {
 				affect_total(i.get());
 				profile.sections[static_cast<std::size_t>(Section::kRecalc)] += recalc_timer.delta().count();
 			}
-			++recalc;
 			++profile.counters[static_cast<std::size_t>(Counter::kRecalcPlayers)];
 		}
 		profile.sections[static_cast<std::size_t>(Section::kDescriptorLoop)] += descriptor_timer.delta().count();
 	}
-	const auto total_elapsed = total_timer.delta().count();
-	profile.sections[static_cast<std::size_t>(Section::kTotal)] = total_elapsed;
+	profile.sections[static_cast<std::size_t>(Section::kTotal)] = total_timer.delta().count();
 	player_affect_update_profiler::record_run(profile);
-	log("player affect update: timer %f, num affected players %d, all %d recalc %d", total_elapsed, count, c_all, recalc);
 }
 
 // This file update battle affects only
@@ -439,15 +432,12 @@ void battle_affect_update(CharData *ch) {
 
 // раз в минуту
 void mobile_affect_update() {
-	log("mobile_affect_update() start, affected_mobs size=%zu", affected_mobs.size());
 	using mobile_affect_update_profiler::Counter;
 	using mobile_affect_update_profiler::RunStats;
 	using mobile_affect_update_profiler::Section;
 
 	RunStats profile;
 	utils::CExecutionTimer total_timer;
-	int count = 0;
-	int recalc = 0;
 
 	utils::CExecutionTimer copy_timer;
 	auto copy = affected_mobs;
@@ -459,7 +449,6 @@ void mobile_affect_update() {
 		int was_charmed = false, charmed_msg = false;
 		bool was_purged = false;
 		bool need_recalc = false;
-		++count;
 		++profile.counters[static_cast<std::size_t>(Counter::kMobs)];
 //		if (!ch->in_used_zone()) {
 //			return;
@@ -530,7 +519,6 @@ void mobile_affect_update() {
 				utils::CExecutionTimer recalc_timer;
 				affect_total(ch);
 				profile.sections[static_cast<std::size_t>(Section::kRecalc)] += recalc_timer.delta().count();
-				++recalc;
 				++profile.counters[static_cast<std::size_t>(Counter::kRecalcMobs)];
 			}
 			{
@@ -589,10 +577,8 @@ void mobile_affect_update() {
 		profile.sections[static_cast<std::size_t>(Section::kMobLoop)] += mob_timer.delta().count();
 	}
 
-	const auto total_elapsed = total_timer.delta().count();
-	profile.sections[static_cast<std::size_t>(Section::kTotal)] = total_elapsed;
+	profile.sections[static_cast<std::size_t>(Section::kTotal)] = total_timer.delta().count();
 	mobile_affect_update_profiler::record_run(profile);
-	log("mobile affect update: timer %f, num mobs %d recalc %d", total_elapsed, count, recalc);
 }
 
 void RemoveAffectFromCharAndRecalculate(CharData *ch, ESpell spell_id) {

--- a/src/gameplay/affects/mobile_affect_update_profiler.cpp
+++ b/src/gameplay/affects/mobile_affect_update_profiler.cpp
@@ -10,13 +10,11 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include "utils/logger.h"
 
 namespace mobile_affect_update_profiler {
 namespace {
 
 constexpr std::size_t kWindowSize = 256;
-constexpr std::size_t kReportEveryNRuns = 10;
 
 constexpr std::array<const char *, static_cast<std::size_t>(Section::kNumSections)> kSectionNames{
 	"total",
@@ -106,10 +104,6 @@ class Profiler {
 		for (std::size_t i = 0; i < m_counters.size(); ++i) {
 			m_counters[i].add(static_cast<double>(stats.counters[i]));
 		}
-
-		if (m_runs % kReportEveryNRuns == 0) {
-			report();
-		}
 	}
 
 	std::string render() const {
@@ -157,36 +151,6 @@ class Profiler {
 	}
 
  private:
-	void report() const {
-		log("%s", fmt::format("mobile_affect_update profile: runs={} window={}", m_runs, kWindowSize).c_str());
-		for (std::size_t i = 0; i < m_sections.size(); ++i) {
-			log("%s",
-				fmt::format(
-					"mobile_affect_update profile section={} avg={:.6f}s min={:.6f}s p50={:.6f}s p95={:.6f}s p99={:.6f}s max={:.6f}s n={}",
-					kSectionNames[i],
-					m_sections[i].avg(),
-					m_sections[i].min(),
-					m_sections[i].percentile(0.50),
-					m_sections[i].percentile(0.95),
-					m_sections[i].percentile(0.99),
-					m_sections[i].max(),
-					m_sections[i].count()).c_str());
-		}
-		for (std::size_t i = 0; i < m_counters.size(); ++i) {
-			log("%s",
-				fmt::format(
-					"mobile_affect_update profile counter={} avg={:.2f} min={:.0f} p50={:.0f} p95={:.0f} p99={:.0f} max={:.0f} n={}",
-					kCounterNames[i],
-					m_counters[i].avg(),
-					m_counters[i].min(),
-					m_counters[i].percentile(0.50),
-					m_counters[i].percentile(0.95),
-					m_counters[i].percentile(0.99),
-					m_counters[i].max(),
-					m_counters[i].count()).c_str());
-		}
-	}
-
 	std::size_t m_runs = 0;
 	std::array<Distribution, static_cast<std::size_t>(Section::kNumSections)> m_sections;
 	std::array<Distribution, static_cast<std::size_t>(Counter::kNumCounters)> m_counters;

--- a/src/gameplay/affects/player_affect_update_profiler.cpp
+++ b/src/gameplay/affects/player_affect_update_profiler.cpp
@@ -10,13 +10,11 @@
 #include <vector>
 
 #include <fmt/format.h>
-#include "utils/logger.h"
 
 namespace player_affect_update_profiler {
 namespace {
 
 constexpr std::size_t kWindowSize = 256;
-constexpr std::size_t kReportEveryNRuns = 10;
 
 constexpr std::array<const char *, static_cast<std::size_t>(Section::kNumSections)> kSectionNames{
 	"total",
@@ -104,10 +102,6 @@ class Profiler {
 		for (std::size_t i = 0; i < m_counters.size(); ++i) {
 			m_counters[i].add(static_cast<double>(stats.counters[i]));
 		}
-
-		if (m_runs % kReportEveryNRuns == 0) {
-			report();
-		}
 	}
 
 	std::string render() const {
@@ -155,36 +149,6 @@ class Profiler {
 	}
 
  private:
-	void report() const {
-		log("%s", fmt::format("player_affect_update profile: runs={} window={}", m_runs, kWindowSize).c_str());
-		for (std::size_t i = 0; i < m_sections.size(); ++i) {
-			log("%s",
-				fmt::format(
-					"player_affect_update profile section={} avg={:.6f}s min={:.6f}s p50={:.6f}s p95={:.6f}s p99={:.6f}s max={:.6f}s n={}",
-					kSectionNames[i],
-					m_sections[i].avg(),
-					m_sections[i].min(),
-					m_sections[i].percentile(0.50),
-					m_sections[i].percentile(0.95),
-					m_sections[i].percentile(0.99),
-					m_sections[i].max(),
-					m_sections[i].count()).c_str());
-		}
-		for (std::size_t i = 0; i < m_counters.size(); ++i) {
-			log("%s",
-				fmt::format(
-					"player_affect_update profile counter={} avg={:.2f} min={:.0f} p50={:.0f} p95={:.0f} p99={:.0f} max={:.0f} n={}",
-					kCounterNames[i],
-					m_counters[i].avg(),
-					m_counters[i].min(),
-					m_counters[i].percentile(0.50),
-					m_counters[i].percentile(0.95),
-					m_counters[i].percentile(0.99),
-					m_counters[i].max(),
-					m_counters[i].count()).c_str());
-		}
-	}
-
 	std::size_t m_runs = 0;
 	std::array<Distribution, static_cast<std::size_t>(Section::kNumSections)> m_sections;
 	std::array<Distribution, static_cast<std::size_t>(Counter::kNumCounters)> m_counters;


### PR DESCRIPTION
## Что

Продолжение чистки syslog (после PR #3346 и #3348). Четыре независимых кластера спама — каждый отдельным коммитом, чтобы можно было выборочно откатить.

### 1. `Purge/extract` (commit 4d1446da2)
- `world_objects.cpp` — `Start obj PurgeExtractedList` (каждый pulse, виден на скриншоте) и `add obj to extracted list ...`
- `world_characters.cpp` — `Start mob PurgeExtractedList` и `add mob to extracted list ...`

Момент Purge уже трассируется OTel-спанами `Characters::PurgeExtractedList` / `WorldObjects::PurgeExtractedList` в `Heartbeat::pulse()`.

### 2. Профайлеры player/mobile_affect_update (commit 23f48b36f)
Автоматический `report()` в syslog (~18 строк каждые 10 запусков) — нужен был для разбора конкретных багов, баги исправлены. Инфраструктура профайлера и god-команда `profile` (`do_profile.cpp`) **сохранены** — отчёт можно посмотреть on-demand.

### 3. `affect update: timer ...` (commit 7eaec15d8)
В `affect_data.cpp` три симметричных лога каждые 2 секунды:
- `player affect update: timer ..., num affected players ..., all ..., recalc ...`
- `mobile affect update: timer ..., num mobs ..., recalc ...`
- `mobile_affect_update() start, affected_mobs size=...`

Локальные счётчики `count`/`c_all`/`recalc`, которые только в эти логи и шли, тоже убраны — они дублировались с `profile.counters[kAffectedPlayers]`/`[kRecalcPlayers]`/`[kRecalcMobs]`, которые остались.

### 4. `script_trigger_check` + dungeon context (commit d1f3268d3)
В `dg_scripts.cpp`:
- `script_trigger_check() mode N всего: M ms.` — дублируется OTel-метрикой `script.trigger.duration` и span'ом `Script Trigger Check` в той же функции.
- `dungeon смена контекста с 0 на 2 номер триггера ... строка ...` — отладочная трассировка скрипт-команды context в зоне dungeon.

## Test plan

- [x] `meson setup build -Dbuild_profile=release -Dbuild_tests=true`
- [x] `ninja -C build` — чисто, без предупреждений
- [ ] CI на PR

## Связанное

- PR #3346 — `Heartbeat pulse` (смёрджен)
- PR #3348 — heartbeat memory/nusage + MSDP INFO