### PR TITLE
fix(build): устранить предупреждения компилятора (gcc 13)

### DIFF
--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -48,7 +48,7 @@
 
 namespace {
 
-uint8_t get_day_today() {
+[[maybe_unused]] uint8_t get_day_today() {
 	time_t rawtime;
 	struct tm *timeinfo;
 

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -2591,13 +2591,13 @@ void find_replacement(void *go,
 			}
 		} else if (!str_cmp(field, "Currency")) {
 			// %actor.Currency(<text_id>)% - кол-во любой валюты на руках (валюта задаётся id-аргументом).
-			const auto &money_cur = currencies::FindByTextIdNoCase(subfield);
-			if (money_cur.GetId() < 0) {
+			const auto *money_cur = &currencies::FindByTextIdNoCase(subfield);
+			if (money_cur->GetId() < 0) {
 				char errbuf[kMaxInputLength];
 				snprintf(errbuf, sizeof(errbuf), "actor.Currency: unknown currency '%s'!", subfield);
 				trig_log(trig, errbuf);
 			}
-			snprintf(str, str_size, "%ld", money_cur.GetId() >= 0 ? currencies::GetHand(*mob, money_cur.GetTextId()) : 0L);
+			snprintf(str, str_size, "%ld", money_cur->GetId() >= 0 ? currencies::GetHand(*mob, money_cur->GetTextId()) : 0L);
 		} else if (!str_cmp(field, "AddCurrency")) {
 			// %actor.AddCurrency(<text_id>, <amount>)% - начислить (минус снимает). Слава и immortal-валюты не начисляются (страж откажет).
 			auto args = utils::Split(subfield, ',');
@@ -5762,8 +5762,8 @@ void do_dg_add_currency(void * /*go*/, Script * /*sc*/, Trigger *trig, int/* scr
 		trig_log(trig, buf2);
 		return;
 	}
-	const auto &cur = currencies::FindByTextIdNoCase(cur_id);
-	if (cur.GetId() < 0) {
+	const auto *cur = &currencies::FindByTextIdNoCase(cur_id);
+	if (cur->GetId() < 0) {
 		snprintf(buf2, sizeof(buf2), "dg_addcurrency: unknown currency '%s'!", cur_id);
 		trig_log(trig, buf2);
 		return;
@@ -5774,7 +5774,7 @@ void do_dg_add_currency(void * /*go*/, Script * /*sc*/, Trigger *trig, int/* scr
 		trig_log(trig, buf2);
 		return;
 	}
-	currencies::AddHand(*ch, cur.GetTextId(), atoi(value_c));
+	currencies::AddHand(*ch, cur->GetTextId(), atoi(value_c));
 }
 
 int timed_script_driver(void *go, Trigger *trig, int type, int mode) {

--- a/src/engine/ui/cmd/do_hire.cpp
+++ b/src/engine/ui/cmd/do_hire.cpp
@@ -119,7 +119,7 @@ long CalcHirePrice(CharData *ch, CharData *victim) {
 	long finalPrice = MAX(min_price, (int) ceil(price - hirePoints));
 
 	SendToTC(ch, true, true, true,
-				   "Параметры персонажа: RMRT: %.4lf, CHA: %.4lf, INT: %.4lf, TOTAL: %.4lf. Цена чармиса:  %.4lf. Итоговая цена: %d \r\n",
+				   "Параметры персонажа: RMRT: %.4lf, CHA: %.4lf, INT: %.4lf, TOTAL: %.4lf. Цена чармиса:  %.4lf. Итоговая цена: %ld \r\n",
 				   rem_hirePoints, cha_hirePoints, int_hirePoints, hirePoints, price, finalPrice);
 	return std::min(finalPrice, kMaxHirePrice);
 }

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -334,7 +334,7 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 	SendMsgToChar(buf, ch);
 
 	snprintf(buf, sizeof(buf),
-			"Glory: [%d], ConstGlory: [%d], AC: [%d/%d(%d)], Броня: [%d], Попадания: [%2d/%2d/%d], Повреждения: [%2d/%2d/%d]\r\n",
+			"Glory: [%d], ConstGlory: [%ld], AC: [%d/%d(%d)], Броня: [%d], Попадания: [%2d/%2d/%d], Повреждения: [%2d/%2d/%d]\r\n",
 			Glory::get_glory(k->get_uid()),
 			currencies::GetHand(*k, currencies::kGlory),
 			GET_AC(k),

--- a/src/gameplay/core/experience.cpp
+++ b/src/gameplay/core/experience.cpp
@@ -541,7 +541,7 @@ long long get_extend_exp(long long exp, CharData *ch, CharData *victim) {
 	}
 
 	SendToTC(ch, false, true, false,
-				   "&RУ моба еще %d убийств без замакса, экспа %d, убито %d&n\r\n",
+				   "&RУ моба еще %d убийств без замакса, экспа %lld, убито %d&n\r\n",
 				   victim->mob_specials.MaxFactor,
 				   exp,
 				   ch->mobmax_get(vnum));

--- a/src/gameplay/fight/fight.cpp
+++ b/src/gameplay/fight/fight.cpp
@@ -1444,7 +1444,7 @@ void using_charmice_skills(CharData *ch) {
 			msg << ch->get_name() << " использует оглушение: " << ((do_skill_without_command && skill_ready) ? "ДА" : "НЕТ") << "\r\n";
 			msg << "Проверка шанса применения: " << (do_skill_without_command ? "ДА" : "НЕТ");
 			msg << ", скилл откатился: " << (skill_ready ? "ДА" : "НЕТ") << "\r\n";
-			SendToTC(master, true, true, true, msg.str().c_str());
+			SendToTC(master, true, true, true, "%s", msg.str().c_str());
 		}
 		if (do_skill_without_command && skill_ready) {
 			ch->battle_affects.set(kEafOverwhelm);
@@ -1456,7 +1456,7 @@ void using_charmice_skills(CharData *ch) {
 			msg << ch->get_name() << " использует богатырский молот: " << ((do_skill_without_command && skill_ready) ? "ДА" : "НЕТ") << "\r\n";
 			msg << "Проверка шанса применения: " << (do_skill_without_command ? "ДА" : "НЕТ");
 			msg << ", скилл откатился: " << (skill_ready ? "ДА" : "НЕТ") << "\r\n";
-			SendToTC(master, true, true, true, msg.str().c_str());
+			SendToTC(master, true, true, true, "%s", msg.str().c_str());
 		}
 		if (do_skill_without_command && skill_ready) {
 			ch->battle_affects.set(kEafHammer);
@@ -1468,7 +1468,7 @@ void using_charmice_skills(CharData *ch) {
 			msg << ch->get_name() << " использует метнуть : " << ((do_skill_without_command && skill_ready) ? "ДА" : "НЕТ") << "\r\n";
 			msg << "Проверка шанса применения: " << (do_skill_without_command ? "ДА" : "НЕТ");
 			msg << ", скилл откатился: " << (skill_ready ? "ДА" : "НЕТ") << "\r\n";
-			SendToTC(master, true, true, true, msg.str().c_str());
+			SendToTC(master, true, true, true, "%s", msg.str().c_str());
 		}
 		if (do_skill_without_command && skill_ready) {
 			ch->SetExtraAttack(kExtraAttackThrow, ch->GetEnemy());
@@ -1481,7 +1481,7 @@ void using_charmice_skills(CharData *ch) {
 			msg << ch->get_name() << " использует подножку : " << ((do_skill_without_command && skill_ready) ? "ДА" : "НЕТ") << "\r\n";
 			msg << "Проверка шанса применения: " << (do_skill_without_command ? "ДА" : "НЕТ");
 			msg << ", скилл откатился: " << (skill_ready ? "ДА" : "НЕТ") << "\r\n";
-			SendToTC(master, true, true, true, msg.str().c_str());
+			SendToTC(master, true, true, true, "%s", msg.str().c_str());
 		}
 		if (do_skill_without_command && skill_ready) {
 			if (ch->GetPosition() < EPosition::kFight) return;
@@ -1495,7 +1495,7 @@ void using_charmice_skills(CharData *ch) {
 			msg << ch->get_name() << " использует ВИХРЬ : " << ((do_skill_without_command && skill_ready) ? "ДА" : "НЕТ") << "\r\n";
 			msg << "Проверка шанса применения: " << (do_skill_without_command ? "ДА" : "НЕТ");
 			msg << ", скилл откатился: " << (skill_ready ? "ДА" : "НЕТ") << "\r\n";
-			SendToTC(master, true, true, true, msg.str().c_str());
+			SendToTC(master, true, true, true, "%s", msg.str().c_str());
 		}
 		if (do_skill_without_command && skill_ready) {
 			if (ch->GetPosition() < EPosition::kFight) return;

--- a/src/gameplay/skills/pick.cpp
+++ b/src/gameplay/skills/pick.cpp
@@ -83,7 +83,7 @@ PickProbabilityInformation get_pick_probability(CharData *ch, int lock_complexit
 		text_info << std::boolalpha << "Шанс взлома: " << pbi.unlock_probability << "%, шанс сломать замок: " << pbi.brake_lock_probability << "%, возможность прокачки скила: " << pbi.skill_train_allowed << "\r\n";
 		text_info << std::boolalpha << "Сложность замка: " << lock_complexity << ", разница между скилом и сложностью замка: " << skill_difference << "\r\n";
 		text_info << std::boolalpha << "Возможность прокачки скила (от сложности скила): " << skill_train_allowed << ", ограничение прокачки по сложности скила: "  << complexity_restriction << "\r\n";
-		SendToTC(ch, true, true, true, text_info.str().c_str());
+		SendToTC(ch, true, true, true, "%s", text_info.str().c_str());
 	}
 
 	return pbi;

--- a/src/gameplay/skills/skills.cpp
+++ b/src/gameplay/skills/skills.cpp
@@ -1311,7 +1311,7 @@ void SendSkillRollMsg(CharData *ch, CharData *victim, ESkill skill_id,
 		   << " SavType:" << saving_name.at(MUD::Skill(skill_id).save_type)
 		   << " Saving:" << save
 		<< kColorNrm << "\r\n";
-	SendToTC(ch, false, true, true, buffer.str().c_str());
+	SendToTC(ch, false, true, true, "%s", buffer.str().c_str());
 	if (GET_GOD_FLAG(ch, EGf::kSkillTester) && skill_id != ESkill::kUndefined) {
 		buffer.str("");
 		buffer << "SKILLTEST:;" << GET_NAME(ch)
@@ -1339,7 +1339,7 @@ void SendSkillBalanceMsg(CharData *ch, const std::string &skill_name, int percen
 		   << " Prob: " << prob
 		   << " Success: " << (success ? "yes" : "no")
 		   << kColorNrm << "\r\n";
-	SendToTC(ch, false, true, true, buffer.str().c_str());
+	SendToTC(ch, false, true, true, "%s", buffer.str().c_str());
 }
 
 int CalcCurrentSkill(CharData *ch, const ESkill skill_id, CharData *vict, bool /* need_log */) {
@@ -1962,7 +1962,7 @@ void ImproveSkill(CharData *ch, const ESkill skill, int success, CharData *victi
 	prob -= 5 * wis_bonus(GetRealWis(ch), WIS_MAX_SKILLS);
 	prob += number(1, trained_skill * 5);
 	int skill_is = number(1, std::max(1, prob));
-	SendToTC(ch, true, true, true,"ImprooveSkill: prob=%d, div=%d, skill_is=%d, success=%d", prob, div, skill_is, success);
+	SendToTC(ch, true, true, true,"ImprooveSkill: prob=%d, div=%ld, skill_is=%d, success=%d", prob, div, skill_is, success);
 	if ((victim && skill_is <= GetRealInt(ch) * GetRealLevel(victim) / GetRealLevel(ch))
 		|| (!victim && skill_is <= GetRealInt(ch))) {
 		if (success) {

--- a/src/simulator/character_builder.cpp
+++ b/src/simulator/character_builder.cpp
@@ -229,7 +229,7 @@ void CharacterBuilder::grant_class_skills_and_feats()
 	for (const auto &spell : class_info.spells) {
 		if (level >= spell.GetMinLevel() && remort >= spell.GetMinRemort()) {
 			SET_BIT(GET_SPELL_TYPE(m_result, spell.GetId()), ESpellType::kKnow);
-			SET_SPELL_MEM(m_result, spell.GetId(), 1000);
+			SET_SPELL_MEM(m_result, spell.GetId(), 255);
 		}
 	}
 }


### PR DESCRIPTION
Устранены все предупреждения компилятора (gcc 13.3, сборка с `-Dunity=off` — без unity варнинги перестают маскироваться склейкой TU).

## Было 16 варнингов

**format-security** (нелитеральная строка в `SendToTC` без аргументов формата) — добавлен `"%s"`:
- `fight.cpp` (×5), `pick.cpp`, `skills.cpp` (×2)

**format=** (`%d` против `long`/`long long`):
- `do_hire.cpp` finalPrice → `%ld`
- `do_stat.cpp` ConstGlory → `%ld`
- `experience.cpp` exp → `%lld`
- `skills.cpp` div → `%ld`

**dangling-reference** (ложное у gcc13: `FindByTextIdNoCase` возвращает ссылку на стабильный объект реестра валют, не на временный) — в `dg_scripts.cpp` заменил `const auto&` на указатель `const auto* = &...` (без копии — `CurrencyInfo` некопируем из-за `unique_ptr`).

**unused-function** — `char_player.cpp::get_day_today()` помечена `[[maybe_unused]]`.

**overflow** — `character_builder.cpp` клал `1000` в `ubyte SplMem` (обрезалось до 232) → `255` (максимум поля).

## Проверка

Полная сборка `-Dunity=off`: **0 предупреждений, 0 ошибок**, бинарь и тесты линкуются.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
