### PR TITLE
fix(world): не терять свойства мобов и предметов при конвертации в YAML/SQLite (#3384, #3386)

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -369,6 +369,19 @@ void GameLoader::BootWorld(std::unique_ptr<world_loader::IWorldDataSource> data_
 	// idempotent if BootMudDataBase later runs.
 	text_id::Init();
 
+	// CharData::set_skill() / CObjectPrototype::set_skill() drop any skill
+	// whose id is invalid, and a skill is "invalid" until the skills config is
+	// loaded (MUD::Skills().IsInvalid). BootMudDataBase loads it before
+	// BootWorld for the running server, but `-S` / `scheck` call BootWorld
+	// directly and skip it -- so without this, every mob and object skill is
+	// silently dropped while loading the world to resave it, and the round
+	// trip loses them (issue #3391). Guarded so the normal boot, which already
+	// loaded the config, does not reload it.
+	if (!MUD::Skills().IsInitizalized())
+	{
+		MUD::CfgManager().LoadCfg("skills");
+	}
+
 	// Create default data source if none provided
 	if (!data_source)
 	{

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -1842,6 +1842,13 @@ void SqliteWorldDataSource::LoadMobDestinations()
 		if (dest_order >= 0 && dest_order < static_cast<int>(mob.mob_specials.dest.size()))
 		{
 			mob.mob_specials.dest[dest_order] = room_vnum;
+			// dest_count drives GET_DEST / the movement-route logic; rows are
+			// ordered by dest_order so this leaves dest_count == number of
+			// destinations, matching the legacy parser (issue #3384).
+			if (dest_order + 1 > mob.mob_specials.dest_count)
+			{
+				mob.mob_specials.dest_count = dest_order + 1;
+			}
 			destinations_set++;
 		}
 	}

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -1294,7 +1294,8 @@ void SqliteWorldDataSource::LoadMobs()
 					  "attr_str, attr_dex, attr_int, attr_wis, attr_con, attr_cha, "
 					  "attr_str_add, hp_regen, armour_bonus, mana_regen, cast_success, morale, "
 					  "initiative_add, absorb, aresist, mresist, presist, bare_hand_attack, "
-					  "like_work, max_factor, extra_attack, mob_remort, special_bitvector, role "
+					  "like_work, max_factor, extra_attack, mob_remort, special_bitvector, role, "
+					  "speed "
 					  "FROM mobs WHERE enabled = 1 ORDER BY vnum";
 
 	sqlite3_stmt *stmt;
@@ -1427,6 +1428,12 @@ void SqliteWorldDataSource::LoadMobs()
 			CharData::role_t role(role_str);
 			mob.set_role(role);
 		}
+
+		// Movement speed: -1 == default cadence (the common 3-field legacy
+		// position line). Older DBs without the column read NULL -> -1, the
+		// same default the YAML loader uses (issue #3384 class).
+		mob.mob_specials.speed = (sqlite3_column_type(stmt, 57) == SQLITE_NULL)
+			? -1 : sqlite3_column_int(stmt, 57);
 
 		// Set NPC flag
 
@@ -2839,8 +2846,8 @@ void SqliteWorldDataSource::SaveMobRecord(int mob_vnum, CharData &mob)
 		"attr_str, attr_dex, attr_int, attr_wis, attr_con, attr_cha, "
 		"attr_str_add, hp_regen, armour_bonus, mana_regen, cast_success, morale, "
 		"initiative_add, absorb, aresist, mresist, presist, bare_hand_attack, "
-		"like_work, max_factor, extra_attack, mob_remort, special_bitvector, role, enabled) "
-		"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)";
+		"like_work, max_factor, extra_attack, mob_remort, special_bitvector, role, speed, enabled) "
+		"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)";
 
 	if (sqlite3_prepare_v2(m_db, insert_sql, -1, &stmt, nullptr) != SQLITE_OK)
 	{
@@ -2960,6 +2967,9 @@ void SqliteWorldDataSource::SaveMobRecord(int mob_vnum, CharData &mob)
 	{
 		sqlite3_bind_null(stmt, col++);
 	}
+
+	// Movement speed (issue #3384 class)
+	sqlite3_bind_int(stmt, col++, mob.mob_specials.speed);
 
 	int rc = sqlite3_step(stmt);
 	if (rc != SQLITE_DONE)

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -1974,6 +1974,9 @@ void SqliteWorldDataSource::LoadObjects()
 	// Load object applies
 	LoadObjectApplies();
 
+	// Load object skills (legacy `S` lines, issue #3386)
+	LoadObjectSkills();
+
 	// Load object triggers
 	LoadObjectTriggers();
 
@@ -2136,6 +2139,36 @@ void SqliteWorldDataSource::LoadObjectApplies()
 	sqlite3_finalize(stmt);
 
 	log("   Loaded %d object applies.", applies_loaded);
+}
+
+void SqliteWorldDataSource::LoadObjectSkills()
+{
+	const char *sql = "SELECT obj_vnum, skill_id, value FROM obj_skills";
+
+	sqlite3_stmt *stmt;
+	if (sqlite3_prepare_v2(m_db, sql, -1, &stmt, nullptr) != SQLITE_OK)
+	{
+		return;
+	}
+
+	int skills_loaded = 0;
+	while (sqlite3_step(stmt) == SQLITE_ROW)
+	{
+		int obj_vnum = sqlite3_column_int(stmt, 0);
+		int skill_id = sqlite3_column_int(stmt, 1);
+		int value = sqlite3_column_int(stmt, 2);
+
+		int rnum = obj_proto.get_rnum(obj_vnum);
+		if (rnum < 0) continue;
+
+		// Mirrors the legacy `S` line handler; without it object skill
+		// bonuses are silently dropped in the SQLite world (issue #3386).
+		obj_proto[rnum]->set_skill(static_cast<ESkill>(skill_id), value);
+		skills_loaded++;
+	}
+	sqlite3_finalize(stmt);
+
+	log("   Loaded %d object skills.", skills_loaded);
 }
 
 void SqliteWorldDataSource::LoadObjectTriggers()
@@ -3263,6 +3296,20 @@ void SqliteWorldDataSource::SaveObjectRecord(int obj_vnum, CObjectPrototype *obj
 				sqlite3_step(stmt);
 				sqlite3_finalize(stmt);
 			}
+		}
+	}
+
+	// Save object skills (legacy `S` lines, issue #3386)
+	const char *obj_skill_sql = "INSERT OR REPLACE INTO obj_skills (obj_vnum, skill_id, value) VALUES (?, ?, ?)";
+	for (const auto &kv : obj->get_skills())
+	{
+		if (sqlite3_prepare_v2(m_db, obj_skill_sql, -1, &stmt, nullptr) == SQLITE_OK)
+		{
+			sqlite3_bind_int(stmt, 1, obj_vnum);
+			sqlite3_bind_int(stmt, 2, to_underlying(kv.first));
+			sqlite3_bind_int(stmt, 3, kv.second);
+			sqlite3_step(stmt);
+			sqlite3_finalize(stmt);
 		}
 	}
 

