### PR TITLE
perf(affect_total): итерировать фиты персонажа, не всю таблицу (#3193)

### DIFF
--- a/src/gameplay/affects/affect_data.cpp
+++ b/src/gameplay/affects/affect_data.cpp
@@ -722,10 +722,10 @@ void affect_total(CharData *ch) {
 	}
 	ch->obj_bonus().apply_affects(ch);
 
-	for (const auto &feat : MUD::Feats()) {
-		if (CanUseFeat(ch, feat.GetId())) {
-			feat.effects.ImposeApplies(ch);
-			feat.effects.ImposeSkillsMods(ch);
+	for (auto feat_id = EFeat::kFirst; feat_id <= EFeat::kLast; ++feat_id) {
+		if (ch->HaveFeat(feat_id) && CanUseFeat(ch, feat_id)) {
+			MUD::Feat(feat_id).effects.ImposeApplies(ch);
+			MUD::Feat(feat_id).effects.ImposeSkillsMods(ch);
 		}
 	}
 


### PR DESCRIPTION
## Проблема

В `affect_total` (строка 725) цикл итерирует все ~154 фита через `MUD::Feats()` (итератор по `std::map`). Для каждого вызывается `CanUseFeat`, хотя у персонажа обычно 20–30 фитов из 158.

Closes #3193 (частично — пункт «Loop over feats»)

## Решение

Итерация по целочисленному диапазону `[kFirst..kLast]` с `HaveFeat`-тестом как ранним выходом:

```cpp
// было:
for (const auto &feat : MUD::Feats()) {
    if (CanUseFeat(ch, feat.GetId())) { ... }
}

// стало:
for (auto feat_id = EFeat::kFirst; feat_id <= EFeat::kLast; ++feat_id) {
    if (ch->HaveFeat(feat_id) && CanUseFeat(ch, feat_id)) { ... }
}
```

`HaveFeat` — bitset-тест, без обращения к map и без проверок класса/ремортов. ~130 из 158 итераций сводятся к одному bitset-тесту. `Reload` не затрагивается — глобального состояния нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)