### PR TITLE
feat(tell): переносить длинный приват по словам (#3429)

### DIFF
--- a/src/gameplay/communication/talk.cpp
+++ b/src/gameplay/communication/talk.cpp
@@ -9,6 +9,7 @@
 #include "engine/entities/char_data.h"
 #include "engine/ui/color.h"
 #include "remember.h"
+#include "utils/utils_string.h"
 
 void do_echo(CharData *ch, char *argument, int cmd, int subcmd);
 
@@ -89,7 +90,13 @@ void perform_tell(CharData *ch, CharData *vict, char *arg) {
 	} else {
 		snprintf(buf, kMaxStringLength, "Кто-то сказал вам : '%s'", arg);
 	}
-	snprintf(buf1, kMaxStringLength, "%s%s%s\r\n", kColorBoldCyn, utils::CAP(buf), kColorNrm);
+	// перенос длинного телла по словам на ширину экрана получателя
+	// (stringLength == 0 -- лимит не задан, не переносим; NPC -- player_specials нет)
+	std::string tell_line = utils::CAP(buf);
+	if (!vict->IsNpc() && vict->player_specials->saved.stringLength > 0) {
+		tell_line = utils::OutWordsList(tell_line, vict->player_specials->saved.stringLength, " ");
+	}
+	snprintf(buf1, kMaxStringLength, "%s%s%s\r\n", kColorBoldCyn, tell_line.c_str(), kColorNrm);
 	SendMsgToChar(buf1, vict);
 	if (!vict->IsNpc()) {
 		vict->remember_add(buf1, Remember::ALL);

--- a/src/utils/utils_string.cpp
+++ b/src/utils/utils_string.cpp
@@ -1045,19 +1045,28 @@ void kill_ems(std::string &str) {
 	str.erase(std::remove(str.begin(), str.end(), '\r'), str.end());
 }
 
-std::string utils::OutWordsList(const std::vector<std::string> &words, size_t max_length) {
+std::string utils::OutWordsList(const std::vector<std::string> &words, size_t max_length,
+		const std::string &separator) {
 	std::string result;
 	size_t line_length = 0;
 	bool first = true;
+	// separator -- это и есть то, что стоит между словами на одной строке
+	// (", " для списка, " " для обычного переноса по словам). На переносе
+	// строки хвостовые пробелы у разделителя срезаем, чтобы не оставлять их
+	// перед \r\n (для "," получаем ",\r\n", для " " -- просто "\r\n").
+	std::string eol_separator = separator;
+	while (!eol_separator.empty() && eol_separator.back() == ' ') {
+		eol_separator.pop_back();
+	}
 
 	for (const auto &word : words) {
 		if (!first) {
-			if (line_length + 2 + word.size() > max_length) {
-				result += ",\r\n";
+			if (line_length + separator.size() + word.size() > max_length) {
+				result += eol_separator + "\r\n";
 				line_length = 0;
 			} else {
-				result += ", ";
-				line_length += 2;
+				result += separator;
+				line_length += separator.size();
 			}
 		}
 		result += word;
@@ -1067,14 +1076,15 @@ std::string utils::OutWordsList(const std::vector<std::string> &words, size_t ma
 	return result;
 }
 
-std::string utils::OutWordsList(const std::string &words_str, size_t max_length) {
+std::string utils::OutWordsList(const std::string &words_str, size_t max_length,
+		const std::string &separator) {
 	std::vector<std::string> words;
 	std::istringstream stream(words_str);
 	std::string word;
 	while (stream >> word) {
 		words.push_back(word);
 	}
-	return OutWordsList(words, max_length);
+	return OutWordsList(words, max_length, separator);
 }
 
 namespace utils {

--- a/src/utils/utils_string.h
+++ b/src/utils/utils_string.h
@@ -296,11 +296,15 @@ std::string &colorCAP(std::string &&txt);
 char *CAP(char *txt);
 std::string CAP(const std::string txt);
 
-// формирует строку из списка слов, разделенных ", "
-// при превышении max_length переносит на новую строку
-std::string OutWordsList(const std::vector<std::string> &words, size_t max_length);
+// формирует строку из списка слов, разделенных separator (то, что стоит
+// между словами на строке: ", " для списка, " " для переноса по словам)
+// при превышении max_length переносит на новую строку, срезая хвостовой
+// пробел разделителя перед \r\n. separator по умолчанию ", " -- прежнее поведение
+std::string OutWordsList(const std::vector<std::string> &words, size_t max_length,
+		const std::string &separator = ", ");
 // то же, но на вход строка со словами через пробелы
-std::string OutWordsList(const std::string &words_str, size_t max_length);
+std::string OutWordsList(const std::string &words_str, size_t max_length,
+		const std::string &separator = ", ");
 
 /// Вернуть строку пола персонажа по числовому значению (to_underlying(ch->get_sex())).
 std::string sprintGender(int gender_value);


### PR DESCRIPTION
Часть #3429 — форматированный перенос длинных сообщений. Первая итерация: **приваты**.

> ⚠️ Стекается поверх #3447 (хелпер `OutWordsList` с разделителем). Пока #3447 не слит, этот PR показывает и его коммит; после мёржа #3447 останется только коммит привата.

## Что

Длинный телл показывался получателю одной сплошной строкой. Теперь сообщение переносится по словам через `utils::OutWordsList(line, width, " ")` на ширину экрана получателя (`player_specials->saved.stringLength`).

Защиты:
- `stringLength == 0` (лимит не задан) — не переносим;
- NPC-получатель — не трогаем (у моба нет `player_specials`).

Эхо отправителю («Вы сказали…») в этой итерации не трогаю — при необходимости добавлю отдельно.

Дальше по #3429: почта и доски (вариант А — построчный перенос с сохранением абзацев).

## Проверка

`ninja -C build` — собирается чисто, линкуется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)