--- a/src/engine/db/sqlite_world_data_source.h
+++ b/src/engine/db/sqlite_world_data_source.h
@@ -75,6 +75,7 @@ private:
 	// Object loading helpers
 	void LoadObjectFlags();
 	void LoadObjectApplies();
+	void LoadObjectSkills();
 	void LoadObjectTriggers();
 	void LoadObjectExtraDescriptions();
 

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -2150,6 +2150,19 @@ CObjectPrototype* YamlWorldDataSource::ParseObjectFile(const std::string &file_p
 				}
 			}
 
+			// Skills granted by the object (legacy `S` lines). Mirrors the
+			// boot_data_files.cpp `case 'S'` handler; without it the object's
+			// skill bonuses are silently dropped in the YAML world (issue #3386).
+			if (root["skills"] && root["skills"].IsSequence())
+			{
+				for (const auto &skill_node : root["skills"])
+				{
+					int skill_id = GetInt(skill_node, "skill_id", 0);
+					int value = GetInt(skill_node, "value", 0);
+					obj_ptr->set_skill(static_cast<ESkill>(skill_id), value);
+				}
+			}
+
 			// Extra values (V-строки): данные зелий и контейнеров с жидкостью.
 			// Без чтения этой секции зелья в YAML-мире выходят без заклинаний (issue #3218).
 			if (root["extra_values"] && root["extra_values"].IsMap())

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1507,6 +1507,13 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 	// Sex
 	mob.set_sex(static_cast<EGender>(ParseGender(root["sex"])));
 
+	// Movement speed. parse_simple_mob leaves speed == -1 when the position
+	// line has only three fields (the common case) and stores an explicit
+	// value otherwise. The converter omits the -1 default, so fall back to
+	// -1 here -- without it every such mob loads with speed 0 and walks on
+	// the wrong cadence (same dropped-property class as #3384/#3386).
+	mob.mob_specials.speed = GetInt(root, "speed", -1);
+
 	// Race -- legacy clamps to [kBasic, kLastNpcRace] (boot_data_files.cpp).
 	mob.player_data.Race = std::clamp(static_cast<ENpcRace>(GetInt(root, "race", ENpcRace::kBasic)),
 									  ENpcRace::kBasic, ENpcRace::kLastNpcRace);

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -32,6 +32,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>
+#include <utility>
+#include <vector>
 #include <regex>
 #include <filesystem>
 #include <fstream>
@@ -3671,32 +3673,33 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 			yaml.DecreaseIndent();
 		}
 
-		// Skills (with comments)
-		bool has_skills = false;
-		for (ESkill skill_id = ESkill::kFirst; skill_id <= ESkill::kLast; ++skill_id)
+		// Skills (with comments). Use the raw trained-skill map (skillLevel),
+		// NOT GetSkill(): GetSkill() layers on instance context -- equipment,
+		// affects and a kDominationArena clamp keyed off in_room -- which is
+		// meaningless for a prototype (in_room is NOWHERE) and would zero mob
+		// skills on resave. Mirrors WorldChecksum::SerializeMob and the loader
+		// so skills survive the round-trip (issue #3391).
+		std::vector<std::pair<int, int>> mob_skills;
+		for (const auto &kv : mob.GetCharSkills())
 		{
-			if (mob.GetSkill(skill_id) > 0)
+			if (kv.second.skillLevel > 0)
 			{
-				has_skills = true;
-				break;
+				mob_skills.emplace_back(static_cast<int>(kv.first), kv.second.skillLevel);
 			}
 		}
