### PR TITLE
fix(version): дата сборки всегда актуальна при каждом ninja

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -328,6 +328,7 @@ compiler_id = '@0@ @1@ (@2@-@3@)'.format(
 version_cpp = custom_target('version_gen',
   input: 'src/version.cpp.in',
   output: 'version.cpp',
+  build_always_stale: true,
   command: [
     py3,
     files('tools/meson/generate_version.py'),

--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -11,7 +11,7 @@
 
 const char* REVISION = "$ Build revision: ${REVISION} $";
 const char* revision = "${REVISION}";
-const char* build_datetime = __DATE__ " " __TIME__;
+const char* build_datetime = "${BUILD_DATETIME}";
 const char* build_compiler = "${BUILD_COMPILER}";
 const char* build_features = "${BUILD_FEATURES}";
 

--- a/tools/meson/generate_version.py
+++ b/tools/meson/generate_version.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+from datetime import datetime
 
 input_file, output_file, git_rev, buildtype, build_features, build_compiler = sys.argv[1:]
 
@@ -9,6 +10,7 @@ with open(input_file, encoding='koi8-r') as f:
 content = content.replace('${REVISION}', f'{git_rev} ({buildtype})')
 content = content.replace('${BUILD_COMPILER}', build_compiler)
 content = content.replace('${BUILD_FEATURES}', build_features)
+content = content.replace('${BUILD_DATETIME}', datetime.now().strftime('%b %d %Y %H:%M:%S'))
 
 with open(output_file, 'w', encoding='koi8-r') as f:
     f.write(content)


### PR DESCRIPTION
## Проблема

`__DATE__`/`__TIME__` раскрываются компилятором в момент компиляции.
При unity-сборке ninja кэширует unity-файлы — если ни один входной файл
не менялся, `version.cpp` не перекомпилировался и дата в `ver` устаревала.

## Решение

- `build_always_stale: true` в `custom_target` — генератор запускается при каждом `ninja`
- Текущая дата/время вставляется Python-скриптом (`${BUILD_DATETIME}`), а не макросами компилятора

Теперь каждый `ninja` гарантированно обновляет дату сборки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)