### PR TITLE
perf(point_update): обрабатывать только активных, без скана character_list (#3414)

### DIFF
--- a/src/engine/db/world_characters.cpp
+++ b/src/engine/db/world_characters.cpp
@@ -52,6 +52,10 @@ void Characters::push_front(const CharData::shared_ptr &character) {
 	}
 	character->subscribe_for_rnum_changes(m_rnum_change_observer);
 
+	if (!character->IsNpc()) {
+		m_players.insert(character.get());    // #3414: все игроки в игре
+	}
+
 	if (character->purged()) {
 		/*
 		* Anton Gorev (2017/10/29): It is possible is character quit the game without
@@ -166,6 +170,8 @@ void Characters::remove(CharData *character) {
 		character->ZeroCooldowns();
 		chardata_cooldown_list.erase(clist);
 	}
+	m_active.erase(character);     // #3414: убрать из активного набора
+	m_players.erase(character);    // #3414: убрать из списка игроков
 	m_list.erase(index_i->second);
 	m_character_raw_ptr_to_character_ptr.erase(index_i);
 	auto tmp_it = std::find_if(combat_list.begin(), combat_list.end(), [character] (auto it) {return (it.ch == character); });

--- a/src/engine/db/world_characters.h
+++ b/src/engine/db/world_characters.h
@@ -54,6 +54,14 @@ class Characters {
 	void AddToExtractedList(CharData *ch);
 	void PurgeExtractedList();
 
+	// #3414: активный набор для point_update. Мобы помечаются в mobile_activity
+	// (mark_active) и сбрасываются каждый point_update (clear_active); игроки
+	// держатся постоянно (наполняется в push_front, чистится в remove).
+	void mark_active(CharData *ch) { m_active.insert(ch); }
+	const auto &active() const { return m_active; }
+	const auto &players() const { return m_players; }
+	void clear_active() { m_active.clear(); }
+
  private:
 	using character_raw_ptr_to_character_ptr_t = std::unordered_map<const void *, list_t::iterator>;
 	using set_t = std::unordered_set<const CharData *>;
@@ -63,6 +71,8 @@ class Characters {
 	std::unordered_set<CharData *>  m_extracted_list;
 	character_raw_ptr_to_character_ptr_t m_character_raw_ptr_to_character_ptr;
 	vnum_to_characters_set_t m_vnum_to_characters_set;
+	std::unordered_set<CharData *> m_active;     // #3414: активные мобы (за окно между point_update)
+	std::unordered_set<CharData *> m_players;    // #3414: все игроки в игре
 	CharacterRNum_ChangeObserver::shared_ptr m_rnum_change_observer;
 	list_t m_purge_list;
 	set_t m_purge_set;

--- a/src/engine/db/world_characters.h
+++ b/src/engine/db/world_characters.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 class Characters {
  public:
@@ -61,6 +62,14 @@ class Characters {
 	const auto &active() const { return m_active; }
 	const auto &players() const { return m_players; }
 	void clear_active() { m_active.clear(); }
+	// Снимок набора для point_update: активные мобы + все игроки (одним вектором).
+	std::vector<CharData *> active_and_players() const {
+		std::vector<CharData *> result;
+		result.reserve(m_active.size() + m_players.size());
+		result.insert(result.end(), m_active.begin(), m_active.end());
+		result.insert(result.end(), m_players.begin(), m_players.end());
+		return result;
+	}
 
  private:
 	using character_raw_ptr_to_character_ptr_t = std::unordered_map<const void *, list_t::iterator>;

--- a/src/gameplay/ai/mobact.cpp
+++ b/src/gameplay/ai/mobact.cpp
@@ -931,6 +931,7 @@ void mobile_activity(int activity_level, int missed_pulses) {
 		  continue;
 	  }
 	  ++processed_mobs;
+	  character_list.mark_active(ch.get());    // #3414: запомнить активного моба для point_update
 
 	  // Examine call for special procedure
 	  if (ch->IsFlagged(EMobFlag::kSpec) && !no_specials) {

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1534,13 +1534,24 @@ void point_update() {
 	double t_cond = 0.0, t_hp = 0.0, t_mob = 0.0, t_move = 0.0, t_pos = 0.0, t_idle = 0.0;
 	std::size_t scanned = 0, profiled_chars = 0;
 
-	for (auto &ch : character_list) {
-		const auto i = ch.get();
-		++scanned;
+	// #3414: вместо скана всего character_list -- только активные мобы
+	// (их помечает mobile_activity) и все игроки в игре. Снимок указателей,
+	// чтобы отложенные extract не ломали обход set'ов между итерациями.
+	std::vector<CharData *> to_update;
+	to_update.reserve(character_list.active().size() + character_list.players().size());
+	for (auto *m : character_list.active()) {
+		to_update.push_back(m);
+	}
+	for (auto *p : character_list.players()) {
+		to_update.push_back(p);
+	}
+	character_list.clear_active();
 
-		if (i->purged() || (i->IsNpc() && !i->in_used_zone())) {
+	for (auto *i : to_update) {
+		++scanned;
+		if (i->purged()) {
 			continue;
-	  	}
+		}
 
 		if (i->IsNpc()) {
 			i->inc_restore_timer(kSecsPerMudHour);

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1534,17 +1534,10 @@ void point_update() {
 	double t_cond = 0.0, t_hp = 0.0, t_mob = 0.0, t_move = 0.0, t_pos = 0.0, t_idle = 0.0;
 	std::size_t scanned = 0, profiled_chars = 0;
 
-	// #3414: вместо скана всего character_list -- только активные мобы
-	// (их помечает mobile_activity) и все игроки в игре. Снимок указателей,
-	// чтобы отложенные extract не ломали обход set'ов между итерациями.
-	std::vector<CharData *> to_update;
-	to_update.reserve(character_list.active().size() + character_list.players().size());
-	for (auto *m : character_list.active()) {
-		to_update.push_back(m);
-	}
-	for (auto *p : character_list.players()) {
-		to_update.push_back(p);
-	}
+	// #3414: вместо скана всего character_list -- только активные мобы (их
+	// помечает mobile_activity) и все игроки в игре. Снимок, чтобы отложенные
+	// extract не ломали обход set'ов между итерациями.
+	const auto to_update = character_list.active_and_players();
 	character_list.clear_active();
 
 	for (auto *i : to_update) {


### PR DESCRIPTION
**Пример решения по #3414 — на валидацию @kvirund (draft, не для мёржа как есть).**

Шаг в сторону #3180: **без новых глобалов** — активный набор живёт в самом реестре `Characters`.

## Суть
`point_update` больше не сканирует весь `character_list` (десятки тысяч мобов мира ради пропуска неактивных — это и давало спайк ~111 мс). Вместо этого:

- **`Characters::m_active`** — мобы, которых `mobile_activity` уже признал активными. Врезка строго O(1) (`mark_active(ch)` сразу после `++processed_mobs`), без новых проходов в и так перегруженном мобакте. Сбрасывается каждый `point_update` (`clear_active`).
- **`Characters::m_players`** — все игроки в игре. Наполняется в `push_front` (единственная точка входа PC в `character_list`), чистится в `remove`. По игрокам идём всегда → поведение PC не меняется, **включая link-dead** (их не теряем, в отличие от обхода `descriptor_list`).
- `point_update` берёт снимок `active()+players()` в вектор, `clear_active()`, затем идёт по снимку. Висячие указатели исключены чисткой в `Characters::remove` + проверкой `purged()` на каждой итерации.

## Открытые вопросы для валидации
1. **Смена семантики мобов:** регенерируются только активные мобы, а не все в used-зоне. Для простаивающих безвредно (полный HP, ресет восстановит), но это сознательное изменение — ок?
2. **`m_players` как владелец PC** vs альтернативы (descriptor_list) — устраивает ли такой выбор владельца в духе #3180?
3. Тот же приём напрашивается и для самого `mobile_activity` (отдельная задача — мобакт перегружен).

## Проверка
Инкрементальная сборка (`ninja -C build`) — без ошибок. Замер до/после удобно снять профайлером частей из #3412 (там `просмотрено` должно резко упасть).

Связано: #3414, #3180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)