### PR TITLE
fix(save): порог логирования Crash_frac_save_all — больше 2 мс

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -2478,12 +2478,12 @@ void Crash_frac_save_all(int frac_part) {
 
 			utils::CExecutionTimer timer;
 			Crash_crashsave(d->character.get());
-			if (timer.delta().count() > 0.1)
+			if (timer.delta().count() > 0.002)
 				log("Crash_frac_save_all: Crash_crashsave, timer %f, save player: %s", timer.delta().count(), d->character->get_name().c_str());
 
 			utils::CExecutionTimer timer1;
 			d->character->save_char();
-			if (timer1.delta().count() > 0.1)
+			if (timer1.delta().count() > 0.002)
 				log("Crash_frac_save_all: save_char, timer %f, save player: %s", timer1.delta().count(), d->character->get_name().c_str());
 			d->character->UnsetFlag(EPlrFlag::kCrashSave);
 			saved_count++;


### PR DESCRIPTION
## Что
В `Crash_frac_save_all` (`obj_save.cpp`) замеры `Crash_crashsave` и `save_char` логировались при длительности **> 0.1 с (100 мс)**. Меняю отсечку на **> 0.002 с (2 мс)** в обоих местах:
```cpp
if (timer.delta().count() > 0.002)   // было 0.1
    log("Crash_frac_save_all: Crash_crashsave, timer %f, save player: %s", ...);
...
if (timer1.delta().count() > 0.002)  // было 0.1
    log("Crash_frac_save_all: save_char, timer %f, save player: %s", ...);
```
Теперь в лог попадают и сохранения, которые заметно дольше нормы, но не дотягивали до прежнего порога в 100 мс.

## Проверка
Сборка `ninja -C build` — без ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)