### PR TITLE
feat(yaml): сейвы и резисты мобов -- именованная карта вместо позиций

### DIFF
--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1643,31 +1643,90 @@ CharData YamlWorldDataSource::ParseMobNode(const YAML::Node &root)
 			mob.set_role(role);
 		}
 
-		if (enhanced["resistances"] && enhanced["resistances"].IsSequence())
+		// Resistances. The current format is a named map (kFire: 10, kMind: 5,
+		// ...) so the meaning of each value is explicit and the file order is
+		// decoupled from the EResist enum order. A missing key means 0 (the
+		// loader's zero-initialized default), so only non-zero entries appear.
+		if (enhanced["resistances"])
 		{
-			int idx = 0;
-			for (const auto &val_node : enhanced["resistances"])
+			const auto &node = enhanced["resistances"];
+			if (node.IsMap())
 			{
-				int value = std::clamp(val_node.as<int>(), kMinResistance, kMaxNpcResist);
-				if (idx < static_cast<int>(mob.add_abils.apply_resistance.size()))
+				for (const auto &kv : node)
 				{
-					mob.add_abils.apply_resistance[idx] = value;
+					const std::string key = kv.first.as<std::string>();
+					try
+					{
+						const auto r = ITEM_BY_NAME<EResist>(key);
+						mob.add_abils.apply_resistance[r] =
+							std::clamp(kv.second.as<int>(), kMinResistance, kMaxNpcResist);
+					}
+					catch (const std::out_of_range &)
+					{
+						log("SYSERR: unknown EResist '%s' on mob '%s', skipped",
+							key.c_str(), mob.get_npc_name().c_str());
+					}
 				}
-				idx++;
+			}
+			else if (node.IsSequence())
+			{
+				// DEPRECATED: legacy positional list [v0, v1, ...]. Read for
+				// backward compatibility with worlds generated before the named
+				// map; remove once the new format has settled and no such worlds
+				// remain (re-saving any world rewrites it as a map).
+				int idx = 0;
+				for (const auto &val_node : node)
+				{
+					int value = std::clamp(val_node.as<int>(), kMinResistance, kMaxNpcResist);
+					if (idx < static_cast<int>(mob.add_abils.apply_resistance.size()))
+					{
+						mob.add_abils.apply_resistance[idx] = value;
+					}
+					idx++;
+				}
 			}
 		}
 
-		if (enhanced["saves"] && enhanced["saves"].IsSequence())
+		// Saves -- same named-map format and rationale as resistances.
+		if (enhanced["saves"])
 		{
-			int idx = 0;
-			for (const auto &val_node : enhanced["saves"])
+			const auto &node = enhanced["saves"];
+			if (node.IsMap())
 			{
-				int value = std::clamp(val_node.as<int>(), kMinSaving, kMaxSaving);
-				if (idx < static_cast<int>(mob.add_abils.apply_saving_throw.size()))
+				for (const auto &kv : node)
 				{
-					mob.add_abils.apply_saving_throw[idx] = value;
+					const std::string key = kv.first.as<std::string>();
+					try
+					{
+						const int s = to_underlying(ITEM_BY_NAME<ESaving>(key));
+						if (s >= 0 && s < static_cast<int>(mob.add_abils.apply_saving_throw.size()))
+						{
+							mob.add_abils.apply_saving_throw[s] =
+								std::clamp(kv.second.as<int>(), kMinSaving, kMaxSaving);
+						}
+					}
+					catch (const std::out_of_range &)
+					{
+						log("SYSERR: unknown ESaving '%s' on mob '%s', skipped",
+							key.c_str(), mob.get_npc_name().c_str());
+					}
 				}
-				idx++;
+			}
+			else if (node.IsSequence())
+			{
+				// DEPRECATED: legacy positional list -- see the resistances
+				// branch above. Kept for backward compatibility, remove once the
+				// named map format has settled.
+				int idx = 0;
+				for (const auto &val_node : node)
+				{
+					int value = std::clamp(val_node.as<int>(), kMinSaving, kMaxSaving);
+					if (idx < static_cast<int>(mob.add_abils.apply_saving_throw.size()))
+					{
+						mob.add_abils.apply_saving_throw[idx] = value;
+					}
+					idx++;
+				}
 			}
 		}
 
