### PR TITLE
feat(dg-scripts): obj.CanBeSeen — проверка видимости предмета игроком

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -3335,6 +3335,13 @@ void find_replacement(void *go,
 			snprintf(str, str_size, "%d", GET_OBJ_VNUM(obj));
 		} else if (!str_cmp(field, "type")) {
 			snprintf(str, str_size, "%d", (int) obj->get_type());
+		} else if (!str_cmp(field, "CanBeSeen")) {
+			CharData *viewer = *subfield ? get_char(subfield) : nullptr;
+			if (viewer && !CAN_SEE_OBJ(viewer, obj)) {
+				snprintf(str, str_size, "0");
+			} else {
+				snprintf(str, str_size, "1");
+			}
 		} else if (!str_cmp(field, "timer")) {
 			snprintf(str, str_size, "%d", obj->get_timer());
 		} else if (!str_cmp(field, "objmax")) {


### PR DESCRIPTION
## Проблема

В слепоте при «потереть медальон» (obj 2198, триггер 2103) лошади загружаются бесконечно и не убегают (#3436).

Команда `потереть` отрабатывает независимо от того, видит игрок медальон или нет. Слепой игрок медальон не видит, лошадь оседлать не может (`oforce %actor% оседлать лошадь` не находит цель), каждое следующее «потереть» лоадит новую лошадь.

Для мобов есть `%char.canbeseen%`, а для предметов аналога не было — проверить «видит ли игрок предмет» из триггера было нельзя.

## Решение

Добавлено поле `CanBeSeen` для объектов в `find_replacement` (`dg_scripts.cpp`):

```
%self.canbeseen(%actor%)%
```

Возвращает `1`, если указанный персонаж видит предмет (`CAN_SEE_OBJ`), иначе `0`. Без аргумента возвращает `1`. Семантика и логика повторяют мобовский `CanBeSeen`.

## Как чинить сам триггер 2103

В начало command-триггера «потереть» добавить проверку:

```
if !%self.canbeseen(%actor%)%
  osend %actor% Вы не видите медальон.
  halt
end
```

Это правка зоны (`lib/world/trg/21.trg`), оставляю на усмотрение автора зоны — можно через веб-панель.

Refs #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)