+		std::sort(mob_skills.begin(), mob_skills.end());
 
-		if (has_skills)
+		if (!mob_skills.empty())
 		{
 			yaml.Key("skills");
 			yaml.BeginSequence();
 			yaml.IncreaseIndent();
 
-			for (ESkill skill_id = ESkill::kFirst; skill_id <= ESkill::kLast; ++skill_id)
+			for (const auto &kv : mob_skills)
 			{
-				int skill_value = mob.GetSkill(skill_id);
-				if (skill_value > 0)
-				{
-					out << yaml.GetIndent() << "- skill_id: " << static_cast<int>(skill_id);
-					out << "  # " << GetSkillNameComment(skill_id) << std::endl;
-					out << yaml.GetIndent() << "  value: " << skill_value << std::endl;
-				}
+				out << yaml.GetIndent() << "- skill_id: " << kv.first;
+				out << "  # " << GetSkillNameComment(static_cast<ESkill>(kv.first)) << std::endl;
+				out << yaml.GetIndent() << "  value: " << kv.second << std::endl;
 			}
 
 			yaml.DecreaseIndent();

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -3928,21 +3928,22 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 					yaml.DecreaseIndent();
 				}
 
-				// Destinations
-				bool has_destinations = false;
-				for (int dest : mob.mob_specials.dest)
-				{
-					if (dest != 0) { has_destinations = true; break; }
-				}
-				if (has_destinations)
+				// Destinations: emit only the real route (dest[0..dest_count-1]),
+				// NOT the full kMaxDest array. dest_count is the count the
+				// legacy loader and the converter use; padding the sequence
+				// with the array's trailing zeros makes the loader read
+				// dest_count too large with bogus 0 destinations, breaking the
+				// round-trip for every patrolling mob (issue #3384/#3391).
+				if (mob.mob_specials.dest_count > 0)
 				{
 					yaml.Key("destinations");
 					yaml.BeginSequence();
 					yaml.IncreaseIndent();
 
-					for (int dest : mob.mob_specials.dest)
+					for (int d = 0; d < mob.mob_specials.dest_count
+						&& d < static_cast<int>(mob.mob_specials.dest.size()); ++d)
 					{
-						yaml.SequenceItem(dest);
+						yaml.SequenceItem(mob.mob_specials.dest[d]);
 					}
 
 					yaml.DecreaseIndent();
@@ -4324,6 +4325,33 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 					out << "  # " << GetApplyTypeNameComment(location) << std::endl;
 					out << yaml.GetIndent() << "  modifier: " << modifier << std::endl;
 				}
+			}
+
+			yaml.DecreaseIndent();
+		}
+
+		// Skills granted by the object (legacy `S` lines). Without this the
+		// C++ emitter drops them on -S/OLC resave (same class as the SaveMobs
+		// fix); object skill bonuses would vanish on every resave. Mirrors the
+		// converter/loader (issues #3386/#3391).
+		std::vector<std::pair<int, int>> obj_skills;
+		for (const auto &kv : obj->get_skills())
+		{
+			obj_skills.emplace_back(static_cast<int>(kv.first), kv.second);
+		}
+		std::sort(obj_skills.begin(), obj_skills.end());
+
+		if (!obj_skills.empty())
+		{
+			yaml.Key("skills");
+			yaml.BeginSequence();
+			yaml.IncreaseIndent();
+
+			for (const auto &kv : obj_skills)
+			{
+				out << yaml.GetIndent() << "- skill_id: " << kv.first;
+				out << "  # " << GetSkillNameComment(static_cast<ESkill>(kv.first)) << std::endl;
+				out << yaml.GetIndent() << "  value: " << kv.second << std::endl;
 			}
 
 			yaml.DecreaseIndent();

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -29,6 +29,7 @@
 
 #include <yaml-cpp/yaml.h>
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <iomanip>
 #include <regex>
@@ -482,6 +483,20 @@ int YamlWorldDataSource::ParseEnum(const YAML::Node &node, const std::string &di
 	}
 
 	std::string name = node.as<std::string>();
+	// A raw integer value (the converter emits one whenever the enum index
+	// has no symbolic name -- e.g. an out-of-range default_pos like 15) must
+	// round-trip verbatim instead of collapsing to the default; otherwise
+	// legacy<->yaml drift on such values, and the SQLite path (which stores
+	// the int directly) would disagree too (issue #3384 class).
+	if (!name.empty())
+	{
+		char *end = nullptr;
+		const long as_int = std::strtol(name.c_str(), &end, 10);
+		if (*end == '\0')
+		{
+			return static_cast<int>(as_int);
+		}
+	}
 	auto &dm = DictionaryManager::Instance();
 	long val = dm.Lookup(dict_name, name, default_val);
 	return static_cast<int>(val);

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1693,13 +1693,18 @@ CharData YamlWorldDataSource::ParseMobFile(const std::string &file_path)
 			int idx = 0;
 			for (const auto &dest_node : enhanced["destinations"])
 			{
-				int room_vnum = dest_node.as<int>();
-				if (idx < static_cast<int>(mob.mob_specials.dest.size()))
+				if (idx >= static_cast<int>(mob.mob_specials.dest.size()))
 				{
-					mob.mob_specials.dest[idx] = room_vnum;
+					break;
 				}
+				mob.mob_specials.dest[idx] = dest_node.as<int>();
 				idx++;
 			}
+			// dest_count drives GET_DEST and the whole movement-route logic;
+			// without it the dest[] array we just filled stays invisible and
+			// the mob never walks its patrol (issue #3384, matches the legacy
+			// interpret_espec "Destination" handler in boot_data_files.cpp).
+			mob.mob_specials.dest_count = idx;
 		}
 	}
 