@@ -3854,28 +3913,61 @@ void YamlWorldDataSource::EmitMobBody(Koi8rYamlEmitter &yaml, std::ostream &out,
 				yaml.Value(role_str);
 			}
 
-			// Resistances. The Python converter always emits this block
-			// (even all-zero), so we mirror that for round-trip parity --
-			// otherwise the diff shows `/enhanced/resistances: missing in
-			// v2` for every mob with default resistances.
-			yaml.Key("resistances");
-			yaml.BeginSequence();
-			yaml.IncreaseIndent();
-			for (const auto &val : mob.add_abils.apply_resistance)
+			// Resistances. Emitted as a named map (kFire: 10, kMind: 5, ...)
+			// so each value is self-describing and the file order is
+			// independent of the EResist enum order. Only non-zero entries are
+			// written; a missing key -- or a missing block -- means 0, matching
+			// the loader's zero-initialized defaults.
+			bool has_resistances = false;
+			for (int i = EResist::kFirstResist; i <= EResist::kLastResist; ++i)
 			{
-				yaml.SequenceItem(val);
+				if (mob.add_abils.apply_resistance[i] != 0)
+				{
+					has_resistances = true;
+					break;
+				}
 			}
-			yaml.DecreaseIndent();
+			if (has_resistances)
+			{
+				yaml.Key("resistances");
+				yaml.BeginBlock();
+				for (int i = EResist::kFirstResist; i <= EResist::kLastResist; ++i)
+				{
+					const int value = mob.add_abils.apply_resistance[i];
+					if (value != 0)
+					{
+						yaml.Key(NAME_BY_ITEM<EResist>(static_cast<EResist>(i)));
+						yaml.Value(value);
+					}
+				}
+				yaml.EndBlock();
+			}
 
-			// Saves -- same rationale as resistances.
-			yaml.Key("saves");
-			yaml.BeginSequence();
-			yaml.IncreaseIndent();
-			for (const auto &val : mob.add_abils.apply_saving_throw)
+			// Saves -- same named-map format and rationale as resistances.
+			bool has_saves = false;
+			for (int i = to_underlying(ESaving::kFirst); i <= to_underlying(ESaving::kLast); ++i)
 			{
-				yaml.SequenceItem(val);
+				if (mob.add_abils.apply_saving_throw[i] != 0)
+				{
+					has_saves = true;
+					break;
+				}
 			}
