### PR TITLE
fix(reset): пишем "В списке репопа" до сброса зоны

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -2066,9 +2066,10 @@ void ZoneUpdate() {
 					}
 				}
 			}
-			std::stringstream ss;
 			DecayObjectsOnRepop(zone_repop_list);
-			ss << "В списке репопа: " << zone_table[zone].vnum << " ";
+			// Логируем попадание в список репопа до самого сброса, иначе строка
+			// печатается уже после "Stop zone" этой зоны (см. issue #3380).
+			mudlog(fmt::format("В списке репопа: {} ", zone_table[zone].vnum), LGH, kLvlGod, SYSLOG, true);
 			if (zone_table[zone].vnum < dungeons::kZoneStartDungeons) {
 				ResetZone(zone);
 				zones_reset_count++;
@@ -2081,7 +2082,6 @@ void ZoneUpdate() {
 				zone_table[zone].time_awake = time(nullptr);
 				zone_table[zone].first_enter.clear();
 			}
-			mudlog(ss.str(), LGH, kLvlGod, SYSLOG, true);
 			out << " ]\r\n[ Time reset: " << fmt::format("{:.3f} ms", timer_count.delta().count() * 1000.0);
 			mudlog(out.str(), LGH, kLvlGod, SYSLOG, true);
 			it = reset_q.erase(it);


### PR DESCRIPTION
Closes #3380

## Проблема
В логе репопа строка `В списке репопа: N` печаталась не в тему — уже **после** того, как зона сброшена:

```
[Reset] Stop zone (916) Рипейские горы - дорога к ирию
В списке репопа: 916                 <- зона уже сброшена
Auto zone reset: ... (916) ]
[ Time reset: 3.050 ms
[Reset] Start zone (918) ...
```

## Причина
В `ZoneUpdate()` (`src/engine/db/db.cpp`) сообщение собиралось в `std::stringstream ss` до вызова `ResetZone()`, но `mudlog(ss.str(), ...)` стоял **после** блока сброса. `ResetZone()` внутри пишет свои `[Reset] Start/Stop zone`, поэтому отложенный вывод оказывался после них.

## Фикс
Логируем `В списке репопа: N` сразу после `DecayObjectsOnRepop()` и **до** `ResetZone()`, лишний `stringstream` убран. Порядок становится логичным:

```
В списке репопа: 916
[Reset] Start zone (916) ...
[Reset] Stop zone (916) ...
Auto zone reset: ... (916) ] [ Time reset: ... ms
[Reset] Start zone (918) ...
```

Поведение `Auto zone reset / Time reset` не трогал — оно и должно идти после сброса (там тайминг).

Собрано и слинковано локально (`ninja -C build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)