### PR TITLE
fix(shops): продаём вещи с no-классом, блокируем только anti-класс

### DIFF
--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -299,8 +299,10 @@ void shop_node::process_buy(CharData *ch, CharData *keeper, char *argument) {
 		return;
 	}
 
-	if (invalid_anti_class_proto(ch, proto)
-		|| invalid_no_class_proto(ch, proto)) {
+	// Блокируем продажу только для anti-класса ("Недоступен"): такую вещь нельзя
+	// ни носить, ни взять (обжигает). Вещи с no-классом ("Неудобен") продаём:
+	// носить их можно, к тому же в магазине покупают и чармисам (issue #3356).
+	if (invalid_anti_class_proto(ch, proto)) {
 		tell_to_char(keeper, ch, "Мне жаль, но эта вещь тебе не подходит.");
 		return;
 	}


### PR DESCRIPTION
Follow-up к #3356 (comment).

## Контекст
Изначально в #3356: при покупке вещи «Недоступен» (anti-класс) деньги списывались, а вещь обжигала и падала. Базовый отказ-без-денег в `process_buy` уже есть:
```cpp
if (invalid_anti_class_proto(ch, proto) || invalid_no_class_proto(ch, proto)) {
    tell_to_char(keeper, ch, "Мне жаль, но эта вещь тебе не подходит.");
    return;  // деньги не списываются
}
```
Но условие блокировало **и** no-класс («Неудобен»). По уточнению из комментария:
> в магазинах покупают не только для себя, но и например чармисам, надо разрешить продажу invalid_no_class — их нельзя использовать, но носить можно.

## Фикс
Оставляю отказ **только для anti-класса** (вещь нельзя ни носить, ни взять — обжигает). Вещи с no-классом («Неудобен») снова продаются (носить можно, берут чармисам). Деньги при отказе по-прежнему не списываются (`return` до оплаты).

Изменение в одну строку условия в `process_buy` (`src/gameplay/economics/shops_implementation.cpp`).

Собрано и слинковано (`ninja -C build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)