### PR TITLE
feat(admin-api): лог неудачных входов в админ-панель для fail2ban

### DIFF
--- a/src/engine/network/admin_api.cpp
+++ b/src/engine/network/admin_api.cpp
@@ -11,6 +11,7 @@
 #include "engine/db/obj_prototypes.h"
 #include "engine/db/world_data_source_manager.h"
 #include "utils/id_converter.h"
+#include "utils/logger.h"
 #include "engine/db/world_objects.h"
 #include "engine/db/world_characters.h"
 #include "engine/db/global_objects.h"
@@ -245,6 +246,14 @@ void admin_api_parse(DescriptorData *d, char *argument) {
 			std::string username_utf8 = request.value("username", "");
 			std::string password = request.value("password", "");
 
+			// IP клиента приходит от веб-панели (Admin API ходит через
+			// unix-сокет, поэтому реального адреса у дескриптора нет).
+			// Фолбэк на d->host ("unix-socket"), если фронт не передал.
+			std::string client_ip = request.value("client_ip", "");
+			if (client_ip.empty()) {
+				client_ip = d->host;
+			}
+
 			// Convert username from UTF-8 to KOI8-R (server's internal encoding)
 			std::string username = utf8_to_koi8r(username_utf8);
 
@@ -259,6 +268,8 @@ void admin_api_parse(DescriptorData *d, char *argument) {
 			} else {
 				admin_api_send_error(d, "Authentication failed");
 				mudlog(fmt::format("Admin API: authentication failed for user '{}'", username), BRF, kLvlGod, IMLOG, true);
+				// Отдельный лог для fail2ban (issue #3388).
+				admin_panel_access_log(client_ip.c_str(), username.c_str());
 			}
 			return;
 		}

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -318,6 +318,25 @@ void ip_log(const char *ip) {
 	fclose(iplog);
 }
 
+// Лог неудачных входов в админ-панель (Admin API) для fail2ban (issue #3388).
+// Формат строки языконезависимый и стабильный для разбора:
+//   <дата> :: accesadminpanel: login failed ip=<IP> user='<name>'
+void admin_panel_access_log(const char *ip, const char *username) {
+	const auto filename = runtime_config.log_dir() + "/accesadminpanel.log";
+
+	FILE *file = fopen(filename.c_str(), "a");
+	if (!file) {
+		log("SYSERR: can't open %s!", filename.c_str());
+		return;
+	}
+
+	write_time(file);
+	fprintf(file, "accesadminpanel: login failed ip=%s user='%s'\n",
+			ip && *ip ? ip : "unknown",
+			username ? username : "");
+	fclose(file);
+}
+
 /*
  * Перегрузка функции mudlog, которая первым параметром вместо char *, принимает строку
  */

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -22,6 +22,7 @@ void shop_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void olc_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void imm_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void err_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void admin_panel_access_log(const char *ip, const char *username);
 [[noreturn]] void fatal_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void ip_log(const char *ip);
 

--- a/tools/web_admin/app.py
+++ b/tools/web_admin/app.py
@@ -107,9 +107,15 @@ def login():
         username = request.form.get('username')
         password = request.form.get('password')
 
+        # IP клиента для лога неудачных входов (fail2ban, issue #3388).
+        # За обратным прокси берём первый адрес из X-Forwarded-For.
+        forwarded = request.headers.get('X-Forwarded-For', '')
+        client_ip = forwarded.split(',')[0].strip() if forwarded else request.remote_addr
+
         # Try to authenticate with MUD
         try:
-            test_client = MudAdminClient(SOCKET_PATH, username=username, password=password)
+            test_client = MudAdminClient(SOCKET_PATH, username=username, password=password,
+                                         client_ip=client_ip)
             # Test connection with real command
             response = test_client._send_command('list_zones')
 

