### PR TITLE
feat(pray): форматирование вывода "воззвать" богам (#3429)

### DIFF
--- a/src/engine/ui/cmd/do_pray_gods.cpp
+++ b/src/engine/ui/cmd/do_pray_gods.cpp
@@ -11,6 +11,7 @@
 #include "gameplay/communication/remember.h"
 #include "engine/core/handler.h"
 #include "gameplay/fight/common.h"
+#include "utils/utils_string.h"
 
 void do_pray_gods(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	char arg1[kMaxInputLength];
@@ -85,8 +86,18 @@ void do_pray_gods(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				|| (GET_GOD_FLAG(i->character.get(), EGf::kDemigod)
 					&& (GetRealLevel(ch) < 6)))
 				&& (i->character.get() != ch)) {
-				SendMsgToChar(buf, i->character.get());
-				i->character->remember_add(buf, Remember::ALL);
+				CharData *god = i->character.get();
+				// движковая дата + перенос по словам под ширину экрана получателя.
+				// Переносим всю собранную строку, чтобы в расчёт ширины попал и
+				// префикс ("[комната] имя воззвал к богам ..."), и таймстамп.
+				// Цветокоды OutWordsList уже не считает за ширину.
+				std::string line = Remember::time_format() + buf;
+				if (!god->IsNpc() && god->player_specials->saved.stringLength > 0) {
+					// WrapText съедает хвостовой \r\n -- возвращаем его обратно
+					line = utils::WrapText(line, god->player_specials->saved.stringLength) + "\r\n";
+				}
+				SendMsgToChar(line.c_str(), god);
+				god->remember_add(buf, Remember::ALL);
 			}
 		}
 	}

--- a/src/utils/utils_string.cpp
+++ b/src/utils/utils_string.cpp
@@ -1060,8 +1060,11 @@ std::string utils::OutWordsList(const std::vector<std::string> &words, size_t ma
 	}
 
 	for (const auto &word : words) {
+		// ширину считаем по видимой длине -- цветокоды (&R, &n и т.п.) на экране
+		// места не занимают, иначе строки с цветом переносятся раньше времени
+		const size_t word_len = GetStringWithoutColors(word).size();
 		if (!first) {
-			if (line_length + separator.size() + word.size() > max_length) {
+			if (line_length + separator.size() + word_len > max_length) {
 				result += eol_separator + "\r\n";
 				line_length = 0;
 			} else {
@@ -1070,7 +1073,7 @@ std::string utils::OutWordsList(const std::vector<std::string> &words, size_t ma
 			}
 		}
 		result += word;
-		line_length += word.size();
+		line_length += word_len;
 		first = false;
 	}
 	return result;


### PR DESCRIPTION
Закрывает часть #3429 (форматирование вывода: воззвать).

## Что

1. **«Воззвать» богам теперь переносится по словам** под ширину экрана каждого получателя-бога (по аналогии с тивеллом, #3448), и к рассылке добавляется движковый таймстамп (`Remember::time_format()`).

   Переносится **вся собранная строка целиком** — `time_format() + "[комната] имя воззвал к богам с сообщением : 'текст'"` — поэтому в расчёт ширины попадает и префикс, и дата. Раньше учитывался бы только текст, и первая строка с префиксом не влезала / обрезалась (см. комментарий в #3429: «не влезло воззвать … учитывать не сам текст, а и префикс»).

2. **`OutWordsList` считает ширину по видимой длине** (`GetStringWithoutColors`) — цветокоды (`&R`, `&n`) на экране места не занимают и не должны вызывать преждевременный перенос. Это попутно чинит перенос для тивелла/почты/досок.

## Детали

- Перенос — per-recipient (у каждого бога своя `stringLength`); при `stringLength == 0` перенос не делается.
- `WrapText` съедает хвостовой `\r\n` — возвращаю его обратно после переноса.
- `remember_add` оставлен на сырой `buf` (система remember сама добавляет `time_format` при сохранении, чтобы не задвоить дату в «вспомнить»).
- Дату в своём клиенте автор уберёт (теперь её даёт движок).

Собрано на master, чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
