### PR TITLE
feat(observability): dead-man алёрт в Telegram при пропаже логов циркуля

### DIFF
--- a/tools/observability/.env.example
+++ b/tools/observability/.env.example
@@ -1,0 +1,15 @@
+# Скопируйте в .env (gitignored) и заполните своими значениями.
+#
+# Запуск наблюдательного стека использует эти переменные (см. data-dir override):
+DATA_DIR=/var/lib/mud-observability
+UID=1000
+GID=1000
+#
+# Dead-man алёрт в Telegram (grafana/provisioning/alerting/deadman.yaml):
+#   BYLINS_ROOSTER_TOKEN  — токен Telegram-бота (BotFather).
+#   BYLINS_ROOSTER_CHATID — id канала/чата для уведомлений (напр. -100xxxxxxxxxx).
+#   GRAFANA_EXTERNAL_URL  — внешний URL Grafana без слэша на конце; используется
+#                           в кликабельной ссылке на логи (напр. https://grafana.example.com).
+BYLINS_ROOSTER_TOKEN=
+BYLINS_ROOSTER_CHATID=
+GRAFANA_EXTERNAL_URL=

--- a/tools/observability/docker-compose.observability.yml
+++ b/tools/observability/docker-compose.observability.yml
@@ -74,6 +74,11 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin123
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
+      # Dead-man алёрт (provisioning/alerting/deadman.yaml). Значения — из
+      # tools/observability/.env (gitignored, см. .env.example). В репу не коммитим.
+      - BYLINS_ROOSTER_TOKEN=${BYLINS_ROOSTER_TOKEN:-}
+      - BYLINS_ROOSTER_CHATID=${BYLINS_ROOSTER_CHATID:-}
+      - GRAFANA_EXTERNAL_URL=${GRAFANA_EXTERNAL_URL:-}
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./dashboards:/var/lib/grafana/dashboards:ro

--- a/tools/observability/grafana/provisioning/alerting/deadman.yaml
+++ b/tools/observability/grafana/provisioning/alerting/deadman.yaml
@@ -1,0 +1,102 @@
+apiVersion: 1
+
+# Dead-man алёрт: если от циркуля нет логов в Loki дольше порога — шлём в Телеграм.
+# Принцип: sum(count_over_time(...[12m])) instant-запросом. Если поток молчит ≥12 мин,
+# Loki возвращает пусто → NoData → noDataState=Alerting. execErrState=Alerting,
+# чтобы недоступность Loki тоже считалась тревогой (иначе — слепы).
+#
+# Серверо-зависимые значения берутся из env (tools/observability/.env, gitignored;
+# см. .env.example): BYLINS_ROOSTER_TOKEN, BYLINS_ROOSTER_CHATID, GRAFANA_EXTERNAL_URL.
+
+contactPoints:
+  - orgId: 1
+    name: bylins-telegram
+    receivers:
+      - uid: bylins_telegram_rooster
+        type: telegram
+        settings:
+          bottoken: ${BYLINS_ROOSTER_TOKEN}
+          chatid: ${BYLINS_ROOSTER_CHATID}
+          parse_mode: HTML
+          message: |-
+            {{ if eq .Status "firing" -}}
+            🔴 <b>Циркуль молчит</b>
+            {{ range .Alerts }}
+            Сервис: <code>{{ .Labels.service }}</code>
+            Severity: <code>{{ .Labels.severity }}</code>
+            {{ .Annotations.summary }}
+            🔎 <a href="{{ .Annotations.logs_url }}">Логи сервиса в Grafana</a>
+            {{ end }}
+            {{- else -}}
+            ✅ <b>Логи снова идут</b>
+            {{ range .Alerts }}
+            Сервис: <code>{{ .Labels.service }}</code>
+            {{ end }}
+            {{- end }}
+        disableResolveMessage: false
+
+groups:
+  - orgId: 1
+    name: dead-man-logs
+    folder: Dead-man
+    interval: 1m
+    rules:
+      - uid: deadman_bylins_new
+        title: "Логи циркуля молчат: bylins-new (основной)"
+        condition: C
+        for: 0m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+          service: bylins-bylins-new-4000
+        annotations:
+          summary: "Основной сервер Былин не шлёт логи в Loki уже ≥12 минут."
+          logs_url: "${GRAFANA_EXTERNAL_URL}/explore?schemaVersion=1&amp;orgId=1&amp;panes=%7B%22adm%22%3A%7B%22datasource%22%3A%22loki%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%7Bservice_name%3D%5C%22bylins-bylins-new-4000%5C%22%7D%22%2C%22datasource%22%3A%7B%22type%22%3A%22loki%22%2C%22uid%22%3A%22loki%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D%7D"
+        notification_settings:
+          receiver: bylins-telegram
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: loki
+            model:
+              datasource:
+                type: loki
+                uid: loki
+              editorMode: code
+              expr: 'sum(count_over_time({service_name="bylins-bylins-new-4000"} [12m]))'
+              queryType: instant
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: reduce
+              reducer: last
+              expression: A
+              refId: B
+              datasource:
+                type: __expr__
+                uid: __expr__
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              expression: B
+              refId: C
+              datasource:
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    type: lt
+                    params: [1]


### PR DESCRIPTION
## Зачем

Раньше пропажа логов циркуля никак не сигнализировалась — узнавали постфактум. Этот PR добавляет **dead-man алёрт**: если основной сервер перестаёт слать логи, в Telegram-канал прилетает уведомление.

## Что делает

Grafana-провижининг (`tools/observability/grafana/provisioning/alerting/deadman.yaml`):

- **Правило:** `sum(count_over_time({service_name="bylins-bylins-new-4000"}[12m]))` instant-запросом. Если поток молчит ≥12 мин → Loki возвращает пусто → `NoData` → `noDataState=Alerting`. `execErrState=Alerting` — недоступность Loki тоже считается тревогой (иначе слепы).
- **Контакт:** Telegram, кастомный HTML-шаблон — заголовок (🔴/✅), `severity`, имя сервиса моноширинным, кликабельная ссылка на логи сервиса в Grafana Explore.
- **Маршрутизация:** через `notification_settings.receiver` (без правки корневой notification policy).

## Серверо-зависимые значения — через env

В репозитории **нет секретов и привязки к конкретному серверу**. Токен бота, `chat_id` канала и внешний URL Grafana берутся из `tools/observability/.env` (gitignored). Добавлен `.env.example`:

- `BYLINS_ROOSTER_TOKEN` — токен Telegram-бота;
- `BYLINS_ROOSTER_CHATID` — id канала;
- `GRAFANA_EXTERNAL_URL` — внешний URL Grafana для ссылки на логи.

Grafana раскрывает `${...}` в provisioning-файлах из своего окружения; переменные проброшены в сервис `grafana` в `docker-compose.observability.yml`.

## Проверка

Развёрнуто и проверено вживую: fire-test (подмена на несуществующий сервис → NoData) даёт 🔴 в канал без ошибок парсинга Telegram; возврат на реальный сервис → ✅; в норме правило в Normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)