### PR TITLE
fix(docker): OTEL_LOCAL_PORT для порта OTLP-endpoint циркуля

### DIFF
--- a/tools/docker/docker-compose.full.yml
+++ b/tools/docker/docker-compose.full.yml
@@ -1,14 +1,16 @@
 # Combined-стек: игровой сервер (circle с admin_api+otel+yaml) + web-админка.
 #
-# Телеметрия: циркуль запускается с host-сетью, поэтому OTLP-endpoint берётся
-# из configuration.xml мира как есть — localhost:<порт> бьёт в коллектор ЭТОГО
-# сервера (4319 у gateway, 4318 у agent). Один и тот же compose работает на
-# любом сервере без переопределения портов.
+# Телеметрия: циркуль запускается с host-сетью, поэтому localhost:<порт> из
+# configuration.xml мира бьёт в локальный приёмник ЭТОГО сервера. На agent-хостах
+# это стандартный 4318 (конфиг мира уже верен). На gateway-хосте 4318 занят
+# внешним TLS-приёмником, а локальный plaintext — на 4319: там задайте
+# OTEL_LOCAL_PORT=4319, и entrypoint перепишет порт. Один и тот же compose
+# работает на любом сервере; порт-исключение задаётся одной переменной хоста.
 #
 # Подготовка:
-#   - распакуйте мир в каталог (внутри misc/, world/, text/ ...). В его
-#     configuration.xml уже должен быть рабочий telemetry-endpoint этого сервера;
-#   - задайте MUD_WORLD_DIR (обязательно).
+#   - распакуйте мир в каталог (внутри cfg/, world/, text/ ...);
+#   - задайте MUD_WORLD_DIR (обязательно);
+#   - на gateway-хосте задайте OTEL_LOCAL_PORT=4319 (см. про телеметрию выше).
 #
 # Запуск (контекст сборки circle — корень репозитория):
 #   MUD_WORLD_DIR=/home/you/worlds/w/lib \
@@ -44,6 +46,11 @@ services:
       WORLD_DIR: /world
       MUD_PORT: "${MUD_PORT:-4000}"
       FORCE_CONFIG: "${FORCE_CONFIG:-1}"
+      # Порт локального OTLP-приёмника на ЭТОМ хосте. Пусто (по умолчанию) — порт
+      # берётся из конфига мира (на agent-хостах это стандартный 4318). На
+      # gateway-хосте задайте OTEL_LOCAL_PORT=4319 (там 4318 занят внешним
+      # TLS-приёмником, локальный plaintext — на 4319), entrypoint перепишет порт.
+      OTEL_LOCAL_PORT: "${OTEL_LOCAL_PORT:-}"
     restart: unless-stopped
 
   web-admin:

