### PR TITLE
feat(dg): char.leader(UID) — установка следования из триггера

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -13,6 +13,7 @@
 #include "engine/db/obj_prototypes.h"
 #include "engine/db/utils_find_obj_id_by_vnum.h"
 #include "engine/core/handler.h"
+#include "engine/ui/cmd/do_follow.h"  // circle_follow для char.leader(UID) (#3398)
 #include "dg_event.h"
 #include "engine/ui/color.h"
 #include "gameplay/clans/house.h"
@@ -3126,7 +3127,25 @@ void find_replacement(void *go,
 					snprintf(str, str_size, "%s", out.c_str());
 				}
 			} else if (!str_cmp(field, "leader")) {
-				if (mob->has_master()) {
+				if (subfield && *subfield) {
+					// %actor.leader(UID)% -- установить следование за указанным
+					// персонажем (по UID или имени), как делает команда follow (#3398).
+					CharData *new_leader = get_char(subfield);
+					if (new_leader && new_leader != mob && !circle_follow(mob, new_leader)) {
+						if (mob->has_master()) {
+							stop_follower(mob, kSfEmpty);
+						}
+						mob->removeGroupFlags();
+						for (auto *f : mob->followers) {
+							f->removeGroupFlags();
+						}
+						new_leader->add_follower(mob);
+						// возвращаем UID нового лидера (если следование удалось установить)
+						if (mob->get_master() == new_leader) {
+							snprintf(str, str_size, "%c%ld", uid_type, new_leader->get_uid());
+						}
+					}
+				} else if (mob->has_master()) {
 					snprintf(str, str_size, "%c%ld", uid_type, (mob->get_master())->get_uid());
 				}
 			} else if (!str_cmp(field, "group")) {


### PR DESCRIPTION
Closes #3398

## Что сделано
Поле `leader` у char-переменной в DG-скриптах теперь работает в обе стороны:
- **`%actor.leader%`** (без параметра) — как и раньше, возвращает UID того, за кем следует персонаж;
- **`%actor.leader(UID)%`** (с параметром) — устанавливает следование за указанным персонажем (по UID или имени).

## Как реализовано
Логика установки повторяет команду `follow` (do_follow.cpp), чтобы вести себя предсказуемо:
```cpp
CharData *new_leader = get_char(subfield);          // по UID (%x.id%) или имени
if (new_leader && new_leader != mob && !circle_follow(mob, new_leader)) {
    if (mob->has_master()) stop_follower(mob, kSfEmpty);   // снять прежнего лидера
    mob->removeGroupFlags();
    for (auto *f : mob->followers) f->removeGroupFlags();
    new_leader->add_follower(mob);
    // при успехе вернуть UID нового лидера
}
```
- `circle_follow` защищает от «хоровода» (циклического следования);
- `add_follower` сохраняет штатные проверки (одна комната, kNoGroup и т.п.) и выдаёт обычные сообщения о начале следования;
- при успехе выражение возвращает UID нового лидера, иначе — пусто.

Геттер не тронут (поведение прежнее).

Собрано и слинковано (`ninja -C build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)