### PR TITLE
fix(olc): flush OLC save-list при ребуте через WorldDataSource

### DIFF
--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -75,6 +75,7 @@
 #ifdef HAVE_SQLITE
 #include "engine/db/sqlite_world_data_source.h"
 #endif
+#include "engine/db/world_data_source_manager.h"
 #include "utils/utils.h"
 #include <cstring>
 #include <cerrno>
@@ -967,14 +968,15 @@ void stop_game(ush_int port) {
 				sprintf(buf, "OLC: Reboot saving %s for zone %d.",
 						save_info_msg[(int) entry->type], zone_table[rznum].vnum);
 				log("%s", buf);
+				auto* data_source = world_loader::WorldDataSourceManager::Instance().GetDataSource();
 				switch (entry->type) {
-					case OLC_SAVE_ROOM: redit_save_to_disk(rznum);
+					case OLC_SAVE_ROOM: data_source->SaveRooms(rznum);
 						break;
-					case OLC_SAVE_OBJ: oedit_save_to_disk(rznum);
+					case OLC_SAVE_OBJ: data_source->SaveObjects(rznum);
 						break;
-					case OLC_SAVE_MOB: medit_save_to_disk(rznum);
+					case OLC_SAVE_MOB: data_source->SaveMobs(rznum);
 						break;
-					case OLC_SAVE_ZONE: zedit_save_to_disk(rznum);
+					case OLC_SAVE_ZONE: data_source->SaveZone(rznum);
 						break;
 					default: log("Unexpected olc_save_list->type");
 						break;


### PR DESCRIPTION
## Проблема

Отложенный flush `olc_save_list` перед ребутом (`comm.cpp`) звал легаси-функции `redit_save_to_disk` / `oedit_save_to_disk` / `medit_save_to_disk` / `zedit_save_to_disk` напрямую — они всегда пишут легаси-формат. При YAML/SQLite-мире с удалённым легаси-каталогом запись падает (`Can't write ...`).

Единственный живой источник записей в этот список — миграция `ConvertObjValues` (`db.cpp:359`, ставит `OLC_SAVE_OBJ` при апгрейде флагов предметов). Под YAML она уходила в легаси-запись.

## Решение

Переключил flush на абстракцию `WorldDataSourceManager::GetDataSource()->Save*()`, которая выбирает бэкенд по формату мира (legacy / yaml / sqlite). Для legacy поведение не меняется.

Парная правка к #3504 (там тот же фикс для интерактивного сохранения зоны в `zedit`).

## Проверка

- Сборка проходит.
- Зеркалит паттерн из `oedit`/`redit`/`medit`/`trigedit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)