### PR TITLE
feat(boards,mail): переносить длинный текст по словам (#3429)

### DIFF
--- a/src/gameplay/communication/boards/boards.cpp
+++ b/src/gameplay/communication/boards/boards.cpp
@@ -237,7 +237,10 @@ void DoBoard(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		}
 		std::ostringstream out;
 		const auto messages_index = num - 1;
-		special_message_format(out, board.get_message(messages_index));
+		// ширина экрана читателя для переноса тела сообщения (0 -- лимит не задан)
+		const size_t width = (!ch->IsNpc() && ch->player_specials->saved.stringLength > 0)
+				? ch->player_specials->saved.stringLength : 0;
+		special_message_format(out, board.get_message(messages_index), width);
 		page_string(ch->desc, out.str());
 		set_last_read(ch, board.get_type(), board.messages[messages_index]->date);
 	} else if (CompareParam(buffer, "писать")

--- a/src/gameplay/communication/boards/boards_formatters.cpp
+++ b/src/gameplay/communication/boards/boards_formatters.cpp
@@ -1,4 +1,5 @@
 #include "boards_formatters.h"
+#include "utils/utils_string.h"
 
 #include "engine/entities/char_data.h"
 #include "engine/ui/color.h"
@@ -195,15 +196,17 @@ Boards::Board::Formatter::shared_ptr FormattersBuilder::create(const BoardTypes 
 	}
 }
 
-void special_message_format(std::ostringstream &out, const Message::shared_ptr message) {
+void special_message_format(std::ostringstream &out, const Message::shared_ptr message, size_t max_length) {
 	char timeBuf[17];
 	strftime(timeBuf, sizeof(timeBuf), "%H:%M %d-%m-%Y", localtime(&message->date));
 
+	// тело сообщения переносим по словам на ширину экрана читателя, сохраняя
+	// абзацы (max_length == 0 -- без переноса, прежнее поведение)
 	out << "[" << message->num + 1 << "] "
 		<< timeBuf << " "
 		<< "(" << message->author << ") :: "
 		<< message->subject << "\r\n\r\n"
-		<< message->text << "\r\n";
+		<< utils::WrapText(message->text, max_length) << "\r\n";
 }
 }
 

--- a/src/gameplay/communication/boards/boards_formatters.h
+++ b/src/gameplay/communication/boards/boards_formatters.h
@@ -9,7 +9,8 @@ class CharData;    // to avoid inclusion of "char.hpp"
 
 namespace Boards {
 void special_message_format(std::ostringstream &out,
-							const Message::shared_ptr message);    // TODO: Get rid of this special case.
+							const Message::shared_ptr message,
+							size_t max_length = 0);    // TODO: Get rid of this special case.
 
 class FormattersBuilder {
  public:

--- a/src/gameplay/communication/mail.cpp
+++ b/src/gameplay/communication/mail.cpp
@@ -9,6 +9,7 @@
 ************************************************************************ */
 
 #include "mail.h"
+#include "utils/utils_string.h"
 
 #include "engine/db/world_objects.h"
 #include "engine/core/handler.h"
@@ -534,6 +535,11 @@ void receive(CharData *ch, CharData *mailman) {
 
 		std::string text = coder::base64_decode(i->second.text);
 		utils::Trim(text);
+		// переносим тело письма по словам на ширину экрана получателя, сохраняя
+		// абзацы (stringLength == 0 -- лимит не задан, не переносим)
+		if (!ch->IsNpc() && ch->player_specials->saved.stringLength > 0) {
+			text = utils::WrapText(text, ch->player_specials->saved.stringLength);
+		}
 		obj->set_action_description(buf_ + text + "\r\n\r\n");
 		PlaceObjToInventory(obj.get(), ch);
 		act("$n дал$g вам письмо.", false, mailman, 0, ch, kToVict);

--- a/src/utils/utils_string.cpp
+++ b/src/utils/utils_string.cpp
@@ -1087,6 +1087,27 @@ std::string utils::OutWordsList(const std::string &words_str, size_t max_length,
 	return OutWordsList(words, max_length, separator);
 }
 
+std::string utils::WrapText(const std::string &text, size_t max_length) {
+	std::string result;
+	std::istringstream stream(text);
+	std::string line;
+	bool first = true;
+	// разбиваем по '\n', каждую строку переносим отдельно -- авторские
+	// переносы и пустые строки (абзацы) сохраняются
+	while (std::getline(stream, line)) {
+		if (!line.empty() && line.back() == '\r') {  // срезаем хвостовой '\r' от \r\n
+			line.pop_back();
+		}
+		if (!first) {
+			result += "\r\n";
+		}
+		first = false;
+		// max_length == 0 -- без переноса; иначе пустая строка вернётся пустой
+		result += (max_length == 0) ? line : OutWordsList(line, max_length, " ");
+	}
+	return result;
+}
+
 namespace utils {
 std::string sprintGender(int gender_value) {
 	int nr = 0;

--- a/src/utils/utils_string.h
+++ b/src/utils/utils_string.h
@@ -305,6 +305,11 @@ std::string OutWordsList(const std::vector<std::string> &words, size_t max_lengt
 // то же, но на вход строка со словами через пробелы
 std::string OutWordsList(const std::string &words_str, size_t max_length,
 		const std::string &separator = ", ");
+// переносит многострочный текст по словам на ширину max_length, сохраняя
+// авторские переносы строк и пустые строки (абзацы): каждая исходная строка
+// переносится независимо через OutWordsList(line, max_length, " ").
+// max_length == 0 -- перенос не выполняется (текст возвращается как есть с \r\n)
+std::string WrapText(const std::string &text, size_t max_length);
 
 /// Вернуть строку пола персонажа по числовому значению (to_underlying(ch->get_sex())).
 std::string sprintGender(int gender_value);


### PR DESCRIPTION
Часть #3429 — форматированный перенос длинных сообщений. Доски и почта (вариант А: построчный перенос с сохранением абзацев).

## Хелпер

`utils::WrapText(text, max_length)` — переносит многострочный текст по словам на ширину `max_length` через `OutWordsList(line, max_length, " ")`, **сохраняя авторские переносы строк и пустые строки (абзацы)**: каждая исходная строка переносится независимо. `max_length == 0` — текст возвращается как есть.

## Применение

- **Доски** (`special_message_format`): добавлен параметр ширины (дефолт `0`), тело сообщения переносится на `stringLength` читателя. Ширина пробрасывается из `boards.cpp` при чтении (`читать N`). Второй вызов формата (новости) использует дефолт `0` — поведение не меняется.
- **Почта** (`receive()`): тело письма переносится на `stringLength` получателя перед записью в `action_description`.

Защита везде: NPC и `stringLength == 0` — без переноса.

## Известное ограничение

`WrapText` разбивает строку по словам (`>>`), поэтому **внутри строки** ведущие/множественные пробелы (ручной отступ) схлопываются. Переносы строк и абзацы сохраняются. Для тел писем/сообщений это приемлемо; если где-то нужен ручной отступ — отдельная история.

## Проверка

`ninja -C build` — собирается чисто, без предупреждений; линкуется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)