### PR TITLE
fix(restore): имплементатор не режется арена-ограничением (#3476)

### DIFF
--- a/src/engine/ui/cmd_god/do_restore.cpp
+++ b/src/engine/ui/cmd_god/do_restore.cpp
@@ -24,7 +24,7 @@ void DoRestore(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	else {
 		// имм с привилегией arena может ресторить только чаров, находящихся с ним на этой же арене
 		// плюс исключается ситуация, когда они в одной зоне, но чар не в клетке арены
-		if (privilege::CheckFlag(ch, privilege::kArenaMaster)) {
+		if (privilege::CheckFlag(ch, privilege::kArenaMaster) && !privilege::IsImpl(ch)) {
 			if (!ROOM_FLAGGED(vict->in_room, ERoomFlag::kArena) || world[ch->in_room]->zone_rn != world[vict->in_room]->zone_rn) {
 				SendMsgToChar("Не положено...\r\n", ch);
 				return;


### PR DESCRIPTION
Closes #3476

## Симптом
Имм 34 уровня: `restore верий` -> «Не положено...».

## Причина
В `DoRestore` (do_restore.cpp) restore у имма с флагом **arena** (`kArenaMaster`) разрешён только на цель в арена-комнате той же зоны:
```cpp
if (privilege::CheckFlag(ch, privilege::kArenaMaster)) {
    if (!ROOM_FLAGGED(vict->in_room, kArena) || разные зоны) { "Не положено"; return; }
}
```
Это применялось и к **имплементаторам**. Если у имма 34 в privilege.lst есть флаг `arena`, он попадал под ограничение и не мог ресторить вне арены.

Аналогичная арена-проверка для заклинаний `IsSpellPermit` имплементаторов **исключает**:
```cpp
if (!IsImmortal(ch) || IsImpl(ch) || CheckFlag(kUseSkills)) return true;
```

## Фикс
То же исключение в `DoRestore`:
```cpp
if (privilege::CheckFlag(ch, privilege::kArenaMaster) && !privilege::IsImpl(ch)) {
```
`kLvlImplementator == 34`, так что имм 34 теперь ресторит без ограничения; арена-имм без impl-тира — по-прежнему только на арене.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
