### PR TITLE
fix(necromancer): «сожрать труп» снова лечит умертвий (#3482)

### DIFF
--- a/src/engine/ui/cmd/do_eat.cpp
+++ b/src/engine/ui/cmd/do_eat.cpp
@@ -104,7 +104,9 @@ void do_eat(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	one_argument(argument, arg);
 
 	if (subcmd == kScmdDevour) {
-		if (ch->IsFlagged(EMobFlag::kResurrected)
+		// kUndead покрывает и умертвий (animate dead), и оживлённых (kResurrection):
+		// раньше тут было kResurrected, но animate dead его больше не ставит (issue #3482)
+		if (ch->IsFlagged(EMobFlag::kUndead)
 			&& CanUseFeat(ch->get_master(), EFeat::kZombieDrover)) {
 			feed_charmice(ch, arg);
 			return;


### PR DESCRIPTION
Closes #3482

## Симптом
Раньше умертвия чернокнижника восстанавливались, поедая труп («сожрать труп»), теперь нет.

## Причина
Команда «сожрать» (`do_eat`, `kScmdDevour`) лечит нежить (`feed_charmice`) только при условии:
```cpp
if (ch->IsFlagged(EMobFlag::kResurrected) && CanUseFeat(ch->get_master(), EFeat::kZombieDrover))
```
Хотфикс `c76033fa0` («animate-dead kResurrected fix») перестал ставить `kResurrected` на призываемых умертвий — теперь у них только `kUndead` (`kResurrected` остался лишь у оживлённых заклинанием `kResurrection`). Поэтому гейт стал ложным, и для умертвия (NPC) `do_eat` уходил в тихий `return` — лечения нет.

## Фикс
Проверяем `kUndead` вместо `kResurrected` — этот флаг есть у обоих типов нежити (и `animate dead`, и `kResurrection`):
```cpp
if (ch->IsFlagged(EMobFlag::kUndead) && CanUseFeat(ch->get_master(), EFeat::kZombieDrover))
```

Сборка чистая.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