--- a/tools/docker/entrypoint.py
+++ b/tools/docker/entrypoint.py
@@ -7,9 +7,14 @@ Entrypoint для образа циркуля (combined-стек circle + web-ad
   - admin_api: enabled=true, socket_path в выделенном каталоге (run/admin_api.sock);
   - telemetry: enabled=true, logs mode=otel-only.
 
-OTLP-endpoint НЕ трогаем — он берётся из конфига мира как есть. Циркуль запущен
-с network_mode=host, поэтому localhost:<порт> из конфига бьёт прямо в коллектор
-этого сервера (4319 у gateway, 4318 у agent), и переопределять ничего не нужно.
+OTLP-endpoint по умолчанию НЕ трогаем — он берётся из конфига мира как есть.
+Циркуль запущен с network_mode=host, поэтому localhost:<порт> из конфига бьёт
+прямо в локальный приёмник этого сервера. На agent-хостах локальный приём сидит
+на стандартном порту (4318), и конфиг мира уже верен. Исключение — gateway-хост:
+там стандартный 4318 занят ВНЕШНИМ TLS-приёмником, а локальный plaintext-приём —
+на 4319. Чтобы один и тот же образ работал на обоих, на gateway-хосте задают
+OTEL_LOCAL_PORT (=4319), и entrypoint переписывает порт OTLP-endpoint'ов под него.
+Без этой переменной поведение прежнее.
 
 Форсирование отключается переменной FORCE_CONFIG=0 (тогда берётся конфиг мира как есть).
 
@@ -80,8 +85,7 @@ def force_config(cfg_path, socket_rel):
     if not found:
         text = force_block(text, "admin_api", admin_block)
 
-    # --- telemetry: enabled + otel-only. Endpoint НЕ трогаем (берётся из конфига
-    # мира; localhost-порт бьёт в коллектор этого сервера через network_mode=host).
+    # --- telemetry: enabled + otel-only (порт endpoint'а — см. OTEL_LOCAL_PORT ниже).
     text, found = edit_within(
         text,
         "telemetry",
@@ -94,6 +98,26 @@ def force_config(cfg_path, socket_rel):
         log("ВНИМАНИЕ: <telemetry> в конфиге мира нет — телеметрия не настроена, "
             "форсирую только admin_api")
 
+    # Опционально переписать порт OTLP-endpoint'ов под локальный приёмник хоста.
+    # По умолчанию (OTEL_LOCAL_PORT не задан) порт берётся из конфига мира — на
+    # agent-хостах стандартный 4318 уже верен. На gateway-хосте 4318 занят внешним
+    # TLS-приёмником, а локальный plaintext — на 4319; там задают OTEL_LOCAL_PORT,
+    # и тот же образ работает прозрачно на любом сервере.
+    local_port = os.environ.get("OTEL_LOCAL_PORT", "").strip()
+    if local_port and not local_port.isdigit():
+        log(f"ВНИМАНИЕ: OTEL_LOCAL_PORT={local_port!r} не число — порт не изменён")
+        local_port = ""
+    if local_port:
+        text, port_found = edit_within(
+            text,
+            "telemetry",
+            [(r"((?:localhost|127\.0\.0\.1):)\d+", rf"\g<1>{local_port}")],
+        )
+        if port_found:
+            log(f"telemetry: OTLP-порт переписан на {local_port} (OTEL_LOCAL_PORT)")
+        else:
+            log("ВНИМАНИЕ: <telemetry> нет — OTEL_LOCAL_PORT не применён")
+
     if text == original:
         log("конфиг уже соответствует — изменений нет")
         return
@@ -103,8 +127,8 @@ def force_config(cfg_path, socket_rel):
         open(orig_backup, "wb").write(raw)
         log(f"оригинал сохранён в {orig_backup}")
     open(cfg_path, "wb").write(text.encode("latin-1"))
-    log(f"конфиг обновлён: admin_api=on socket={socket_rel} telemetry logs=otel-only "
-        "(endpoint оставлен из конфига мира)")
+    log(f"конфиг обновлён: admin_api=on socket={socket_rel} telemetry logs=otel-only"
+        + (f" otlp-port={local_port}" if local_port else " (endpoint из конфига мира)"))
 
 
 def main():


### PR DESCRIPTION
## Проблема

Контейнер циркуля исходит из того, что `localhost:<порт>` из `configuration.xml` мира всегда ведёт в **локальный** OTLP-приёмник этого сервера. Это верно на **agent**-хостах (там локальный plaintext-приём на стандартном `4318`), но **ломается на gateway-хосте**:

- на gateway `4318` занят **внешним TLS+auth** receiver'ом (туда стучатся удалённые agent'ы);
- локальный plaintext-приём на gateway живёт на `4319`.

В итоге циркуль с дефолтным `4318` попадает в TLS-приёмник, шлёт туда plain HTTP → handshake падает каждые ~5с, и **логи/метрики/трейсы локального циркуля не доходят** (`http: TLS handshake error ... client sent an HTTP request to an HTTPS server`).

Суть: номер `4318` перегружен — «локальный приём» на agent-хосте и «внешний приём» на gateway-хосте. Один и тот же конфиг мира поэтому непереносим между ролями.

## Решение

Опциональная переменная окружения **`OTEL_LOCAL_PORT`**:

- если задана — `entrypoint.py` переписывает порт OTLP-endpoint'ов внутри `<telemetry>` (байт-безопасно, тем же механизмом `edit_within`, что уже правит `enabled`/`mode`);
- если не задана — **поведение прежнее** (порт берётся из конфига мира как есть), так что agent-хосты не затронуты;
- на gateway-хосте в compose задаётся `OTEL_LOCAL_PORT=4319` — и один и тот же образ работает прозрачно на любом сервере.

gateway-докер рассматривается как порт-исключение, задаваемое **одной переменной хоста**, без правки конфигов мира руками и без изменений на стороне удалённого agent'а/циркуля.

## Изменения

- `tools/docker/entrypoint.py` — обработка `OTEL_LOCAL_PORT` + обновлён docstring/комментарии.
- `tools/docker/docker-compose.full.yml` — проброс `OTEL_LOCAL_PORT: "${OTEL_LOCAL_PORT:-}"` + обновлённое описание.

## Проверка

- `python3 -m py_compile` — OK.
- Юнит-тест логики замены на sample `<telemetry>`: `localhost:4318` → `localhost:4319` (3 вхождения), `enabled=true`, `mode=otel-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)