--- a/tests/world_checksum_serialization.cpp
+++ b/tests/world_checksum_serialization.cpp
@@ -192,4 +192,83 @@ TEST(SerializeObject, ObjectsDifferingOnlyByExtraValuesSerializeDifferently) {
 		<< "Potions with different POTION_SPELL* must hash differently";
 }
 
+// Issue #3384: the YAML/SQLite mob loaders filled mob_specials.dest[] but
+// forgot to set dest_count, so the patrol route was invisible at runtime
+// (GET_DEST keys off dest_count) yet the static checksum would only catch it
+// if dest_count is part of the serialized form. Pin both halves down.
+TEST(SerializeMob, MobsDifferingOnlyByDestinationsSerializeDifferently) {
+	CharData a, b;
+	a.SetNpcAttribute(true);
+	b.SetNpcAttribute(true);
+	a.mob_specials.dest[0] = 100;
+	a.mob_specials.dest[1] = 200;
+	a.mob_specials.dest_count = 2;
+
+	const std::string sa = WorldChecksum::SerializeMob(42, a);
+	const std::string sb = WorldChecksum::SerializeMob(42, b);
+	EXPECT_NE(sa, sb)
+		<< "Mobs with different destinations must hash differently";
+}
+
+// The exact #3384 failure mode: dest[] is populated identically but dest_count
+// is left at 0 (loader bug) vs the correct count (legacy). The checksum MUST
+// distinguish them, otherwise the regression hides behind a green run.
+TEST(SerializeMob, DestCountIsPartOfChecksum) {
+	CharData with_count, without_count;
+	with_count.SetNpcAttribute(true);
+	without_count.SetNpcAttribute(true);
+	with_count.mob_specials.dest[0] = 100;
+	without_count.mob_specials.dest[0] = 100;
+	with_count.mob_specials.dest_count = 1;
+	without_count.mob_specials.dest_count = 0;   // the loader bug
+
+	const std::string sa = WorldChecksum::SerializeMob(42, with_count);
+	const std::string sb = WorldChecksum::SerializeMob(42, without_count);
+	EXPECT_NE(sa, sb)
+		<< "Same dest[] but different dest_count must hash differently";
+}
+
+// parse_simple_mob leaves speed == -1 for 3-field position lines and an
+// explicit value for 4-field ones. The YAML/SQLite loaders used to drop the
+// field entirely, so every mob reloaded with speed 0. Pin speed into the
+// checksum so the divergence is caught (same class as #3384/#3386).
+TEST(SerializeMob, MobsDifferingOnlyBySpeedSerializeDifferently) {
+	CharData a, b;
+	a.SetNpcAttribute(true);
+	b.SetNpcAttribute(true);
+	a.mob_specials.speed = -1;   // legacy default for 3-field lines
+	b.mob_specials.speed = 0;    // what the buggy loader produced
+
+	const std::string sa = WorldChecksum::SerializeMob(42, a);
+	const std::string sb = WorldChecksum::SerializeMob(42, b);
+	EXPECT_NE(sa, sb)
+		<< "Mobs with different movement speed must hash differently";
+}
+
+// Issue #3386: the object converter/loaders dropped the legacy `S` skill
+// lines. SerializeObject must include the skill map so a dropped skill shows
+// up as a Legacy-vs-YAML checksum mismatch instead of slipping through.
+TEST(SerializeObject, IncludesSkillBindings) {
+	auto obj = std::make_shared<CObjectPrototype>(42);
+	obj->set_skill(static_cast<ESkill>(20), 10);
+	obj->set_skill(static_cast<ESkill>(166), 10);
+
+	const std::string out = WorldChecksum::SerializeObject(obj);
+	EXPECT_NE(std::string::npos, out.find("20:10"))
+		<< "object skill 20:10 must appear in checksum input; got: " << out;
+	EXPECT_NE(std::string::npos, out.find("166:10"))
+		<< "object skill 166:10 must appear in checksum input; got: " << out;
+}
+
+TEST(SerializeObject, ObjectsDifferingOnlyBySkillsSerializeDifferently) {
+	auto a = std::make_shared<CObjectPrototype>(42);
+	auto b = std::make_shared<CObjectPrototype>(42);
+	a->set_skill(static_cast<ESkill>(20), 10);
+
+	const std::string sa = WorldChecksum::SerializeObject(a);
+	const std::string sb = WorldChecksum::SerializeObject(b);
+	EXPECT_NE(sa, sb)
+		<< "Objects with different skill bindings must hash differently";
+}
+
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -1303,13 +1303,13 @@ class SqliteSaver(BaseSaver):
                 short_desc, long_desc, alignment, mob_type, level, hitroll_penalty, armor,
                 hp_dice_count, hp_dice_size, hp_bonus, dam_dice_count, dam_dice_size, dam_bonus,
                 gold_dice_count, gold_dice_size, gold_bonus, experience,
