### PR TITLE
feat(vnum): поиск предметов по фильтру (vnum f ...)

### DIFF
--- a/src/engine/ui/cmd_god/do_tabulate.cpp
+++ b/src/engine/ui/cmd_god/do_tabulate.cpp
@@ -5,19 +5,28 @@
 #include "engine/entities/char_data.h"
 #include "gameplay/magic/magic_utils.h"
 #include "engine/ui/modify.h"
+#include "engine/ui/objects_filter.h"
 #include "engine/db/obj_prototypes.h"
 #include "engine/olc/olc.h"
 #include "engine/db/global_objects.h"
 #include "utils/utils_string.h"
+#include "utils/utils_time.h"
 
 #include <fmt/format.h>
 
 int TabulateMobsByName(char *searchname, CharData *ch);
 int TabulateObjsByAliases(char *searchname, CharData *ch);
 int TabulateObjsByFlagName(char *searchname, CharData *ch);
+int TabulateObjsByFilter(char *argument, CharData *ch);
 int TabulateRoomsByName(char *searchname, CharData *ch);
 int TabulateTrigsByObjLoad(char *searchname, CharData *ch);
 int TabulateMobsByDeadLoad(char *vnum, CharData *ch);
+
+// Поиск по фильтру (vnum f ...) совпадает с сокращением "f" слова "filter",
+// поэтому проверяется до "flag" -- иначе одиночное "f" ушло бы во флаги.
+static bool IsFilterKey(const char *str) {
+	return utils::IsAbbr(str, "filter") || !str_cmp(str, "фильтр");
+}
 
 void DoTabulate(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	half_chop(argument, buf, buf2);
@@ -27,6 +36,7 @@ void DoTabulate(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			&& !utils::IsAbbr(buf, "obj")
 			&& !utils::IsAbbr(buf, "room")
 			&& !utils::IsAbbr(buf, "flag")
+			&& !IsFilterKey(buf)
 			&& !utils::IsAbbr(buf, "существо")
 			&& !utils::IsAbbr(buf, "предмет")
 			&& !utils::IsAbbr(buf, "флаг")
@@ -34,7 +44,9 @@ void DoTabulate(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			&& !utils::IsAbbr(buf, "trig")
 			&& !utils::IsAbbr(buf, "триггер")
 			&& !utils::IsAbbr(buf, "load"))) {
-		SendMsgToChar("Usage: vnum { obj | mob | flag | room | trig | load} <name>\r\n", ch);
+		SendMsgToChar("Usage: vnum { obj | mob | flag | f | room | trig | load} <name>\r\n"
+					  "  f <фильтр> -- поиск предметов по фильтру (как в хранилище клана),\r\n"
+					  "                например: vnum f Адлительность\r\n", ch);
 		return;
 	}
 
@@ -42,37 +54,61 @@ void DoTabulate(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		if (!TabulateMobsByName(buf2, ch)) {
 			SendMsgToChar("Нет существа с таким именем.\r\n", ch);
 		}
-	}
-
-	if ((utils::IsAbbr(buf, "obj")) || (utils::IsAbbr(buf, "предмет"))) {
+	} else if ((utils::IsAbbr(buf, "obj")) || (utils::IsAbbr(buf, "предмет"))) {
 		if (!TabulateObjsByAliases(buf2, ch)) {
 			SendMsgToChar("Нет предмета с таким названием.\r\n", ch);
 		}
-	}
-
-	if ((utils::IsAbbr(buf, "flag")) || (utils::IsAbbr(buf, "флаг"))) {
+	} else if (IsFilterKey(buf)) {
+		TabulateObjsByFilter(buf2, ch);
+	} else if ((utils::IsAbbr(buf, "flag")) || (utils::IsAbbr(buf, "флаг"))) {
 		if (!TabulateObjsByFlagName(buf2, ch)) {
 			SendMsgToChar("Нет объектов с таким флагом.\r\n", ch);
 		}
-	}
-
-	if ((utils::IsAbbr(buf, "room")) || (utils::IsAbbr(buf, "комната"))) {
+	} else if ((utils::IsAbbr(buf, "room")) || (utils::IsAbbr(buf, "комната"))) {
 		if (!TabulateRoomsByName(buf2, ch)) {
 			SendMsgToChar("Нет объектов с таким флагом.\r\n", ch);
 		}
-	}
-
-	if (utils::IsAbbr(buf, "trig") || utils::IsAbbr(buf, "триггер")) {
+	} else if (utils::IsAbbr(buf, "trig") || utils::IsAbbr(buf, "триггер")) {
 		if (!TabulateTrigsByObjLoad(buf2, ch)) {
 			SendMsgToChar("Нет триггеров, загружающих такой объект.\r\n", ch);
 		}
-	}
-
-	if (utils::IsAbbr(buf, "load") || utils::IsAbbr(buf, "загрузка")) {
+	} else if (utils::IsAbbr(buf, "load") || utils::IsAbbr(buf, "загрузка")) {
 		if (!TabulateMobsByDeadLoad(buf2, ch)) {
 			SendMsgToChar("Нет мобов, загружаюющих такой объект по списку dead load.\r\n", ch);
 		}
 	}
+}
+
+// Поиск прототипов предметов через ParseFilter (те же фильтры, что в хранилище
+// клана и на базаре). Последней строкой печатает время поиска.
+int TabulateObjsByFilter(char *argument, CharData *ch) {
+	ParseFilter filter(ParseFilter::CLAN);
+	if (!filter.parse_filter(ch, filter, argument)) {
+		// parse_filter сам сообщил об ошибке или показал справку по фильтрам.
+		return 0;
+	}
+
+	utils::CExecutionTimer timer;
+	int found = 0;
+	std::string out;
+	char line[kMaxStringLength];
+	for (const auto &i : obj_proto) {
+		// ch не передаём: у прототипов нет наносимых меток (custom label).
+		if (filter.check(i.get(), nullptr)) {
+			snprintf(line, sizeof(line), "%3d. [%7d] %-50s %s\r\n",
+					 ++found, i->get_vnum(),
+					 utils::RemoveColors(i->get_short_description()).c_str(),
+					 filter.show_obj_aff(i.get()).c_str());
+			out += line;
+		}
+	}
+	if (found == 0) {
+		out += "Ничего не найдено.\r\n";
+	}
+	out += fmt::format("Просмотрено прототипов: {}, найдено: {}, время поиска: {:.3f} мс.\r\n",
+					   obj_proto.size(), found, timer.delta().count() * 1000.0);
+	page_string(ch->desc, out);
+	return found;
 }
 
 int TabulateMobsByName(char *searchname, CharData *ch) {

--- a/src/engine/ui/objects_filter.cpp
+++ b/src/engine/ui/objects_filter.cpp
@@ -96,7 +96,7 @@ ENoFlag class_specific_no_flag(ECharClass c) {
 // независимо запрещают использование, и в display даже именованы
 // по-разному -- "Недоступен" / "Неудобен", -- но игроку оба запрещают
 // носить (#3269).
-bool obj_blocked_for_class(const ObjData *obj, ECharClass c) {
+bool obj_blocked_for_class(const CObjectPrototype *obj, ECharClass c) {
 	if (obj->has_anti_flag(EAntiFlag::kMage) && is_magic_class(c)) {
 		return true;
 	}
@@ -507,7 +507,7 @@ bool ParseFilter::init_affect(char *str, size_t str_len) {
 }
 
 /// имя, метка для клан-хранов
-bool ParseFilter::check_name(ObjData *obj, CharData *ch) const {
+bool ParseFilter::check_name(const CObjectPrototype *obj, CharData *ch) const {
 	bool result = false;
 	char name_obj[kMaxStringLength];
 	strcpy(name_obj, obj->get_PName(ECase::kNom).c_str());
@@ -522,14 +522,14 @@ bool ParseFilter::check_name(ObjData *obj, CharData *ch) const {
 		result = true;
 	} else if (ch
 		&& filter_type == CLAN
-		&& CHECK_CUSTOM_LABEL(name, obj, ch)) {
+		&& CHECK_CUSTOM_LABEL(name, static_cast<const ObjData *>(obj), ch)) {
 		result = true;
 	}
 
 	return result;
 }
 
-bool ParseFilter::check_type(ObjData *obj) const {
+bool ParseFilter::check_type(const CObjectPrototype *obj) const {
 	if (type < 0
 		|| type == obj->get_type()) {
 		return true;
@@ -538,7 +538,7 @@ bool ParseFilter::check_type(ObjData *obj) const {
 	return false;
 }
 
-bool ParseFilter::check_state(ObjData *obj) const {
+bool ParseFilter::check_state(const CObjectPrototype *obj) const {
 	bool result = false;
 	if (state < 0) {
 		result = true;
@@ -569,7 +569,7 @@ bool ParseFilter::check_state(ObjData *obj) const {
 	return result;
 }
 
-bool ParseFilter::check_skill(ObjData *obj) const {
+bool ParseFilter::check_skill(const CObjectPrototype *obj) const {
 	if (skill_id == ESkill::kUndefined)
 		return true;
 	if (obj->has_skills()) {
@@ -581,13 +581,13 @@ bool ParseFilter::check_skill(ObjData *obj) const {
 	return false;
 }
 
-bool ParseFilter::check_profession(ObjData *obj) const {
+bool ParseFilter::check_profession(const CObjectPrototype *obj) const {
 	if (profession == ECharClass::kUndefined)
 		return true;
 	return !obj_blocked_for_class(obj, profession);
 }
 
-bool ParseFilter::check_wear(ObjData *obj) const {
+bool ParseFilter::check_wear(const CObjectPrototype *obj) const {
 	if (wear == EWearFlag::kUndefined
 		|| CAN_WEAR(obj, wear)) {
 		return true;
@@ -595,7 +595,7 @@ bool ParseFilter::check_wear(ObjData *obj) const {
 	return false;
 }
 
-bool ParseFilter::check_weap_class(ObjData *obj) const {
+bool ParseFilter::check_weap_class(const CObjectPrototype *obj) const {
 	if (MUD::Skills().IsInvalid(weap_class) || weap_class == static_cast<ESkill>(obj->get_spec_param())) {
 		return true;
 	}
@@ -628,7 +628,7 @@ bool ParseFilter::check_rent(int obj_price) const {
 	return result;
 }
 
-bool ParseFilter::check_remorts(ObjData *obj) const {
+bool ParseFilter::check_remorts(const CObjectPrototype *obj) const {
 	int obj_remorts = 0;
 
 	if (obj->get_minimum_remorts() != 0) {
@@ -661,7 +661,7 @@ bool ParseFilter::check_remorts(ObjData *obj) const {
 	return false;
 }
 
-bool ParseFilter::check_affect_weap(ObjData *obj) const {
+bool ParseFilter::check_affect_weap(const CObjectPrototype *obj) const {
 	if (!affect_weap.empty()) {
 		for (auto it = affect_weap.begin(); it != affect_weap.end(); ++it) {
 			if (!CompareBits(obj->get_affect_flags(), weapon_affects, *it)) {
@@ -672,7 +672,7 @@ bool ParseFilter::check_affect_weap(ObjData *obj) const {
 	return true;
 }
 
-std::string ParseFilter::show_obj_aff(ObjData *obj) {
+std::string ParseFilter::show_obj_aff(const CObjectPrototype *obj) {
 	if (!affect_apply.empty()) {
 		for (auto it = affect_apply.begin(); it != affect_apply.end(); ++it) {
 			for (int i = 0; i < kMaxObjAffect; ++i) {
@@ -697,7 +697,7 @@ std::string ParseFilter::show_obj_aff(ObjData *obj) {
 	return " ";
 }
 
-bool ParseFilter::check_affect_apply(ObjData *obj) const {
+bool ParseFilter::check_affect_apply(const CObjectPrototype *obj) const {
 	bool result = true;
 	if (!affect_apply.empty()) {
 		for (auto it = affect_apply.begin(); it != affect_apply.end() && result; ++it) {
@@ -713,7 +713,7 @@ bool ParseFilter::check_affect_apply(ObjData *obj) const {
 	return result;
 }
 
-bool ParseFilter::check_affect_extra(ObjData *obj) const {
+bool ParseFilter::check_affect_extra(const CObjectPrototype *obj) const {
 	if (!affect_extra.empty()) {
 		for (auto it = affect_extra.begin(); it != affect_extra.end(); ++it) {
 			if (!CompareBits(obj->get_extra_flags(), extra_bits, *it)) {
@@ -748,7 +748,7 @@ bool ParseFilter::check_realtime(ExchangeItem *exch_obj) const {
 	return result;
 }
 
-bool ParseFilter::check(ObjData *obj, CharData *ch) {
+bool ParseFilter::check(const CObjectPrototype *obj, CharData *ch) {
 	if (check_name(obj, ch)
 		&& check_type(obj)
 		&& check_state(obj)

--- a/src/engine/ui/objects_filter.h
+++ b/src/engine/ui/objects_filter.h
@@ -20,6 +20,7 @@
 class CharData;
 struct ExchangeItem;
 class ObjData;
+class CObjectPrototype;
 
 
 // для парса строки с фильтрами в клан-хранах и базаре
@@ -43,7 +44,7 @@ struct ParseFilter {
 	bool init_realtime(const char *str);
 	bool init_profession(const char *str);
 	size_t affects_cnt() const;
-	bool check(ObjData *obj, CharData *ch);
+	bool check(const CObjectPrototype *obj, CharData *ch);
 	bool check(ExchangeItem *exch_obj);
 	bool parse_filter(const CharData *ch, ParseFilter &filter, const char *argument);
 	bool init_skill(char*);
@@ -51,7 +52,7 @@ struct ParseFilter {
 	std::string print() const;
 	std::string name;      // имя предмета
 	std::string owner;     // имя продавца (базар)
-	std::string show_obj_aff(ObjData *obj);
+	std::string show_obj_aff(const CObjectPrototype *obj);
 
  private:
 	std::vector<int> affect_apply; // аффекты apply_types
@@ -75,21 +76,21 @@ struct ParseFilter {
 	int filter_type;       // CLAN/EXCHANGE
 	ESkill skill_id;
 	ECharClass profession; // профессия (фильтр анти-классов на предмете)
-	bool check_name(ObjData *obj, CharData *ch = nullptr) const;
-	bool check_type(ObjData *obj) const;
-	bool check_state(ObjData *obj) const;
-	bool check_wear(ObjData *obj) const;
-	bool check_weap_class(ObjData *obj) const;
+	bool check_name(const CObjectPrototype *obj, CharData *ch = nullptr) const;
+	bool check_type(const CObjectPrototype *obj) const;
+	bool check_state(const CObjectPrototype *obj) const;
+	bool check_wear(const CObjectPrototype *obj) const;
+	bool check_weap_class(const CObjectPrototype *obj) const;
 	bool check_cost(int obj_price) const;
 	bool check_rent(int obj_price) const;
-	bool check_remorts(ObjData *obj) const;
-	bool check_affect_weap(ObjData *obj) const;
-	bool check_affect_apply(ObjData *obj) const;
-	bool check_affect_extra(ObjData *obj) const;
+	bool check_remorts(const CObjectPrototype *obj) const;
+	bool check_affect_weap(const CObjectPrototype *obj) const;
+	bool check_affect_apply(const CObjectPrototype *obj) const;
+	bool check_affect_extra(const CObjectPrototype *obj) const;
 	bool check_owner(ExchangeItem *exch_obj) const;
 	bool check_realtime(ExchangeItem *exch_obj) const;
-	bool check_skill(ObjData *obj) const;
-	bool check_profession(ObjData *obj) const;
+	bool check_skill(const CObjectPrototype *obj) const;
+	bool check_profession(const CObjectPrototype *obj) const;
 };
 
 #endif //BYLINS_SRC_UTILS_OBJECTS_FILTER_H_


### PR DESCRIPTION
Closes #3382

## Что сделано
Добавил подкоманду `vnum f <фильтр>` — поиск прототипов предметов через `ParseFilter` (`src/engine/ui/objects_filter.*`), те же фильтры, что в хранилище клана и на базаре:

| Ключ | Что фильтрует |
|------|----------------|
| `Т` | тип предмета | 
| `С` | состояние |
| `О` | место одевания |
| `К` | класс оружия |
| `А` | название аффекта (до трёх `Аxxx`, есть короткие `А1/А2/А3` для слотов под камни) |
| `Ц` | цена (`+`/`-`) |
| `Р` | рента (`+`/`-`) |
| `М` | морты (`+`/`-`/`=`) |
| `У` | умение |
| `П` | профессия (отсекает запрещённые классу) |
| `И` | имя |

Например: `vnum f Адлительность`, `vnum f Т оружие К секиры`, `vnum f П воин`.

## Как прикручены фильтры
`obj_proto` хранит `CObjectPrototype` (обычные предметы — `ObjData`, крафтовые — `CObject`), а `ParseFilter::check`/`check_*`/`show_obj_aff` принимали `ObjData*`. Обобщил их сигнатуры до `const CObjectPrototype*`:
- все методы, которые они вызывают, есть в базовом классе `CObjectPrototype`;
- существующие вызовы из `exchange.cpp` и `house.cpp` передают `ObjData*` → апкаст, правок не требуют (полный билд линкуется);
- ветка с `CHECK_CUSTOM_LABEL` (метки игрока) выполняется только при `ch != nullptr` (реальные предметы клана/базара), там оставлен `static_cast` к `ObjData*`. Для прототипов в `vnum f` передаётся `ch = nullptr`, поэтому ветка не задействуется.

## Нюанс с `f`
`f` — сокращение и `filter`, и `flag`. Подкоманда фильтра проверяется до `flag`, так что одиночное `vnum f` уходит в фильтр (как в задаче), а русское `vnum ф` по-прежнему во флаги (`фильтр` целиком — тоже фильтр). Заодно цепочка `if` переведена в `else if`, чтобы не было двойного срабатывания.

## Время поиска
Последней строкой, как просили, выводится: `Просмотрено прототипов: N, найдено: M, время поиска: X.XXX мс.` (через `utils::CExecutionTimer`).

Собрано и слинковано локально (`ninja -C build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)