### PR TITLE
fix(olc): zedit сохраняет зону через WorldDataSource

### DIFF
--- a/src/engine/olc/zedit.cpp
+++ b/src/engine/olc/zedit.cpp
@@ -16,6 +16,7 @@
 #include "engine/db/help.h"
 #include "engine/entities/zone.h"
 #include "engine/db/global_objects.h"
+#include "engine/db/world_data_source_manager.h"
 #include "utils/logger.h"
 #include "utils/utils.h"
 #include "engine/structs/structs.h"
@@ -417,7 +418,8 @@ void zedit_save_internally(DescriptorData *d) {
 		zone_table[OLC_ZNUM(d)].entrance = OLC_ZONE(d)->entrance;
 	}
 //	olc_add_to_save_list(zone_table[OLC_ZNUM(d)].vnum, OLC_SAVE_ZONE);
-	zedit_save_to_disk(OLC_ZNUM(d));
+	auto* data_source = world_loader::WorldDataSourceManager::Instance().GetDataSource();
+	data_source->SaveZone(OLC_ZNUM(d));
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
## Проблема

При работе с YAML-миром (легаси-каталог мира удалён) сохранение зоны в OLC падало:

```
SYSERR: OLC: zedit_save_to_disk:  Can't write zone 310.
```

## Причина

`zedit` (сохранение зоны) звал `zedit_save_to_disk()` напрямую — а она всегда пишет легаси-формат в `ZON_PREFIX`. Если каталога легаси-мира нет, `fopen` падает.

Остальные редакторы (`oedit`, `redit`, `medit`, `trigedit`) уже сохраняют через абстракцию `WorldDataSourceManager::GetDataSource()->Save*()`, которая выбирает бэкенд по формату мира (legacy / yaml / sqlite). `zedit` был единственным, кто её обходил.

## Решение

Перевёл сохранение зоны в `zedit` на тот же путь — `data_source->SaveZone(OLC_ZNUM(d))`. Для legacy-формата поведение не меняется: его `SaveZone` оборачивает тот же `zedit_save_to_disk`.

## Проверка

- Сборка проходит.
- Изменение зеркалит уже принятый паттерн из `oedit.cpp:284-285` / `redit.cpp:267-268` / `medit.cpp:514-515`.

## Смежное (не входит в этот PR)

`comm.cpp:968-974` (flush OLC save-list при ребуте) тоже зовёт легаси `*_save_to_disk` напрямую для всех типов; единственный живой источник записей — миграция `ConvertObjValues` (`db.cpp:359`, `OLC_SAVE_OBJ`). Под YAML это отдельный латентный путь — стоит решить отдельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)