### PR TITLE
fix(yaml): сохраняем и читаем умения предметов в YAML

### DIFF
--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -2145,6 +2145,18 @@ CObjectPrototype* YamlWorldDataSource::ParseObjectFile(const std::string &file_p
 				}
 			}
 
+			// Умения предмета (legacy S-строки). Без этой секции предметы,
+			// дающие умения, грузились из YAML без них (issue #3386).
+			if (root["skills"] && root["skills"].IsSequence())
+			{
+				for (const auto &skill_node : root["skills"])
+				{
+					int skill_id = GetInt(skill_node, "skill_id", 0);
+					int value = GetInt(skill_node, "value", 0);
+					obj_ptr->set_skill(static_cast<ESkill>(skill_id), value);
+				}
+			}
+
 			// Extra values (V-строки): данные зелий и контейнеров с жидкостью.
 			// Без чтения этой секции зелья в YAML-мире выходят без заклинаний (issue #3218).
 			if (root["extra_values"] && root["extra_values"].IsMap())
@@ -4281,6 +4293,23 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 					out << "  # " << GetApplyTypeNameComment(location) << std::endl;
 					out << yaml.GetIndent() << "  modifier: " << modifier << std::endl;
 				}
+			}
+
+			yaml.DecreaseIndent();
+		}
+
+		// Умения предмета (legacy S-строки), issue #3386.
+		if (obj->has_skills())
+		{
+			yaml.Key("skills");
+			yaml.BeginSequence();
+			yaml.IncreaseIndent();
+
+			for (const auto &[skill_id, value] : obj->get_skills())
+			{
+				out << yaml.GetIndent() << "- skill_id: " << static_cast<int>(skill_id);
+				out << "  # " << GetSkillNameComment(skill_id) << std::endl;
+				out << yaml.GetIndent() << "  value: " << value << std::endl;
 			}
 
 			yaml.DecreaseIndent();

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -2684,8 +2684,9 @@ def parse_obj_file(filepath):
                 idx += 1
 
 
-            # Parse extra data (A, E, M, T sections)
+            # Parse extra data (A, E, M, T, S sections)
             obj['applies'] = []
+            obj['skills'] = []
             obj['extra_descs'] = []
             obj['triggers'] = []
 
@@ -2701,6 +2702,16 @@ def parse_obj_file(filepath):
                             obj['applies'].append({
                                 'location': int(parts[0]),
                                 'modifier': int(parts[1])
+                            })
+                elif line == 'S':
+                    # Skill (умение предмета): "S\n<skill_id> <value>", issue #3386
+                    idx += 1
+                    if idx < len(lines):
+                        parts = lines[idx].split()
+                        if len(parts) >= 2:
+                            obj['skills'].append({
+                                'skill_id': int(parts[0]),
+                                'value': int(parts[1])
                             })
                 elif line == 'E':
                     # Extra description
@@ -2847,6 +2858,19 @@ def obj_to_yaml(obj):
             a['modifier'] = apply['modifier']
             applies.append(a)
         data['applies'] = applies
+
+    # Skills (умения предмета, legacy S-строки), issue #3386
+    if obj.get('skills'):
+        skills = CommentedSeq()
+        for skill in obj['skills']:
+            s = CommentedMap()
+            s['skill_id'] = skill['skill_id']
+            skill_name = get_skill_name(skill['skill_id'])
+            if skill_name:
+                s.yaml_add_eol_comment(skill_name, 'skill_id')
+            s['value'] = skill['value']
+            skills.append(s)
+        data['skills'] = skills
 
     # Extra descriptions
     if obj.get('extra_descs'):


### PR DESCRIPTION
Closes #3386

## Проблема
У предмета 91710 в legacy-файле есть умения (`S 20 10`, `S 166 10`), но после загрузки из YAML `stat` их не показывает — «по стату нет умений».

## Причина
Умения предмета (`obj->set_skill`, legacy `S`-строки) терялись во **всём** YAML-конвейере:
- конвертер `convert_to_yaml.py` извлекал умения только у мобов, не у предметов;
- загрузчик `ParseObjectFile` секцию умений не читал;
- сейвер при сохранении предмета умения не писал.

В результате `skills` просто отсутствовали в YAML-файле предмета (там есть `applies`, но нет `skills`), и данные пропадали при конвертации.

## Фикс
Симметрично тому, как сделаны умения у мобов:
- **конвертер**: парсим `S`-строки предмета → секция `skills`;
- **загрузчик** (`ParseObjectFile`): читаем `root["skills"]` → `obj->set_skill`;
- **сейвер**: пишем `skills` при сохранении предмета.

Формат секции — список `{skill_id, value}` с комментарием-именем умения:
```yaml
skills:
- skill_id: 20   # kLeadership
  value: 10
- skill_id: 166  # kJinx
  value: 10
```

## Проверка
- Прогнал обновлённый конвертер на `lib/world/obj/917.obj`: объект 91710 теперь даёт `skills: [{20,10},{166,10}]`, round-trip `obj_to_yaml` пишет корректную секцию.
- C++ собран и слинкован (`ninja -C build`).
- Существующий YAML-мир надо **переконвертировать** из legacy, чтобы умения появились в уже сгенерированных файлах.

## Не вошло
SQLite-путь тем же багом не закрыт (нужна таблица `obj_skills` + чтение в `sqlite_world_data_source`). Issue про YAML — вынес отдельно, если потребуется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)