### PR TITLE
fix(admin_api): симметричный read API (spec_param, room-echo, JSON-GET сущностей)

### DIFF
--- a/src/engine/network/admin_api/crud_handlers.cpp
+++ b/src/engine/network/admin_api/crud_handlers.cpp
@@ -729,6 +729,7 @@ void HandleUpdateRoom(DescriptorData* d, int room_vnum, const char* json_data)
 		json response;
 		response["status"] = "ok";
 		response["message"] = "Room updated successfully";
+		response["room"] = SerializeRoom(*world[rnum], room_vnum);   // symmetry: echo full room like mob/object
 		SendJsonResponse(d, response);
 	}
 	catch (const json::parse_error&)

--- a/src/engine/network/admin_api/serializers.cpp
+++ b/src/engine/network/admin_api/serializers.cpp
@@ -194,6 +194,7 @@ json SerializeObject(const CObjectPrototype& obj, int vnum)
 	obj_data["description"] = Koi8rToUtf8(obj.get_description());
 	obj_data["action_desc"] = Koi8rToUtf8(obj.get_action_description());
 	obj_data["type"] = static_cast<int>(obj.get_type());
+	obj_data["spec_param"] = obj.get_spec_param();   // symmetry: ParseObjectUpdate reads it
 
 	// Extra flags (4 planes)
 	obj_data["extra_flags"] = json::array();

--- a/tools/web_admin/app.py
+++ b/tools/web_admin/app.py
@@ -500,6 +500,37 @@ def api_zone(vnum):
     return jsonify(mud.get_zone(vnum))
 
 
+# Symmetric JSON read of individual entities (mirror the update/create payloads).
+# Previously only HTML edit forms (/room, /object, ...) existed; a programmatic
+# client could write but not read entities back as JSON.
+@app.route('/api/rooms/<int:vnum>')
+@login_required
+def api_room(vnum):
+    """API: Get room details (full, symmetric with /room/<v>/update)"""
+    return jsonify(get_mud_client().get_room(vnum))
+
+
+@app.route('/api/objects/<int:vnum>')
+@login_required
+def api_object(vnum):
+    """API: Get object details (full, symmetric with /object/<v>/update)"""
+    return jsonify(get_mud_client().get_object(vnum))
+
+
+@app.route('/api/mobs/<int:vnum>')
+@login_required
+def api_mob(vnum):
+    """API: Get mob details (full, symmetric with /mob/<v>/update)"""
+    return jsonify(get_mud_client().get_mob(vnum))
+
+
+@app.route('/api/triggers/<int:vnum>')
+@login_required
+def api_trigger(vnum):
+    """API: Get trigger details (full, symmetric with /trigger/<v>/update)"""
+    return jsonify(get_mud_client().get_trigger(vnum))
+
+
 # ===== API ENDPOINTS FOR AUTOCOMPLETE =====
 
 @app.route('/api/search/mobs')


### PR DESCRIPTION
Делает admin/web API **симметричным**: read возвращает всё, что принимает write. Раньше можно было писать сущность через API, но прочитать её полным JSON — нет (только HTML-формы редактора), а сериализация теряла часть полей → read-modify-write терял данные.

## Изменения
- **`SerializeObject`**: отдаёт `spec_param` (его принимает `ParseObjectUpdate`, а read не возвращал → терялся при чтении-правке-записи).
- **`HandleUpdateRoom`**: возвращает полный `room` (`SerializeRoom`), как уже делают update мобов/объектов (раньше — только `status`/`message`).
- **web_admin**: JSON-GET роуты `/api/{rooms,objects,mobs,triggers}/<vnum>` (зовут уже существующие socket-команды `get_*`). Раньше программного JSON-read сущностей не было.

## Проверено (round-trip: write → read-via-API → сравнить)
- `GET /api/objects/<v>` → `spec_param` совпадает с диском (143), material/type_specific на месте.
- `GET /api/rooms/<v>` → `room_flags=[12,0,0,0]` (kNoEntryMob|kIndoors), sector, exits.
- `GET /api/mobs/<v>` → `mob_flags` включая plane-1 (kAppearsWinter и т.п.).
- `GET /api/triggers/<v>` → name/narg/arglist/script.
- `update_room` echo теперь возвращает полный room.
