### PR TITLE
fix(clan): охранник замка блокирует вход своим в крови (#3349)

### DIFF
--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -867,8 +867,14 @@ bool Clan::MayEnter(CharData *ch, RoomRnum room, bool mode) {
 		// вход через дверь - контролирует охранник
 		case kHouseAtrium:
 			for (const auto mobs : world[ch->in_room]->people) {
-				if (clan->guard == GET_MOB_VNUM(mobs)
-					&& !isMember) {
+				if (clan->guard != GET_MOB_VNUM(mobs)) {
+					continue;
+				}
+				if (!isMember) {
+					return false;
+				}
+				if (NORENTABLE(ch)) {
+					SendMsgToChar("Пускай сначала кровь с тебя стечет, а потом входи сколько угодно.\r\n", ch);
 					return false;
 				}
 			}
@@ -885,9 +891,7 @@ bool Clan::MayEnter(CharData *ch, RoomRnum room, bool mode) {
 
 			// с временным флагом тоже курят
 			if (NORENTABLE(ch)) {
-				if (mode == kHouseAtrium) {
-					SendMsgToChar("Пускай сначала кровь с тебя стечет, а потом входи сколько угодно.\r\n", ch);
-				}
+				SendMsgToChar("Пускай сначала кровь с тебя стечет, а потом входи сколько угодно.\r\n", ch);
 				return false;
 			}
 


### PR DESCRIPTION
## Проблема

Охранник клана проверял только чужих (`!isMember`). Члены дружины в состоянии «в крови» (`NORENTABLE`) могли войти в замок без ограничений — охранник их не останавливал.

`check_player_in_house` также вызывает `MayEnter(kHouseAtrium)`, поэтому исправление работает и при выдворении уже находящихся внутри.

## Изменения

**`kHouseAtrium`** — цикл по охраннику переработан:
```cpp
for (const auto mobs : world[ch->in_room]->people) {
    if (clan->guard != GET_MOB_VNUM(mobs)) continue;
    if (!isMember) return false;
    if (NORENTABLE(ch)) {
        SendMsgToChar("Пускай сначала кровь с тебя стечет...\r\n", ch);
        return false;
    }
}
```

**`kHousePortal`** — убрано мёртвое условие `if (mode == kHouseAtrium)` (в ветке портала `mode` всегда `true`, сообщение никогда не показывалось).

## Тест-план
- [ ] Член дружины в крови + охранник стоит → заблокирован с сообщением
- [ ] Член дружины не в крови + охранник стоит → проходит
- [ ] Чужой + охранник стоит → заблокирован
- [ ] Охранника нет → свободный доступ (поведение не изменилось)