### PR TITLE
fix(equip): пересчитывать сеты при батч-надевании/снятии (#3358)

### DIFF
--- a/src/engine/ui/cmd/do_equip.cpp
+++ b/src/engine/ui/cmd/do_equip.cpp
@@ -327,6 +327,7 @@ void do_wear(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		if (!items_worn) {
 			SendMsgToChar("Увы, но надеть вам нечего.\r\n", ch);
 		} else {
+			ch->obj_bonus().update(ch);
 			affect_total(ch);
 		}
 	} else if (dotmode == kFindAlldot) {
@@ -349,6 +350,7 @@ void do_wear(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				obj = next_obj;
 			}
 			if (items_worn > 0) {
+				ch->obj_bonus().update(ch);
 				affect_total(ch);
 			}
 		}

--- a/src/engine/ui/cmd/do_remove.cpp
+++ b/src/engine/ui/cmd/do_remove.cpp
@@ -61,6 +61,7 @@ void do_remove(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			SendMsgToChar("На вас не надето предметов этого типа.\r\n", ch);
 			return;
 		}
+		ch->obj_bonus().update(ch);
 		affect_total(ch);
 	} else if (dotmode == kFindAlldot) {
 		if (!*arg) {
@@ -82,6 +83,7 @@ void do_remove(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				SendMsgToChar(buf, ch);
 				return;
 			}
+			ch->obj_bonus().update(ch);
 			affect_total(ch);
 		}
 	} else        // Returns object pointer but we don't need it, just true/false.


### PR DESCRIPTION
## Причина

Регрессия из PR #3359: при батч-надевании/снятии (`надеть всё`, `снять всё`) флаг `skip_total=true`
пропускает в `EquipObj`/`UnequipChar` блок:
```cpp
if (!skip_total) {
    if (obj_sets::is_set_item(obj)) {
        ch->obj_bonus().update(ch);   // ← пропускается
    }
    affect_total(ch);
}
```

Финальный `affect_total` вызывает только `obj_bonus().apply_affects(ch)` — применяет
уже посчитанный результат. Но `update()` (пересчёт активных сетов по всем слотам)
так и не вызывается → сеты не активируются.

## Решение

Добавлен `ch->obj_bonus().update(ch)` перед финальным `affect_total(ch)`
в обоих батч-циклах `kFindAll` и `kFindAlldot` в `do_equip.cpp` и `do_remove.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)