### PR TITLE
feat(dg-scripts): char.canbeseen принимает аргумент-смотрящего

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -2718,7 +2718,14 @@ void find_replacement(void *go,
 		else if (!str_cmp(field, "cancarryweight"))
 			snprintf(str, str_size, "%d", CAN_CARRY_W(mob));
 		else if (!str_cmp(field, "CanBeSeen")) {
-			if ((type == MOB_TRIGGER) && !CAN_SEE(((CharData *) go), mob)) {
+			// С аргументом %char.canbeseen(<смотрящий>)% - видит ли указанный
+			// персонаж этого (CAN_SEE учитывает слепоту/невидимость/темноту).
+			// Без аргумента сохраняем прежнее поведение: в MOB_TRIGGER проверяем
+			// видимость мобом-хозяином триггера, иначе считаем видимым.
+			CharData *viewer = *subfield ? get_char(subfield) : nullptr;
+			if (viewer) {
+				snprintf(str, str_size, CAN_SEE(viewer, mob) ? "1" : "0");
+			} else if ((type == MOB_TRIGGER) && !CAN_SEE(((CharData *) go), mob)) {
 				snprintf(str, str_size, "0");
 			} else {
 				snprintf(str, str_size, "1");


### PR DESCRIPTION
## Что

По аналогии с недавним `obj.canbeseen` (#3438) — теперь `%char.canbeseen(...)%` принимает смотрящего:

```
%self.canbeseen(%actor%)%   -> 1, если actor видит этого моба, иначе 0
```

`CAN_SEE` учитывает слепоту, невидимость, темноту, holylight.

## Совместимость

Без аргумента поведение не изменилось: в `MOB_TRIGGER` проверяется видимость мобом-хозяином триггера, в остальных случаях возвращается `1`. Существующие триггеры с `%char.canbeseen%` работают как прежде.

Проверено сборкой.

🤖 Generated with [Claude Code](https://claude.com/claude-code)