### PR TITLE
perf(account): писать файл аккаунта только при изменении (#3440)

### DIFF
--- a/src/administration/accounts.cpp
+++ b/src/administration/accounts.cpp
@@ -110,22 +110,38 @@ void Account::list_players(DescriptorData *d) {
 }
 
 void Account::save_to_file() {
-	std::ofstream out;
-	out.open(LIB_ACCOUNTS + this->email);
-	if (out.is_open()) {
-		for (const auto &x : this->dquests) {
-			out << "DaiQ: " << x.id << " " << x.count << " " << x.time << "\n";
-		}
-		for (const auto &x : this->history_logins) {
-			out << "hl: " << x.first << " " << x.second.count << " " << x.second.last_login << "\n";
-		}
-		for (const auto &x : this->players_list) {
-			out << "p: " << x << "\n";
-		}
-		out << "Pwd: " << this->hash_password << "\n";
-		out << "ll: " << this->last_login << "\n";
+	// save_to_file зовётся на каждый save_char, а данные аккаунта почти не
+	// меняются и стабильны между реальными изменениями (нет постоянно
+	// растущих полей). Поэтому собираем содержимое в буфер, и если оно не
+	// изменилось с прошлой записи -- файл не трогаем. Так убираем лишнюю
+	// (и подверженную дисковым столлам) запись из горячего пути сейва (#3440).
+	// Формат вывода байт-в-байт прежний (те же операции <<).
+	std::ostringstream oss;
+	for (const auto &x : this->dquests) {
+		oss << "DaiQ: " << x.id << " " << x.count << " " << x.time << "\n";
 	}
-	out.close();
+	for (const auto &x : this->history_logins) {
+		oss << "hl: " << x.first << " " << x.second.count << " " << x.second.last_login << "\n";
+	}
+	for (const auto &x : this->players_list) {
+		oss << "p: " << x << "\n";
+	}
+	oss << "Pwd: " << this->hash_password << "\n";
+	oss << "ll: " << this->last_login << "\n";
+	const std::string content = oss.str();
+
+	const std::size_t h = std::hash<std::string>{}(content);
+	if (m_saved_hash_valid && h == m_saved_hash) {
+		return;  // аккаунт не менялся -- запись не нужна
+	}
+
+	std::ofstream out(LIB_ACCOUNTS + this->email);
+	if (out.is_open()) {
+		out << content;
+		out.close();
+		m_saved_hash = h;
+		m_saved_hash_valid = true;
+	}
 }
 
 void Account::read_from_file() {

--- a/src/administration/accounts.h
+++ b/src/administration/accounts.h
@@ -43,6 +43,10 @@ class Account {
 	time_t last_login;
 	// История логинов, ключ - айпи, в структуре количество раз, с которых был произведен заход с данного айпи-адреса + дата, когда последний раз выходили с данного айпишника
 	std::unordered_map<std::string, login_index> history_logins;
+	// Хеш последнего записанного содержимого: save_to_file пропускает запись,
+	// если аккаунт не менялся (он зовётся на каждый save_char, #3440).
+	std::size_t m_saved_hash = 0;
+	bool m_saved_hash_valid = false;
 
  public:
 	void purge_erased();


### PR DESCRIPTION
## Зачем

Профилировка `save_char` на боевом (#3440, инструментация из #3443) показала, что фаза `account` (`account->save_to_file`) регулярно доминирует в спайке сейва:

```
save_char prof: Тереза account=0.0316 vars=0.0000 write=0.0001 other=0.0011 total=0.0328
save_char prof: Соромир account=0.0200 ... total=0.0207
save_char prof: Рояна  account=0.0212 ... total=0.0216
```

Файл аккаунта пишется на **каждый** `save_char` (т.е. на каждый дробный сейв игрока), хотя данные аккаунта почти не меняются. Это лишняя запись в горячем пути пульса, к тому же подверженная перемежающимся дисковым столлам (см. разбор в #3440).

## Что

`save_to_file()` теперь собирает содержимое в буфер, хеширует и **пишет файл только если содержимое изменилось** с прошлой записи. Формат вывода байт-в-байт прежний (те же операции `<<`) — загрузка не меняется.

Сравнение по **содержимому** (а не dirty-флаг по местам мутаций) выбрано намеренно: данные аккаунта стабильны между реальными изменениями (нет постоянно растущих полей вроде «времени в игре»), поэтому контент-хеш ничего не пропускает и не даёт потери данных, в отличие от ручных флагов, где легко забыть точку изменения.

Проверено сборкой.

Refs #3440

🤖 Generated with [Claude Code](https://claude.com/claude-code)