### PR TITLE
refactor(crc): убрать повторные чтения файлов в FileCRC (буферный API)

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -944,7 +944,7 @@ int Crash_delete_files(const std::size_t index) {
 				log("SYSERR: Error deleting objects file %s (2): %s", filename, strerror(errno));
 				retcode = false;
 			}
-			FileCRC::reset(player_table[index].uid(), FileCRC::TEXTOBJS);
+			FileCRC::reset(player_table[index].uid(), FileCRC::kTextObjs);
 		}
 	}
 
@@ -964,7 +964,7 @@ int Crash_delete_files(const std::size_t index) {
 				log("SYSERR: deleting timer file %s (2): %s", filename, strerror(errno));
 				retcode = false;
 			}
-			FileCRC::reset(player_table[index].uid(), FileCRC::TIMEOBJS);
+			FileCRC::reset(player_table[index].uid(), FileCRC::kTimeObjs);
 		}
 	}
 
@@ -1043,7 +1043,7 @@ int ReadCrashTimerFile(std::size_t index, int temp) {
 	fclose(fl);
 
 	// Сверка CRC из буфера вместо повторного чтения файла.
-	FileCRC::verify_from_content(player_table[index].uid(), FileCRC::TIMEOBJS,
+	FileCRC::verify_from_content(player_table[index].uid(), FileCRC::kTimeObjs,
 		content.data(), content.size());
 
 	std::memcpy(&rent, content.data(), sizeof(struct SaveRentInfo));
@@ -1157,7 +1157,7 @@ int Crash_write_timer(const std::size_t index) {
 	}
 #endif
 	// CRC из буфера вместо повторного чтения файла (см. FileCRC::update_from_content).
-	FileCRC::update_from_content(player_table[index].uid(), FileCRC::UPDATE_TIMEOBJS,
+	FileCRC::update_from_content(player_table[index].uid(), FileCRC::kTimeObjs,
 		content.data(), content.size());
 	return true;
 }
@@ -1464,7 +1464,7 @@ int Crash_load(CharData *ch) {
 	};
 	fclose(fl);
 	// Сверка CRC из уже прочитанного буфера, без повторного чтения файла.
-	FileCRC::verify_from_content(ch->get_uid(), FileCRC::TEXTOBJS, readdata, fsize);
+	FileCRC::verify_from_content(ch->get_uid(), FileCRC::kTextObjs, readdata, fsize);
 
 	data = readdata;
 	*(data + fsize) = '\0';
@@ -1983,7 +1983,7 @@ int save_char_objects(CharData *ch, int savetype, int rentcost) {
 			mudlog(ss.str(), BRF, kLvlGod, SYSLOG, true);
 		}
 #endif
-		FileCRC::update_from_content(ch->get_uid(), FileCRC::UPDATE_TEXTOBJS,
+		FileCRC::update_from_content(ch->get_uid(), FileCRC::kTextObjs,
 			obj_content.data(), obj_content.size());
 	} else {
 		Crash_delete_files(iplayer);

--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -1023,15 +1023,31 @@ int ReadCrashTimerFile(std::size_t index, int temp) {
 	}
 
 	fseek(fl, 0L, SEEK_END);
-	size = ftell(fl);
+	const long fsize = ftell(fl);
 	rewind(fl);
-	if ((size = size - sizeof(struct SaveRentInfo)) < 0 || size % sizeof(struct SaveTimeInfo)) {
+	if ((size = static_cast<int>(fsize) - sizeof(struct SaveRentInfo)) < 0
+		|| size % sizeof(struct SaveTimeInfo)) {
 		log("WARNING:  Timer file %s is corrupt!", fname);
+		fclose(fl);
 		return false;
 	}
 
+	// Читаем файл целиком в буфер: из него же считаем CRC (без второго
+	// чтения только что прочитанного файла) и парсим записи.
+	std::string content(static_cast<std::size_t>(fsize), '\0');
+	if (fsize > 0 && fread(&content[0], static_cast<std::size_t>(fsize), 1, fl) != 1) {
+		log("SYSERR: I/O Error reading %s timer file.", name.c_str());
+		fclose(fl);
+		return false;
+	}
+	fclose(fl);
+
+	// Сверка CRC из буфера вместо повторного чтения файла.
+	FileCRC::verify_from_content(player_table[index].uid(), FileCRC::TIMEOBJS,
+		content.data(), content.size());
+
+	std::memcpy(&rent, content.data(), sizeof(struct SaveRentInfo));
 	sprintf(buf, "[ReadTimer] Reading timer file %s for %s :", fname, name.c_str());
-	size_t dummy = fread(&rent, sizeof(struct SaveRentInfo), 1, fl);
 	switch (rent.rentcode) {
 		case RENT_RENTED: strncat(buf, " Rent ", sizeof(buf) - strlen(buf) - 1);
 			break;
@@ -1056,15 +1072,11 @@ int ReadCrashTimerFile(std::size_t index, int temp) {
 	log("%s", buf);
 	Crash_create_timer(index, rent.n_items);
 	player_table[index].timer->rent = rent;
-	for (; count < rent.n_items && !feof(fl); count++) {
-		dummy = fread(&info, sizeof(struct SaveTimeInfo), 1, fl);
-		if (ferror(fl)) {
-			log("SYSERR: I/O Error reading %s timer file.", name.c_str());
-			fclose(fl);
-			FileCRC::check_crc(fname, FileCRC::TIMEOBJS, player_table[index].uid());
-			ClearSaveinfo(index);
-			return false;
-		}
+
+	const char *recptr = content.data() + sizeof(struct SaveRentInfo);
+	const std::size_t records = size / sizeof(struct SaveTimeInfo);
+	for (; static_cast<std::size_t>(count) < records && count < rent.n_items; count++) {
+		std::memcpy(&info, recptr + count * sizeof(struct SaveTimeInfo), sizeof(struct SaveTimeInfo));
 		if (info.vnum && info.timer >= -1) {
 			player_table[index].timer->time.push_back(info);
 			++num;
@@ -1076,10 +1088,6 @@ int ReadCrashTimerFile(std::size_t index, int temp) {
 			obj_proto.inc_stored(rnum);
 		}
 	}
-	UNUSED_ARG(dummy);
-
-	fclose(fl);
-	FileCRC::check_crc(fname, FileCRC::TIMEOBJS, player_table[index].uid());
 
 	if (rent.n_items != num) {
 		log("[ReadTimer] Error reading %s timer file - file is corrupt.", fname);

--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -944,7 +944,7 @@ int Crash_delete_files(const std::size_t index) {
 				log("SYSERR: Error deleting objects file %s (2): %s", filename, strerror(errno));
 				retcode = false;
 			}
-			FileCRC::check_crc(filename, FileCRC::UPDATE_TEXTOBJS, player_table[index].uid());
+			FileCRC::reset(player_table[index].uid(), FileCRC::TEXTOBJS);
 		}
 	}
 
@@ -964,7 +964,7 @@ int Crash_delete_files(const std::size_t index) {
 				log("SYSERR: deleting timer file %s (2): %s", filename, strerror(errno));
 				retcode = false;
 			}
-			FileCRC::check_crc(filename, FileCRC::UPDATE_TIMEOBJS, player_table[index].uid());
+			FileCRC::reset(player_table[index].uid(), FileCRC::TIMEOBJS);
 		}
 	}
 
@@ -1444,7 +1444,8 @@ int Crash_load(CharData *ch) {
 	fseek(fl, 0L, SEEK_SET);
 	if (!fread(readdata, fsize, 1, fl) || ferror(fl) || !readdata) {
 		fclose(fl);
-		FileCRC::check_crc(fname, FileCRC::TEXTOBJS, ch->get_uid());
+		// Чтение не удалось -- валидного буфера для сверки CRC нет, сверку
+		// (которая раньше перечитывала файл) тут опускаем и просто выходим.
 		SendMsgToChar("\r\n** Ошибка чтения файла описания вещей **\r\n"
 					  "Проблемы с восстановлением ваших вещей из файла.\r\n"
 					  "Обращайтесь за помощью к Богам.\r\n", ch);
@@ -1454,7 +1455,8 @@ int Crash_load(CharData *ch) {
 		return (1);
 	};
 	fclose(fl);
-	FileCRC::check_crc(fname, FileCRC::TEXTOBJS, ch->get_uid());
+	// Сверка CRC из уже прочитанного буфера, без повторного чтения файла.
+	FileCRC::verify_from_content(ch->get_uid(), FileCRC::TEXTOBJS, readdata, fsize);
 
 	data = readdata;
 	*(data + fsize) = '\0';

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -1915,13 +1915,15 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 	} else
 		this->set_hit(std::min(this->get_hit(), this->get_real_max_hit()));
 
-	fbclose(fl);
+	// Сверка CRC из буфера fb (весь файл уже в памяти) -- до fbclose, который
+	// освобождает буфер; без повторного чтения только что прочитанного файла.
 	// здесь мы закладываемся на то, что при ребуте это все сейчас пропускается и это нормально,
 	// иначе в таблице crc будут пустые имена, т.к. сама плеер-таблица еще не сформирована
 	// и в любом случае при ребуте это все пересчитывать не нужно
 	if (!(load_flags & ELoadCharFlags::kNoCrcCheck)) {
-		FileCRC::check_crc(filename, FileCRC::PLAYER, this->get_uid());
+		FileCRC::verify_from_content(this->get_uid(), FileCRC::PLAYER, fl->buf, fl->size);
 	}
+	fbclose(fl);
 
 	return (id);
 }

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -912,7 +912,7 @@ void Player::save_char() {
 		mudlog(ss.str(), BRF, kLvlGod, SYSLOG, true);
 	}
 #endif
-	FileCRC::update_from_content(this->get_uid(), FileCRC::UPDATE_PLAYER, pfile.data(), pfile.size());
+	FileCRC::update_from_content(this->get_uid(), FileCRC::kPlayer, pfile.data(), pfile.size());
 
 	// восстанавливаем аффекты
 	// add spell and eq affections back in now
@@ -1930,7 +1930,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 	// иначе в таблице crc будут пустые имена, т.к. сама плеер-таблица еще не сформирована
 	// и в любом случае при ребуте это все пересчитывать не нужно
 	if (!(load_flags & ELoadCharFlags::kNoCrcCheck)) {
-		FileCRC::verify_from_content(this->get_uid(), FileCRC::PLAYER, fl->buf, fl->size);
+		FileCRC::verify_from_content(this->get_uid(), FileCRC::kPlayer, fl->buf, fl->size);
 	}
 	fbclose(fl);
 

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 
 #include "utils/file_crc.h"
+#include "utils/buffered_file_writer.h"
 #include "utils/backtrace.h"
 
 #include "gameplay/communication/ignores_loader.h"
@@ -327,7 +328,7 @@ std::string Player::quested_print() const {
 	return quested_.print();
 }
 
-void Player::quested_save(FILE *saved) const {
+void Player::quested_save(BufferedFileWriter &saved) const {
 	quested_.save(saved);
 }
 
@@ -347,7 +348,7 @@ void Player::mobmax_remove(int vnum) {
 	mobmax_.remove(vnum);
 }
 
-void Player::mobmax_save(FILE *saved) const {
+void Player::mobmax_save(BufferedFileWriter &saved) const {
 	mobmax_.save(saved);
 }
 
@@ -407,7 +408,7 @@ void Player::dps_add_exp(int exp, bool battle) {
 #define NO_EXTRANEOUS_TRIGGERS
 
 void Player::save_char() {
-	FILE *saved;
+	BufferedFileWriter saved;
 	char filename[kMaxStringLength];
 	int i;
 	time_t li;
@@ -431,10 +432,7 @@ void Player::save_char() {
 
 	// Запись чара в новом формате
 	get_filename(GET_NAME(this), filename, kPlayersFile);
-	if (!(saved = fopen(filename, "w"))) {
-		perror("Unable open charfile");
-		return;
-	}
+	// Пишем в буфер в памяти (BufferedFileWriter), файл создаётся в конце.
 	// подготовка
 	// снимаем все возможные аффекты
 	for (i = 0; i < EEquipPos::kNumEquipPos; i++) {
@@ -451,163 +449,163 @@ void Player::save_char() {
 	affected.clear();
 
 	if (!get_name().empty()) {
-		fprintf(saved, "Name: %s\n", GET_NAME(this));
+		saved.printf("Name: %s\n", GET_NAME(this));
 	}
-	fprintf(saved, "Levl: %d\n", this->GetLevel());
-	fprintf(saved, "Clas: %d\n", to_underlying(this->GetClass()));
-	fprintf(saved, "LstL: %ld\n", static_cast<long int>(this->get_last_logon()));
+	saved.printf("Levl: %d\n", this->GetLevel());
+	saved.printf("Clas: %d\n", to_underlying(this->GetClass()));
+	saved.printf("LstL: %ld\n", static_cast<long int>(this->get_last_logon()));
 	// сохраняем last_ip, который должен содержать айпишник с последнего удачного входа
 	if (player_table[this->get_pfilepos()].last_ip.empty()) {
 		player_table[this->get_pfilepos()].last_ip = "Unknown";
 	}
-	fprintf(saved, "Host: %s\n", player_table[this->get_pfilepos()].last_ip.c_str());
-	fprintf(saved, "Id  : %ld\n", this->get_uid());
-	fprintf(saved, "Exp : %ld\n", this->get_exp());
-	fprintf(saved, "Rmrt: %d\n", this->get_remort());
+	saved.printf("Host: %s\n", player_table[this->get_pfilepos()].last_ip.c_str());
+	saved.printf("Id  : %ld\n", this->get_uid());
+	saved.printf("Exp : %ld\n", this->get_exp());
+	saved.printf("Rmrt: %d\n", this->get_remort());
 	// флаги
 	*buf = '\0';
 	char_specials.saved.act.tascii(FlagData::kPlanesNumber, buf, sizeof(buf));
-	fprintf(saved, "Act : %s\n", buf);
+	saved.printf("Act : %s\n", buf);
 	if (GET_EMAIL(this))//edited WorM 2010.08.27 перенесено чтоб грузилось для сохранения в индексе игроков
 	{
-		fprintf(saved, "EMal: %s\n", GET_EMAIL(this));
+		saved.printf("EMal: %s\n", GET_EMAIL(this));
 	}
 	// это пишем обязательно посленим, потому что после него ничего не прочитается
-	fprintf(saved, "Rebt: следующие далее поля при перезагрузке не парсятся\n\n");
+	saved.printf("Rebt: следующие далее поля при перезагрузке не парсятся\n\n");
 	// дальше пишем как хотим и что хотим
 
-	fprintf(saved, "NmI : %s\n", GET_PAD(this, 0));
-	fprintf(saved, "NmR : %s\n", GET_PAD(this, 1));
-	fprintf(saved, "NmD : %s\n", GET_PAD(this, 2));
-	fprintf(saved, "NmV : %s\n", GET_PAD(this, 3));
-	fprintf(saved, "NmT : %s\n", GET_PAD(this, 4));
-	fprintf(saved, "NmP : %s\n", GET_PAD(this, 5));
+	saved.printf("NmI : %s\n", GET_PAD(this, 0));
+	saved.printf("NmR : %s\n", GET_PAD(this, 1));
+	saved.printf("NmD : %s\n", GET_PAD(this, 2));
+	saved.printf("NmV : %s\n", GET_PAD(this, 3));
+	saved.printf("NmT : %s\n", GET_PAD(this, 4));
+	saved.printf("NmP : %s\n", GET_PAD(this, 5));
 	if (!this->get_passwd().empty())
-		fprintf(saved, "Pass: %s\n", this->get_passwd().c_str());
+		saved.printf("Pass: %s\n", this->get_passwd().c_str());
 	if (!this->player_data.title.empty())
-		fprintf(saved, "Titl: %s\n", this->player_data.title.c_str());
+		saved.printf("Titl: %s\n", this->player_data.title.c_str());
 	if (!this->player_data.description.empty()) {
 		snprintf(buf, sizeof(buf), "%s", this->player_data.description.c_str());
 		kill_ems(buf);
-		fprintf(saved, "Desc:\n%s~\n", buf);
+		saved.printf("Desc:\n%s~\n", buf);
 	}
 	if (POOFIN(this))
-		fprintf(saved, "PfIn: %s\n", POOFIN(this));
+		saved.printf("PfIn: %s\n", POOFIN(this));
 	if (POOFOUT(this))
-		fprintf(saved, "PfOt: %s\n", POOFOUT(this));
-	fprintf(saved, "Sex : %d %s\n", static_cast<int>(this->get_sex()), genders[(int) this->get_sex()]);
-	fprintf(saved, "Kin : %d %s\n", GET_KIN(this), PlayerRace::GetKinNameByNum(GET_KIN(this), this->get_sex()).c_str());
+		saved.printf("PfOt: %s\n", POOFOUT(this));
+	saved.printf("Sex : %d %s\n", static_cast<int>(this->get_sex()), genders[(int) this->get_sex()]);
+	saved.printf("Kin : %d %s\n", GET_KIN(this), PlayerRace::GetKinNameByNum(GET_KIN(this), this->get_sex()).c_str());
 	li = this->player_data.time.birth;
-	fprintf(saved, "Brth: %ld %s\n", static_cast<long int>(li), ctime(&li));
+	saved.printf("Brth: %ld %s\n", static_cast<long int>(li), ctime(&li));
 	// Gunner
 	tmp += this->player_data.time.played;
-	fprintf(saved, "Plyd: %d\n", tmp);
+	saved.printf("Plyd: %d\n", tmp);
 	// Gunner end
 	li = this->player_data.time.logon;
-	fprintf(saved, "Last: %ld %s\n", static_cast<long int>(li), ctime(&li));
-	fprintf(saved, "Hite: %d\n", GET_HEIGHT(this));
-	fprintf(saved, "Wate: %d\n", GET_WEIGHT(this));
-	fprintf(saved, "Size: %d\n", GET_SIZE(this));
+	saved.printf("Last: %ld %s\n", static_cast<long int>(li), ctime(&li));
+	saved.printf("Hite: %d\n", GET_HEIGHT(this));
+	saved.printf("Wate: %d\n", GET_WEIGHT(this));
+	saved.printf("Size: %d\n", GET_SIZE(this));
 	// структуры
-	fprintf(saved, "Alin: %d\n", GET_ALIGNMENT(this));
+	saved.printf("Alin: %d\n", GET_ALIGNMENT(this));
 	*buf = '\0';
 	AFF_FLAGS(this).tascii(FlagData::kPlanesNumber, buf, sizeof(buf));
-	fprintf(saved, "Aff : %s\n", buf);
+	saved.printf("Aff : %s\n", buf);
 
 	// дальше не по порядку
 	// статсы
-	fprintf(saved, "Str : %d\n", this->GetInbornStr());
-	fprintf(saved, "Int : %d\n", this->GetInbornInt());
-	fprintf(saved, "Wis : %d\n", this->GetInbornWis());
-	fprintf(saved, "Dex : %d\n", this->GetInbornDex());
-	fprintf(saved, "Con : %d\n", this->GetInbornCon());
-	fprintf(saved, "Cha : %d\n", this->GetInbornCha());
+	saved.printf("Str : %d\n", this->GetInbornStr());
+	saved.printf("Int : %d\n", this->GetInbornInt());
+	saved.printf("Wis : %d\n", this->GetInbornWis());
+	saved.printf("Dex : %d\n", this->GetInbornDex());
+	saved.printf("Con : %d\n", this->GetInbornCon());
+	saved.printf("Cha : %d\n", this->GetInbornCha());
 
 	if (GetRealLevel(this) < kLvlImmortal) {
-		fprintf(saved, "Feat:\n");
+		saved.printf("Feat:\n");
 		for (auto feat : MUD::Class(this->GetClass()).feats) {
 			if (this->HaveFeat(feat.GetId())) {
-				fprintf(saved, "%d %s\n", to_underlying(feat.GetId()), MUD::Feat(feat.GetId()).GetCName());
+				saved.printf("%d %s\n", to_underlying(feat.GetId()), MUD::Feat(feat.GetId()).GetCName());
 			}
 		}
-		fprintf(saved, "0 0\n");
+		saved.printf("0 0\n");
 	}
 
 	if (GetRealLevel(this) < kLvlImmortal) {
-		fprintf(saved, "FtTm:\n");
+		saved.printf("FtTm:\n");
 		for (auto tf : this->timed_feat) {
-			fprintf(saved, "%d %ld %s\n", to_underlying(tf.first), std::max(0L, static_cast<long>(tf.second - time(0))), MUD::Feat(tf.first).GetCName());
+			saved.printf("%d %ld %s\n", to_underlying(tf.first), std::max(0L, static_cast<long>(tf.second - time(0))), MUD::Feat(tf.first).GetCName());
 		}
-		fprintf(saved, "0 0\n");
+		saved.printf("0 0\n");
 	}
 
 	// скилы
 	if (GetRealLevel(this) < kLvlImmortal) {
-		fprintf(saved, "Skil:\n");
+		saved.printf("Skil:\n");
 		int skill_val;
 		for (const auto &skill : MUD::Skills()) {
 			if (skill.IsAvailable()) {
 				skill_val = this->GetTrainedSkill(skill.GetId());
 				if (skill_val) {
-					fprintf(saved, "%d %d %s\n", to_underlying(skill.GetId()), skill_val, skill.GetName());
+					saved.printf("%d %d %s\n", to_underlying(skill.GetId()), skill_val, skill.GetName());
 				}
 			}
 		}
-		fprintf(saved, "0 0\n");
+		saved.printf("0 0\n");
 	}
 
 	// города
-	fprintf(saved, "Cits: %s\n", this->cities_to_str().c_str());
+	saved.printf("Cits: %s\n", this->cities_to_str().c_str());
 
 	// Задержки на скилы
 	if (GetRealLevel(this) < kLvlImmortal) {
-		fprintf(saved, "SkTm:\n");
+		saved.printf("SkTm:\n");
 		for (auto skj : this->timed_skill) {
-			fprintf(saved, "%d %ld %s\n", to_underlying(skj.first), std::max(static_cast<long int>(0), static_cast<long int>(skj.second - time(0))), MUD::Skill(skj.first).GetName());
+			saved.printf("%d %ld %s\n", to_underlying(skj.first), std::max(static_cast<long int>(0), static_cast<long int>(skj.second - time(0))), MUD::Skill(skj.first).GetName());
 		}
-		fprintf(saved, "0 0\n");
+		saved.printf("0 0\n");
 	}
 
 	if (GetRealLevel(this) < kLvlImmortal && !IS_MANA_CASTER(this)) {
-		fprintf(saved, "Spel:\n");
+		saved.printf("Spel:\n");
 		for (auto spell_id = ESpell::kFirst; spell_id <= ESpell::kLast; ++spell_id) {
 			if (GET_SPELL_TYPE(this, spell_id)) {
-				fprintf(saved, "%d %d %s\n", to_underlying(spell_id),
+				saved.printf("%d %d %s\n", to_underlying(spell_id),
 						GET_SPELL_TYPE(this, spell_id), MUD::Spell(spell_id).GetCName());
 			}
 		}
-		fprintf(saved, "0 0\n");
+		saved.printf("0 0\n");
 	}
 
 	if (GetRealLevel(this) < kLvlImmortal && !IS_MANA_CASTER(this)) {
-		fprintf(saved, "TSpl:\n");
+		saved.printf("TSpl:\n");
 		for (auto & temp_spell : this->temp_spells) {
-			fprintf(saved,
+			saved.printf(
 					"%d %ld %ld %s\n",
 					to_underlying(temp_spell.first),
 					static_cast<long int>(temp_spell.second.set_time),
 					static_cast<long int>(temp_spell.second.duration),
 					MUD::Spell(temp_spell.first).GetCName());
 		}
-		fprintf(saved, "0 0 0\n");
+		saved.printf("0 0 0\n");
 	}
 
 	// Замемленые спелы
 	if (GetRealLevel(this) < kLvlImmortal) {
-		fprintf(saved, "SpMe:\n");
+		saved.printf("SpMe:\n");
 		for (auto spell_id = ESpell::kFirst; spell_id <= ESpell::kLast; ++spell_id) {
 			if (GET_SPELL_MEM(this, spell_id))
-				fprintf(saved, "%d %d\n", to_underlying(spell_id), GET_SPELL_MEM(this, spell_id));
+				saved.printf("%d %d\n", to_underlying(spell_id), GET_SPELL_MEM(this, spell_id));
 		}
-		fprintf(saved, "0 0\n");
+		saved.printf("0 0\n");
 	}
 
 	// Мемящиеся спелы
 	if (GetRealLevel(this) < kLvlImmortal) {
-		fprintf(saved, "SpTM:\n");
+		saved.printf("SpTM:\n");
 		for (struct SpellMemQueueItem *qi = this->mem_queue.queue; qi != nullptr; qi = qi->next)
-			fprintf(saved, "%d\n", to_underlying(qi->spell_id));
-		fprintf(saved, "0\n");
+			saved.printf("%d\n", to_underlying(qi->spell_id));
+		saved.printf("0\n");
 	}
 
 	// Рецепты
@@ -615,107 +613,107 @@ void Player::save_char() {
 	{
 		im_rskill *rs;
 		im_recipe *r;
-		fprintf(saved, "Rcps:\n");
+		saved.printf("Rcps:\n");
 		for (rs = GET_RSKILL(this); rs; rs = rs->link) {
 			if (rs->perc <= 0)
 				continue;
 			r = &imrecipes[rs->rid];
-			fprintf(saved, "%d %d %s\n", r->id, rs->perc, r->name);
+			saved.printf("%d %d %s\n", r->id, rs->perc, r->name);
 		}
-		fprintf(saved, "-1 -1\n");
+		saved.printf("-1 -1\n");
 	}
 
-	fprintf(saved, "Hrol: %d\n", GET_HR(this));
-	fprintf(saved, "Drol: %d\n", GET_DR(this));
-	fprintf(saved, "Ac  : %d\n", GET_AC(this));
-	fprintf(saved, "Hry : %d\n", this->get_hryvn());
-	fprintf(saved, "Tglo: %ld\n", static_cast<long int>(this->getGloryRespecTime()));
-	fprintf(saved, "Hit : %d/%d\n", this->get_hit(), this->get_max_hit());
-	fprintf(saved, "Mana: %d/%d\n", this->mem_queue.stored, (this)->mem_queue.total);
-	fprintf(saved, "Move: %d/%d\n", this->get_move(), this->get_max_move());
-	fprintf(saved, "Gold: %ld\n", get_gold());
-	fprintf(saved, "Bank: %ld\n", get_bank());
-	fprintf(saved, "ICur: %d\n", get_ice_currency());
-	fprintf(saved, "Ruble: %ld\n", get_ruble());
-	fprintf(saved, "Wimp: %d\n", GET_WIMP_LEV(this));
-	fprintf(saved, "Frez: %d\n", GET_FREEZE_LEV(this));
-	fprintf(saved, "Invs: %d\n", GET_INVIS_LEV(this));
-	fprintf(saved, "Room: %d\n", GET_LOADROOM(this));
+	saved.printf("Hrol: %d\n", GET_HR(this));
+	saved.printf("Drol: %d\n", GET_DR(this));
+	saved.printf("Ac  : %d\n", GET_AC(this));
+	saved.printf("Hry : %d\n", this->get_hryvn());
+	saved.printf("Tglo: %ld\n", static_cast<long int>(this->getGloryRespecTime()));
+	saved.printf("Hit : %d/%d\n", this->get_hit(), this->get_max_hit());
+	saved.printf("Mana: %d/%d\n", this->mem_queue.stored, (this)->mem_queue.total);
+	saved.printf("Move: %d/%d\n", this->get_move(), this->get_max_move());
+	saved.printf("Gold: %ld\n", get_gold());
+	saved.printf("Bank: %ld\n", get_bank());
+	saved.printf("ICur: %d\n", get_ice_currency());
+	saved.printf("Ruble: %ld\n", get_ruble());
+	saved.printf("Wimp: %d\n", GET_WIMP_LEV(this));
+	saved.printf("Frez: %d\n", GET_FREEZE_LEV(this));
+	saved.printf("Invs: %d\n", GET_INVIS_LEV(this));
+	saved.printf("Room: %d\n", GET_LOADROOM(this));
 //	li = this->player_data.time.birth;
-//	fprintf(saved, "Brth: %ld %s\n", static_cast<long int>(li), ctime(&li));
-	fprintf(saved, "Lexc: %ld\n", static_cast<long>(this->get_last_exchange()));
-	fprintf(saved, "Badp: %d\n", GET_BAD_PWS(this));
+//	saved.printf("Brth: %ld %s\n", static_cast<long int>(li), ctime(&li));
+	saved.printf("Lexc: %ld\n", static_cast<long>(this->get_last_exchange()));
+	saved.printf("Badp: %d\n", GET_BAD_PWS(this));
 
 	for (unsigned i = 0; i < board_date_.size(); ++i) {
-		fprintf(saved, "Br%02u: %llu\n", i + 1, static_cast<unsigned long long>(board_date_.at(i)));
+		saved.printf("Br%02u: %llu\n", i + 1, static_cast<unsigned long long>(board_date_.at(i)));
 	}
 
 	for (int i = 0; i < START_STATS_TOTAL; ++i)
-		fprintf(saved, "St%02d: %i\n", i, this->get_start_stat(i));
+		saved.printf("St%02d: %i\n", i, this->get_start_stat(i));
 
 	if (GetRealLevel(this) < kLvlImmortal)
-		fprintf(saved, "Hung: %d\n", GET_COND(this, FULL));
+		saved.printf("Hung: %d\n", GET_COND(this, FULL));
 	if (GetRealLevel(this) < kLvlImmortal)
-		fprintf(saved, "Thir: %d\n", GET_COND(this, THIRST));
+		saved.printf("Thir: %d\n", GET_COND(this, THIRST));
 	if (GetRealLevel(this) < kLvlImmortal)
-		fprintf(saved, "Drnk: %d\n", GET_COND(this, DRUNK));
+		saved.printf("Drnk: %d\n", GET_COND(this, DRUNK));
 
-	fprintf(saved, "Reli: %d %s\n", GET_RELIGION(this), religion_name[GET_RELIGION(this)][(int) this->get_sex()]);
-	fprintf(saved,
+	saved.printf("Reli: %d %s\n", GET_RELIGION(this), religion_name[GET_RELIGION(this)][(int) this->get_sex()]);
+	saved.printf(
 			"Race: %d %s\n",
 			GET_RACE(this),
 			PlayerRace::GetRaceNameByNum(GET_KIN(this), GET_RACE(this), this->get_sex()).c_str());
-	fprintf(saved, "DrSt: %d\n", GET_DRUNK_STATE(this));
-	fprintf(saved, "Olc : %d\n", GET_OLC_ZONE(this));
+	saved.printf("DrSt: %d\n", GET_DRUNK_STATE(this));
+	saved.printf("Olc : %d\n", GET_OLC_ZONE(this));
 	*buf = '\0';
 	this->player_specials->saved.pref.tascii(FlagData::kPlanesNumber, buf, sizeof(buf));
-	fprintf(saved, "Pref: %s\n", buf);
-	fprintf(saved, "MgSh: %d\n", static_cast<int>(GetBriefShieldsMode()));
+	saved.printf("Pref: %s\n", buf);
+	saved.printf("MgSh: %d\n", static_cast<int>(GetBriefShieldsMode()));
 
 	if (MUTE_DURATION(this) > 0 && this->IsFlagged(EPlrFlag::kMuted))
-		fprintf(saved,
+		saved.printf(
 				"PMut: %ld %d %ld %s~\n",
 				MUTE_DURATION(this),
 				GET_MUTE_LEV(this),
 				MUTE_GODID(this),
 				MUTE_REASON(this));
 	if (NAME_DURATION(this) > 0 && this->IsFlagged(EPlrFlag::kNameDenied))
-		fprintf(saved,
+		saved.printf(
 				"PNam: %ld %d %ld %s~\n",
 				NAME_DURATION(this),
 				GET_NAME_LEV(this),
 				NAME_GODID(this),
 				NAME_REASON(this));
 	if (DUMB_DURATION(this) > 0 && this->IsFlagged(EPlrFlag::kDumbed))
-		fprintf(saved,
+		saved.printf(
 				"PDum: %ld %d %ld %s~\n",
 				DUMB_DURATION(this),
 				GET_DUMB_LEV(this),
 				DUMB_GODID(this),
 				DUMB_REASON(this));
 	if (HELL_DURATION(this) > 0 && this->IsFlagged(EPlrFlag::kHelled))
-		fprintf(saved,
+		saved.printf(
 				"PHel: %ld %d %ld %s~\n",
 				HELL_DURATION(this),
 				GET_HELL_LEV(this),
 				HELL_GODID(this),
 				HELL_REASON(this));
 	if (GCURSE_DURATION(this) > 0)
-		fprintf(saved,
+		saved.printf(
 				"PGcs: %ld %d %ld %s~\n",
 				GCURSE_DURATION(this),
 				GET_GCURSE_LEV(this),
 				GCURSE_GODID(this),
 				GCURSE_REASON(this));
 	if (FREEZE_DURATION(this) > 0 && this->IsFlagged(EPlrFlag::kFrozen))
-		fprintf(saved,
+		saved.printf(
 				"PFrz: %ld %d %ld %s~\n",
 				FREEZE_DURATION(this),
 				GET_FREEZE_LEV(this),
 				FREEZE_GODID(this),
 				FREEZE_REASON(this));
 	if (UNREG_DURATION(this) > 0)
-		fprintf(saved,
+		saved.printf(
 				"PUnr: %ld %d %ld %s~\n",
 				UNREG_DURATION(this),
 				GET_UNREG_LEV(this),
@@ -725,7 +723,7 @@ void Player::save_char() {
 	if (KARMA(this)) {
 		snprintf(buf, sizeof(buf), "%s", KARMA(this));
 		kill_ems(buf);
-		fprintf(saved, "Karm:\n%s~\n", buf);
+		saved.printf("Karm:\n%s~\n", buf);
 	}
 	if (!LOGON_LIST(this).empty()) {
 		log("Saving logon list.");
@@ -733,45 +731,45 @@ void Player::save_char() {
 		for (const auto &logon : LOGON_LIST(this)) {
 			buffer << logon.ip << " " << logon.count << " " << logon.lasttime << "\n";
 		}
-		fprintf(saved, "LogL:\n%s~\n", buffer.str().c_str());
+		saved.printf("LogL:\n%s~\n", buffer.str().c_str());
 	}
-	fprintf(saved, "GdFl: %ld\n", this->player_specials->saved.GodsLike);
-	fprintf(saved, "NamG: %d\n", (this)->player_specials->saved.NameGod);
-	fprintf(saved, "NaID: %ld\n", (this)->player_specials->saved.NameIDGod);
-	fprintf(saved, "StrL: %d\n", (this)->player_specials->saved.stringLength);
-	fprintf(saved, "StrW: %d\n", (this)->player_specials->saved.stringWidth);
-	fprintf(saved, "NtfE: %ld\n", (this)->player_specials->saved.ntfyExchangePrice);
+	saved.printf("GdFl: %ld\n", this->player_specials->saved.GodsLike);
+	saved.printf("NamG: %d\n", (this)->player_specials->saved.NameGod);
+	saved.printf("NaID: %ld\n", (this)->player_specials->saved.NameIDGod);
+	saved.printf("StrL: %d\n", (this)->player_specials->saved.stringLength);
+	saved.printf("StrW: %d\n", (this)->player_specials->saved.stringWidth);
+	saved.printf("NtfE: %ld\n", (this)->player_specials->saved.ntfyExchangePrice);
 
 	if (this->remember_get_num() != Remember::DEF_REMEMBER_NUM) {
-		fprintf(saved, "Rmbr: %u\n", this->remember_get_num());
+		saved.printf("Rmbr: %u\n", this->remember_get_num());
 	}
 
 	if (EXCHANGE_FILTER(this))
-		fprintf(saved, "ExFl: %s\n", EXCHANGE_FILTER(this));
+		saved.printf("ExFl: %s\n", EXCHANGE_FILTER(this));
 
 	for (const auto &cur : get_ignores()) {
 		if (0 != cur->id) {
-			fprintf(saved, "Ignr: [%lu]%ld\n", cur->mode, cur->id);
+			saved.printf("Ignr: [%lu]%ld\n", cur->mode, cur->id);
 		}
 	}
 
 	// affected_type
 	if (!tmp_aff.empty()) {
-		fprintf(saved, "Affs:\n");
+		saved.printf("Affs:\n");
 		for (auto &aff : tmp_aff) {
 			if (aff->type >= ESpell::kFirst) {
-				fprintf(saved, "%d %d %d %d %d %d %s\n", to_underlying(aff->type), aff->duration,
+				saved.printf("%d %d %d %d %d %d %s\n", to_underlying(aff->type), aff->duration,
 						aff->modifier, aff->location, static_cast<int>(aff->bitvector),
 						static_cast<int>(aff->battleflag), MUD::Spell(aff->type).GetCName());
 			}
 		}
-		fprintf(saved, "0 0 0 0 0 0\n");
+		saved.printf("0 0 0 0 0 0\n");
 	}
 
 	// порталы
 	std::ostringstream out;
 	this->player_specials->runestones.Serialize(out);
-	fprintf(saved, "%s", out.str().c_str());
+	saved.printf("%s", out.str().c_str());
 
 	for (auto x : this->daily_quest) {
 		std::stringstream buffer;
@@ -780,7 +778,7 @@ void Player::save_char() {
 			buffer << "DaiQ: " << x.first << " " << x.second << " " << it->second << "\n";
 		else
 			buffer << "DaiQ: " << x.first << " " << x.second << " 0\n";
-		fprintf(saved, "%s", buffer.str().c_str());
+		saved.printf("%s", buffer.str().c_str());
 	}
 
 	for (i = 0; i < 1 + LAST_LOG; ++i) {
@@ -788,41 +786,41 @@ void Player::save_char() {
 			log("SYSERR: Saving NULL logs for char %s", GET_NAME(this));
 			break;
 		}
-		fprintf(saved, "Logs: %d %d\n", i, GET_LOGS(this)[i]);
+		saved.printf("Logs: %d %d\n", i, GET_LOGS(this)[i]);
 	}
 
-	fprintf(saved, "Disp: %ld\n", disposable_flags_.to_ulong());
+	saved.printf("Disp: %ld\n", disposable_flags_.to_ulong());
 
-	fprintf(saved, "Ripa: %llu\n", GetStatistic(CharStat::ArenaRip));
-	fprintf(saved, "Wina: %llu\n", GetStatistic(CharStat::ArenaWin));
-	fprintf(saved, "Riar: %llu\n", GetStatistic(CharStat::ArenaRemortRip));
-	fprintf(saved, "Wiar: %llu\n", GetStatistic(CharStat::ArenaRemortWin));
-	fprintf(saved, "Riad: %llu\n", GetStatistic(CharStat::ArenaDomRip));
-	fprintf(saved, "Wida: %llu\n", GetStatistic(CharStat::ArenaDomWin));
-	fprintf(saved, "Ridr: %llu\n", GetStatistic(CharStat::ArenaDomRemortRip));
-	fprintf(saved, "Widr: %llu\n", GetStatistic(CharStat::ArenaDomRemortWin));
-	fprintf(saved, "Ripm: %llu\n", GetStatistic(CharStat::MobRip));
-	fprintf(saved, "Ripd: %llu\n", GetStatistic(CharStat::DtRip));
-	fprintf(saved, "Ripo: %llu\n", GetStatistic(CharStat::OtherRip));
-	fprintf(saved, "Ripp: %llu\n", GetStatistic(CharStat::PkRip));
-	fprintf(saved, "Rimt: %llu\n", GetStatistic(CharStat::MobRemortRip));
-	fprintf(saved, "Ridt: %llu\n", GetStatistic(CharStat::DtRemortRip));
-	fprintf(saved, "Riot: %llu\n", GetStatistic(CharStat::OtherRemortRip));
-	fprintf(saved, "Ript: %llu\n", GetStatistic(CharStat::PkRemortRip));
-	fprintf(saved, "Expa: %llu\n", GetStatistic(CharStat::ArenaExpLost));
-	fprintf(saved, "Expm: %llu\n", GetStatistic(CharStat::MobExpLost));
-	fprintf(saved, "Expd: %llu\n", GetStatistic(CharStat::DtExpLost));
-	fprintf(saved, "Expo: %llu\n", GetStatistic(CharStat::OtherExpLost));
-	fprintf(saved, "Expp: %llu\n", GetStatistic(CharStat::PkExpLost));
-	fprintf(saved, "Exmt: %llu\n", GetStatistic(CharStat::MobRemortExpLost));
-	fprintf(saved, "Exdt: %llu\n", GetStatistic(CharStat::DtRemortExpLost));
-	fprintf(saved, "Exot: %llu\n", GetStatistic(CharStat::OtherRemortExpLost));
-	fprintf(saved, "Expt: %llu\n", GetStatistic(CharStat::PkRemortExpLost));
+	saved.printf("Ripa: %llu\n", GetStatistic(CharStat::ArenaRip));
+	saved.printf("Wina: %llu\n", GetStatistic(CharStat::ArenaWin));
+	saved.printf("Riar: %llu\n", GetStatistic(CharStat::ArenaRemortRip));
+	saved.printf("Wiar: %llu\n", GetStatistic(CharStat::ArenaRemortWin));
+	saved.printf("Riad: %llu\n", GetStatistic(CharStat::ArenaDomRip));
+	saved.printf("Wida: %llu\n", GetStatistic(CharStat::ArenaDomWin));
+	saved.printf("Ridr: %llu\n", GetStatistic(CharStat::ArenaDomRemortRip));
+	saved.printf("Widr: %llu\n", GetStatistic(CharStat::ArenaDomRemortWin));
+	saved.printf("Ripm: %llu\n", GetStatistic(CharStat::MobRip));
+	saved.printf("Ripd: %llu\n", GetStatistic(CharStat::DtRip));
+	saved.printf("Ripo: %llu\n", GetStatistic(CharStat::OtherRip));
+	saved.printf("Ripp: %llu\n", GetStatistic(CharStat::PkRip));
+	saved.printf("Rimt: %llu\n", GetStatistic(CharStat::MobRemortRip));
+	saved.printf("Ridt: %llu\n", GetStatistic(CharStat::DtRemortRip));
+	saved.printf("Riot: %llu\n", GetStatistic(CharStat::OtherRemortRip));
+	saved.printf("Ript: %llu\n", GetStatistic(CharStat::PkRemortRip));
+	saved.printf("Expa: %llu\n", GetStatistic(CharStat::ArenaExpLost));
+	saved.printf("Expm: %llu\n", GetStatistic(CharStat::MobExpLost));
+	saved.printf("Expd: %llu\n", GetStatistic(CharStat::DtExpLost));
+	saved.printf("Expo: %llu\n", GetStatistic(CharStat::OtherExpLost));
+	saved.printf("Expp: %llu\n", GetStatistic(CharStat::PkExpLost));
+	saved.printf("Exmt: %llu\n", GetStatistic(CharStat::MobRemortExpLost));
+	saved.printf("Exdt: %llu\n", GetStatistic(CharStat::DtRemortExpLost));
+	saved.printf("Exot: %llu\n", GetStatistic(CharStat::OtherRemortExpLost));
+	saved.printf("Expt: %llu\n", GetStatistic(CharStat::PkRemortExpLost));
 
 	// не забываем рестить ману и при сейве
 	this->set_who_mana(MIN(kWhoManaMax,
 						   this->get_who_mana() + (time(0) - this->get_who_last()) * kWhoManaRestPerSecond));
-	fprintf(saved, "Wman: %u\n", this->get_who_mana());
+	saved.printf("Wman: %u\n", this->get_who_mana());
 
 	// added by WorM (Видолюб) 2010.06.04 бабки потраченные на найм(возвращаются при креше)
 	i = 0;
@@ -849,7 +847,7 @@ void Player::save_char() {
 
 					int i = ((aff->duration - 1) / 2) * found_follower->mob_specials.hire_price;
 					if (i != 0) {
-						fprintf(saved, "GldH: %d\n", i);
+						saved.printf("GldH: %d\n", i);
 					}
 					break;
 				}
@@ -860,31 +858,31 @@ void Player::save_char() {
 	this->quested_save(saved);
 	this->mobmax_save(saved);
 	save_pkills(this, saved);
-	fprintf(saved, "Map : %s\n", map_options_.bit_list_.to_string().c_str());
-	fprintf(saved, "TrcG: %d\n", ext_money_[ExtMoney::kTorcGold]);
-	fprintf(saved, "TrcS: %d\n", ext_money_[ExtMoney::kTorcSilver]);
-	fprintf(saved, "TrcB: %d\n", ext_money_[ExtMoney::kTorcBronze]);
-	fprintf(saved, "TrcL: %d %d\n", today_torc_.first, today_torc_.second);
+	saved.printf("Map : %s\n", map_options_.bit_list_.to_string().c_str());
+	saved.printf("TrcG: %d\n", ext_money_[ExtMoney::kTorcGold]);
+	saved.printf("TrcS: %d\n", ext_money_[ExtMoney::kTorcSilver]);
+	saved.printf("TrcB: %d\n", ext_money_[ExtMoney::kTorcBronze]);
+	saved.printf("TrcL: %d %d\n", today_torc_.first, today_torc_.second);
 
 	if (get_reset_stats_cnt(stats_reset::Type::MAIN_STATS) > 0) {
-		fprintf(saved, "CntS: %d\n", get_reset_stats_cnt(stats_reset::Type::MAIN_STATS));
+		saved.printf("CntS: %d\n", get_reset_stats_cnt(stats_reset::Type::MAIN_STATS));
 	}
 
 	if (get_reset_stats_cnt(stats_reset::Type::RACE) > 0) {
-		fprintf(saved, "CntR: %d\n", get_reset_stats_cnt(stats_reset::Type::RACE));
+		saved.printf("CntR: %d\n", get_reset_stats_cnt(stats_reset::Type::RACE));
 	}
 
 	if (get_reset_stats_cnt(stats_reset::Type::FEATS) > 0) {
-		fprintf(saved, "CntF: %d\n", get_reset_stats_cnt(stats_reset::Type::FEATS));
+		saved.printf("CntF: %d\n", get_reset_stats_cnt(stats_reset::Type::FEATS));
 	}
 
 	auto it = this->charmeeHistory.begin();
 	if (this->charmeeHistory.size() > 0 &&
 		(IS_SPELL_SET(this, ESpell::kCharm, ESpellType::kKnow) ||
 		CanUseFeat(this, EFeat::kEmployer) || this->IsImmortal())) {
-		fprintf(saved, "Chrm:\n");
+		saved.printf("Chrm:\n");
 		for (; it != this->charmeeHistory.end(); ++it) {
-			fprintf(saved, "%d %d %d %d %d %d\n",
+			saved.printf("%d %d %d %d %d %d\n",
 					it->first,
 					it->second.CharmedCount,
 					it->second.spentGold,
@@ -892,10 +890,21 @@ void Player::save_char() {
 					it->second.currRemortAvail,
 					it->second.isFavorite);
 		}
-		fprintf(saved, "0 0 0 0 0 0\n");// терминирующая строчка
+		saved.printf("0 0 0 0 0 0\n");// терминирующая строчка
 	}
-	fprintf(saved, "Tlgr: %lu\n", this->player_specials->saved.telegram_id);
-	fclose(saved);
+	saved.printf("Tlgr: %lu\n", this->player_specials->saved.telegram_id);
+
+	// Накопленный буфер пишем на диск в бинарном режиме (байты файла == байты
+	// буфера на всех платформах) и из него же считаем CRC -- без перечитывания
+	// только что записанного файла.
+	const std::string &pfile = saved.str();
+	FILE *pf = fopen(filename, "wb");
+	if (!pf) {
+		perror("Unable open charfile");
+		return;
+	}
+	fwrite(pfile.data(), 1, pfile.size(), pf);
+	fclose(pf);
 #ifndef _WIN32
 	if (chmod(filename, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP) < 0) {
 		std::stringstream ss;
@@ -903,7 +912,7 @@ void Player::save_char() {
 		mudlog(ss.str(), BRF, kLvlGod, SYSLOG, true);
 	}
 #endif
-	FileCRC::check_crc(filename, FileCRC::UPDATE_PLAYER, this->get_uid());
+	FileCRC::update_from_content(this->get_uid(), FileCRC::UPDATE_PLAYER, pfile.data(), pfile.size());
 
 	// восстанавливаем аффекты
 	// add spell and eq affections back in now

--- a/src/engine/entities/char_player.h
+++ b/src/engine/entities/char_player.h
@@ -35,6 +35,8 @@ enum {
 	DIS_TOTAL_NUM
 };
 
+class BufferedFileWriter;
+
 class Player : public CharData {
  public:
 	Player();
@@ -75,14 +77,14 @@ class Player : public CharData {
 	bool quested_get(int vnum) const;
 	std::string quested_get_text(int vnum) const;
 	std::string quested_print() const;
-	void quested_save(FILE *saved) const; // TODO мб убрать
+	void quested_save(BufferedFileWriter &saved) const;
 
 	// обертка на MobMax
 	int mobmax_get(int vnum) const;
 	void mobmax_add(CharData *ch, int vnum, int count, int level);
 	void mobmax_load(CharData *ch, int vnum, int count, int level);
 	void mobmax_remove(int vnum);
-	void mobmax_save(FILE *saved) const; ///< TODO мб убрать
+	void mobmax_save(BufferedFileWriter &saved) const;
 	void show_mobmax();
 
 	// обертка на Dps

--- a/src/engine/entities/player_i.h
+++ b/src/engine/entities/player_i.h
@@ -23,6 +23,7 @@ enum ELoadCharFlags : int {
 struct MERCDATA;
 
 class Account;
+class BufferedFileWriter;
 namespace DpsSystem {
 class Dps;
 }
@@ -74,13 +75,13 @@ class PlayerI {
 	virtual bool quested_get(int/* vnum*/) const { return false; };
 	virtual std::string quested_get_text(int/* vnum*/) const { return ""; };
 	virtual std::string quested_print() const { return ""; };
-	virtual void quested_save(FILE * /*saved*/) const {};
+	virtual void quested_save(BufferedFileWriter & /*saved*/) const {};
 
 	virtual int mobmax_get(int/* vnum*/) const { return 0; };
 	virtual void mobmax_add(CharData * /*ch*/, int/* vnum*/, int/* count*/, int/* level*/) {};
 	virtual void mobmax_load(CharData * /*ch*/, int/* vnum*/, int/* count*/, int/* level*/) {};
 	virtual void mobmax_remove(int/* vnum*/) {};
-	virtual void mobmax_save(FILE * /*saved*/) const {};
+	virtual void mobmax_save(BufferedFileWriter & /*saved*/) const {};
 
 	virtual void dps_add_dmg(int/* type*/, int/* dmg*/, int/* over_dmg*/ = 0, CharData * /*ch*/ = nullptr) {};
 	virtual void dps_clear(int/* type*/) {};

--- a/src/gameplay/fight/pk.cpp
+++ b/src/gameplay/fight/pk.cpp
@@ -13,6 +13,8 @@
 
 #include "pk.h"
 
+#include "utils/buffered_file_writer.h"
+
 #include "engine/db/global_objects.h"
 #include "engine/ui/color.h"
 #include "gameplay/clans/house.h"
@@ -793,8 +795,8 @@ void pk_free_list(CharData *ch) {
 }
 
 // сохранение списка пк-местей в файл персонажа
-void save_pkills(CharData *ch, FILE *saved) {
-	fprintf(saved, "Pkil:\n");
+void save_pkills(CharData *ch, BufferedFileWriter &saved) {
+	saved.printf("Pkil:\n");
 	for (auto it = ch->pk_map.begin(); it != ch->pk_map.end() && !ch->IsFlagged(EPlrFlag::kDeleted);) {
 		auto &pk = it->second;
 		if (pk.kill_num > 0 && IsCorrectUnique(pk.unique)) {
@@ -817,11 +819,11 @@ void save_pkills(CharData *ch, FILE *saved) {
 				it = ch->pk_map.erase(it);
 				continue;
 			}
-			fprintf(saved, "%ld %ld %ld\n", pk.unique, pk.kill_num, pk.revenge_num);
+			saved.printf("%ld %ld %ld\n", pk.unique, pk.kill_num, pk.revenge_num);
 		}
 		++it;
 	}
-	fprintf(saved, "~\n");
+	saved.printf("~\n");
 }
 
 // Проверка может ли ch начать аргессивные действия против victim

--- a/src/gameplay/fight/pk.h
+++ b/src/gameplay/fight/pk.h
@@ -19,6 +19,7 @@
 #include <string>
 
 class ObjData;    // forward declaration to avoid inclusion of obj.hpp and any dependencies of that header.
+class BufferedFileWriter;
 
 //*************************************************************************
 // Основные функци и разрешения конфликтных ситуаций между игроками
@@ -94,7 +95,7 @@ void UpdatePkLogs(CharData *ch, CharData *victim);
 
 //*************************************************************************
 // Системные функции сохранения/загрузки ПК флагов
-void save_pkills(CharData *ch, FILE *saved);
+void save_pkills(CharData *ch, BufferedFileWriter &saved);
 
 //*************************************************************************
 bool has_clan_members_in_group(CharData *ch);

--- a/src/gameplay/mechanics/mobmax.cpp
+++ b/src/gameplay/mechanics/mobmax.cpp
@@ -3,6 +3,8 @@
 // Part of Bylins http://www.mud.ru
 
 #include "mobmax.h"
+
+#include "utils/buffered_file_writer.h"
 #include "dungeons.h"
 
 #include "engine/entities/char_data.h"
@@ -169,11 +171,11 @@ int MobMax::get_kill_count(int vnum) const {
 }
 
 // * Сохранение в плеер-файл.
-void MobMax::save(FILE *saved) const {
-	fprintf(saved, "Mobs:\n");
+void MobMax::save(BufferedFileWriter &saved) const {
+	saved.printf("Mobs:\n");
 	for (MobMaxType::const_reverse_iterator it = mobmax_.rbegin(); it != mobmax_.rend(); ++it)
-		fprintf(saved, "%d %d\n", it->vnum, it->count);
-	fprintf(saved, "~\n");
+		saved.printf("%d %d\n", it->vnum, it->count);
+	saved.printf("~\n");
 }
 
 // * Для очистки всех замаксов при реморте.

--- a/src/gameplay/mechanics/mobmax.h
+++ b/src/gameplay/mechanics/mobmax.h
@@ -14,6 +14,8 @@
 
 int get_max_kills(const int level);
 
+class BufferedFileWriter;
+
 class MobMax {
  public:
 	using mobmax_stats_t = std::map<int, int>;    ///< maps level to count
@@ -27,7 +29,7 @@ class MobMax {
 	void add(CharData *ch, int vnum, int count, int level);
 	void load(CharData *ch, int vnum, int count, int level);
 	void remove(int vnum);
-	void save(FILE *saved) const;
+	void save(BufferedFileWriter &saved) const;
 	void clear();
 
  private:

--- a/src/gameplay/quests/quested.cpp
+++ b/src/gameplay/quests/quested.cpp
@@ -4,6 +4,8 @@
 
 #include "quested.h"
 
+#include "utils/buffered_file_writer.h"
+
 #include "engine/entities/char_data.h"
 
 void smash_tilde(char *str);
@@ -63,9 +65,9 @@ std::string Quested::print() const {
 	return text.str();
 }
 
-void Quested::save(FILE *saved) const {
+void Quested::save(BufferedFileWriter &saved) const {
 	for (QuestedType::const_iterator it = quested_.begin(); it != quested_.end(); ++it) {
-		fprintf(saved, "Qst : %d %s~\n", it->first, it->second.c_str());
+		saved.printf("Qst : %d %s~\n", it->first, it->second.c_str());
 	}
 }
 

--- a/src/gameplay/quests/quested.h
+++ b/src/gameplay/quests/quested.h
@@ -11,6 +11,8 @@
 #include "engine/core/sysdep.h"
 #include "engine/structs/structs.h"
 
+class BufferedFileWriter;
+
 class Quested {
  public:
 	void add(CharData *ch, int vnum, char *text);
@@ -20,7 +22,7 @@ class Quested {
 	bool get(int vnum) const;
 	std::string get_text(int vnum) const;
 	std::string print() const;
-	void save(FILE *saved) const;
+	void save(BufferedFileWriter &saved) const;
 
  private:
 	// выполненные квесты

--- a/src/utils/buffered_file_writer.h
+++ b/src/utils/buffered_file_writer.h
@@ -1,0 +1,46 @@
+// Part of Bylins http://www.mud.ru
+
+#ifndef UTILS_BUFFERED_FILE_WRITER_H_
+#define UTILS_BUFFERED_FILE_WRITER_H_
+
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+
+// printf-совместимый писатель в буфер std::string в памяти.
+//
+// Формат-строки и аргументы -- ровно как у fprintf, поэтому вывод побайтово
+// совпадает с прежней записью fprintf. Отличия от FBFILE/fbprintf: форматирует
+// через vsnprintf (с измерением длины), поэтому переполнения буфера нет при
+// любой длине поля. Буфер потом отдаётся на запись файла и на подсчёт CRC --
+// без перечитывания только что записанного файла.
+class BufferedFileWriter {
+ public:
+	BufferedFileWriter() { m_buf.reserve(8192); }
+
+	__attribute__((format(printf, 2, 3)))
+	void printf(const char *format, ...) {
+		va_list args;
+		va_start(args, format);
+		va_list measure;
+		va_copy(measure, args);
+		const int need = vsnprintf(nullptr, 0, format, measure);
+		va_end(measure);
+		if (need > 0) {
+			const std::size_t old = m_buf.size();
+			m_buf.resize(old + static_cast<std::size_t>(need) + 1);
+			vsnprintf(&m_buf[old], static_cast<std::size_t>(need) + 1, format, args);
+			m_buf.resize(old + static_cast<std::size_t>(need));  // отбросить добавленный '\0'
+		}
+		va_end(args);
+	}
+
+	const std::string &str() const { return m_buf; }
+
+ private:
+	std::string m_buf;
+};
+
+#endif  // UTILS_BUFFERED_FILE_WRITER_H_
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/utils/file_crc.cpp
+++ b/src/utils/file_crc.cpp
@@ -161,23 +161,15 @@ void save(bool force_save) {
 	file.close();
 }
 
-void create_message(std::string &name, int mode, const uint32_t &expected, const uint32_t &calculated) {
+void create_message(std::string &name, EType file, const uint32_t &expected, const uint32_t &calculated) {
 	char time_buf[20];
 	time_t ct = time(nullptr);
 	strftime(time_buf, sizeof(time_buf), "%d-%m-%y %H:%M:%S", localtime(&ct));
 	std::string file_type;
-	switch (mode) {
-		case PLAYER: file_type = "player";
-			break;
-
-		case TEXTOBJS: file_type = "textobjs";
-			break;
-
-		case TIMEOBJS: file_type = "timeobjs";
-			break;
-
-		default: file_type = "error mode";
-			break;
+	switch (file) {
+		case kPlayer:   file_type = "player";   break;
+		case kTextObjs: file_type = "textobjs"; break;
+		case kTimeObjs: file_type = "timeobjs"; break;
 	}
 
 	add_message("%s несовпадение контрольной суммы %s файла: %s (expected: %u; calculated: %u)",
@@ -197,69 +189,58 @@ void show(CharData *ch) {
 }
 
 // Внутренний upsert: создаёт запись uid при отсутствии и кладёт CRC в поле
-// по типу файла. Принимает и обычные, и UPDATE_-режимы. Возвращает запись
-// (nullptr при неизвестном режиме). Флаг need_save -- забота вызывающего.
-static PlayerCRC *set_crc_field(long uid, int mode, uint32_t crc) {
+// по типу файла. Флаг need_save -- забота вызывающего.
+static void set_crc_field(long uid, EType file, uint32_t crc) {
 	auto it = crc_list.find(uid);
 	if (it == crc_list.end()) {
 		it = crc_list.emplace(uid, CRCListPtr(new PlayerCRC)).first;
 	}
-	switch (mode) {
-		case PLAYER:   case UPDATE_PLAYER:   it->second->player = crc; break;
-		case TEXTOBJS: case UPDATE_TEXTOBJS: it->second->textobjs = crc; break;
-		case TIMEOBJS: case UPDATE_TIMEOBJS: it->second->timeobjs = crc; break;
-		default:
-			add_message("SYSERROR: FileCRC: неподдерживаемый режим CRC %d", mode);
-			return nullptr;
+	switch (file) {
+		case kPlayer:   it->second->player = crc;   break;
+		case kTextObjs: it->second->textobjs = crc; break;
+		case kTimeObjs: it->second->timeobjs = crc; break;
 	}
 	it->second->name = GetNameByUnique(uid);
-	return it->second.get();
 }
 
-// Чтение текущего CRC поля по типу файла (для сверки). false при неизвестном режиме.
-static bool get_crc_field(const PlayerCRC &p, int mode, uint32_t &out) {
-	switch (mode) {
-		case PLAYER:   case UPDATE_PLAYER:   out = p.player;   return true;
-		case TEXTOBJS: case UPDATE_TEXTOBJS: out = p.textobjs; return true;
-		case TIMEOBJS: case UPDATE_TIMEOBJS: out = p.timeobjs; return true;
-		default: return false;
+// Чтение текущего CRC поля по типу файла (для сверки).
+static uint32_t get_crc_field(const PlayerCRC &p, EType file) {
+	switch (file) {
+		case kPlayer:   return p.player;
+		case kTextObjs: return p.textobjs;
+		case kTimeObjs: return p.timeobjs;
 	}
+	return 0;  // недостижимо: switch исчерпывающий по EType
 }
 
 // Записывает CRC из готового буфера в памяти, без перечитывания файла.
 // Вызывается при сохранении: CRC считается из того же буфера, что и на диск.
-void update_from_content(long uid, int mode, const char *data, std::size_t len) {
-	if (set_crc_field(uid, mode, CRC32_function(data, static_cast<unsigned long>(len)))) {
-		need_save = true;
-	}
+void update_from_content(long uid, EType file, const char *data, std::size_t len) {
+	set_crc_field(uid, file, CRC32_function(data, static_cast<unsigned long>(len)));
+	need_save = true;
 }
 
 // Сброс CRC файла игрока в 0: файл удалён (Crash_delete_files). Раньше для
 // этого звали check_crc на уже удалённом файле, чтобы получить 0 чтением.
-void reset(long uid, int mode) {
-	if (set_crc_field(uid, mode, 0)) {
-		need_save = true;
-	}
+void reset(long uid, EType file) {
+	set_crc_field(uid, file, 0);
+	need_save = true;
 }
 
 // Сверка CRC из готового буфера со снимком в crc_list (вместо повторного
 // чтения файла на загрузке). Возвращает true при совпадении; при расхождении
 // -- сообщение имму в лог и false. Если снимка ещё нет -- заводит базовый
 // (как делал check_crc для режимов сверки) и возвращает true.
-bool verify_from_content(long uid, int mode, const char *data, std::size_t len) {
+bool verify_from_content(long uid, EType file, const char *data, std::size_t len) {
 	const uint32_t crc = CRC32_function(data, static_cast<unsigned long>(len));
 	auto it = crc_list.find(uid);
 	if (it == crc_list.end()) {
-		set_crc_field(uid, mode, crc);
+		set_crc_field(uid, file, crc);
 		return true;
 	}
-	uint32_t stored = 0;
-	if (!get_crc_field(*it->second, mode, stored)) {
-		add_message("SYSERROR: FileCRC::verify_from_content: неподдерживаемый режим CRC %d", mode);
-		return false;
-	}
+	const uint32_t stored = get_crc_field(*it->second, file);
 	if (stored != crc) {
-		create_message(it->second->name, mode, stored, crc);
+		create_message(it->second->name, file, stored, crc);
 		return false;
 	}
 	return true;

--- a/src/utils/file_crc.cpp
+++ b/src/utils/file_crc.cpp
@@ -284,27 +284,73 @@ void show(CharData *ch) {
 		SendMsgToChar(message.c_str(), ch);
 }
 
-// Обновляет CRC игрока из готового буфера в памяти, не перечитывая файл.
-// Вызывается при сохранении предметов (save_char_objects): CRC считается из
-// того же буфера, который пишется на диск -- экономит чтение только что
-// записанного файла. Поддерживает только режимы записи предметов и таймеров.
-void update_from_content(long uid, int mode, const char *data, std::size_t len) {
-	if (mode != UPDATE_TEXTOBJS && mode != UPDATE_TIMEOBJS) {
-		add_message("SYSERROR: update_from_content: неподдерживаемый режим CRC %d", mode);
-		return;
-	}
-	const uint32_t crc = CRC32_function(data, static_cast<unsigned long>(len));
+// Внутренний upsert: создаёт запись uid при отсутствии и кладёт CRC в поле
+// по типу файла. Принимает и обычные, и UPDATE_-режимы. Возвращает запись
+// (nullptr при неизвестном режиме). Флаг need_save -- забота вызывающего.
+static PlayerCRC *set_crc_field(long uid, int mode, uint32_t crc) {
 	auto it = crc_list.find(uid);
 	if (it == crc_list.end()) {
 		it = crc_list.emplace(uid, CRCListPtr(new PlayerCRC)).first;
 	}
-	if (mode == UPDATE_TEXTOBJS) {
-		it->second->textobjs = crc;
-	} else {
-		it->second->timeobjs = crc;
+	switch (mode) {
+		case PLAYER:   case UPDATE_PLAYER:   it->second->player = crc; break;
+		case TEXTOBJS: case UPDATE_TEXTOBJS: it->second->textobjs = crc; break;
+		case TIMEOBJS: case UPDATE_TIMEOBJS: it->second->timeobjs = crc; break;
+		default:
+			add_message("SYSERROR: FileCRC: неподдерживаемый режим CRC %d", mode);
+			return nullptr;
 	}
 	it->second->name = GetNameByUnique(uid);
-	need_save = true;
+	return it->second.get();
+}
+
+// Чтение текущего CRC поля по типу файла (для сверки). false при неизвестном режиме.
+static bool get_crc_field(const PlayerCRC &p, int mode, uint32_t &out) {
+	switch (mode) {
+		case PLAYER:   case UPDATE_PLAYER:   out = p.player;   return true;
+		case TEXTOBJS: case UPDATE_TEXTOBJS: out = p.textobjs; return true;
+		case TIMEOBJS: case UPDATE_TIMEOBJS: out = p.timeobjs; return true;
+		default: return false;
+	}
+}
+
+// Записывает CRC из готового буфера в памяти, без перечитывания файла.
+// Вызывается при сохранении: CRC считается из того же буфера, что и на диск.
+void update_from_content(long uid, int mode, const char *data, std::size_t len) {
+	if (set_crc_field(uid, mode, CRC32_function(data, static_cast<unsigned long>(len)))) {
+		need_save = true;
+	}
+}
+
+// Сброс CRC файла игрока в 0: файл удалён (Crash_delete_files). Раньше для
+// этого звали check_crc на уже удалённом файле, чтобы получить 0 чтением.
+void reset(long uid, int mode) {
+	if (set_crc_field(uid, mode, 0)) {
+		need_save = true;
+	}
+}
+
+// Сверка CRC из готового буфера со снимком в crc_list (вместо повторного
+// чтения файла на загрузке). Возвращает true при совпадении; при расхождении
+// -- сообщение имму в лог и false. Если снимка ещё нет -- заводит базовый
+// (как делал check_crc для режимов сверки) и возвращает true.
+bool verify_from_content(long uid, int mode, const char *data, std::size_t len) {
+	const uint32_t crc = CRC32_function(data, static_cast<unsigned long>(len));
+	auto it = crc_list.find(uid);
+	if (it == crc_list.end()) {
+		set_crc_field(uid, mode, crc);
+		return true;
+	}
+	uint32_t stored = 0;
+	if (!get_crc_field(*it->second, mode, stored)) {
+		add_message("SYSERROR: FileCRC::verify_from_content: неподдерживаемый режим CRC %d", mode);
+		return false;
+	}
+	if (stored != crc) {
+		create_message(it->second->name, mode, stored, crc);
+		return false;
+	}
+	return true;
 }
 
 } // namespace FileCRC

--- a/src/utils/file_crc.cpp
+++ b/src/utils/file_crc.cpp
@@ -68,17 +68,6 @@ uint32_t calculate_str_crc(const std::string &text) {
 	return CRC32_function(text.c_str(), text.size());
 }
 
-// * Подсчет crc для файла.
-uint32_t calculate_file_crc(const char *name) {
-	std::ifstream in(name, std::ios::binary);
-	if (!in.is_open())
-		return 0;
-
-	std::ostringstream t_out;
-	t_out << in.rdbuf();
-	return calculate_str_crc(t_out.str());
-}
-
 // * Загрузка глобального списка crc.
 void load() {
 	const char *file_name = LIB_PLRSTUFF"crc.lst";
@@ -197,83 +186,6 @@ void create_message(std::string &name, int mode, const uint32_t &expected, const
 				name.c_str(),
 				static_cast<unsigned>(expected),
 				static_cast<unsigned>(calculated));
-}
-
-/**
-* Проверка crc файлоа плеера.
-* \param mode - PLAYER для просто сверки, UPDATE_PLAYER - для сверки с перезаписью нового crc.
-*/
-void check_crc(const char *filename, int mode, long uid) {
-	CRCListType::const_iterator it = crc_list.find(uid);
-	if (it != crc_list.end()) {
-		switch (mode) {
-			case PLAYER: {
-				const auto crc = calculate_file_crc(filename);
-				if (it->second->player != crc) {
-					create_message(it->second->name, mode, it->second->player, crc);
-				}
-				break;
-			}
-
-			case TEXTOBJS: {
-				const auto crc = calculate_file_crc(filename);
-				if (it->second->textobjs != crc) {
-					create_message(it->second->name, mode, it->second->textobjs, crc);
-				}
-				break;
-			}
-
-			case TIMEOBJS: {
-				const auto crc = calculate_file_crc(filename);
-				if (it->second->timeobjs != crc) {
-					create_message(it->second->name, mode, it->second->timeobjs, crc);
-				}
-				break;
-			}
-
-			case UPDATE_PLAYER: it->second->player = calculate_file_crc(filename);
-				it->second->name = GetNameByUnique(uid);
-				break;
-
-			case UPDATE_TEXTOBJS: it->second->textobjs = calculate_file_crc(filename);
-				it->second->name = GetNameByUnique(uid);
-				break;
-
-			case UPDATE_TIMEOBJS: it->second->timeobjs = calculate_file_crc(filename);
-				it->second->name = GetNameByUnique(uid);
-				break;
-
-			default:
-				add_message("SYSERROR: мы не должны были сюда попасть, uid: %ld, mode: %d, func: %s",
-							uid,
-							mode,
-							__func__);
-				return;
-		}
-	} else {
-		CRCListPtr tmp_crc(new PlayerCRC);
-		tmp_crc->name = GetNameByUnique(uid);
-		switch (mode) {
-			case PLAYER:
-			case UPDATE_PLAYER: tmp_crc->player = calculate_file_crc(filename);
-				break;
-
-			case TEXTOBJS:
-			case UPDATE_TEXTOBJS: tmp_crc->textobjs = calculate_file_crc(filename);
-				break;
-
-			case TIMEOBJS:
-			case UPDATE_TIMEOBJS: tmp_crc->timeobjs = calculate_file_crc(filename);
-				break;
-
-			default: add_message("SYSERROR: мы не должны были сюда попасть2, mode: %d, func: %s", mode, __func__);
-				break;
-		}
-		crc_list[uid] = tmp_crc;
-	}
-
-	if (mode >= UPDATE_PLAYER)
-		need_save = true;
 }
 
 // * Вывод лога событий имму по show crc.

--- a/src/utils/file_crc.h
+++ b/src/utils/file_crc.h
@@ -17,7 +17,6 @@ enum { PLAYER, TEXTOBJS, TIMEOBJS, UPDATE_PLAYER, UPDATE_TEXTOBJS, UPDATE_TIMEOB
 void load();
 void save(bool force_save = false);
 void show(CharData *ch);
-void check_crc(const char *name, int mode, long uid);
 // Записывает CRC из готового буфера в памяти (при сохранении), без чтения файла.
 void update_from_content(long uid, int mode, const char *data, std::size_t len);
 // Сбрасывает CRC указанного файла игрока в 0 (файл удалён).

--- a/src/utils/file_crc.h
+++ b/src/utils/file_crc.h
@@ -18,8 +18,13 @@ void load();
 void save(bool force_save = false);
 void show(CharData *ch);
 void check_crc(const char *name, int mode, long uid);
-// Обновляет CRC из готового буфера, без чтения файла с диска.
+// Записывает CRC из готового буфера в памяти (при сохранении), без чтения файла.
 void update_from_content(long uid, int mode, const char *data, std::size_t len);
+// Сбрасывает CRC указанного файла игрока в 0 (файл удалён).
+void reset(long uid, int mode);
+// Сверяет CRC из готового буфера со снимком (при загрузке, вместо чтения файла).
+// true -- совпало или снимка не было; false + сообщение имму -- при расхождении.
+bool verify_from_content(long uid, int mode, const char *data, std::size_t len);
 
 } // namespace FileCRC
 

--- a/src/utils/file_crc.h
+++ b/src/utils/file_crc.h
@@ -11,19 +11,20 @@
 
 namespace FileCRC {
 
-// UPDATE_х идут после обычных флагов
-enum { PLAYER, TEXTOBJS, TIMEOBJS, UPDATE_PLAYER, UPDATE_TEXTOBJS, UPDATE_TIMEOBJS };
+// Тип файла игрока, для которого считается/сверяется CRC. Глагол (запись,
+// сверка, сброс) определяется именем функции, поэтому достаточно типа файла.
+enum EType { kPlayer, kTextObjs, kTimeObjs };
 
 void load();
 void save(bool force_save = false);
 void show(CharData *ch);
 // Записывает CRC из готового буфера в памяти (при сохранении), без чтения файла.
-void update_from_content(long uid, int mode, const char *data, std::size_t len);
+void update_from_content(long uid, EType file, const char *data, std::size_t len);
 // Сбрасывает CRC указанного файла игрока в 0 (файл удалён).
-void reset(long uid, int mode);
+void reset(long uid, EType file);
 // Сверяет CRC из готового буфера со снимком (при загрузке, вместо чтения файла).
 // true -- совпало или снимка не было; false + сообщение имму -- при расхождении.
-bool verify_from_content(long uid, int mode, const char *data, std::size_t len);
+bool verify_from_content(long uid, EType file, const char *data, std::size_t len);
 
 } // namespace FileCRC
 

--- a/tests/buffered_file_writer.cpp
+++ b/tests/buffered_file_writer.cpp
@@ -5,9 +5,11 @@
 // any length without truncation or overflow (the reason we use vsnprintf rather
 // than the legacy fbprintf/vsprintf).
 
-#include "utils/buffered_file_writer.h"
-
+// gtest first: on clang-cl (Windows) the project headers pull conf.h/sysdep.h
+// ahead of the system headers, which breaks the MSVC/clang intrinsic headers.
 #include <gtest/gtest.h>
+
+#include "utils/buffered_file_writer.h"
 
 #include <cstdio>
 #include <string>

--- a/tests/buffered_file_writer.cpp
+++ b/tests/buffered_file_writer.cpp
@@ -1,0 +1,65 @@
+// Part of Bylins http://www.mud.ru
+// Golden tests for BufferedFileWriter: its printf must produce byte-identical
+// output to snprintf for the same format/args (so converting pfile fprintf to
+// it keeps the on-disk bytes and the CRC stable), and it must handle fields of
+// any length without truncation or overflow (the reason we use vsnprintf rather
+// than the legacy fbprintf/vsprintf).
+
+#include "utils/buffered_file_writer.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+TEST(BufferedFileWriter, MatchesSnprintfForMixedFormats) {
+	BufferedFileWriter w;
+	w.printf("Trcg: %d\n", 1234);
+	w.printf("Name: %s~\n", "test");
+	w.printf("Nums: %lld %lu %.2f\n", static_cast<long long>(-5), static_cast<unsigned long>(7), 3.14159);
+
+	char buf[256];
+	std::string expect;
+	snprintf(buf, sizeof(buf), "Trcg: %d\n", 1234);
+	expect += buf;
+	snprintf(buf, sizeof(buf), "Name: %s~\n", "test");
+	expect += buf;
+	snprintf(buf, sizeof(buf), "Nums: %lld %lu %.2f\n",
+		static_cast<long long>(-5), static_cast<unsigned long>(7), 3.14159);
+	expect += buf;
+
+	EXPECT_EQ(w.str(), expect);
+}
+
+TEST(BufferedFileWriter, HandlesLongFieldWithoutTruncation) {
+	// Single field far larger than any internal start size -- must not overflow
+	// or truncate (legacy fbprintf/vsprintf would have been unsafe here).
+	const std::string big(100000, 'x');
+	BufferedFileWriter w;
+	w.printf("%s", big.c_str());
+	EXPECT_EQ(w.str().size(), big.size());
+	EXPECT_EQ(w.str(), big);
+}
+
+TEST(BufferedFileWriter, EmptyThenAppends) {
+	BufferedFileWriter w;
+	EXPECT_TRUE(w.str().empty());
+	w.printf("a");
+	w.printf("b%d", 2);
+	w.printf("");  // empty format must be a no-op
+	EXPECT_EQ(w.str(), "ab2");
+}
+
+TEST(BufferedFileWriter, PreservesEmbeddedFormatlessText) {
+	BufferedFileWriter w;
+	w.printf("plain line with 100%% and ~ tilde\n");
+	char buf[128];
+	snprintf(buf, sizeof(buf), "plain line with 100%% and ~ tilde\n");
+	EXPECT_EQ(w.str(), std::string(buf));
+}
+
+}  // namespace
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/file_crc.cpp
+++ b/tests/file_crc.cpp
@@ -2,9 +2,11 @@
 // Tests for the buffer-based FileCRC API (update/verify/reset) that replaces
 // the old "write file, then read it back to compute CRC" flow.
 
-#include "utils/file_crc.h"
-
+// gtest first: on clang-cl (Windows) the project headers pull conf.h/sysdep.h
+// ahead of the system headers, which breaks the MSVC/clang intrinsic headers.
 #include <gtest/gtest.h>
+
+#include "utils/file_crc.h"
 
 #include <string>
 

--- a/tests/file_crc.cpp
+++ b/tests/file_crc.cpp
@@ -16,52 +16,52 @@ namespace {
 TEST(FileCrcBuffer, UpdateThenVerifyMatches) {
 	const long uid = 7700001;
 	const std::string a = "hello world\n$\n$\n";
-	FileCRC::update_from_content(uid, FileCRC::UPDATE_TEXTOBJS, a.data(), a.size());
-	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, a.data(), a.size()));
+	FileCRC::update_from_content(uid, FileCRC::kTextObjs, a.data(), a.size());
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::kTextObjs, a.data(), a.size()));
 }
 
 TEST(FileCrcBuffer, VerifyDetectsMismatch) {
 	const long uid = 7700002;
 	const std::string a = "alpha";
 	const std::string b = "beta!";
-	FileCRC::update_from_content(uid, FileCRC::UPDATE_TIMEOBJS, a.data(), a.size());
-	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::TIMEOBJS, b.data(), b.size()));
+	FileCRC::update_from_content(uid, FileCRC::kTimeObjs, a.data(), a.size());
+	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::kTimeObjs, b.data(), b.size()));
 }
 
 TEST(FileCrcBuffer, ResetZeroesCrc) {
 	const long uid = 7700003;
 	const std::string a = "some object data";
-	FileCRC::update_from_content(uid, FileCRC::UPDATE_TEXTOBJS, a.data(), a.size());
-	ASSERT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, a.data(), a.size()));
-	FileCRC::reset(uid, FileCRC::TEXTOBJS);
+	FileCRC::update_from_content(uid, FileCRC::kTextObjs, a.data(), a.size());
+	ASSERT_TRUE(FileCRC::verify_from_content(uid, FileCRC::kTextObjs, a.data(), a.size()));
+	FileCRC::reset(uid, FileCRC::kTextObjs);
 	// stored crc is now 0; the buffer's crc is non-zero -> mismatch
-	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, a.data(), a.size()));
+	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::kTextObjs, a.data(), a.size()));
 }
 
 TEST(FileCrcBuffer, VerifyWithoutSnapshotEstablishesBaseline) {
 	const long uid = 7700004;
 	const std::string a = "baseline content";
 	// No prior snapshot: verify must accept it and remember it as the baseline.
-	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::PLAYER, a.data(), a.size()));
-	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::PLAYER, a.data(), a.size()));
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::kPlayer, a.data(), a.size()));
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::kPlayer, a.data(), a.size()));
 }
 
 TEST(FileCrcBuffer, FileTypesAreIndependent) {
 	const long uid = 7700005;
 	const std::string text = "text objects";
 	const std::string time = "time objects";
-	FileCRC::update_from_content(uid, FileCRC::UPDATE_TEXTOBJS, text.data(), text.size());
-	FileCRC::update_from_content(uid, FileCRC::UPDATE_TIMEOBJS, time.data(), time.size());
-	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, text.data(), text.size()));
-	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TIMEOBJS, time.data(), time.size()));
+	FileCRC::update_from_content(uid, FileCRC::kTextObjs, text.data(), text.size());
+	FileCRC::update_from_content(uid, FileCRC::kTimeObjs, time.data(), time.size());
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::kTextObjs, text.data(), text.size()));
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::kTimeObjs, time.data(), time.size()));
 	// text content checked against the timeobjs slot must not match
-	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::TIMEOBJS, text.data(), text.size()));
+	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::kTimeObjs, text.data(), text.size()));
 }
 
 TEST(FileCrcBuffer, EmptyBufferIsStable) {
 	const long uid = 7700006;
-	FileCRC::update_from_content(uid, FileCRC::UPDATE_TEXTOBJS, "", 0);
-	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, "", 0));
+	FileCRC::update_from_content(uid, FileCRC::kTextObjs, "", 0);
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::kTextObjs, "", 0));
 }
 
 }  // namespace

--- a/tests/file_crc.cpp
+++ b/tests/file_crc.cpp
@@ -1,0 +1,69 @@
+// Part of Bylins http://www.mud.ru
+// Tests for the buffer-based FileCRC API (update/verify/reset) that replaces
+// the old "write file, then read it back to compute CRC" flow.
+
+#include "utils/file_crc.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace {
+
+// Each test uses a distinct uid: crc_list is process-global and shared across
+// tests, so unique uids keep them independent.
+
+TEST(FileCrcBuffer, UpdateThenVerifyMatches) {
+	const long uid = 7700001;
+	const std::string a = "hello world\n$\n$\n";
+	FileCRC::update_from_content(uid, FileCRC::UPDATE_TEXTOBJS, a.data(), a.size());
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, a.data(), a.size()));
+}
+
+TEST(FileCrcBuffer, VerifyDetectsMismatch) {
+	const long uid = 7700002;
+	const std::string a = "alpha";
+	const std::string b = "beta!";
+	FileCRC::update_from_content(uid, FileCRC::UPDATE_TIMEOBJS, a.data(), a.size());
+	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::TIMEOBJS, b.data(), b.size()));
+}
+
+TEST(FileCrcBuffer, ResetZeroesCrc) {
+	const long uid = 7700003;
+	const std::string a = "some object data";
+	FileCRC::update_from_content(uid, FileCRC::UPDATE_TEXTOBJS, a.data(), a.size());
+	ASSERT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, a.data(), a.size()));
+	FileCRC::reset(uid, FileCRC::TEXTOBJS);
+	// stored crc is now 0; the buffer's crc is non-zero -> mismatch
+	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, a.data(), a.size()));
+}
+
+TEST(FileCrcBuffer, VerifyWithoutSnapshotEstablishesBaseline) {
+	const long uid = 7700004;
+	const std::string a = "baseline content";
+	// No prior snapshot: verify must accept it and remember it as the baseline.
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::PLAYER, a.data(), a.size()));
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::PLAYER, a.data(), a.size()));
+}
+
+TEST(FileCrcBuffer, FileTypesAreIndependent) {
+	const long uid = 7700005;
+	const std::string text = "text objects";
+	const std::string time = "time objects";
+	FileCRC::update_from_content(uid, FileCRC::UPDATE_TEXTOBJS, text.data(), text.size());
+	FileCRC::update_from_content(uid, FileCRC::UPDATE_TIMEOBJS, time.data(), time.size());
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, text.data(), text.size()));
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TIMEOBJS, time.data(), time.size()));
+	// text content checked against the timeobjs slot must not match
+	EXPECT_FALSE(FileCRC::verify_from_content(uid, FileCRC::TIMEOBJS, text.data(), text.size()));
+}
+
+TEST(FileCrcBuffer, EmptyBufferIsStable) {
+	const long uid = 7700006;
+	FileCRC::update_from_content(uid, FileCRC::UPDATE_TEXTOBJS, "", 0);
+	EXPECT_TRUE(FileCRC::verify_from_content(uid, FileCRC::TEXTOBJS, "", 0));
+}
+
+}  // namespace
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -53,7 +53,8 @@ test_sources = files(
     'msg_container.cpp',
     'spell_messages.cpp',
     'skill_messages.cpp',
-    'fight_messages.cpp'
+    'fight_messages.cpp',
+    'file_crc.cpp'
 )
 
 fs = import('fs')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -54,7 +54,8 @@ test_sources = files(
     'spell_messages.cpp',
     'skill_messages.cpp',
     'fight_messages.cpp',
-    'file_crc.cpp'
+    'file_crc.cpp',
+    'buffered_file_writer.cpp'
 )
 
 fs = import('fs')


