### PR TITLE
fix(mode): обрыв соединения при «реж ширина» (replace за концом строки)

### DIFF
--- a/src/engine/ui/cmd/do_mode.cpp
+++ b/src/engine/ui/cmd/do_mode.cpp
@@ -567,7 +567,8 @@ void SetScreen(CharData *ch, char *argument, int flag) {
 		ch->player_specials->saved.stringLength = size;
 		SendMsgToChar("Выводим тестовую строку:\r\n", ch);
 		for (auto i = 5; i <= size; i +=5) {
-			out.replace(i - 1, i / 100 + 2, std::to_string(i));
+			const auto num = std::to_string(i);
+			out.replace(i - 1, num.length(), num);   // длина строки не меняется -- позиции не уползают
 		}
 		SendMsgToChar(ch, "%s\r\n", out.c_str());
 		ch->save_char();


### PR DESCRIPTION
## Проблема
Команда `реж ширина 300` выбивала игрока:
```
[system] Соединение завершено(обрыв).  STD exception:
basic_string::replace: __pos (which is 289) > this->size() (which is 287)
```

## Причина
`SetScreen()` (`do_mode.cpp`) строит тестовую «линейку», подставляя числа в строку из точек:
```cpp
std::string out(size + size/100 + 2, '.');
for (auto i = 5; i <= size; i += 5)
    out.replace(i - 1, i / 100 + 2, std::to_string(i));
```
Счётчик заменяемых символов `i/100+2` не равен числу цифр: для `i>=200` он даёт 4-5, тогда как число трёхзначное (3 символа). `replace(pos, count, str)` при `count > str.size()` **укорачивает** строку, поэтому позиции `i-1` постепенно уползают за её конец. На ширине 300 к `i=290` получаем `pos 289 > size 287` → `std::out_of_range` → обрыв соединения.

## Фикс
Заменяем ровно столько символов, сколько в числе:
```cpp
for (auto i = 5; i <= size; i += 5) {
    const auto num = std::to_string(i);
    out.replace(i - 1, num.length(), num);   // длина строки не меняется
}
```
Длина `out` не меняется → позиции `i-1` всегда валидны, краша нет.

## Проверка
Сборка `ninja -C build` — без ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)