### PR TITLE
feat(runes): предупреждать волхва, когда заряд руны падает ниже 20 (#3422)

### DIFF
--- a/src/gameplay/magic/spells.cpp
+++ b/src/gameplay/magic/spells.cpp
@@ -2295,6 +2295,7 @@ void add_rune_stats(CharData *ch, int vnum, int spelltype) {
 }
 
 void extract_item(CharData *ch, ObjData *obj, int spelltype) {
+	constexpr int kRuneCrackCharge = 20;   // issue #3422: ниже этого заряда руна трещит
 	int extract = false;
 	if (!obj) {
 		return;
@@ -2307,6 +2308,14 @@ void extract_item(CharData *ch, ObjData *obj, int spelltype) {
 		if (GET_OBJ_VAL(obj, 2) <= 0
 			&& IS_SET(obj->get_spec_param(), kItemDecayEmpty)) {
 			extract = true;
+		} else if (spelltype == ESpellType::kRunes
+			&& GET_OBJ_VAL(obj, 2) > 0
+			&& GET_OBJ_VAL(obj, 2) < kRuneCrackCharge) {
+			// issue #3422: руна на исходе -- предупреждаем волхва
+			snprintf(buf, kMaxStringLength,
+					 "$o%s покрыл$U трещинами и скоро рассыплется в тлен.",
+					 char_get_custom_label(obj, ch).c_str());
+			act(buf, false, ch, obj, nullptr, kToChar);
 		}
 	} else if (spelltype != ESpellType::kRunes) {
 		extract = true;


### PR DESCRIPTION
Closes #3422.

## Что

Когда заряд руны падает ниже 20 (но руна ещё не рассыпалась) — волхв получает предупреждение, что руна покрылась трещинами и скоро рассыплется.

В `extract_item()` (`spells.cpp`), после списания заряда `obj->dec_val(2)`:
```cpp
} else if (spelltype == ESpellType::kRunes
    && GET_OBJ_VAL(obj, 2) > 0
    && GET_OBJ_VAL(obj, 2) < kRuneCrackCharge) {   // 20
    snprintf(buf, kMaxStringLength,
             "$o%s покрыл$U трещинами и скоро рассыплется в тлен.",
             char_get_custom_label(obj, ch).c_str());
    act(buf, false, ch, obj, nullptr, kToChar);
}
```

- срабатывает при каждом касте руной, пока остаток в диапазоне 1..19 (напоминание, что пора менять);
- при заряде 0 руна по-прежнему «рассыпалась у вас в руках» и удаляется (существующая логика, не тронута);
- порог вынесен в `kRuneCrackCharge` (= 20, как в issue).

## Проверка
Сборка `ninja -C build` (release, -Wall -Wextra) — без ошибок и предупреждений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)