### PR DESCRIPTION
Вторая часть оптимизации CRC-подсистемы (продолжение #3369, **цель — ветка PR #3369**). Убирает все повторные чтения файлов в `FileCRC`: подсистема больше не читает файлы сама, а считает/сверяет CRC из буферов, которые вызывающий код и так держит в памяти.

## Что сделано
- **Буферный API `FileCRC`**: `update_from_content` (запись), `verify_from_content`→`bool` (сверка), `reset` (сброс для удалённого файла) поверх общего внутреннего сеттера.
- **Загрузка** `.obj`/`.time`/pfile: сверка CRC из уже прочитанного буфера вместо второго чтения файла. `ReadCrashTimerFile` переписан на «слить в буфер → сверить → парсить из буфера» (заодно починена утечка дескриптора в ветке corrupt).
- **Удаление** (`Crash_delete_files`): прямой `reset` вместо `check_crc` на уже удалённом файле.
- **Сохранение pfile**: переведено с ~160 `fprintf(FILE*)` на `BufferedFileWriter` — printf-совместимый писатель в `std::string` через `vsnprintf` (без переполнения при любой длине поля, в отличие от legacy `fbprintf`/`vsprintf`). CRC из буфера, файл пишется бинарно.
- Удалены осиротевшие `check_crc` и `calculate_file_crc` — `FileCRC` больше не делает файлового I/O.

## Тесты
- `tests/file_crc.cpp` — буферный API (roundtrip, обнаружение расхождения, reset, базовый снимок, независимость типов файлов).
- `tests/buffered_file_writer.cpp` — golden-тесты writer'а (побайтовое совпадение с `snprintf`, длинные поля без обрезки).
- Полный сьют: **429 passed**.

Refs #3368