--- a/tools/web_admin/fail2ban.md
+++ b/tools/web_admin/fail2ban.md
@@ -1,0 +1,50 @@
+# Защита админ-панели через fail2ban
+
+При включённом Admin API сервер пишет неудачные попытки входа в админ-панель
+(неверный пароль при авторизации через сайт) в отдельный лог
+`accesadminpanel.log` в каталоге логов сервера (`log_dir` из конфигурации).
+
+Формат строки (язык-нейтральный, удобен для разбора):
+
+```
+19-09-25 14:30:05 :: accesadminpanel: login failed ip=203.0.113.7 user='вася'
+```
+
+IP берётся из поля `client_ip` запроса `auth`, которое проставляет веб-панель
+(`tools/web_admin`): за обратным прокси — первый адрес из `X-Forwarded-For`,
+иначе `remote_addr`. Если фронт IP не передал, в логе будет `unix-socket`.
+
+## Фильтр fail2ban
+
+`/etc/fail2ban/filter.d/accesadminpanel.conf`:
+
+```ini
+[Definition]
+failregex = ^.*accesadminpanel: login failed ip=<HOST> user=
+# В логе дата в формате DD-MM-YY HH:MM:SS — это нестандартно для fail2ban,
+# поэтому datepattern задаём явно.
+datepattern = ^%%d-%%m-%%y %%H:%%M:%%S
+```
+
+## Jail
+
+`/etc/fail2ban/jail.d/accesadminpanel.conf`:
+
+```ini
+[accesadminpanel]
+enabled  = true
+filter   = accesadminpanel
+logpath  = /path/to/mud/log/accesadminpanel.log
+maxretry = 5
+findtime = 600
+bantime  = 3600
+```
+
+Путь `logpath` укажите на реальный `accesadminpanel.log` сервера.
+
+## Проверка фильтра
+
+```bash
+fail2ban-regex /path/to/mud/log/accesadminpanel.log \
+    /etc/fail2ban/filter.d/accesadminpanel.conf
+```

--- a/tools/web_admin/mud_client.py
+++ b/tools/web_admin/mud_client.py
@@ -8,10 +8,12 @@ import json
 class MudAdminClient:
     """Client for communicating with MUD Admin API via Unix socket"""
 
-    def __init__(self, socket_path='admin_api.sock', username=None, password=None):
+    def __init__(self, socket_path='admin_api.sock', username=None, password=None, client_ip=None):
         self.socket_path = socket_path
         self.username = username
         self.password = password
+        # IP клиента веб-панели, прокидывается в auth для лога fail2ban (issue #3388).
+        self.client_ip = client_ip
         self.authenticated = False
     
     def _recv_line(self, sock, max_size=1048576):
@@ -40,6 +42,8 @@ class MudAdminClient:
             # Authenticate if credentials provided
             if self.username and self.password:
                 auth_cmd = {"command": "auth", "username": self.username, "password": self.password}
+                if self.client_ip:
+                    auth_cmd["client_ip"] = self.client_ip
                 sock.sendall((json.dumps(auth_cmd) + '\n').encode())
                 auth_resp_data = self._recv_line(sock)
                 auth_resp = json.loads(auth_resp_data.decode())


### PR DESCRIPTION
Closes #3388

## Что сделано
При включённом Admin API неудачные попытки входа в админ-панель (неверный пароль при авторизации через сайт) пишутся в **отдельный лог `accesadminpanel.log`** (в каталоге `log_dir` сервера) с временем, IP клиента и именем пользователя — чтобы fail2ban мог банить перебор.

Формат строки — язык-нейтральный, стабильный для разбора:
```
19-09-25 14:30:05 :: accesadminpanel: login failed ip=203.0.113.7 user='вася'
```

## Откуда IP
Admin API ходит через **unix-сокет**, поэтому реального IP у соединения нет (`d->host` = `"unix-socket"`). IP клиента прокидывает веб-панель в поле `client_ip` запроса `auth`:
- **web_admin (Flask)**: берём `X-Forwarded-For` (первый адрес) или `remote_addr` и передаём в `MudAdminClient(..., client_ip=...)` → в JSON `auth`;
- **сервер** (`admin_api_parse`): читаем `client_ip`, при провале auth пишем в лог; фолбэк на `d->host`, если фронт IP не передал.

## Файлы
- `src/utils/logger.{cpp,h}` — `admin_panel_access_log(ip, username)`;
- `src/engine/network/admin_api.cpp` — вызов при неудачной авторизации + чтение `client_ip`;
- `tools/web_admin/{app.py,mud_client.py}` — проброс IP клиента;
- `tools/web_admin/fail2ban.md` — пример `filter`/`jail` и `datepattern` (формат даты `DD-MM-YY` нестандартен для fail2ban, поэтому задаётся явно).

## Проверка
- C++ собран и слинкован (`ninja -C build`);
- синтаксис питона (`app.py`, `mud_client.py`) проверен.

## Примечание
Логируются только **неудачные** входы (как в задаче). Если боевой фронт — не этот Flask, а внешний сайт, ему нужно слать `client_ip` в запросе `auth` по тому же контракту (сервер уже готов его принять).

🤖 Generated with [Claude Code](https://claude.com/claude-code)