### PR TITLE
perf(save): профилировка save_char/save_char_objects по фазам (#3440)

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -1847,6 +1847,10 @@ int save_char_objects(CharData *ch, int savetype, int rentcost) {
 		return false;
 	}
 
+	// Таймер всей функции -- чтобы поймать спайки ниже порога total_io (#3440):
+	// если время не в трёх замеренных фазах, оно всплывёт в "other".
+	utils::CExecutionTimer fn_timer;
+
 	// удаление !рент предметов
 	if (savetype != RENT_CRASH) {
 		Crash_extract_norent_eq(ch);
@@ -2014,9 +2018,13 @@ int save_char_objects(CharData *ch, int savetype, int rentcost) {
 	// Дисковый write почти не зависит от числа предметов и обычно доминирует,
 	// поэтому "меньше предметов, но дольше" -- это про занятость диска, не про items.
 	const double total_io_sec = serialize_sec + obj_io_sec + timer_io_sec;
-	if (total_io_sec > 0.04) {
-		log("save_char_objects: %s items=%d serialize=%.4f write=%.4f crc=%.4f time_io=%.4f total=%.4f",
-			GET_NAME(ch), num, serialize_sec, write_sec, crc_sec, timer_io_sec, total_io_sec);
+	const double fn_sec = fn_timer.delta().count();
+	// "other" -- время вне трёх замеренных фаз (calcitems, расчёт ренты,
+	// экстракты, Crash_create_timer и пр.). Если спайк тут -- видно сразу.
+	const double other_sec = fn_sec - total_io_sec;
+	if (fn_sec > 0.02) {
+		log("save_char_objects: %s items=%d serialize=%.4f write=%.4f crc=%.4f time_io=%.4f other=%.4f total=%.4f",
+			GET_NAME(ch), num, serialize_sec, write_sec, crc_sec, timer_io_sec, other_sec, fn_sec);
 	}
 
 	if (savetype == RENT_CRASH) {

--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -7,6 +7,7 @@
 #include <sys/stat.h>
 
 #include "utils/file_crc.h"
+#include "utils/utils_time.h"
 #include "utils/buffered_file_writer.h"
 #include "utils/backtrace.h"
 
@@ -418,6 +419,11 @@ void Player::save_char() {
 
 	if (this->IsNpc() || this->get_pfilepos() < 0)
 		return;
+
+	// Профилировка save_char (#3440): общий таймер функции + фазы.
+	utils::CExecutionTimer fn_timer;
+	double d_account = 0.0, d_vars = 0.0, d_write = 0.0;
+
 	if (this->account == nullptr) {
 		this->account = Account::get_account(GET_EMAIL(this));
 		if (this->account == nullptr) {
@@ -426,9 +432,9 @@ void Player::save_char() {
 			this->account = temp_account;
 		}
 	}
-	this->account->save_to_file();
+	{ utils::CExecutionTimer t; this->account->save_to_file(); d_account = t.delta().count(); }
 	log("Save char %s", GET_NAME(this));
-	save_char_vars(this);
+	{ utils::CExecutionTimer t; save_char_vars(this); d_vars = t.delta().count(); }
 
 	// Запись чара в новом формате
 	get_filename(GET_NAME(this), filename, kPlayersFile);
@@ -898,6 +904,7 @@ void Player::save_char() {
 	// буфера на всех платформах) и из него же считаем CRC -- без перечитывания
 	// только что записанного файла.
 	const std::string &pfile = saved.str();
+	utils::CExecutionTimer wt;
 	FILE *pf = fopen(filename, "wb");
 	if (!pf) {
 		perror("Unable open charfile");
@@ -912,6 +919,7 @@ void Player::save_char() {
 		mudlog(ss.str(), BRF, kLvlGod, SYSLOG, true);
 	}
 #endif
+	d_write = wt.delta().count();
 	FileCRC::update_from_content(this->get_uid(), FileCRC::kPlayer, pfile.data(), pfile.size());
 
 	// восстанавливаем аффекты
@@ -940,6 +948,13 @@ void Player::save_char() {
 		player_table[i].set_uid(this->get_uid());
 		player_table[i].plr_class = GetClass();
 		//end by WorM
+	}
+
+	const double fn_sec = fn_timer.delta().count();
+	const double other_sec = fn_sec - d_account - d_vars - d_write;
+	if (fn_sec > 0.02) {
+		log("save_char prof: %s account=%.4f vars=%.4f write=%.4f other=%.4f total=%.4f",
+			GET_NAME(this), d_account, d_vars, d_write, other_sec, fn_sec);
 	}
 }
 


### PR DESCRIPTION
## Зачем

Спайки дробного сейва: Кекропс **28мс** в `Crash_crashsave` (объекты), Эстор **40мс** в `save_char` (чар). По данным с боевого это **не I/O и не объём**: файл Куруша 50КБ пишется быстрее, чем 7КБ Кекропса; у обоих пусто в скрипт-переменных и памяти. Значит время горит в CPU какой-то фазы сейва, специфичной для игрока. Существующий лог `save_char_objects` печатал разбивку только при `total_io > 0.04` — 28мс Кекропса под порог не попадали.

## Что

- **`save_char_objects`**: таймер всей функции + поле `other` (время вне замеренных `serialize/write/crc/time_io` — это `calcitems`, расчёт ренты, экстракты, `Crash_create_timer`). Порог лога снижен 0.04 → 0.02.
- **`save_char`**: под-таймеры `account` / `vars` / `write` + `other` (сериализация полей + снятие/возврат экипировки). Лог при `total > 0.02`.

Логируется только на медленном сейве (спама нет). После локализации замеры убираем и чиним конкретную фазу.

Refs #3440

🤖 Generated with [Claude Code](https://claude.com/claude-code)