### PR TITLE
fix(spells): починить линковку spell_create_water при unity=off

### DIFF
--- a/src/gameplay/handlers/spell_create_water.cpp
+++ b/src/gameplay/handlers/spell_create_water.cpp
@@ -10,9 +10,7 @@
 #include "engine/db/global_objects.h"
 #include "gameplay/magic/spell_messages.h"
 #include "gameplay/mechanics/liquid.h"
-
-// defined elsewhere (no header); forward-declared as spells.cpp did.
-void weight_change_object(ObjData *obj, int weight);
+#include "engine/core/utils_char_obj.inl"    // weight_change_object -- inline, нужен #include (не forward-decl), иначе при unity=off падает линковка
 
 namespace handlers {
 


### PR DESCRIPTION
## Симптом

Сборка с **`-Dunity=off`** падает на линковке:

```
undefined reference to `weight_change_object(ObjData*, int)'
```
в `handlers::SpellCreateWater` (`spell_create_water.cpp`).

## Причина

`weight_change_object` — **inline**-функция из `engine/core/utils_char_obj.inl`. В `spell_create_water.cpp` вместо `#include` этого `.inl` стояло **forward-объявление**:
```cpp
// defined elsewhere (no header); forward-declared as spells.cpp did.
void weight_change_object(ObjData *obj, int weight);
```
Для inline-функции это неверно: в этом TU нет тела, компилятор генерирует вызов внешнего символа, которого никто не экспортирует.

- **unity=on** — файл склеивается в общий TU с теми, кто `.inl` включает (`do_pour`/`do_drink`/`poisoning`), тело видно → линкуется (баг замаскирован).
- **unity=off** — каждый `.cpp` отдельно → тела нет → `undefined reference`.

## Фикс

Подключаем `.inl` напрямую, как остальные вызывающие:
```cpp
#include "engine/core/utils_char_obj.inl"
```
Forward-декларация удалена.

Проверено полной сборкой с **`-Dunity=off`** (circle + tests линкуются, exit 0).

> Примечание: тот же `spell_create_water.cpp` с forward-декларацией есть и на `unstable` — там нужен такой же фикс (после мёржа этот файл одинаков на обеих ветках).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
