### PR TITLE
fix(prompt): не показывать служебный kReligion в таймерах статуса

### DIFF
--- a/src/engine/core/iosystem.cpp
+++ b/src/engine/core/iosystem.cpp
@@ -1166,7 +1166,8 @@ std::string MakePrompt(DescriptorData *d) {
 			for (auto timed : ch->timed_skill) {
 				int display_time = (timed.second - time(0) - 1) / 60 + 1;
 
-				if (display_time > 0 && timed.first != ESkill::kWarcry && timed.first != ESkill::kTurnUndead) {
+				if (display_time > 0 && timed.first != ESkill::kWarcry && timed.first != ESkill::kTurnUndead
+					&& timed.first != ESkill::kReligion) {
 					fmt::format_to(std::back_inserter(out), "{}:{} ",
 							  MUD::Skill(timed.first).GetAbbr(), +display_time);
 				}


### PR DESCRIPTION
## Проблема

После молитвы/жертвы («моли геор») в строке статуса появлялось `Error:12` (#3434).

## Причина

Молитва навешивает timed-skill `kReligion` на 12 минут (`do_pray.cpp:100`). При включённом флаге `kDispTimed` промпт печатает каждый временной скилл как `аббревиатура:минуты` (`iosystem.cpp:1169`), исключая только `kWarcry` и `kTurnUndead`. Аббревиатура `kReligion` в `skills.xml` — буквально `abbr="Error"`, отсюда `Error:12` (12 — оставшиеся минуты).

## Решение

`kReligion` — служебное умение (`mode="kService"`), и одной аббревиатурой молитву и жертву всё равно не покрыть. Исключаем его из показа таймеров рядом с `kWarcry`/`kTurnUndead`.

Fixes #3434

🤖 Generated with [Claude Code](https://claude.com/claude-code)