### PR TITLE
fix(magic): групповая призма не вышибает из замка (#3455)

### DIFF
--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -2125,7 +2125,12 @@ EStageResult RunCastUnaffects(CharData *ch, TTarget *target, ESpell spell_id,
 		if constexpr (std::is_same_v<TTarget, CharData>) {
 			// PK-action check: keyed on the first dispelled affect's spell flags; a
 			// disallowed action aborts the removal entirely. Char target only.
-			if (ch != target) {
+			// issue.spell-ally-aggression (#3455): a benign cast (violent="N") that only
+			// incidentally strips a buff is not an aggressive act. Gate the PK check on the
+			// cast spell's per-target violence verdict, exactly like CastAffect does -- without
+			// it, group prismatic aura stripping an ally's sanctuary tripped pk_agro_action and
+			// evicted the caster from the clan castle. Violent dispels still aggro.
+			if (ch != target && MUD::Spell(spell_id).IsViolentAgainst(ch, target)) {
 				const auto primary = to_remove.front().spell;
 				if (MUD::Spell(primary).IsFlagged(kNpcAffectNpc)) {
 					if (!pk_agro_action(ch, target)) {


### PR DESCRIPTION
Closes #3455

## Симптом
На ветке `unstable` групповая призма (`kGroupPrismaticAura`) вышибает кастера из клан-замка: лог полон `pk_agro_action: <кастер> vs <враг согрупника>, pkType=...`. Одиночная призма и групповое освящение работают нормально.

## Причина
`kPrismaticAura` и `kSanctuary` - взаимоисключающие ауры (у каждой в `<unaffect>` стоит снятие другой), обе `violent="N"`, обе с флагом `kNpcAffectNpc`.

Коммит `8b1eed1c7` закрыл агр в **аффект-пути** (`CastAffect`), обернув pk-проверку в gate `IsViolentAgainst`. Но **unaffect-путь** (`RunCastUnaffects`) остался без gate:

```cpp
if (!to_remove.empty()) {
    ...
    if (ch != target) {                                   // нет проверки violence
        const auto primary = to_remove.front().spell;     // = снимаемое освящение
        if (MUD::Spell(primary).IsFlagged(kNpcAffectNpc))  // kSanctuary имеет флаг
            if (!pk_agro_action(ch, target)) ...           // агр -> выдворение
```

Групповая призма кастует `kPrismaticAura` на согрупников. У согрупника есть освящение → блок снятия запускается → `pk_agro_action(ch, согрупник)` → в замке → выдворение.

Почему остальное работает:
- **одиночная призма** кастуется на себя (`ch == victim`), pk-блок пропускается;
- **групповое освящение** снимает `kPrismaticAura`, которой у согрупников обычно нет → `to_remove` пуст (тот же баг латентен).

Наблюдение Заратина «и призма, и санка в аффектах одновременно» подтверждает: pk срабатывает **до** снятия и независимо от ролла `DispelSucceeds` - снятие может провалиться (обе ауры остаются), а выдворение уже произошло.

## Фикс
Та же защита, что в `CastAffect`: gate pk-проверки на violence кастуемого заклинания.

```cpp
if (ch != target && MUD::Spell(spell_id).IsViolentAgainst(ch, target)) {
```

Благие ауры (`violent="N"`) больше не агрят при попутном снятии чужого баффа; агрессивные диспелы (`violent="Y"`) продолжают агрить как прежде.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
