### PR TITLE
fix(where): единая колоночная сетка вывода 'где', без рекурсии

### DIFF
--- a/src/engine/ui/cmd/do_where.cpp
+++ b/src/engine/ui/cmd/do_where.cpp
@@ -12,13 +12,21 @@
 #include "utils/utils_time.h"
 #include "gameplay/mechanics/dungeons.h"
 #include "engine/db/obj_prototypes.h"
+#include "engine/ui/cmd/do_where.h"
 
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 void PerformImmortWhere(CharData *ch, char *arg);
 void PerformMortalWhere(CharData *ch, char *arg);
-bool PrintImmWhereObj(CharData *ch, char *arg, int num);
 bool PrintObjectLocation(int num, const ObjData *obj, CharData *ch);
+
+static std::string ResolveSpecialLocation(const ObjData *obj, CharData *ch);
+static std::vector<std::string> ResolveObjLocationLines(const ObjData *obj, CharData *ch);
+static bool CollectWhereObjects(CharData *ch, char *arg, int &num, std::vector<where_format::WhereRow> &rows);
 
 void DoWhere(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	one_argument(argument, arg);
@@ -54,24 +62,29 @@ void PerformImmortWhere(CharData *ch, char *arg) {
 		}
 		SendMsgToChar(ss.str(), ch);
 	} else {
+		std::vector<where_format::WhereRow> rows;
 		for (const auto &i : character_list) {
 			if (CAN_SEE(ch, i)
 				&& i->in_room != kNowhere
 				&& isname(arg, i->GetCharAliases())) {
 				ZoneData *zone = &zone_table[world[i->in_room]->zone_rn];
 				found = 1;
-				ss << fmt::format("{:>3}. {} ({:>6}) {:<25} - [{:>7}] {}. Название зоны: '{}'\r\n",
-								  num++,
-								  i->IsNpc() ? "Моб:   " : "Игрок: ",
-								  GET_MOB_VNUM(i),
-								  GET_NAME(i),
-								  GET_ROOM_VNUM(i->in_room),
-								  world[i->in_room]->name,
-								  zone->name.c_str());
+				where_format::WhereRow row;
+				row.num = num++;
+				row.kind = i->IsNpc() ? where_format::ERowKind::kMob : where_format::ERowKind::kPlayer;
+				row.vnum = GET_MOB_VNUM(i);
+				row.name = GET_NAME(i);
+				row.location_lines.push_back(fmt::format("[{:>7}] {}. Зона: '{}'",
+						GET_ROOM_VNUM(i->in_room), world[i->in_room]->name, zone->name.c_str()));
+				rows.push_back(std::move(row));
 			}
 		}
-		SendMsgToChar(ss.str(), ch);
-		if (!PrintImmWhereObj(ch, arg, num) && !found) {
+		if (CollectWhereObjects(ch, arg, num, rows)) {
+			found = 1;
+		}
+		if (found) {
+			SendMsgToChar(where_format::FormatWhere(rows), ch);
+		} else {
 			SendMsgToChar("Нет ничего похожего.\r\n", ch);
 		}
 	}
@@ -79,25 +92,27 @@ void PerformImmortWhere(CharData *ch, char *arg) {
 
 /**
 * Иммский поиск шмоток по 'где' с проходом как по глобальному списку, так
-* и по спискам хранилищ и почты.
+* и по спискам хранилищ и почты. Собирает найденное в rows, продолжая
+* сквозную нумерацию из num; возвращает true, если что-то добавлено.
 */
-bool PrintImmWhereObj(CharData *ch, char *arg, int num) {
+static bool CollectWhereObjects(CharData *ch, char *arg, int &num, std::vector<where_format::WhereRow> &rows) {
 	bool found = false;
 
 	/* maybe it is possible to create some index instead of linear search */
 	world_objects.foreach([&](const ObjData::shared_ptr& object) {
 	  if (isname(arg, object->get_aliases())) {
-		  if (PrintObjectLocation(num, object.get(), ch)) {
-			  found = true;
-			  num++;
-		  }
+		  where_format::WhereRow row;
+		  row.num = num++;
+		  row.kind = where_format::ERowKind::kObject;
+		  row.vnum = GET_OBJ_VNUM(object.get());
+		  row.name = object->get_short_description();
+		  row.location_lines = ResolveObjLocationLines(object.get(), ch);
+		  rows.push_back(std::move(row));
+		  found = true;
 	  }
 	});
 
-	if (found) {
-		return true;
-	}
-	return false;
+	return found;
 }
 
 void PerformMortalWhere(CharData *ch, char *arg) {
@@ -156,85 +171,123 @@ void PerformMortalWhere(CharData *ch, char *arg) {
 	}
 }
 
+namespace {
+
+const char *RowKindLabel(where_format::ERowKind kind) {
+	switch (kind) {
+		case where_format::ERowKind::kMob: return "Моб";
+		case where_format::ERowKind::kPlayer: return "Игрок";
+		default: return "Вещь";
+	}
+}
+
+} // namespace
+
+std::string where_format::FormatWhere(const std::vector<WhereRow> &rows) {
+	int max_num = 0;
+	for (const auto &row : rows) {
+		max_num = std::max(max_num, row.num);
+	}
+	const int num_width = std::max(2, static_cast<int>(std::to_string(max_num).size()));
+
+	std::string out;
+	for (const auto &row : rows) {
+		const std::string prefix = fmt::format("{:>{}}. {:<5} [{:>7}] {:<25} - ",
+				row.num, num_width, RowKindLabel(row.kind), row.vnum, row.name);
+		// Отступ строк-продолжений = длине префикса, чтобы разделитель " - "
+		// встал ровно под разделителем первой строки.
+		const std::string cont = fmt::format("{:>{}}", " - ", static_cast<int>(prefix.size()));
+
+		out += prefix;
+		if (!row.location_lines.empty()) {
+			out += row.location_lines.front();
+		}
+		out += "\r\n";
+		for (std::size_t i = 1; i < row.location_lines.size(); ++i) {
+			out += cont;
+			out += row.location_lines[i];
+			out += "\r\n";
+		}
+	}
+	return out;
+}
+
+// Спец-локации предмета (базар / магазин / клан / депот / почта / иначе).
+// Возвращает одну строку без хвостового перевода строки.
+static std::string ResolveSpecialLocation(const ObjData *obj, CharData *ch) {
+	for (ExchangeItem *j = exchange_item_list; j; j = j->next) {
+		if (GET_EXCHANGE_ITEM(j)->get_unique_id() == obj->get_unique_id()) {
+			return fmt::format("продается на базаре, лот #{}", GET_EXCHANGE_ITEM_LOT(j));
+		}
+	}
+	for (const auto &shop : GlobalObjects::Shops()) {
+		if (shop->GetObjFromShop(obj->get_unique_id())) {
+			return fmt::format("можно купить в магазине: {}", shop->GetDictionaryName());
+		}
+	}
+	std::string str = Clan::print_imm_where_obj(obj);
+	if (str.empty()) {
+		str = Depot::print_imm_where_obj(obj);
+	}
+	if (str.empty()) {
+		str = Parcel::FindParcelObj(obj);
+	}
+	if (!str.empty()) {
+		// эти помощники возвращают строку с хвостовым "\r\n" - срезаем его,
+		// перевод строки добавит FormatWhere.
+		while (!str.empty() && (str.back() == '\r' || str.back() == '\n')) {
+			str.pop_back();
+		}
+		return str;
+	}
+	if (obj->get_in_room() == kNowhere) {
+		return "находится где-то там, далеко-далеко...";
+	}
+	return "расположение не найдено.";
+}
+
+// Разворачивает локацию предмета в строки без рекурсии: для предмета внутри
+// контейнера цепочка вложенности даёт несколько строк-продолжений.
+static std::vector<std::string> ResolveObjLocationLines(const ObjData *obj, CharData *ch) {
+	std::vector<std::string> lines;
+	for (const ObjData *cur = obj;;) {
+		if (cur->get_in_room() > kNowhere) {
+			lines.push_back(fmt::format("[{:>7}] {}",
+					GET_ROOM_VNUM(cur->get_in_room()), world[cur->get_in_room()]->name));
+			return lines;
+		}
+		if (cur->get_carried_by()) {
+			lines.push_back(fmt::format("затарено {} [{}] в комнате [{}]",
+					PERS(cur->get_carried_by(), ch, 4), GET_MOB_VNUM(cur->get_carried_by()),
+					world[cur->get_carried_by()->in_room]->vnum));
+			return lines;
+		}
+		if (cur->get_worn_by()) {
+			lines.push_back(fmt::format("надет на {} [{}] в комнате [{}]",
+					PERS(cur->get_worn_by(), ch, 3), GET_MOB_VNUM(cur->get_worn_by()),
+					world[cur->get_worn_by()->in_room]->vnum));
+			return lines;
+		}
+		if (cur->get_in_obj() && !Clan::is_clan_chest(cur->get_in_obj())) {// || Clan::is_ingr_chest(cur->get_in_obj())) сделать отдельный поиск
+			lines.push_back(fmt::format("лежит в [{}] {}, который находится",
+					GET_OBJ_VNUM(cur->get_in_obj()), cur->get_in_obj()->get_PName(ECase::kPre)));
+			cur = cur->get_in_obj();
+			continue;
+		}
+		lines.push_back(ResolveSpecialLocation(cur, ch));
+		return lines;
+	}
+}
+
 // возвращает true если объект был выведен
 bool PrintObjectLocation(int num, const ObjData *obj, CharData *ch) {
-	std::stringstream ss;
-	if (num > 0) {
-		ss << fmt::format("{:>2}. ", num);
-		if (ch->IsGrGod()) {
-			ss <<  fmt::format("[{:>7}] {:<25} - ", GET_OBJ_VNUM(obj), obj->get_short_description().c_str());
-		} else {
-			ss << fmt::format("{:<34} - ", obj->get_short_description().c_str());
-		}
-	} else {
-		ss << fmt::format("{:>41}", " - ");
-	}
-
-	if (obj->get_in_room() > kNowhere) {
-		ss << fmt::format("[{:>7}] {}", GET_ROOM_VNUM(obj->get_in_room()), world[obj->get_in_room()]->name);
-		ss << "\r\n";
-		SendMsgToChar(ss.str().c_str(), ch);
-	} else if (obj->get_carried_by()) {
-		ss << fmt::format("затарено {} [{}] в комнате [{}]", PERS(obj->get_carried_by(), ch, 4), GET_MOB_VNUM(obj->get_carried_by()),
-						  world[obj->get_carried_by()->in_room]->vnum);
-		ss << "\r\n";
-		SendMsgToChar(ss.str().c_str(), ch);
-	} else if (obj->get_worn_by()) {
-		ss << fmt::format("надет на {} [{}] в комнате [{}]", PERS(obj->get_worn_by(), ch, 3), GET_MOB_VNUM(obj->get_worn_by()),
-						  world[obj->get_worn_by()->in_room]->vnum);
-		ss << "\r\n";
-		SendMsgToChar(ss.str().c_str(), ch);
-	} else if (obj->get_in_obj() && !Clan::is_clan_chest(obj->get_in_obj())) {// || Clan::is_ingr_chest(obj->get_in_obj())) сделать отдельный поиск
-		ss << fmt::format("лежит в [{}] {}, который находится \r\n",
-				GET_OBJ_VNUM(obj->get_in_obj()), obj->get_in_obj()->get_PName(ECase::kPre).c_str());
-		SendMsgToChar(ss.str().c_str(), ch);
-		PrintObjectLocation(0, obj->get_in_obj(), ch);
-	} else {
-		for (ExchangeItem *j = exchange_item_list; j; j = j->next) {
-			if (GET_EXCHANGE_ITEM(j)->get_unique_id() == obj->get_unique_id()) {
-				ss << fmt::format("продается на базаре, лот #{}\r\n", GET_EXCHANGE_ITEM_LOT(j));
-				SendMsgToChar(ss.str().c_str(), ch);
-				return true;
-			}
-		}
-		for (const auto &shop : GlobalObjects::Shops()) {
-			const auto tmp_obj = shop->GetObjFromShop(obj->get_unique_id());
-			if (!tmp_obj) {
-				continue;
-			}
-			ss << fmt::format("можно купить в магазине: {}\r\n", shop->GetDictionaryName());
-			SendMsgToChar(ss.str().c_str(), ch);
-			return true;
-		}
-		std::string str = Clan::print_imm_where_obj(obj);
-
-		if (!str.empty()) {
-			ss << str;
-			SendMsgToChar(ss.str().c_str(), ch);
-			return true;
-		}
-		str = Depot::print_imm_where_obj(obj);
-		if (!str.empty()) {
-			ss << str;
-			SendMsgToChar(ss.str().c_str(), ch);
-			return true;
-		}
-		str = Parcel::FindParcelObj(obj);
-		if (!str.empty()) {
-			ss << str;
-			SendMsgToChar(ss.str().c_str(), ch);
-			return true;
-		}
-		if (obj->get_in_room() == kNowhere) {
-			ss << "находится где-то там, далеко-далеко...\r\n";
-			SendMsgToChar(ss.str().c_str(), ch);
-		} else {
-			ss << "расположение не найдено.\r\n";
-			SendMsgToChar(ss.str().c_str(), ch);
-		}
-		return true;
-	}
-
+	where_format::WhereRow row;
+	row.num = num;
+	row.kind = where_format::ERowKind::kObject;
+	row.vnum = GET_OBJ_VNUM(obj);
+	row.name = obj->get_short_description();
+	row.location_lines = ResolveObjLocationLines(obj, ch);
+	SendMsgToChar(where_format::FormatWhere({row}), ch);
 	return true;
 }
 

--- a/src/engine/ui/cmd/do_where.h
+++ b/src/engine/ui/cmd/do_where.h
@@ -5,10 +5,41 @@
 #ifndef BYLINS_SRC_CMD_WHERE_H_
 #define BYLINS_SRC_CMD_WHERE_H_
 
+#include <string>
+#include <vector>
+
 class CharData;
+class ObjData;
 
 void DoWhere(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/);
 void DoFindObjByRnum(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/);
+
+// Форматирование вывода команды 'где'. Вынесено сюда (без зависимостей от
+// состояния мира), чтобы покрыть вёрстку юнит-тестами; см. tests/where.format.cpp.
+namespace where_format {
+
+enum class ERowKind {
+	kMob,
+	kPlayer,
+	kObject
+};
+
+// Одна строка результата 'где' с уже разрезолвленной локацией.
+// location_lines: первая строка печатается после разделителя " - ",
+// остальные - выровненными строками-продолжениями (вложенные контейнеры).
+struct WhereRow {
+	int num = 0;
+	ERowKind kind = ERowKind::kObject;
+	int vnum = 0;
+	std::string name;
+	std::vector<std::string> location_lines;
+};
+
+// Рендерит весь блок вывода 'где' единой колоночной сеткой:
+//   {num}. {Моб|Игрок|Вещь} [{vnum}] {имя} - {локация}
+std::string FormatWhere(const std::vector<WhereRow> &rows);
+
+} // namespace where_format
 
 #endif //BYLINS_SRC_CMD_WHERE_H_
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -55,7 +55,8 @@ test_sources = files(
     'skill_messages.cpp',
     'fight_messages.cpp',
     'file_crc.cpp',
-    'buffered_file_writer.cpp'
+    'buffered_file_writer.cpp',
+    'where.format.cpp'
 )
 
 fs = import('fs')

--- a/tests/where.format.cpp
+++ b/tests/where.format.cpp
@@ -1,0 +1,139 @@
+// Тесты вёрстки вывода команды "где" (where_format::FormatWhere).
+// Проверяется весь блок вывода целиком: строка моба + строки предметов +
+// строка-продолжение для предмета внутри контейнера.
+//
+// Кодировка KOI8-R: кириллица здесь однобайтовая, поэтому байтовая длина
+// строки == ширине колонки, и индексная арифметика ниже корректна.
+
+#include "engine/ui/cmd/do_where.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+using where_format::ERowKind;
+using where_format::FormatWhere;
+using where_format::WhereRow;
+
+std::vector<std::string> SplitLines(const std::string &s) {
+	std::vector<std::string> out;
+	std::size_t pos = 0;
+	std::size_t nl;
+	while ((nl = s.find("\r\n", pos)) != std::string::npos) {
+		out.push_back(s.substr(pos, nl - pos));
+		pos = nl + 2;
+	}
+	if (pos < s.size()) {
+		out.push_back(s.substr(pos));
+	}
+	return out;
+}
+
+WhereRow Mob(int num, int vnum, std::string name, std::string loc) {
+	WhereRow r;
+	r.num = num;
+	r.kind = ERowKind::kMob;
+	r.vnum = vnum;
+	r.name = std::move(name);
+	r.location_lines.push_back(std::move(loc));
+	return r;
+}
+
+WhereRow Obj(int num, int vnum, std::string name, std::vector<std::string> locs) {
+	WhereRow r;
+	r.num = num;
+	r.kind = ERowKind::kObject;
+	r.vnum = vnum;
+	r.name = std::move(name);
+	r.location_lines = std::move(locs);
+	return r;
+}
+
+// Сценарий из бага: моб с длинным именем + предметы, среди них предмет
+// в контейнере (даёт строку-продолжение с локацией контейнера).
+std::vector<WhereRow> SampleRows() {
+	std::vector<WhereRow> rows;
+	rows.push_back(Mob(1, 85106, "князь Всеволод Большое Гнездо",
+			"[  85132] Княжьи терема. Зона: 'Ростов Великий'"));
+	rows.push_back(Obj(2, 28602, "гнездо сороки", {"[  28675] На ели"}));
+	rows.push_back(Obj(4, 6505, "хрупкое гнездо с птенцами",
+			{"лежит в [6503] сухом дереве, который находится", "[   6510] На краю оврага"}));
+	rows.push_back(Obj(10, 8507, "гнездо", {"[   8592] На дереве"}));
+	return rows;
+}
+
+// Индексы строк в выводе SampleRows():
+//   0 - моб (имя 29 симв., длиннее поля)
+//   1 - "гнездо сороки"
+//   2 - предмет в контейнере (имя ровно 25 симв.)
+//   3 - строка-продолжение (локация контейнера)
+//   4 - "гнездо"
+
+} // namespace
+
+// Каждая строка завершается \r\n и не имеет хвостового пробела (регрессия:
+// раньше строка "...который находится \r\n" несла лишний пробел).
+TEST(WhereFormat, NoTrailingSpace) {
+	const auto out = FormatWhere(SampleRows());
+	ASSERT_NE(out.find("\r\n"), std::string::npos);
+	for (const auto &line : SplitLines(out)) {
+		ASSERT_FALSE(line.empty());
+		EXPECT_NE(line.back(), ' ') << "хвостовой пробел в строке: [" << line << "]";
+	}
+}
+
+// Разделитель " - " (а значит и колонка локации) совпадает у всех строк
+// с именем <= 25 символов и у строки-продолжения контейнера.
+// Регрессия: продолжение печаталось на 1 колонку левее.
+TEST(WhereFormat, LocationColumnAligned) {
+	const auto lines = SplitLines(FormatWhere(SampleRows()));
+	ASSERT_GE(lines.size(), 5u);
+
+	const auto ref = lines[1].rfind(" - ");
+	ASSERT_NE(ref, std::string::npos);
+	EXPECT_EQ(lines[2].rfind(" - "), ref) << "предмет с именем ровно 25 симв.";
+	EXPECT_EQ(lines[3].rfind(" - "), ref) << "строка-продолжение контейнера";
+	EXPECT_EQ(lines[4].rfind(" - "), ref) << "короткое имя";
+
+	// Имя моба (29 симв.) длиннее поля в 25 -> разделитель уезжает вправо на 4.
+	EXPECT_EQ(lines[0].rfind(" - "), ref + 4);
+}
+
+// Предмет в контейнере даёт ровно две строки: первая оканчивается на
+// "находится" (без рекурсии и без хвостового пробела), вторая - локация контейнера.
+TEST(WhereFormat, ContainerYieldsContinuation) {
+	const auto lines = SplitLines(FormatWhere(SampleRows()));
+	ASSERT_GE(lines.size(), 5u);
+
+	EXPECT_NE(lines[2].find("лежит в [6503] сухом дереве, который находится"), std::string::npos);
+	const std::string tail = "находится";
+	ASSERT_GE(lines[2].size(), tail.size());
+	EXPECT_EQ(lines[2].compare(lines[2].size() - tail.size(), tail.size(), tail), 0);
+
+	EXPECT_NE(lines[3].find("[   6510] На краю оврага"), std::string::npos);
+}
+
+// Номера выровнены в одну колонку (точка после номера на одной позиции
+// у однозначных и двузначных номеров). Регрессия: у моба номер был шире.
+TEST(WhereFormat, NumberColumnAligned) {
+	const auto lines = SplitLines(FormatWhere(SampleRows()));
+	ASSERT_GE(lines.size(), 5u);
+	for (int i : {0, 1, 2, 4}) {
+		ASSERT_GT(lines[i].size(), 3u);
+		EXPECT_EQ(lines[i][2], '.') << "номер не выровнен в строке " << i;
+	}
+}
+
+// Колонка типа: моб/предмет подписаны, у моба в хвосте зона.
+TEST(WhereFormat, RowKindLabels) {
+	const auto lines = SplitLines(FormatWhere(SampleRows()));
+	ASSERT_GE(lines.size(), 2u);
+	EXPECT_NE(lines[0].find("Моб"), std::string::npos);
+	EXPECT_NE(lines[0].find("Зона: '"), std::string::npos);
+	EXPECT_NE(lines[1].find("Вещь"), std::string::npos);
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
Closes #3376.

Команда `где` печатала мобов и предметы разной вёрсткой, а предмет внутри контейнера выводился криво. Было:

```
  1. Моб:    ( 85106) князь Всеволод Большое Гнездо - [  85132] Княжьи терема. Название зоны: 'Ростов Великий'
 2. [  28602] гнездо сороки             - [  28675] На ели
 4. [   6505] хрупкое гнездо с птенцами - лежит в [6503] сухом дереве, который находится 
                                       - [   6510] На краю оврага
```

Стало:

```
 1. Моб   [  85106] князь Всеволод Большое Гнездо - [  85132] Княжьи терема. Зона: 'Ростов Великий'
 2. Вещь  [  28602] гнездо сороки             - [  28675] На ели
 4. Вещь  [   6505] хрупкое гнездо с птенцами - лежит в [6503] сухом дереве, который находится
                                              - [   6510] На краю оврага
```

## Что сделано

- **Единая колоночная сетка** `{num}. {Моб|Игрок|Вещь} [vnum] {имя} - {локация}`: номера, тип, vnum, имя и локация выровнены у мобов и предметов (раньше у моба номер был 3-значный против 2-значного у предметов, а колонки имени/локации не совпадали).
- **Убрана рекурсия**: цепочка вложенных контейнеров разворачивается циклом в `ResolveObjLocationLines`, каждый уровень — отдельная выровненная строка-продолжение.
- **Починен контейнерный вывод**: убран хвостовой пробел перед `\r\n`; ширина строки-продолжения выводится из длины префикса, поэтому разделитель `-` встаёт ровно под верхним.
- **Шов под тесты**: форматирование вынесено в `where_format::FormatWhere` (без зависимостей от состояния мира) — `do_where.h`.
- Спец-локации (базар/магазин/клан/депот/почта) срезают свой хвостовой `\r\n`.

## Поведение

Предметы теперь **всегда** показывают vnum (раньше — только для GrGod) и подписаны как `Вещь` — это нужно для общей сетки, т.к. строки мобов vnum показывали всегда. Длинные имена (>25 символов, как у князя) по-прежнему выпирают вправо без обрезки.

## Тесты

`tests/where.format.cpp` — 5 проверок на весь блок вывода (не одну строку): отсутствие хвостовых пробелов, выравнивание колонки локации (включая строку-продолжение), контейнер из ровно двух строк с `находится` на конце, выравнивание номеров, метки типов. Все зелёные.
