### PR TITLE
fix(yaml,sqlite): выставляем dest_count при загрузке маршрутов мобов

### DIFF
--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -1842,6 +1842,12 @@ void SqliteWorldDataSource::LoadMobDestinations()
 		if (dest_order >= 0 && dest_order < static_cast<int>(mob.mob_specials.dest.size()))
 		{
 			mob.mob_specials.dest[dest_order] = room_vnum;
+			// Без dest_count маршрут не виден ни в stat, ни в спецпроке движения
+			// (как в legacy-парсере boot_data_files.cpp). Issue #3384.
+			if (dest_order + 1 > mob.mob_specials.dest_count)
+			{
+				mob.mob_specials.dest_count = dest_order + 1;
+			}
 			destinations_set++;
 		}
 	}

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1693,13 +1693,16 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 			int idx = 0;
 			for (const auto &dest_node : enhanced["destinations"])
 			{
-				int room_vnum = dest_node.as<int>();
-				if (idx < static_cast<int>(mob.mob_specials.dest.size()))
+				if (idx >= static_cast<int>(mob.mob_specials.dest.size()))
 				{
-					mob.mob_specials.dest[idx] = room_vnum;
+					break;
 				}
+				mob.mob_specials.dest[idx] = dest_node.as<int>();
 				idx++;
 			}
+			// Без dest_count маршрут не виден ни в stat, ни в спецпроке движения
+			// (как в legacy-парсере boot_data_files.cpp). Issue #3384.
+			mob.mob_specials.dest_count = idx;
 		}
 	}
 


### PR DESCRIPTION
Closes #3384

## Проблема
У моба (например, 97919) точки маршрута есть в ямл-файле, но `stat` их не показывает — «по стату в ямле нет, хотя в файле есть».

## Причина
В `yaml_world_data_source.cpp` (и в `sqlite_world_data_source.cpp`) загрузчик заполнял массив `mob_specials.dest[]`, но **не выставлял `mob_specials.dest_count`**. А все потребители маршрута считают точки именно по `dest_count`:
- `do_stat.cpp:468` — вывод маршрута в stat;
- `spec_procs.cpp:786` — спецпрок движения моба;
- `dungeons.cpp:562` — данжи.

Поэтому `dest[]` был заполнен, но `dest_count` оставался 0 → маршрут «невидим» и не работал. Legacy-парсер (`boot_data_files.cpp`, `CASE("Destination")`) `dest_count` инкрементирует — отсюда расхождение.

## Фикс
- **YAML**: после чтения `enhanced.destinations` выставляем `dest_count = idx` (число прочитанных точек), заодно аккуратнее обрезаем по размеру `dest` через `break`.
- **SQLite**: при заполнении `dest[dest_order]` поднимаем `dest_count` до `dest_order + 1`.

`dest_count` у прототипов зануляется (`mob_specials = {}` в конструкторе `CharData`), так что начальное значение корректно.

Собрано и слинковано локально (`ninja -C build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)