### PR TITLE
refactor(spell): GET_SPELL_MEM/GET_SPELL_TYPE — из макросов в constexpr-функции

### DIFF
--- a/src/engine/entities/char_data.h
+++ b/src/engine/entities/char_data.h
@@ -946,6 +946,16 @@ inline FlagData &AFF_FLAGS(CharData *ch) { return ch->char_specials.saved.affect
 inline const FlagData &AFF_FLAGS(const CharData *ch) { return ch->char_specials.saved.affected_by; }
 inline const FlagData &AFF_FLAGS(const CharData::shared_ptr &ch) { return ch->char_specials.saved.affected_by; }
 
+// Бывшие макросы GET_SPELL_MEM / GET_SPELL_TYPE из utils.h. Возвращают ссылку,
+// т.к. используются и как lvalue (GET_SPELL_MEM(ch, sp)++ и т.п.).
+constexpr ubyte &GET_SPELL_MEM(CharData *ch, ESpell spell) { return ch->real_abils.SplMem[to_underlying(spell)]; }
+constexpr ubyte GET_SPELL_MEM(const CharData *ch, ESpell spell) { return ch->real_abils.SplMem[to_underlying(spell)]; }
+inline ubyte &GET_SPELL_MEM(const CharData::shared_ptr &ch, ESpell spell) { return GET_SPELL_MEM(ch.get(), spell); }
+
+constexpr ubyte &GET_SPELL_TYPE(CharData *ch, ESpell spell) { return ch->real_abils.SplKnw[to_underlying(spell)]; }
+constexpr ubyte GET_SPELL_TYPE(const CharData *ch, ESpell spell) { return ch->real_abils.SplKnw[to_underlying(spell)]; }
+inline ubyte &GET_SPELL_TYPE(const CharData::shared_ptr &ch, ESpell spell) { return GET_SPELL_TYPE(ch.get(), spell); }
+
 inline bool AFF_FLAGGED(const CharData *ch, const EAffect flag) {
 	return AFF_FLAGS(ch).get(flag);
 }

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -464,9 +464,8 @@ const int kNameLevel = 5;
 #define GET_CLAN_STATUS(ch)    ((ch)->player_specials->clanStatus)
 
 #define IS_SPELL_SET(ch, i, pct) (GET_SPELL_TYPE((ch), (i)) & (pct))
-#define GET_SPELL_TYPE(ch, i) ((ch)->real_abils.SplKnw[to_underlying(i)])
+// GET_SPELL_TYPE / GET_SPELL_MEM -- теперь constexpr-функции в char_data.h
 #define UNSET_SPELL_TYPE(ch, i, pct) (GET_SPELL_TYPE((ch), (i)) &= ~(pct))
-#define GET_SPELL_MEM(ch, i)  ((ch)->real_abils.SplMem[to_underlying(i)])
 #define SET_SPELL_MEM(ch, i, pct) ((ch)->real_abils.SplMem[to_underlying(i)] = (pct))
 
 #define GET_EQ(ch, i)      ((ch)->equipment[i])


### PR DESCRIPTION
## Что

Заменил два макроса из `src/utils/utils.h`:
```cpp
#define GET_SPELL_TYPE(ch, i) ((ch)->real_abils.SplKnw[to_underlying(i)])
#define GET_SPELL_MEM(ch, i)  ((ch)->real_abils.SplMem[to_underlying(i)])
```
на **constexpr-функции** в `char_data.h` — рядом с `AFF_FLAGS` и в том же стиле (перегрузки `CharData*` / `const CharData*` / `CharData::shared_ptr`):

```cpp
constexpr ubyte &GET_SPELL_MEM(CharData *ch, ESpell spell) { return ch->real_abils.SplMem[to_underlying(spell)]; }
constexpr ubyte  GET_SPELL_MEM(const CharData *ch, ESpell spell) { return ch->real_abils.SplMem[to_underlying(spell)]; }
inline    ubyte &GET_SPELL_MEM(const CharData::shared_ptr &ch, ESpell spell) { return GET_SPELL_MEM(ch.get(), spell); }
// аналогично GET_SPELL_TYPE (SplKnw)
```

## Детали

- **Возврат ссылки (`ubyte&`)** — макросы используются и как lvalue: `GET_SPELL_MEM(ch, sp)++`, `GET_SPELL_MEM(ch, sp) = ...`, `UNSET_SPELL_TYPE` (`&= ~pct`). Поэтому нужна именно ссылка, а не значение.
- **Имена сохранены** → все ~152 вызова в коде **не меняются**, поправлены только два заголовка (`+11/-2`).
- **Без шаблонов** (как договаривались).
- **Дом — `char_data.h`**, т.к. `utils.h` не включает `char_data.h` (там `CharData` неполный); а в `char_data.h` `CharData`/`ubyte`/`ESpell`/`to_underlying` уже в области видимости, и все потребители его включают.
- Зависимые макросы `IS_SPELL_SET`, `UNSET_SPELL_TYPE`, `SET_SPELL_MEM` работают как прежде — теперь через новые функции.

## Проверка

Полная сборка (`ninja -C build`, ~все цели) — без ошибок. Это же подтверждает, что макросы реально удалены (иначе одноимённые функции были бы испорчены подстановкой). Тесты эти идентификаторы не используют.

🤖 Generated with [Claude Code](https://claude.com/claude-code)