### PR TITLE
fix(stat): stat по имени снова ищет предмет по всему миру (#3457)

### DIFF
--- a/src/engine/core/target_resolver.cpp
+++ b/src/engine/core/target_resolver.cpp
@@ -497,6 +497,18 @@ ObjData *FindObjAround(CharData *finder, std::string_view name) {
 	return ResolveObj(finder, q);
 }
 
+// World-wide object lookup by name: local scopes first (так первым найдётся то,
+// что под рукой), затем весь реестр world_objects. Восстанавливает поведение
+// старого get_obj_vis -- нужно командам уровня бога вроде do_stat, которым важно
+// найти предмет где угодно в мире (надет на другого игрока, в хранилище и т.п.).
+ObjData *FindObjInWorld(CharData *finder, std::string_view name) {
+	Query q;
+	q.scopes = {Scope::kEquip, Scope::kInventory, Scope::kRoom, Scope::kWorld};
+	q.name = std::string(name);
+	q.walk_containers = true;
+	return ResolveObj(finder, q);
+}
+
 ObjData *FindObjByRnum(ObjRnum rnum) {
 	Query q;
 	q.scopes = {Scope::kRnum};

--- a/src/engine/core/target_resolver.h
+++ b/src/engine/core/target_resolver.h
@@ -188,11 +188,13 @@ std::vector<ObjData *>  ResolveObjs (CharData *searcher, const Query &q);
 //   FindCharInRoom  -- scopes = {kRoom}
 //   FindCharInWorld -- scopes = {kRoom, kWorld}, PC-priority world walk
 //   FindObjAround   -- scopes = {kEquip, kInventory, kRoom}, walks containers
+//   FindObjInWorld  -- scopes = {kEquip, kInventory, kRoom, kWorld} (legacy get_obj_vis)
 //   FindObjByRnum   -- direct world-registry lookup by rnum
 //
 CharData *FindCharInRoom (CharData *finder, std::string_view name);
 CharData *FindCharInWorld(CharData *finder, std::string_view name);
 ObjData  *FindObjAround  (CharData *finder, std::string_view name);
+ObjData  *FindObjInWorld (CharData *finder, std::string_view name);
 ObjData  *FindObjByRnum  (ObjRnum rnum);
 
 // FindPlayer: PC-only world walk. Bypasses CanSee so admin / system code

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -1347,7 +1347,7 @@ void do_stat(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 			if (!*buf2)
 				SendMsgToChar("Состояние какого предмета?\r\n", ch);
 			else {
-				if ((object = target_resolver::FindObjAround(ch, buf2)) != nullptr)
+				if ((object = target_resolver::FindObjInWorld(ch, buf2)) != nullptr)
 					do_stat_object(ch, object);
 				else
 					SendMsgToChar("Нет такого предмета в игре.\r\n", ch);
@@ -1379,7 +1379,7 @@ void do_stat(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 			return;
 		}
 		{
-			object = target_resolver::FindObjAround(ch, buf1);
+			object = target_resolver::FindObjInWorld(ch, buf1);
 		}
 		if (object != nullptr) {
 			do_stat_object(ch, object);


### PR DESCRIPTION
Closes #3457

## Симптом
На `unstable` `stat <имя>` (стат предмета по имени) перестаёт работать, как только бог уходит из комнаты с предметом: сразу после `load obj` стат работает, но когда предмет не рядом - «Ничего похожего с этим именем нет». При этом `где <имя>` исправно показывает все экземпляры (надет на другого игрока, в клан-хранилище, затарен и т.д.).

## Причина
Регрессия рефакторинга `target_resolver`. На `master` стат искал предмет по имени через `get_obj_vis` - глобальный обход всех объектов мира. На `unstable` его заменили на `target_resolver::FindObjAround`, у которой scope только `{kEquip, kInventory, kRoom}` (локально). Поэтому мировой фолбэк в `do_stat` перестал быть мировым.

`FindObjAround` менять нельзя - её используют для таргетинга заклинаний (`magic_utils`) и DG-триггеров, где локальность обязательна.

## Фикс
Добавлен отдельный мировой файндер `target_resolver::FindObjInWorld` со scope `{kEquip, kInventory, kRoom, kWorld}` (как старый `get_obj_vis`: сначала локально, затем весь `world_objects`). `do_stat` зовёт его в обоих местах - `stat object <имя>` и `stat <имя>`. `Scope::kWorld` для объектов в `ResolveObj` уже поддерживался.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
