### PR TITLE
fix(pray): дата в префиксе воззвания (#3429)

### DIFF
--- a/src/engine/ui/cmd/do_pray_gods.cpp
+++ b/src/engine/ui/cmd/do_pray_gods.cpp
@@ -94,7 +94,11 @@ void do_pray_gods(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				// Переносим всю собранную строку, чтобы в расчёт ширины попал и
 				// префикс ("[комната] имя воззвал к богам ..."), и таймстамп.
 				// Цветокоды OutWordsList уже не считает за ширину.
-				std::string line = Remember::time_format() + buf;
+				// движковый префикс с датой и временем (клиентскую дату игроки убирают)
+				char ts[32];
+				const time_t now = time(nullptr);
+				strftime(ts, sizeof(ts), "[%d-%m-%Y %H:%M] ", localtime(&now));
+				std::string line = std::string(ts) + buf;
 				if (!god->IsNpc() && god->player_specials->saved.stringLength > 0) {
 					// WrapText съедает хвостовой \r\n -- возвращаем его обратно
 					line = utils::WrapText(line, god->player_specials->saved.stringLength) + "\r\n";


### PR DESCRIPTION
По #3429: в префиксе воззвания я добавлял только время — забыл дату.

## Было
```cpp
std::string line = Remember::time_format() + buf;   // "[ЧЧ:ММ] " - только время
```

## Стало
```cpp
char ts[32];
const time_t now = time(nullptr);
strftime(ts, sizeof(ts), "[%d-%m-%Y %H:%M] ", localtime(&now));
std::string line = std::string(ts) + buf;
```
Теперь префикс рассылки богам — `[ДД-ММ-ГГГГ ЧЧ:ММ]` (дата + время), как и просили (клиентскую дату игроки убирают).

Сборка чистая.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