-			yaml.DecreaseIndent();
+			if (has_saves)
+			{
+				yaml.Key("saves");
+				yaml.BeginBlock();
+				for (int i = to_underlying(ESaving::kFirst); i <= to_underlying(ESaving::kLast); ++i)
+				{
+					const int value = mob.add_abils.apply_saving_throw[i];
+					if (value != 0)
+					{
+						yaml.Key(NAME_BY_ITEM<ESaving>(static_cast<ESaving>(i)));
+						yaml.Value(value);
+					}
+				}
+				yaml.EndBlock();
+			}
 
 			// Feats
 			bool has_feats = false;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -50,6 +50,7 @@ test_sources = files(
     'trigger_indenter.cpp',
     'trigger_script_parser.cpp',
     'yaml_loader_flag_packing.cpp',
+    'yaml_mob_saves_resistances.cpp',
     'world_checksum_serialization.cpp',
     'dg_string_matching.cpp',
     'dg_var_context.cpp',

--- a/tests/yaml_mob_saves_resistances.cpp
+++ b/tests/yaml_mob_saves_resistances.cpp
@@ -1,0 +1,213 @@
+// Part of Bylins http://www.mud.ru
+// Tests for the named-map serialization of mob saves and resistances.
+//
+// The YAML mob format stores saving throws and resistances as named maps
+// (e.g. "kWill: 10", "kFire: 20") instead of positional integer arrays, so the
+// meaning of each value is explicit and the on-disk order is decoupled from the
+// ESaving / EResist enum order. These tests pin:
+//   * the name<->index mapping the loader relies on (NAME_BY_ITEM/ITEM_BY_NAME);
+//   * order-independence of map parsing;
+//   * the "missing key means 0" / "emit non-zero only" rule, including omitting
+//     the whole block when every value is zero;
+//   * graceful skipping of unknown keys and the ESaving::kNone sentinel;
+//   * the deprecated positional-list backward-compatibility path.
+//
+// The Parse*/Emit* helpers below mirror the reader in
+// YamlWorldDataSource::ParseMobFile and the writer in
+// YamlWorldDataSource::SaveMobs; they use the real enum mapping functions and
+// emitter so a divergence in either is caught here.
+//
+// Guarded by HAVE_YAML: yaml-cpp is only available when the YAML world format
+// is enabled, so in non-YAML builds this file compiles to nothing (same pattern
+// as koi8r.yaml.emitter.cpp).
+
+#ifdef HAVE_YAML
+
+#include "engine/entities/entities_constants.h"
+#include "engine/db/koi8r_yaml_emitter.h"
+#include "engine/structs/structs.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+constexpr std::size_t kNumResist = EResist::kLastResist - EResist::kFirstResist + 1;
+constexpr std::size_t kNumSaves =
+	static_cast<int>(ESaving::kLast) - static_cast<int>(ESaving::kFirst) + 1;
+
+std::array<int, kNumResist> ParseResistances(const YAML::Node &node) {
+	std::array<int, kNumResist> out{};
+	if (node.IsMap()) {
+		for (const auto &kv : node) {
+			try {
+				const auto r = ITEM_BY_NAME<EResist>(kv.first.as<std::string>());
+				out[r] = std::clamp(kv.second.as<int>(), kMinResistance, kMaxNpcResist);
+			} catch (const std::out_of_range &) {
+			}
+		}
+	} else if (node.IsSequence()) {
+		int idx = 0;
+		for (const auto &v : node) {
+			if (idx < static_cast<int>(out.size())) {
+				out[idx] = std::clamp(v.as<int>(), kMinResistance, kMaxNpcResist);
+			}
+			idx++;
+		}
+	}
+	return out;
+}
+
+std::array<int, kNumSaves> ParseSaves(const YAML::Node &node) {
+	std::array<int, kNumSaves> out{};
+	if (node.IsMap()) {
+		for (const auto &kv : node) {
+			try {
+				const int s = static_cast<int>(ITEM_BY_NAME<ESaving>(kv.first.as<std::string>()));
+				if (s >= 0 && s < static_cast<int>(out.size())) {
+					out[s] = std::clamp(kv.second.as<int>(), kMinSaving, kMaxSaving);
+				}
+			} catch (const std::out_of_range &) {
+			}
+		}
+	} else if (node.IsSequence()) {
+		int idx = 0;
+		for (const auto &v : node) {
+			if (idx < static_cast<int>(out.size())) {
+				out[idx] = std::clamp(v.as<int>(), kMinSaving, kMaxSaving);
+			}
+			idx++;
+		}
+	}
+	return out;
+}
+
+std::string EmitResistances(const std::array<int, kNumResist> &vals) {
+	bool any = false;
+	for (const int v : vals) {
+		if (v != 0) {
+			any = true;
+			break;
+		}
+	}
+	std::ostringstream oss;
+	if (any) {
+		Koi8rYamlEmitter yaml(oss);
+		yaml.Key("resistances");
+		yaml.BeginBlock();
+		for (std::size_t i = 0; i < vals.size(); ++i) {
+			if (vals[i] != 0) {
+				yaml.Key(NAME_BY_ITEM<EResist>(static_cast<EResist>(i)));
+				yaml.Value(vals[i]);
+			}
+		}
+		yaml.EndBlock();
+	}
+	return oss.str();
+}
+
+}  // namespace
+
+// The writer emits NAME_BY_ITEM(i) and the loader reads it back with
+// ITEM_BY_NAME; this round-trip is what keeps the file order independent of the
+// enum order. Pinned for every value in both enums.
+TEST(MobSavesResistances, EnumNamesRoundTrip) {
+	for (int i = EResist::kFirstResist; i <= EResist::kLastResist; ++i) {
+		const auto e = static_cast<EResist>(i);
+		EXPECT_EQ(e, ITEM_BY_NAME<EResist>(NAME_BY_ITEM<EResist>(e)));
+	}
+	for (int i = static_cast<int>(ESaving::kFirst); i <= static_cast<int>(ESaving::kLast); ++i) {
+		const auto e = static_cast<ESaving>(i);
+		EXPECT_EQ(e, ITEM_BY_NAME<ESaving>(NAME_BY_ITEM<ESaving>(e)));
+	}
+}
+
+TEST(MobSavesResistances, NamedMapMapsToCorrectIndices) {
+	const auto r = ParseResistances(YAML::Load("kFire: 20\nkMind: 5\nkDark: -10\n"));
+	EXPECT_EQ(20, r[EResist::kFire]);
+	EXPECT_EQ(5, r[EResist::kMind]);
+	EXPECT_EQ(-10, r[EResist::kDark]);
+	// Keys not present default to 0.
+	EXPECT_EQ(0, r[EResist::kAir]);
+	EXPECT_EQ(0, r[EResist::kWater]);
+
+	const auto s = ParseSaves(YAML::Load("kWill: 7\nkStability: 3\n"));
+	EXPECT_EQ(7, s[static_cast<int>(ESaving::kWill)]);
+	EXPECT_EQ(3, s[static_cast<int>(ESaving::kStability)]);
+	EXPECT_EQ(0, s[static_cast<int>(ESaving::kCritical)]);
+}
+
+TEST(MobSavesResistances, MapParsingIsOrderIndependent) {
+	const auto a = ParseSaves(YAML::Load("kWill: 1\nkReflex: 2\n"));
+	const auto b = ParseSaves(YAML::Load("kReflex: 2\nkWill: 1\n"));
+	EXPECT_EQ(a, b);
+	EXPECT_EQ(1, a[static_cast<int>(ESaving::kWill)]);
+	EXPECT_EQ(2, a[static_cast<int>(ESaving::kReflex)]);
+}
+
+// DEPRECATED positional-list format: kept for worlds generated before the named
+// map. Remove this path once the new format has settled.
+TEST(MobSavesResistances, LegacyPositionalListStillParses) {
+	const auto r = ParseResistances(YAML::Load("[1, 2, 3, 4, 5, 6, 7, 8]"));
+	for (int i = 0; i < static_cast<int>(kNumResist); ++i) {
+		EXPECT_EQ(i + 1, r[i]);
+	}
+	const auto s = ParseSaves(YAML::Load("[11, 12, 13, 14]"));
+	EXPECT_EQ(11, s[0]);
+	EXPECT_EQ(14, s[3]);
+}
+
+TEST(MobSavesResistances, UnknownKeyIsSkipped) {
+	const auto r = ParseResistances(YAML::Load("kFire: 7\nkBogus: 99\n"));
+	EXPECT_EQ(7, r[EResist::kFire]);
+	EXPECT_EQ(0, r[EResist::kAir]);
+}
+
+// kNone is the ESaving sentinel; its index is past the array, so it must be
+// ignored rather than writing out of bounds.
+TEST(MobSavesResistances, SaveSentinelKeyIsSkipped) {
+	const auto s = ParseSaves(YAML::Load("kWill: 3\nkNone: 99\n"));
+	EXPECT_EQ(3, s[static_cast<int>(ESaving::kWill)]);
+}
+
+TEST(MobSavesResistances, ValuesAreClamped) {
+	const auto r = ParseResistances(YAML::Load("kFire: 9999\nkAir: -9999\n"));
+	EXPECT_EQ(kMaxNpcResist, r[EResist::kFire]);
+	EXPECT_EQ(kMinResistance, r[EResist::kAir]);
+
+	const auto s = ParseSaves(YAML::Load("kWill: 9999\nkReflex: -9999\n"));
+	EXPECT_EQ(kMaxSaving, s[static_cast<int>(ESaving::kWill)]);
+	EXPECT_EQ(kMinSaving, s[static_cast<int>(ESaving::kReflex)]);
+}
+
+TEST(MobSavesResistances, EmitSkipsZerosAndRoundTrips) {
+	std::array<int, kNumResist> vals{};
+	vals[EResist::kFire] = 20;
+	vals[EResist::kMind] = -5;
+
+	const std::string text = EmitResistances(vals);
+	EXPECT_NE(std::string::npos, text.find("kFire"));
+	EXPECT_NE(std::string::npos, text.find("kMind"));
+	// Zero-valued resistances are not written.
+	EXPECT_EQ(std::string::npos, text.find("kAir"));
+	EXPECT_EQ(std::string::npos, text.find("kWater"));
+
+	const YAML::Node root = YAML::Load(text);
+	EXPECT_EQ(vals, ParseResistances(root["resistances"]));
+}
+
+TEST(MobSavesResistances, EmitOmitsBlockWhenAllZero) {
+	const std::array<int, kNumResist> vals{};
+	EXPECT_TRUE(EmitResistances(vals).empty());
+}
+
+#endif  // HAVE_YAML
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tools/converter/convert_to_yaml.py
+++ b/tools/converter/convert_to_yaml.py
@@ -98,6 +98,28 @@ def _init_yaml_libraries():
         _pyyaml = yaml
 
 