-                default_pos, start_pos, sex, size, height, weight, mob_class, race,
+                default_pos, start_pos, sex, speed, size, height, weight, mob_class, race,
                 attr_str, attr_dex, attr_int, attr_wis, attr_con, attr_cha,
                 attr_str_add, hp_regen, armour_bonus, mana_regen, cast_success, morale,
                 initiative_add, absorb, aresist, mresist, presist, bare_hand_attack,
                 like_work, max_factor, extra_attack, mob_remort, special_bitvector, role,
                 enabled
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ''', (
             vnum,
             *extract_entity_names(mob),
@@ -1333,6 +1333,7 @@ class SqliteSaver(BaseSaver):
             pos.get('default'),
             pos.get('start'),
             mob.get('sex'),
+            mob.get('speed', -1),
             mob.get('size'),
             mob.get('height'),
             mob.get('weight'),
@@ -2142,6 +2143,17 @@ def parse_mob_file(filepath):
                         'start': POSITIONS[pos_start] if pos_start < len(POSITIONS) else pos_start
                     }
                     mob['sex'] = GENDERS[sex] if sex < len(GENDERS) else sex
+                    # parse_simple_mob: a 4th field is the explicit movement
+                    # speed; with only 3 fields speed defaults to -1. Without
+                    # carrying this through, every legacy mob (the 3-field
+                    # common case) reloads with speed 0 and the wrong movement
+                    # cadence. Emit speed only when it differs from -1 so the
+                    # YAML stays clean; the loader defaults to -1 (issue #3384
+                    # class of dropped properties).
+                    if len(parts) >= 4 and parts[3].lstrip('-').isdigit():
+                        mob['speed'] = int(parts[3])
+                    else:
+                        mob['speed'] = -1
                 idx += 1
 
             # Parse extended mob info (E-spec)
@@ -2408,6 +2420,12 @@ def mob_to_yaml(mob):
     # Sex
     if 'sex' in mob:
         data['sex'] = mob['sex']
+
+    # Movement speed -- only emit when it deviates from the -1 default that
+    # parse_simple_mob assigns to 3-field position lines; the loader falls
+    # back to -1 when the key is absent (issue #3384 class).
+    if mob.get('speed', -1) != -1:
+        data['speed'] = mob['speed']
 
     # Attributes
     if mob.get('attributes'):

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -1488,6 +1488,13 @@ class SqliteSaver(BaseSaver):
                 VALUES (?, ?, ?)
             ''', (vnum, location_id, apply['modifier']))
 
+        # Insert skills (legacy `S` lines, issue #3386)
+        for skill in obj.get('skills', []):
+            cursor.execute('''
+                INSERT OR REPLACE INTO obj_skills (obj_vnum, skill_id, value)
+                VALUES (?, ?, ?)
+            ''', (vnum, skill['skill_id'], skill['value']))
+
         # Insert extra descriptions
         insert_extra_descriptions(cursor, 'obj', vnum, obj.get('extra_descs', []))
         # Insert triggers
@@ -2684,10 +2691,11 @@ def parse_obj_file(filepath):
                 idx += 1
 
 
-            # Parse extra data (A, E, M, T sections)
+            # Parse extra data (A, E, M, S, T sections)
             obj['applies'] = []
             obj['extra_descs'] = []
             obj['triggers'] = []
+            obj['skills'] = []
 
             while idx < len(lines):
                 line = lines[idx].strip()
@@ -2726,6 +2734,20 @@ def parse_obj_file(filepath):
                             desc_parts.append(lines[idx].rstrip('~'))
                         ed['description'] = '\r\n'.join(desc_parts)
                         obj['extra_descs'].append(ed)
+                elif line == 'S':
+                    # Skill granted by the object (legacy `S` line:
+                    # `S\n<skill_id> <value>`, boot_data_files.cpp:795).
+                    # Without this branch the object's skill bonuses silently
+                    # vanish in YAML, then SQLite, and finally on every player
+                    # who equips it (issue #3386).
+                    idx += 1
+                    if idx < len(lines):
+                        parts = lines[idx].split()
+                        if len(parts) >= 2:
+                            obj['skills'].append({
+                                'skill_id': int(parts[0]),
+                                'value': int(parts[1])
+                            })
                 elif line.startswith('M '):
                     obj['max_in_world'] = int(line[2:].strip())
                 elif line.startswith('R '):
@@ -2847,6 +2869,19 @@ def obj_to_yaml(obj):
             a['modifier'] = apply['modifier']
             applies.append(a)
         data['applies'] = applies
+
+    # Skills granted by the object (legacy `S` lines, issue #3386).
+    if obj.get('skills'):
+        skills = CommentedSeq()
+        for skill in obj['skills']:
+            s = CommentedMap()
+            s['skill_id'] = skill['skill_id']
+            skill_name = get_skill_name(skill['skill_id'])
+            if skill_name:
+                s.yaml_add_eol_comment(skill_name, 'skill_id')
+            s['value'] = skill['value']
+            skills.append(s)
+        data['skills'] = skills
 
     # Extra descriptions
     if obj.get('extra_descs'):

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -2091,8 +2091,13 @@ def parse_mob_file(filepath):
                         'hitroll_penalty': int(parts[1]) if parts[1].lstrip('-').isdigit() else 20,
                         'armor': int(parts[2]) if parts[2].lstrip('-').isdigit() else 100
                     }
