### PR TITLE
fix(handler): вернуть гард if(showlog) в ExtractObjFromWorld (#3440)

### DIFF
--- a/src/engine/core/handler.cpp
+++ b/src/engine/core/handler.cpp
@@ -1489,8 +1489,7 @@ void ExtractObjFromWorld(ObjData *obj, bool showlog) {
 	utils::CExecutionTimer timer;
 
 	strcpy(name, obj->get_PName(ECase::kNom).c_str());
-//	if (showlog);
-	{
+	if (showlog) {
 		log("[Extract obj] Start for: %s vnum == %d room = %d timer == %d",
 				name, GET_OBJ_VNUM(obj), roomload, obj->get_timer());
 	}
@@ -1551,8 +1550,7 @@ void ExtractObjFromWorld(ObjData *obj, bool showlog) {
 	check_exchange(obj);
 	obj->get_script()->set_purged();
 	world_objects.remove(obj);
-//	if (showlog);
-	{
+	if (showlog) {
 		log("[Extract obj] Stop, delta %f", timer.delta().count());
 	}
 }


### PR DESCRIPTION
## Проблема

В `ExtractObjFromWorld` лог `[Extract obj] Start/Stop` печатался **безусловно** — проверка `if (showlog)` была закомментирована (включали под поиск уже устранённой баги):

```cpp
//	if (showlog);
	{
		log("[Extract obj] Start for: ...");
	}
```

На форс-ренте игрока с большим инвентарём это давало тысячи строк лога за один пульс и сидело в спайке `point_update` (#3440): за проблемный тик — **738 экстрактов = ~1476 строк лога**.

## Решение

Возвращаем гард `if (showlog)`. По умолчанию `showlog = false` и ни один из 124 вызовов не передаёт `true`, поэтому подробный лог гаснет везде. Понадобится для отладки — передать `showlog=true` в нужном вызове.

Refs #3440

🤖 Generated with [Claude Code](https://claude.com/claude-code)