### PR TITLE
fix(world): детерминированный выбор в find_by_rnum (ресет 'P') — #3371

### DIFF
--- a/src/engine/db/world_objects.cpp
+++ b/src/engine/db/world_objects.cpp
@@ -10,6 +10,7 @@
 #include "gameplay/mechanics/dungeons.h"
 
 #include <algorithm>
+#include <vector>
 
 void WorldObjects::WO_VNumChangeObserver::notify(CObjectPrototype &object, const ObjVnum old_vnum) {
 	if (old_vnum != object.get_vnum()) {
@@ -337,14 +338,27 @@ ObjData::shared_ptr WorldObjects::find_by_vnum_and_dec_number(const ObjVnum vnum
 
 ObjData::shared_ptr WorldObjects::find_by_rnum(const ObjRnum rnum, unsigned number) const {
 	const auto set_i = m_rnum_to_object_ptr.find(rnum);
-	if (set_i != m_rnum_to_object_ptr.end()) {
-		for (const auto &object : set_i->second) {
-			if (0 == number) {
-				return object;
-			}
+	if (set_i == m_rnum_to_object_ptr.end()) {
+		return nullptr;
+	}
 
-			--number;
-		}
+	// Бакет хранится в std::unordered_set, поэтому порядок обхода не определён
+	// (зависит от хешей указателей, т.е. от раскладки кучи). Раньше это давало
+	// недетерминированный выбор, когда в мире несколько экземпляров одного
+	// прототипа: например, ресет зоны с командой 'P' клал предмет в случайный
+	// из нескольких одинаковых контейнеров. Упорядочиваем по get_id() (строго
+	// монотонный счётчик создания, max_id.allocate), чтобы выбор был стабильным
+	// и воспроизводимым. Путь холодный (единственный вызыватель -- ветка 'P' в
+	// ResetZoneEssential через SearchObjByRnum), бакет мал, так что сортировка
+	// ничего не стоит. См. issue #3371.
+	std::vector<ObjData::shared_ptr> ordered(set_i->second.begin(), set_i->second.end());
+	std::sort(ordered.begin(), ordered.end(),
+		[](const ObjData::shared_ptr &lhs, const ObjData::shared_ptr &rhs) {
+			return lhs->get_id() < rhs->get_id();
+		});
+
+	if (number < ordered.size()) {
+		return ordered[number];
 	}
 
 	return nullptr;


### PR DESCRIPTION
## Проблема

`WorldObjects::find_by_rnum` возвращал **первый элемент `std::unordered_set`**, порядок обхода которого не определён (зависит от хешей указателей, т.е. от раскладки кучи). Единственный потребитель цепочки `find_by_rnum → find_first_by_rnum → SearchObjByRnum` — ветка `'P'` в `ResetZoneEssential` (`db.cpp`). Когда в мире несколько живых экземпляров одного прототипа-контейнера, выбор «куда положить» был **недетерминированным**.

Проявление (issue #3371): квест «Сказка для охотника» (зона 65). Команда ресета `P 0 6505 0 6503` кладёт гнездо в один из **четырёх** одинаковых сухих деревьев (6503) в комнатах 6510/6530/6532/6534. На разных ресетах гнездо оказывалось в разной комнате — квест то работал, то нет. Подтверждено логами движка (`[Extract obj] ... 6505 room = 6510` против `room = 6532`) и `zreset 65` + `где гнездо`.

## Фикс

Упорядочиваем бакет по `get_id()` (строго монотонный счётчик создания, `max_id.allocate()`) и возвращаем `number`-й элемент. Выбор стал стабильным и воспроизводимым между ребутами.

Почему без регрессии по скорости:
- сохраняется O(1)-хеш-лукап в `m_rnum_to_object_ptr`, упорядочивается только **бакет одного rnum** (число экземпляров vnum, обычно единицы), а не список мира;
- путь холодный — вызывается только при ресете зоны, не на пульсе/в бою/в командах.

`unordered_set` для индексов оставлен намеренно: он backs и зональный индекс (сотни–тысячи объектов), а доминирующая операция — `erase-by-value` при высокой текучке (O(1)). Менять контейнер ради порядка обхода = пессимизировать горячий insert/erase; правильнее детерминировать единственного порядко-зависимого читателя.

## Проверка

`g++ -std=c++20 -fsyntax-only` с реальными флагами основной библиотеки — ок.

## Связь с #3371

Это движковая часть (убирает лотерею для любого квеста с несколькими одинаковыми контейнерами). Точечная правка самого квеста зоны 65 — `arg2=6510` в команде `P` (`P 0 6505 6510 6503`) — делается в данных мира через OLC/YAML на сервере и в репозиторий не входит.

Refs #3371
