### PR TITLE
fix(shop): продавец не продаёт вещь недоступного класса (#3356)

### DIFF
--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -297,6 +297,12 @@ void shop_node::process_buy(CharData *ch, CharData *keeper, char *argument) {
 		return;
 	}
 
+	if (invalid_anti_class(ch, static_cast<const ObjData *>(proto))
+		|| invalid_no_class(ch, static_cast<const ObjData *>(proto))) {
+		tell_to_char(keeper, ch, "Мне жаль, но эта вещь тебе не подходит.");
+		return;
+	}
+
 	const long price = item->get_price();
 	if (!check_money(ch, price, currency)) {
 		snprintf(buf, kMaxStringLength,


### PR DESCRIPTION
## Проблема

При покупке вещи с флагом `!язычники` (или другим ограничением класса/конфессии):
- деньги списывались
- вещь падала на землю (из-за анти-класс проверки при помещении)
- подобрать/продать обратно было невозможно

## Решение

В `process_buy` добавлена проверка `invalid_anti_class` / `invalid_no_class` по прототипу **до** списания денег. Продавец отказывает с сообщением.

```
Кузнец сказал вам : 'Мне жаль, но эта вещь тебе не подходит.'
```

## Тест-план
- [ ] Язычник пытается купить вещь `!язычники` → отказ, деньги не снимаются
- [ ] Воин покупает вещь `!маги` → покупает нормально
- [ ] Вещь без ограничений → покупает нормально