### PR TITLE
fix(buffered_file_writer): guard GCC __attribute__ for MSVC

### DIFF
--- a/src/utils/buffered_file_writer.h
+++ b/src/utils/buffered_file_writer.h
@@ -18,7 +18,14 @@ class BufferedFileWriter {
  public:
 	BufferedFileWriter() { m_buf.reserve(8192); }
 
+// MSVC ne ponimaet GCC-style __attribute__((format(...))). MSVC-shim
+// '#define __attribute__(x)' zhivet v engine/core/sysdep.h, no esli etot
+// zagolovok podtyanyut do sysdep.h (chto v unity-sborkah byvayet --
+// poryadok TU peremeshivayetsya) MSVC padayet s C2059. Stavim guard
+// pryamo zdes, chtoby BufferedFileWriter byl include-order-agnostichnyy.
+#if defined(__GNUC__) || defined(__clang__)
 	__attribute__((format(printf, 2, 3)))
+#endif
 	void printf(const char *format, ...) {
 		va_list args;
 		va_start(args, format);


### PR DESCRIPTION
## Что чинится

`src/utils/buffered_file_writer.h:21`:

```c
__attribute__((format(printf, 2, 3)))
void printf(const char *format, ...);
```

MSVC не понимает GCC-style `__attribute__`. Шим `#define __attribute__(x)`
живёт в `engine/core/sysdep.h`, но если `buffered_file_writer.h`
включается ДО `sysdep.h` — MSVC видит атрибут без шима и валится:

```
buffered_file_writer.h(21): error C2059: syntax error: '('
buffered_file_writer.h(21): error C4430: missing type specifier
buffered_file_writer.h(21): error C2059: syntax error: ')'
```

В unity-сборках TU склеиваются в произвольном порядке — порядок
включений нестабилен. На master CI MSVC проходил случайно, любой
новый файл может перетасовать unity-чанк и вскрыть баг.

## Воспроизведение

PR #3220 (симулятор баланса, #2967) добавляет новые test-файлы.
`windows / MSVC / Base` в его CI взрывается ошибкой выше:
[run 26824294153, job 79087203112](https://github.com/bylins/mud/actions/runs/26824294153/job/79087203112).

## Фикс

Защищаем атрибут компилятор-guard'ом прямо в заголовке:

```c
#if defined(__GNUC__) || defined(__clang__)
    __attribute__((format(printf, 2, 3)))
#endif
    void printf(const char *format, ...);
```

`BufferedFileWriter` становится include-order-agnostic, не зависит от
того, в каком порядке unity-чанки склеит meson.

## Сцена

Самостоятельный фикс, найденный при сведении master в PR #3220.
Аналогично PR #3347 (conf.h MinGW snprintf) — оба unity-build
hygiene фиксы.