### PR TITLE
fix(point_update): мобы снова запоминают спеллы (сравнение с прототипом)

### DIFF
--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1649,13 +1649,15 @@ void point_update() {
 					}
 				}
 				// Remember some spells
-				if (i->mob_specials.have_spell) {
+				if (i->mob_specials.have_spell && GET_MOB_RNUM(i) >= 0) {
+					const auto mob_num = GET_MOB_RNUM(i);
 					auto mana{0};
 					auto count{0};
 					const auto max_mana = GetRealInt(i) * 10;
 					while (count <= to_underlying(ESpell::kLast) && mana < max_mana) {
 						const auto spell_id = real_spell[count];
-						if (GET_SPELL_MEM(i, spell_id) > GET_SPELL_MEM(i, spell_id)) {
+						// Моб добивает память спеллов до уровня своего прототипа.
+						if (GET_SPELL_MEM(mob_proto + mob_num, spell_id) > GET_SPELL_MEM(i, spell_id)) {
 							GET_SPELL_MEM(i, spell_id)++;
 							mana += ((MUD::Spell(spell_id).GetMaxMana() + MUD::Spell(spell_id).GetMinMana()) / 2);
 							i->caster_level += (MUD::Spell(spell_id).IsFlagged(NPC_CALCULATE) ? 1 : 0);


### PR DESCRIPTION
## Проблема

В `point_update()`, блок «Remember some spells» (`game_limits.cpp`), условие восстановления памяти спеллов мобом сравнивало значение **само с собой**:

```cpp
if (GET_SPELL_MEM(i, spell_id) > GET_SPELL_MEM(i, spell_id)) {   // x > x == всегда false
    GET_SPELL_MEM(i, spell_id)++;
    ...
}
```

Следствия:
- мобы **вообще не восстанавливают память спеллов** (тело `if` никогда не выполняется);
- так как `mana` не растёт, `while (count <= kLast && mana < max_mana)` всегда крутится до конца — **~108 холостых итераций на каждом говорящем мобе каждый MUD-час**.

## Причина

Первый операнд потерян при рефакторе (`#2160` / коммит «ускорил point_update»). Исходно сравнивался мем **прототипа** моба (сколько ему положено) с текущим мемом **экземпляра**, и моб добивал память до прототипа:

```cpp
if (GET_SPELL_MEM(mob_proto + mob_num, spell_id) > GET_SPELL_MEM(i, spell_id)) {
```

## Фикс

Возвращаю сравнение с прототипом и страховку `mob_num >= 0`:

```cpp
if (i->mob_specials.have_spell && GET_MOB_RNUM(i) >= 0) {
    const auto mob_num = GET_MOB_RNUM(i);
    ...
        // Моб добивает память спеллов до уровня своего прототипа.
        if (GET_SPELL_MEM(mob_proto + mob_num, spell_id) > GET_SPELL_MEM(i, spell_id)) {
```

Теперь мобы снова восстанавливают память спеллов, а холостые прокрутки прекращаются (как только мем добит до прототипа, `mana` набирается и `while` выходит).

## Проверка

Инкрементальная сборка (`ninja -C build`) — без ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)