### PR TITLE
fix(currency): краш при выводе списка магазина с неизвестной валютой (#3474)

### DIFF
--- a/src/gameplay/economics/currencies.cpp
+++ b/src/gameplay/economics/currencies.cpp
@@ -336,20 +336,22 @@ void CurrencyInfo::Print(CharData */*ch*/, std::ostringstream &buffer) const {
 		<< "\r\n";
 }
 
+static const std::string kCurrencyNoName;
+
 const std::string &CurrencyInfo::GetName(grammar::ECase name_case) const {
-	return names_->GetSingular(name_case);
+	return names_ ? names_->GetSingular(name_case) : kCurrencyNoName;
 }
 
 const std::string &CurrencyInfo::GetPluralName(grammar::ECase name_case) const {
-	return names_->GetPlural(name_case);
+	return names_ ? names_->GetPlural(name_case) : kCurrencyNoName;
 }
 
 const char *CurrencyInfo::GetCName(grammar::ECase name_case) const {
-	return names_->GetSingular(name_case).c_str();
+	return names_ ? names_->GetSingular(name_case).c_str() : "";
 }
 
 const char *CurrencyInfo::GetPluralCName(grammar::ECase name_case) const {
-	return names_->GetPlural(name_case).c_str();
+	return names_ ? names_->GetPlural(name_case).c_str() : "";
 }
 
 const std::string &CurrencyInfo::GetNameWithAmount(long amount, grammar::ECase one_case) const {


### PR DESCRIPTION
Closes #3474

## Краш

`std::string` с `this=0xc0` уходит в `fmt::format` из `print_shop_list` (shops_implementation.cpp:439) по команде «список» у магазина 4025:
```cpp
fmt::arg("currency", MUD::Currencies().FindAvailableItem(currency).GetPluralName(...))
```

## Причина

`shop_node::currency` — это text_id (строка). Для **неизвестной** валюты `FindAvailableItem(string)` возвращает дефолтный kUndefined-объект:
```cpp
return *(items_->at(IdEnum::kUndefined));
```
А этот kUndefined-объект создаётся в конструкторе `InfoContainer` через `std::make_shared<Item>()` — **дефолтным** `CurrencyInfo() = default`, минуя `ParseCurrency` (которая всегда ставит `names_`). Поэтому у него `names_ == nullptr`.

Аксессоры разыменовывали его без проверки:
```cpp
const std::string &CurrencyInfo::GetPluralName(...) const { return names_->GetPlural(...); }  // names_ == nullptr -> SIGSEGV
```
`this=0xc0` в бэктрейсе = доступ к члену std::string по смещению внутри `names_->GetPlural` при нулевом `names_`.

## Фикс

`GetName`/`GetPluralName`/`GetCName`/`GetPluralCName` теперь проверяют `names_` и возвращают пустую строку, если он null. Краша больше нет при любой неизвестной/невалидной валюте.

## Заметка по данным

Стоит отдельно проверить, почему у магазина 4025 валюта не резолвится (поле `currency` пустое/устаревшее после перехода на новую валютную систему). С этим фиксом список выведется (с пустым названием валюты), но корректнее доставить магазину валидный `currency`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