+# Names for the positional save/resistance arrays, kept in sync with the C++
+# enums ESaving / EResist (src/engine/entities/entities_constants.h). The YAML
+# emits these as named maps so each value is self-describing; the C++ loader
+# reads them back by name via ITEM_BY_NAME<>, so the file order is decoupled
+# from the enum order.
+ESAVING_NAMES = ('kWill', 'kCritical', 'kStability', 'kReflex')
+ERESIST_NAMES = ('kFire', 'kAir', 'kWater', 'kEarth',
+                 'kVitality', 'kMind', 'kImmunity', 'kDark')
+
+
+def _named_value_map(values, names):
+    """Build a CommentedMap {name: value} from a positional list, emitting only
+    non-zero entries -- a missing key means 0 on load. Returns None when every
+    value is zero so the caller can omit the block entirely."""
+    result = CommentedMap()
+    for i, name in enumerate(names):
+        value = int(values[i]) if i < len(values) else 0
+        if value != 0:
+            result[name] = value
+    return result if result else None
+
+
 def log_warning(message, vnum=None, filepath=None):
     """Log a warning message without stack trace (thread-safe)."""
     global _warnings_count
@@ -2614,9 +2636,13 @@ def mob_to_yaml(mob):
         
         # Array fields
         if enh.get('resistances'):
