### PR TITLE
feat(dg): world.loadobj(vnum, chance) (#3453)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -1889,13 +1889,13 @@ void find_replacement(void *go,
 			} else if (!str_cmp(field, "loadobj") && num > 0) {
 				// world.loadobj(vnum, chance): загрузить предмет с шансом chance (1..1000 промилле),
 				// учитывая MIW. Размещение делает штатная команда load по типу триггера.
-				// Поле ничего не подставляет в скрипт (пустая строка): иначе при рекурсивной
-				// подстановке "1"/"0" примутся за значение и пойдёт спам ошибок, хотя загрузка
-				// и выполнится. Нужен контроль успеха - проверяйте вручную через if и load.
+				// Возвращает "1" при загрузке, иначе "0". Загруженный предмет доступен через
+				// %LoadedUid% (выставляет load-команда).
 				const auto rnum = GetObjRnum(num);
 
 				if (rnum <= 0) {
 					trig_log(trig, fmt::format("Указан неверный параметр vnum ({}) в loadobj", num).c_str());
+					snprintf(str, str_size, "0");
 					return;
 				}
 				// второй аргумент (шанс) после vnum в subfield
@@ -1910,6 +1910,7 @@ void find_replacement(void *go,
 
 				if (chance < 1 || chance > 1000) {
 					trig_log(trig, fmt::format("Неверный шанс ({}) в loadobj, нужно 1..1000", chance).c_str());
+					snprintf(str, str_size, "0");
 					return;
 				}
 				// проверка максимума в мире (логика как в CanBeLoaded)
@@ -1918,10 +1919,12 @@ void find_replacement(void *go,
 					|| (obj_proto.actual_count(rnum) < GetObjMIW(rnum));
 
 				if (!can_load) {
+					snprintf(str, str_size, "0");
 					return;
 				}
 				// бросок шанса
 				if (number(1, 1000) > chance) {
+					snprintf(str, str_size, "0");
 					return;
 				}
 				// размещение штатной командой load в зависимости от типа триггера
@@ -1931,8 +1934,9 @@ void find_replacement(void *go,
 					case MOB_TRIGGER: do_mload((CharData *) go, loadarg, 0, 0, trig); break;
 					case OBJ_TRIGGER: do_dgoload((ObjData *) go, loadarg, 0, 0, trig); break;
 					case WLD_TRIGGER: do_wload((RoomData *) go, loadarg, 0, 0, trig); break;
-					default: break;
+					default: snprintf(str, str_size, "0"); return;
 				}
+				snprintf(str, str_size, "1");
 			} else if ((!str_cmp(field, "maxobj") || !str_cmp(field, "maxobjs")) && num > 0) {
 				num = GetObjRnum(num);
 				if (num >= 0) {

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -1889,11 +1889,13 @@ void find_replacement(void *go,
 			} else if (!str_cmp(field, "loadobj") && num > 0) {
 				// world.loadobj(vnum, chance): загрузить предмет с шансом chance (1..1000 промилле),
 				// учитывая MIW. Размещение делает штатная команда load по типу триггера.
+				// Поле ничего не подставляет в скрипт (пустая строка): иначе при рекурсивной
+				// подстановке "1"/"0" примутся за значение и пойдёт спам ошибок, хотя загрузка
+				// и выполнится. Нужен контроль успеха - проверяйте вручную через if и load.
 				const auto rnum = GetObjRnum(num);
 
 				if (rnum <= 0) {
 					trig_log(trig, fmt::format("Указан неверный параметр vnum ({}) в loadobj", num).c_str());
-					snprintf(str, str_size, "0");
 					return;
 				}
 				// второй аргумент (шанс) после vnum в subfield
@@ -1908,7 +1910,6 @@ void find_replacement(void *go,
 
 				if (chance < 1 || chance > 1000) {
 					trig_log(trig, fmt::format("Неверный шанс ({}) в loadobj, нужно 1..1000", chance).c_str());
-					snprintf(str, str_size, "0");
 					return;
 				}
 				// проверка максимума в мире (логика как в CanBeLoaded)
@@ -1917,12 +1918,10 @@ void find_replacement(void *go,
 					|| (obj_proto.actual_count(rnum) < GetObjMIW(rnum));
 
 				if (!can_load) {
-					snprintf(str, str_size, "0");
 					return;
 				}
 				// бросок шанса
 				if (number(1, 1000) > chance) {
-					snprintf(str, str_size, "0");
 					return;
 				}
 				// размещение штатной командой load в зависимости от типа триггера
@@ -1932,9 +1931,8 @@ void find_replacement(void *go,
 					case MOB_TRIGGER: do_mload((CharData *) go, loadarg, 0, 0, trig); break;
 					case OBJ_TRIGGER: do_dgoload((ObjData *) go, loadarg, 0, 0, trig); break;
 					case WLD_TRIGGER: do_wload((RoomData *) go, loadarg, 0, 0, trig); break;
-					default: snprintf(str, str_size, "0"); return;
+					default: break;
 				}
-				snprintf(str, str_size, "1");
 			} else if ((!str_cmp(field, "maxobj") || !str_cmp(field, "maxobjs")) && num > 0) {
 				num = GetObjRnum(num);
 				if (num >= 0) {

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -1490,6 +1490,11 @@ int text_processed(char *field, char *subfield, TriggerVar vd, char *str, size_t
 	return false;
 }
 
+// Команды загрузки из dg_*cmd.cpp - для world.loadobj (загрузка по типу триггера)
+void do_mload(CharData *ch, char *argument, int cmd, int subcmd, Trigger *trig);
+void do_dgoload(ObjData *obj, char *argument, int cmd, int subcmd, Trigger *trig);
+void do_wload(RoomData *room, char *argument, int cmd, int subcmd, Trigger *trig);
+
 void find_replacement(void *go,
 					  Script *sc,
 					  Trigger *trig,
@@ -1881,6 +1886,55 @@ void find_replacement(void *go,
 				} else {
 					snprintf(str, str_size, "0");
 				}
+			} else if (!str_cmp(field, "loadobj") && num > 0) {
+				// world.loadobj(vnum, chance): загрузить предмет с шансом chance (1..1000 промилле),
+				// учитывая MIW. Размещение делает штатная команда load по типу триггера.
+				const auto rnum = GetObjRnum(num);
+
+				if (rnum <= 0) {
+					trig_log(trig, fmt::format("Указан неверный параметр vnum ({}) в loadobj", num).c_str());
+					snprintf(str, str_size, "0");
+					return;
+				}
+				// второй аргумент (шанс) после vnum в subfield
+				const char *p = subfield;
+				while (*p && *p != ',' && *p != ' ') {
+					p++;
+				}
+				while (*p == ',' || *p == ' ') {
+					p++;
+				}
+				const int chance = atoi(p);
+
+				if (chance < 1 || chance > 1000) {
+					trig_log(trig, fmt::format("Неверный шанс ({}) в loadobj, нужно 1..1000", chance).c_str());
+					snprintf(str, str_size, "0");
+					return;
+				}
+				// проверка максимума в мире (логика как в CanBeLoaded)
+				const bool can_load = stable_objs::IsTimerUnlimited(obj_proto[rnum].get())
+					|| (GetObjMIW(rnum) < 0)
+					|| (obj_proto.actual_count(rnum) < GetObjMIW(rnum));
+
+				if (!can_load) {
+					snprintf(str, str_size, "0");
+					return;
+				}
+				// бросок шанса
+				if (number(1, 1000) > chance) {
+					snprintf(str, str_size, "0");
+					return;
+				}
+				// размещение штатной командой load в зависимости от типа триггера
+				char loadarg[kMaxInputLength];
+				snprintf(loadarg, sizeof(loadarg), "obj %d", num);
+				switch (type) {
+					case MOB_TRIGGER: do_mload((CharData *) go, loadarg, 0, 0, trig); break;
+					case OBJ_TRIGGER: do_dgoload((ObjData *) go, loadarg, 0, 0, trig); break;
+					case WLD_TRIGGER: do_wload((RoomData *) go, loadarg, 0, 0, trig); break;
+					default: snprintf(str, str_size, "0"); return;
+				}
+				snprintf(str, str_size, "1");
 			} else if ((!str_cmp(field, "maxobj") || !str_cmp(field, "maxobjs")) && num > 0) {
 				num = GetObjRnum(num);
 				if (num >= 0) {


### PR DESCRIPTION
Closes #3453

## Что

Добавлено поле DG-скриптов `%world.loadobj(vnum, chance)%`:

- грузит предмет `vnum` с вероятностью `chance` в промилле (`1..1000`);
- учитывает максимум в мире (MIW) - логика та же, что в `world.CanBeLoaded` (безлимитный таймер или `MIW < 0` или `actual_count < MIW`);
- размещение выполняет штатная команда `load` в зависимости от типа триггера (`mload`/`oload`/`wload`), тип берётся из контекста триггера - собственная логика размещения не дублируется;
- возвращает `"1"` при успешной загрузке, иначе `"0"`. Загруженный предмет доступен через `%LoadedUid%` (выставляет load-команда).

## Пример

```
* с шансом 5% положить предмет 1234 (в комнату/инвентарь по типу триггера)
if %world.loadobj(1234, 50)%
  ...
end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
