### PR TITLE
issue.remove-poison-hotfix: make inflicted poison curable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ subprojects/fmt
 subprojects/gtest
 subprojects/yaml-cpp
 subprojects/zlib
+/1/

--- a/src/gameplay/mechanics/poison.cpp
+++ b/src/gameplay/mechanics/poison.cpp
@@ -84,7 +84,7 @@ namespace {
 				if (!vict->IsNpc()) {
 					i.duration *= 30;
 				}
-				i.battleflag = kAfSameTime;
+				i.battleflag = kAfSameTime | kAfCurable;
 
 				if (!poison_affect_join(ch, vict, i)) {
 					was_poisoned = false;
@@ -124,7 +124,7 @@ namespace {
 					i.duration *= 30;
 				}
 				i.modifier = affect_modifier;
-				i.battleflag = kAfSameTime;
+				i.battleflag = kAfSameTime | kAfCurable;
 
 				if (!poison_affect_join(ch, vict, i)) {
 					was_poisoned = false;
@@ -170,7 +170,7 @@ namespace {
 				if (!vict->IsNpc()) {
 					i.duration *= 30;
 				}
-				i.battleflag = kAfSameTime;
+				i.battleflag = kAfSameTime | kAfCurable;
 
 				if (!poison_affect_join(ch, vict, i)) {
 					was_poisoned = false;
@@ -216,7 +216,7 @@ namespace {
 					i.duration *= 30;
 				}
 				i.caster_id = ch->get_uid();
-				i.battleflag = kAfSameTime;
+				i.battleflag = kAfSameTime | kAfCurable;
 
 				if (!poison_affect_join(ch, vict, i)) {
 					was_poisoned = false;
@@ -267,7 +267,7 @@ namespace {
 					}
 					af.modifier = -GetRealLevel(ch) / 6 * 2;
 					af.affect_type = EAffect::kPoisoned;
-					af.battleflag = kAfSameTime;
+					af.battleflag = kAfSameTime | kAfCurable;
 
 					for (int i = EApply::kStr; i <= EApply::kCha; i++) {
 						af.location = static_cast<EApply>(i);
@@ -290,7 +290,7 @@ namespace {
 					af.location = EApply::kInitiative;
 					af.modifier = -GetRealLevel(ch) / 6;
 					af.affect_type = EAffect::kPoisoned;
-					af.battleflag = kAfSameTime;
+					af.battleflag = kAfSameTime | kAfCurable;
 					ImposeAffect(vict, af, false, false, false, false);
 					SendMsgToChar(ch, "%sОт действия вашего яда %s стал%s заметно медленнее двигаться!%s\r\n",
 								  kColorGrn, sight::PersonName(vict, ch, 0), grammar::VisSexEnding(sight::CanSee((ch), (vict)), (vict)->get_sex(), 1), kColorNrm);
@@ -328,28 +328,28 @@ void PerformToxicate(CharData *ch, CharData *vict, int modifier) {
 	af[0].duration = CalcDuration(ch, vict, ESkill::kUndefined, 1, 0, 0, 0);
 	af[0].modifier = -std::min(2, (modifier + 29) / 40);
 	af[0].affect_type = EAffect::kPoisoned;
-	af[0].battleflag = kAfSameTime;
+	af[0].battleflag = kAfSameTime | kAfCurable;
 	// change damroll
 	af[1].type = ESpell::kPoison;
 	af[1].location = EApply::kDamroll;
 	af[1].duration = af[0].duration;
 	af[1].modifier = -std::min(2, (modifier + 29) / 30);
 	af[1].affect_type = EAffect::kPoisoned;
-	af[1].battleflag = kAfSameTime;
+	af[1].battleflag = kAfSameTime | kAfCurable;
 	// change hitroll
 	af[2].type = ESpell::kPoison;
 	af[2].location = EApply::kHitroll;
 	af[2].duration = af[0].duration;
 	af[2].modifier = -std::min(2, (modifier + 19) / 20);
 	af[2].affect_type = EAffect::kPoisoned;
-	af[2].battleflag = kAfSameTime;
+	af[2].battleflag = kAfSameTime | kAfCurable;
 	// change poison level
 	af[3].type = ESpell::kPoison;
 	af[3].location = EApply::kPoison;
 	af[3].duration = af[0].duration;
 	af[3].modifier = GetRealLevel(ch);
 	af[3].affect_type = EAffect::kPoisoned;
-	af[3].battleflag = kAfSameTime;
+	af[3].battleflag = kAfSameTime | kAfCurable;
 
 	for (auto & i : af) {
 		i.caster_id = ch->get_uid();   // автор отравления -- хранится в аффекте (для засчёта убийства)
@@ -503,13 +503,13 @@ void TryDrinkPoison(CharData *ch, ObjData *jar, int amount) {
 		af.modifier = -2;
 		af.location = EApply::kStr;
 		af.affect_type = EAffect::kPoisoned;
-		af.battleflag = kAfSameTime;
+		af.battleflag = kAfSameTime | kAfCurable;
 		ImposeAffect(ch, af, false, false, false, false);
 		af.type = ESpell::kPoison;
 		af.modifier = amount == 0 ? GetRealLevel(ch) * 3 : amount * 3;
 		af.location = EApply::kPoison;
 		af.affect_type = EAffect::kPoisoned;
-		af.battleflag = kAfSameTime;
+		af.battleflag = kAfSameTime | kAfCurable;
 		ImposeAffect(ch, af, false, false, false, false);
 		// самоотравление (выпил яд): автора нет -- caster_id аффектов остаётся 0
 	}


### PR DESCRIPTION
kRemovePoison's <unaffect> narrows eligibility to affects carrying kAfCurable (AffectMatchesFlags: IS_SET(battleflag, kAfCurable)), and its <remove all_of="kPoison|kAconitumPoison|kScopolaPoison|kBelenaPoison| kDaturaPoison"> keys on the affect's ESpell type. The cure pipeline (CastUnaffects -> CollectRemovals) was correct, and the kPoison *spell* affect in spells.xml already carries kAfCurable.

But poison applied by the poison *mechanic* (poison.cpp: herbal poisons, the отравить skill, PerformToxicate/toxic mobs, drinking poisoned liquid) set battleflag = kAfSameTime only -- never kAfCurable. So the affect was filtered out of CollectRemovals and remove-poison removed nothing, even though its all_of list names exactly these poison types.

Add kAfCurable to all 12 poison-affect battleflags in poison.cpp so the inflicted poison declares itself curable and kRemovePoison can match it.

The user's other suspicion -- the <alter_obj> handler applying the spell to a worn item -- is already prevented on master by the bless fix (CastToAlterObjs grabs a collateral item only for spells violent against the target; remove-poison is neutral, so a char cast touches no item).