### PR TITLE
fix(build): ревизия версии берётся на момент сборки (#3472)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -333,7 +333,7 @@ version_cpp = custom_target('version_gen',
   command: [
     py3,
     files('tools/meson/generate_version.py'),
-    '@INPUT@', '@OUTPUT@', git_rev, buildtype, features, compiler_id
+    '@INPUT@', '@OUTPUT@', git_rev, buildtype, features, compiler_id, meson.project_source_root()
   ]
 )
 

--- a/tools/meson/generate_version.py
+++ b/tools/meson/generate_version.py
@@ -1,8 +1,24 @@
 #!/usr/bin/env python3
 import sys
+import subprocess
 from datetime import datetime
 
-input_file, output_file, git_rev, buildtype, build_features, build_compiler = sys.argv[1:]
+input_file, output_file, git_rev, buildtype, build_features, build_compiler, source_root = sys.argv[1:]
+
+# Ревизию берём на МОМЕНТ СБОРКИ, а не конфигурации. Этот скрипт запускается
+# каждым ninja (build_always_stale), поэтому после `git pull` + `ninja` версия
+# обновится сама -- без `meson setup --reconfigure` (issue #3472).
+# Значение из meson (git_rev) остаётся запасным: если git недоступен (например,
+# сборка из распакованного архива), используем его.
+try:
+    rev = subprocess.run(
+        ['git', '-C', source_root, 'rev-parse', '--short', 'HEAD'],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    if rev:
+        git_rev = rev
+except Exception:
+    pass
 
 with open(input_file, encoding='koi8-r') as f:
     content = f.read()


### PR DESCRIPTION
Closes #3472

## Проблема

`git_rev` вычислялся на этапе `meson setup` (meson.build) и замораживался. `generate_version.py` хоть и запускается каждым `ninja` (`build_always_stale`), но получал эту замороженную ревизию аргументом. Поэтому после `git pull` + `ninja` версия показывала **старую** ревизию (обновлялась только дата сборки), и приходилось делать `meson setup --reconfigure build`.

## Фикс

`generate_version.py` теперь сам берёт `git rev-parse --short HEAD` **в момент запуска** (т.е. на каждой сборке). Из meson передаётся `meson.project_source_root()` для `git -C` (корректно при out-of-source build). Значение из meson (`git_rev`) осталось запасным — если git недоступен (сборка из распакованного архива).

## Проверка

```
HEAD = 2e5f863f5 → ninja → version.cpp: 2e5f863f5
git commit (HEAD = 9597dae7a) → ninja БЕЗ reconfigure → version.cpp: 9597dae7a  ✅
```
Ревизия обновляется без `meson setup --reconfigure`. Работает и с `unity=on`, и с `unity=off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