-            enhanced['resistances'] = CommentedSeq(enh['resistances'])
+            resist_map = _named_value_map(enh['resistances'], ERESIST_NAMES)
+            if resist_map is not None:
+                enhanced['resistances'] = resist_map
         if enh.get('saves'):
-            enhanced['saves'] = CommentedSeq(enh['saves'])
+            saves_map = _named_value_map(enh['saves'], ESAVING_NAMES)
+            if saves_map is not None:
+                enhanced['saves'] = saves_map
         if enh.get('feats'):
             enhanced['feats'] = CommentedSeq(enh['feats'])
         if enh.get('spells'):


### PR DESCRIPTION
## Что и зачем

В YAML-формате мобов `saves` (4 шт.) и `resistances` (8 шт.) хранились как позиционные массивы голых чисел:

```yaml
saves:
  - 0
  - 0
  - 0
  - 0
resistances:
  - 0
  - 0
  - 0
  - 0
  - 0
  - 0
  - 0
  - 0
```

Смысл каждой позиции был неочевиден, а перестановка элементов в `ESaving`/`EResist` или добавление нового значения тихо ломали все существующие миры.

## Как теперь

Именованная карта через уже существующий механизм `NAME_BY_ITEM`/`ITEM_BY_NAME` (тот же, которым пишутся строковые enum'ы вроде `kWorm`):

```yaml
saves:
  kWill: 10
  kStability: 5
resistances:
  kFire: 20
  kMind: 15
```

- Чтение идёт по имени → индексу, поэтому **порядок в файле развязан с порядком в enum**.
- **Нули не пишутся**; отсутствие ключа (или всего блока) на чтении означает 0 — совпадает с нуль-инициализацией загрузчика.
- То же поведение продублировано в Python-конвертере (`tools/converter/convert_to_yaml.py`) для паритета.
- **Обратная совместимость**: старый позиционный список по-прежнему читается, помечен как `DEPRECATED` — удалить после устаканивания формата (пересохранение любого мира переписывает его в карту).

## Где менялось

- `src/engine/db/yaml_world_data_source.cpp` — writer (`SaveMobs`) и reader (`ParseMobFile`).
- `tools/converter/convert_to_yaml.py` — эмиссия именованной карты.
- `tests/yaml_mob_saves_resistances.cpp` — новый тест.

## Проверки

- C++ (production и тест) проходят `-fsyntax-only` с реальными флагами сборки `build_yaml`.
- Python-конвертер: `py_compile` + проверка вывода (пропуск нулей, опускание пустого блока).
- Рантайм-предположения теста сверены с реализацией `entities_constants.cpp` (`ITEM_BY_NAME` бросает `out_of_range` на неизвестном ключе; `kNone` — sentinel за границей массива).
- Фактический прогон тестов — на CI.