### PR TITLE
fix(shops): крэш при покупке из-за invalid_anti_class на прототипе (#3356)

### DIFF
--- a/src/gameplay/classes/pc_classes.cpp
+++ b/src/gameplay/classes/pc_classes.cpp
@@ -1274,6 +1274,84 @@ int invalid_no_class(CharData *ch, const ObjData *obj) {
 	return false;
 }
 
+int invalid_anti_class_proto(CharData *ch, const CObjectPrototype *obj) {
+	if (obj->has_anti_flag(EAntiFlag::kCharmice)
+		&& AFF_FLAGGED(ch, EAffect::kCharmed)) {
+		return (true);
+	}
+	if ((ch->IsNpc() || ch->IsImmortal()) && !IS_CHARMICE(ch)) {
+		return (false);
+	}
+	if ((obj->has_anti_flag(EAntiFlag::kNoPkClan) && char_to_pk_clan(ch))) {
+		return (true);
+	}
+	if ((obj->has_anti_flag(EAntiFlag::kMono) && GET_RELIGION(ch) == kReligionMono)
+		|| (obj->has_anti_flag(EAntiFlag::kPoly) && GET_RELIGION(ch) == kReligionPoly)
+		|| (obj->has_anti_flag(EAntiFlag::kMage) && IsMage(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kConjurer) && IS_CONJURER(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kCharmer) && IS_CHARMER(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kWizard) && IS_WIZARD(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kNecromancer) && IS_NECROMANCER(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kFighter) && IsFighter(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kMale) && IS_MALE(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kFemale) && IS_FEMALE(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kSorcerer) && IS_SORCERER(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kWarrior) && IS_WARRIOR(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kGuard) && IS_GUARD(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kThief) && IS_THIEF(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kAssasine) && IS_ASSASINE(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kPaladine) && IS_PALADINE(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kRanger) && IS_RANGER(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kVigilant) && IS_VIGILANT(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kMerchant) && IS_MERCHANT(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kMagus) && IS_MAGUS(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kKiller) && ch->IsFlagged(EPlrFlag::kKiller))
+		|| (obj->has_anti_flag(EAntiFlag::kBattle) && check_agrobd(ch))
+		|| (obj->has_anti_flag(EAntiFlag::kColored) && pk_count(ch))) {
+		return (true);
+	}
+	return (false);
+}
+
+int invalid_no_class_proto(CharData *ch, const CObjectPrototype *obj) {
+	if (obj->has_no_flag(ENoFlag::kCharmice)
+		&& AFF_FLAGGED(ch, EAffect::kCharmed)) {
+		return true;
+	}
+	if (!IS_CHARMICE(ch)
+		&& (ch->IsNpc()
+			|| ch->IsImmortal())) {
+		return false;
+	}
+	if ((obj->has_no_flag(ENoFlag::kMono) && GET_RELIGION(ch) == kReligionMono)
+		|| (obj->has_no_flag(ENoFlag::kPoly) && GET_RELIGION(ch) == kReligionPoly)
+		|| (obj->has_no_flag(ENoFlag::kMage) && IsMage(ch))
+		|| (obj->has_no_flag(ENoFlag::kConjurer) && IS_CONJURER(ch))
+		|| (obj->has_no_flag(ENoFlag::kCharmer) && IS_CHARMER(ch))
+		|| (obj->has_no_flag(ENoFlag::kWizard) && IS_WIZARD(ch))
+		|| (obj->has_no_flag(ENoFlag::kNecromancer) && IS_NECROMANCER(ch))
+		|| (obj->has_no_flag(ENoFlag::kFighter) && IsFighter(ch))
+		|| (obj->has_no_flag(ENoFlag::kMale) && IS_MALE(ch))
+		|| (obj->has_no_flag(ENoFlag::kFemale) && IS_FEMALE(ch))
+		|| (obj->has_no_flag(ENoFlag::kSorcerer) && IS_SORCERER(ch))
+		|| (obj->has_no_flag(ENoFlag::kWarrior) && IS_WARRIOR(ch))
+		|| (obj->has_no_flag(ENoFlag::kGuard) && IS_GUARD(ch))
+		|| (obj->has_no_flag(ENoFlag::kThief) && IS_THIEF(ch))
+		|| (obj->has_no_flag(ENoFlag::kAssasine) && IS_ASSASINE(ch))
+		|| (obj->has_no_flag(ENoFlag::kPaladine) && IS_PALADINE(ch))
+		|| (obj->has_no_flag(ENoFlag::kRanger) && IS_RANGER(ch))
+		|| (obj->has_no_flag(ENoFlag::kVigilant) && IS_VIGILANT(ch))
+		|| (obj->has_no_flag(ENoFlag::kMerchant) && IS_MERCHANT(ch))
+		|| (obj->has_no_flag(ENoFlag::kMagus) && IS_MAGUS(ch))
+		|| (obj->has_no_flag(ENoFlag::kKiller) && ch->IsFlagged(EPlrFlag::kKiller))
+		|| (obj->has_no_flag(ENoFlag::kBattle) && check_agrobd(ch))
+		|| (!IS_VIGILANT(ch) && (obj->has_flag(EObjFlag::kSharpen) || obj->has_flag(EObjFlag::kArmored)))
+		|| (obj->has_no_flag(ENoFlag::kColored) && pk_count(ch))) {
+		return true;
+	}
+	return false;
+}
+
 /*
  * SPELLS AND SKILLS.  This area defines which spells are assigned to
  * which classes, and the minimum level the character must be to use

--- a/src/gameplay/classes/pc_classes.h
+++ b/src/gameplay/classes/pc_classes.h
@@ -6,8 +6,12 @@
 
 #include <array>
 
+class CObjectPrototype;
+
 void advance_level(CharData *ch);
 int invalid_no_class(CharData *ch, const ObjData *obj);
+int invalid_anti_class_proto(CharData *ch, const CObjectPrototype *obj);
+int invalid_no_class_proto(CharData *ch, const CObjectPrototype *obj);
 int GetExtraDamroll(ECharClass class_id, int level);
 long GetExpUntilNextLvl(CharData *ch, int level);
 int GetExtraAc0(ECharClass class_id, int level);

--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -29,6 +29,8 @@ extern char *diag_timer_to_char(const ObjData *obj);    // implemented in the ac
 extern int invalid_anti_class(CharData *ch, const ObjData *obj);    // implemented in class.cpp
 extern int invalid_unique(CharData *ch, const ObjData *obj);    // implemented in class.cpp
 extern int invalid_no_class(CharData *ch, const ObjData *obj);    // implemented in class.cpp
+extern int invalid_anti_class_proto(CharData *ch, const CObjectPrototype *obj);    // implemented in class.cpp
+extern int invalid_no_class_proto(CharData *ch, const CObjectPrototype *obj);    // implemented in class.cpp
 char *find_exdesc(const char *word, const ExtraDescription::shared_ptr &list); // implemented in act.informative.cpp
 namespace ShopExt {
 const int IDENTIFY_COST = 110;
@@ -297,8 +299,8 @@ void shop_node::process_buy(CharData *ch, CharData *keeper, char *argument) {
 		return;
 	}
 
-	if (invalid_anti_class(ch, static_cast<const ObjData *>(proto))
-		|| invalid_no_class(ch, static_cast<const ObjData *>(proto))) {
+	if (invalid_anti_class_proto(ch, proto)
+		|| invalid_no_class_proto(ch, proto)) {
 		tell_to_char(keeper, ch, "Мне жаль, но эта вещь тебе не подходит.");
 		return;
 	}


### PR DESCRIPTION
## Причина краша

`process_buy` вызывал `invalid_anti_class(ch, static_cast<const ObjData *>(proto))`,
где `proto` — указатель на `CObjectPrototype` (прототип предмета из таблицы).

Внутри `invalid_anti_class` первым делом итерируется `obj->get_contains()`.
Для объекта-прототипа это поле не инициализировано (содержит мусор `0x60`),
рекурсивный вызов пытается разыменовать `0x60` → crash.

GDB backtrace:
```
#0  invalid_anti_class (ch=..., obj=0x60) at obj_data.h:204
#1  invalid_anti_class (...) at pc_classes.cpp:1191
#2  ShopExt::shop_node::process_buy (...) at shops_implementation.cpp:300
```

## Решение

Добавлены `invalid_anti_class_proto` / `invalid_no_class_proto` в `pc_classes.cpp` —
идентичны оригинальным, но принимают `const CObjectPrototype*` и не итерируют контейнер
(для прототипа проверка содержимого семантически бессмысленна: покупается сам предмет).

В `process_buy` вызов заменён на новые функции без каста к `ObjData*`.

## Тест

- [ ] Купить предмет у торговца → нет краша
- [ ] Купить предмет, запрещённый классу → «Мне жаль, но эта вещь тебе не подходит»

🤖 Generated with [Claude Code](https://claude.com/claude-code)