-                    # Parse HP dice (format: XdY+Z)
-                    hp_match = re.match(r'(-?\d+)d(-?\d+)([+-]\d+)?', parts[3])
+                    # Parse HP dice (format: XdY+Z). The bonus Z is a *signed*
+                    # value behind a literal '+' separator (matches the legacy
+                    # sscanf "%dd%d+%d"), so a negative bonus reads "0d0+-56".
+                    # The old `([+-]\d+)?` group failed on the "+-" pair and
+                    # silently dropped the bonus to 0 -- e.g. mob 12821's
+                    # damroll -56 became 0 in YAML (issue #3384 class).
+                    hp_match = re.match(r'(-?\d+)d(-?\d+)(?:\+(-?\d+))?', parts[3])
                     if hp_match:
                         mob['stats']['hp'] = {
                             'dice_count': int(hp_match.group(1)),
@@ -2100,7 +2105,7 @@ def parse_mob_file(filepath):
                             'bonus': int(hp_match.group(3)) if hp_match.group(3) else 0
                         }
                     # Parse damage dice
-                    dmg_match = re.match(r'(-?\d+)d(-?\d+)([+-]\d+)?', parts[4])
+                    dmg_match = re.match(r'(-?\d+)d(-?\d+)(?:\+(-?\d+))?', parts[4])
                     if dmg_match:
                         mob['stats']['damage'] = {
                             'dice_count': int(dmg_match.group(1)),
@@ -2113,7 +2118,7 @@ def parse_mob_file(filepath):
             if idx < len(lines):
                 parts = lines[idx].split()
                 if parts:
-                    gold_match = re.match(r'(-?\d+)d(-?\d+)([+-]\d+)?', parts[0])
+                    gold_match = re.match(r'(-?\d+)d(-?\d+)(?:\+(-?\d+))?', parts[0])
                     if gold_match:
                         mob['gold'] = {
                             'dice_count': int(gold_match.group(1)),

--- a/tools/converter/test_convert_to_yaml.py
+++ b/tools/converter/test_convert_to_yaml.py
@@ -24,6 +24,26 @@ from convert_to_yaml import (
 )
 
 
+def _init_ruamel_restoring(test_case):
+    """Switch the module to the ruamel YAML backend for an emit test and
+    restore the previous global state afterwards. Without the restore these
+    globals leak into later tests (e.g. to_literal_block's CR/LF handling)."""
+    import convert_to_yaml
+    prev_lib = convert_to_yaml._yaml_library
+    prev_blocks = convert_to_yaml._use_literal_blocks
+
+    def _restore():
+        convert_to_yaml._yaml_library = prev_lib
+        convert_to_yaml._use_literal_blocks = prev_blocks
+        if prev_lib:
+            convert_to_yaml._init_yaml_libraries()
+
+    test_case.addCleanup(_restore)
+    convert_to_yaml._yaml_library = 'ruamel'
+    convert_to_yaml._use_literal_blocks = True
+    convert_to_yaml._init_yaml_libraries()
+
+
 class TestParseAsciiFlags(unittest.TestCase):
     """Test the parse_ascii_flags function."""
 
@@ -157,6 +177,129 @@ class TestObjectFlagsArrays(unittest.TestCase):
             self.assertEqual(NO_FLAGS[68], 'kCharmice')
         else:
             self.skipTest("NO_FLAGS needs padding for plane 2")
+
+
+class TestObjectSkillLines(unittest.TestCase):
+    """Issue #3386: object `S` (skill) lines must survive conversion.
+
+    The legacy obj format grants skills via an `S` line followed by
+    `<skill_id> <value>` (boot_data_files.cpp:795). Before the fix the
+    converter ignored those lines, so the bonus silently vanished in YAML
+    and SQLite. These tests pin parsing and emission down.
+    """
+
+    # Minimal but complete legacy object with two A (apply) and two S (skill)
+    # sections, mirroring real object #91710.
+    OBJ_BLOCK = (
+        "#1\n"
+        "test obj~\n"
+        "objnom~\n"
+        "objgen~\n"
+        "objdat~\n"
+        "objacc~\n"
+        "objins~\n"
+        "objpre~\n"
+        "A test object lies here.~\n"
+        "~\n"
+        "0 100 100 0\n"
+        "0 0 -1 1\n"
+        "0 0 0\n"
+        "1 0 0\n"
+        "0 0 0 0\n"
+        "1 100 10 5\n"
+        "A\n"
+        "40 8\n"
+        "A\n"
+        "13 20\n"
+        "S\n"
+        "20 10\n"
+        "S\n"
+        "166 10\n"
+        "$\n"
+    )
+
+    def _parse(self):
+        import tempfile
+        from convert_to_yaml import parse_obj_file
+        with tempfile.NamedTemporaryFile('w', suffix='.obj', delete=False,
+                                         encoding='koi8-r') as f:
+            f.write(self.OBJ_BLOCK)
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        objs = parse_obj_file(path)
+        self.assertEqual(len(objs), 1)
+        return objs[0]
+
+    def test_parses_skill_lines(self):
+        obj = self._parse()
+        self.assertEqual(
+            obj.get('skills'),
+            [{'skill_id': 20, 'value': 10}, {'skill_id': 166, 'value': 10}],
+            "object `S` lines must be parsed into obj['skills']")
+
+    def test_applies_still_parsed(self):
+        # Guard against the S-branch accidentally swallowing A lines.
+        obj = self._parse()
+        self.assertEqual(
+            obj.get('applies'),
+            [{'location': 40, 'modifier': 8}, {'location': 13, 'modifier': 20}])
+
+    def test_skills_emitted_to_yaml(self):
+        from convert_to_yaml import obj_to_yaml
+        _init_ruamel_restoring(self)
+        text = obj_to_yaml(self._parse())
+        self.assertIn('skills:', text)
+        self.assertIn('skill_id: 20', text)
+        self.assertIn('skill_id: 166', text)
+
+
+class TestMobSpeedField(unittest.TestCase):
+    """Mob movement speed (4th field of the position line) must survive.
+
+    parse_simple_mob assigns speed = -1 when the position line has only 3
+    fields and the explicit value when it has 4. The converter used to read
+    only position+sex, dropping speed, so every mob reloaded with speed 0
+    (issue #3384 class). These tests pin parsing + emission.
+    """
+
+    def _mob(self, position_line):
+        return (
+            "#1\n"
+            "testmob~\n"
+            "testmob~\ntestmoba~\ntestmobu~\ntestmoba~\ntestmobom~\ntestmobe~\n"
+            "A test mob stands here.~\n"
+            "A long description.\n~\n"
+            "0 0 0 S\n"
+            "1 20 100 1d1+10 1d1+1\n"
+            "0d0+0 100\n"
+            + position_line + "\n"
+        )
+
+    def _parse(self, position_line):
+        import tempfile
+        from convert_to_yaml import parse_mob_file
+        with tempfile.NamedTemporaryFile('w', suffix='.mob', delete=False,
+                                         encoding='koi8-r') as f:
+            f.write(self._mob(position_line))
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        mobs = parse_mob_file(path)
+        self.assertEqual(len(mobs), 1)
+        return mobs[0]
+
+    def test_explicit_speed_parsed(self):
+        # 4-field position line: pos default_pos sex speed
+        self.assertEqual(self._parse("8 8 0 7").get('speed'), 7)
+
+    def test_missing_speed_defaults_to_minus_one(self):
+        # 3-field position line -> legacy default speed == -1
+        self.assertEqual(self._parse("8 8 0").get('speed'), -1)
+
+    def test_default_speed_not_emitted_explicit_is(self):
+        from convert_to_yaml import mob_to_yaml
+        _init_ruamel_restoring(self)
+        self.assertNotIn('speed:', mob_to_yaml(self._parse("8 8 0")))
+        self.assertIn('speed: 7', mob_to_yaml(self._parse("8 8 0 7")))
 
 
 if __name__ == '__main__':

--- a/tools/converter/test_convert_to_yaml.py
+++ b/tools/converter/test_convert_to_yaml.py
@@ -302,6 +302,54 @@ class TestMobSpeedField(unittest.TestCase):
         self.assertIn('speed: 7', mob_to_yaml(self._parse("8 8 0 7")))
 
 
+class TestMobNegativeDiceBonus(unittest.TestCase):
+    r"""A negative dice bonus is written as XdY+-N (e.g. damage 4d3+-56): the
+    legacy '+' is a literal separator and the value behind it is signed. The
+    old regex ([+-]\d+)? failed on the '+-' pair and silently zeroed the bonus
+    -- so e.g. a mob's damroll became 0 after conversion (issue #3384 class).
+    """
+
+    def _mob(self, stats_line, gold_line="0d0+0 100"):
+        return (
+            "#1\n"
+            "testmob~\n"
+            "testmob~\ntestmoba~\ntestmobu~\ntestmoba~\ntestmobom~\ntestmobe~\n"
+            "A test mob stands here.~\n"
+            "A long description.\n~\n"
+            "0 0 0 S\n"
+            + stats_line + "\n"
+            + gold_line + "\n"
+            "8 8 0\n"
+        )
+
+    def _parse(self, stats_line, gold_line="0d0+0 100"):
+        import tempfile
+        from convert_to_yaml import parse_mob_file
+        with tempfile.NamedTemporaryFile('w', suffix='.mob', delete=False,
+                                         encoding='koi8-r') as f:
+            f.write(self._mob(stats_line, gold_line))
+            path = f.name
+        self.addCleanup(os.unlink, path)
+        mobs = parse_mob_file(path)
+        self.assertEqual(len(mobs), 1)
+        return mobs[0]
+
+    def test_negative_damage_bonus(self):
+        m = self._parse("5 0 0 10d4+60 4d3+-56")
+        self.assertEqual(m['stats']['damage']['bonus'], -56)
+        self.assertEqual(m['stats']['hp']['bonus'], 60)  # positive still ok
+
+    def test_negative_gold_bonus(self):
+        m = self._parse("5 0 0 1d1+1 1d1+1", gold_line="0d0+-3 100")
+        self.assertEqual(m['gold']['bonus'], -3)
+
+    def test_positive_and_zero_bonus_unaffected(self):
+        m = self._parse("5 0 0 10d4+60 4d3+12")
+        self.assertEqual(m['stats']['damage']['bonus'], 12)
+        m0 = self._parse("5 0 0 0d0+0 0d0+0")
+        self.assertEqual(m0['stats']['damage']['bonus'], 0)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)
 

--- a/tools/converter/world_schema.sql
+++ b/tools/converter/world_schema.sql
@@ -152,6 +152,8 @@ CREATE TABLE mobs (
     start_pos INTEGER REFERENCES positions(id),
     -- Appearance
     sex INTEGER REFERENCES genders(id),
+    -- Movement speed: -1 == default cadence (3-field position line). Issue #3384 class.
+    speed INTEGER DEFAULT -1,
     size INTEGER DEFAULT 50,
     height INTEGER DEFAULT 170,
     weight INTEGER DEFAULT 70,

--- a/tools/converter/world_schema.sql
+++ b/tools/converter/world_schema.sql
@@ -318,6 +318,16 @@ CREATE TABLE obj_applies (
     FOREIGN KEY (obj_vnum) REFERENCES objects(vnum) ON DELETE CASCADE
 );
 
+-- Skills granted by an object (legacy `S` line: skill_id value). Issue #3386.
+CREATE TABLE obj_skills (
+    obj_vnum INTEGER NOT NULL,
+    skill_id INTEGER NOT NULL,
+    value INTEGER NOT NULL,
+    PRIMARY KEY (obj_vnum, skill_id),
+    FOREIGN KEY (obj_vnum) REFERENCES objects(vnum) ON DELETE CASCADE,
+    FOREIGN KEY (skill_id) REFERENCES skills(id)
+);
+
 -- Rooms
 CREATE TABLE rooms (
     vnum INTEGER PRIMARY KEY,
@@ -427,6 +437,7 @@ CREATE INDEX idx_mob_flags_vnum ON mob_flags(mob_vnum);
 CREATE INDEX idx_mob_skills_vnum ON mob_skills(mob_vnum);
 CREATE INDEX idx_obj_flags_vnum ON obj_flags(obj_vnum);
 CREATE INDEX idx_obj_applies_vnum ON obj_applies(obj_vnum);
+CREATE INDEX idx_obj_skills_vnum ON obj_skills(obj_vnum);
 CREATE INDEX idx_room_flags_vnum ON room_flags(room_vnum);
 CREATE INDEX idx_room_exits_vnum ON room_exits(room_vnum);
 CREATE INDEX idx_room_exits_to ON room_exits(to_room);
@@ -507,6 +518,18 @@ FROM obj_applies oa
 JOIN objects o ON oa.obj_vnum = o.vnum
 JOIN apply_locations al ON oa.location_id = al.id
 ORDER BY oa.obj_vnum, al.name;
+
+-- Object skills (legacy `S` lines)
+CREATE VIEW v_obj_skills AS
+SELECT
+    os.obj_vnum,
+    o.name_nom AS obj_name,
+    s.name AS skill_name,
+    os.value AS skill_value
+FROM obj_skills os
+JOIN objects o ON os.obj_vnum = o.vnum
+JOIN skills s ON os.skill_id = s.id
+ORDER BY os.obj_vnum, s.name;
 
 -- Full room information
 CREATE VIEW v_rooms AS


### PR DESCRIPTION
## Проблема

Issue #3384 и #3386 — один класс бага: свойство есть в legacy-файле мира, но теряется в цепочке `legacy → YAML/SQLite → загрузка`. Полный round-trip со сверкой чексумм на всём мире (992 зоны) вскрыл **четыре** бага этого класса:

| Свойство | Причина потери |
|---|---|
| **Маршруты мобов** (#3384) | загрузчики YAML/SQLite заполняли `dest[]`, но не выставляли `dest_count` — `GET_DEST` и логика патрулирования смотрят на счётчик, поэтому маршрут невидим |
| **Умения предметов** (#3386) | legacy-строки `S` (`set_skill`) не парсились конвертером, не писались в YAML/SQLite (не было таблицы `obj_skills`), не читались загрузчиками |
| **Скорость моба** | 4-е поле строки позиции; в legacy при 3 полях по умолчанию `-1`, конвертер его терял → загрузчики ставили `0` |
| **Бонус кубов `+-N`** | отрицательный бонус пишется как `0d0+-56`; regex конвертера `([+-]\d+)?` не разбирал пару `+-` и обнулял бонус (например, `damroll`) |

Дополнительно: `ParseEnum` в YAML-загрузчике сбрасывал «сырое» числовое значение enum (например `default_pos: 15` вне диапазона) в дефолт вместо того, чтобы пропустить как есть.

## Что сделано

Для каждого бага синхронизированы все точки: конвертер (`convert_to_yaml.py`, `world_schema.sql`), YAML-загрузчик, SQLite-загрузчик (чтение и сохранение) и регрессионные тесты. Коммиты разбиты по багам.

## Проверка

- **Чексуммы ловят регрессии** — тесты `SerializeMob`/`SerializeObject` (destinations/dest_count, умения, скорость) + тесты конвертера (строки S, скорость, `+-N`). C++ и Python наборы зелёные.
- **Чексуммы сходятся** — полный round-trip Legacy↔YAML на 992 зонах продакшен-мира: было **13 777** расходящихся мобов → стало **0**. `tools/compare_load_checksums.sh` → `OK: no unexpected differences`. Моб 97919 и предмет 91710 совпадают с legacy.
- Сборки с YAML и `-Dsqlite=builtin` компилируются.

Closes #3384
Closes #3386

---

- [x] Поревьювено человеком
