### PR TITLE
fix(rooms): не спамить act() в пустую комнату при затухании костра/ямки (#3427)

### DIFF
--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1163,11 +1163,12 @@ void room_point_update() {
 			}
 			world[count]->fires -= std::min(mana, int(world[count]->fires));
 			if (world[count]->fires <= 0) {
-				act("Костер затух.",
-					false, world[count]->first_character(), nullptr, nullptr, kToRoom);
-				act("Костер затух.",
-					false, world[count]->first_character(), nullptr, nullptr, kToChar);
-
+				if (world[count]->first_character()) {   // #3427: не спамить act() в пустую комнату
+					act("Костер затух.",
+						false, world[count]->first_character(), nullptr, nullptr, kToRoom);
+					act("Костер затух.",
+						false, world[count]->first_character(), nullptr, nullptr, kToChar);
+				}
 				world[count]->fires = 0;
 			}
 		}
@@ -1186,7 +1187,8 @@ void room_point_update() {
 */
 		if (world[count]->holes) {
 			world[count]->holes--;
-			if (!world[count]->holes || round_up(world[count]->holes) == world[count]->holes) {
+			if ((!world[count]->holes || round_up(world[count]->holes) == world[count]->holes)
+				&& world[count]->first_character()) {   // #3427: не спамить act() в пустую комнату
 				act("Ямку присыпало землей...",
 					false, world[count]->first_character(), nullptr, nullptr, kToRoom);
 				act("Ямку присыпало землей...",


### PR DESCRIPTION
Closes #3427.

## Проблема
Лог забивается строками:
```
:: No valid target to act('Ямку присыпало землей...')!
```
В периодическом проходе по комнатам (`game_limits.cpp`) сообщения о затухании костра («Костер затух.») и засыпании ямки («Ямку присыпало землей...») слались через `act(..., kToRoom/kToChar)` с якорем `world[count]->first_character()`. Когда в комнате **никого нет**, это `nullptr`, а `obj` тоже `nullptr` — `act()` не может определить комнату и пишет в лог `No valid target to act(...)!`. Поскольку таких комнат много и проход частый — спам.

## Фикс
Вывод сообщений гейчу на наличие персонажа в комнате:
```cpp
if (world[count]->fires <= 0) {
    if (world[count]->first_character()) {   // не спамить в пустую комнату
        act("Костер затух.", ... kToRoom);
        act("Костер затух.", ... kToChar);
    }
    world[count]->fires = 0;
}
```
и аналогично для ямки (`&& world[count]->first_character()` в условии).

Декремент `fires`/`holes` происходит **как прежде** — меняется только показ сообщения (некому показывать → молча). Соседние obj-сообщения в этом же цикле не трогаю — там вторым якорем идёт объект, комната находится по нему.

## Проверка
Сборка `ninja -C build` (release, -Wall -Wextra) — без ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)