### PR TITLE
Issue.remort system

### DIFF
--- a/lib/cfg/remort.xml
+++ b/lib/cfg/remort.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="koi8-r"?>
+<!--
+    issue.remort-system: parameters of the remort (reincarnation) system.
+
+    system points_buy:
+        false - legacy system: +1 to every base stat per remort.
+        true  - proportional system: the highest start stat gains +1 per remort, the
+                others scale to keep their original ratio to it (floored).
+    abilities_reset stop_obligatory_reset / period:
+        a full skill/spell wipe is forced when remort >= stop_obligatory_reset and
+        remort % period == 0 (remort.cpp).
+    skill_cap start_cap / increment:
+        the per-character skill cap is start_cap + remort * increment.
+    hp / moves val:
+        base max hp / max moves a character is reset to on remort (remort.cpp).
+-->
+<remort>
+	<system points_buy="false"/>
+	<abilities_reset stop_obligatory_reset="9" period="3"/>
+	<skill_cap start_cap="80" increment="5"/>
+	<hp val="10"/>
+	<moves val="82"/>
+</remort>

--- a/lib/cfg/remort.xml
+++ b/lib/cfg/remort.xml
@@ -13,6 +13,17 @@
         the per-character skill cap is start_cap + remort * increment.
     hp / moves val:
         base max hp / max moves a character is reset to on remort (remort.cpp).
+    prices:
+        cost (in in-game currency) of performing each remort, paid as a sacrifice in a
+        shrine of the character's faith. <price remort=N currency=text-id amount=A/>
+        gives the cost to reach remort N (a char with N-1 remorts pays price N to gain one).
+        amount must be >= 0; amount 0 means free (no sacrifice, no message).
+        Gaps between/after defined entries inherit the nearest LOWER entry's currency,
+        with the amount raised by increment_percent for each missing step, e.g. with
+        increment_percent=30 and prices at 3 (=6000) and 6, remort 4 costs 6000+30%=7800
+        and remort 5 costs 6000+60%=9600.
+        disabled="Y" makes every remort free. An unknown currency id (with amount>0)
+        blocks that remort and logs an error.
 -->
 <remort>
 	<system points_buy="false"/>
@@ -20,4 +31,12 @@
 	<skill_cap start_cap="80" increment="5"/>
 	<hp val="10"/>
 	<moves val="82"/>
+	<prices increment_percent="30" disabled="Y">
+		<price remort="1" currency="kBronzeGrivna" amount="1000"/>
+		<price remort="2" currency="kBronzeGrivna" amount="3000"/>
+		<price remort="3" currency="kBronzeGrivna" amount="6000"/>
+		<price remort="6" currency="kBronzeGrivna" amount="8000"/>
+		<price remort="11" currency="kRotteFish" amount="1"/>
+		<price remort="12" currency="kKuna" amount="0"/>
+	</prices>
 </remort>

--- a/src/engine/boot/cfg_manager.cpp
+++ b/src/engine/boot/cfg_manager.cpp
@@ -49,6 +49,7 @@
 #include "gameplay/mechanics/corpse.h"
 #include "gameplay/classes/pc_classes.h"
 #include "gameplay/core/reset_stats.h"
+#include "gameplay/core/remort.h"
 #include "gameplay/mechanics/noob.h"
 #include "gameplay/mechanics/celebrates.h"
 #include "gameplay/mechanics/city_guards.h"
@@ -157,6 +158,7 @@ CfgManager::CfgManager() {
 		{"global_drop", CfgDir::kMechanics, [] { return MakeLoader<GlobalDrop::GlobalDropLoader>(); }},
 		{"group_exp_handicap", CfgDir::kMechanics, [] { return MakeLoader<GroupPenaltiesLoader>(); }},
 		{"reset_stats", CfgDir::kMechanics, [] { return MakeLoader<stats_reset::ResetStatsLoader>(); }},
+		{"remort", CfgDir::kRoot, [] { return MakeLoader<remort::RemortLoader>(); }},
 		{"noob", CfgDir::kMechanics, [] { return MakeLoader<Noob::NoobLoader>(); }},
 		{"digging", CfgDir::kMechanics, [] { return MakeLoader<mining::DiggingLoader>(); }},
 		{"celebrates", CfgDir::kMechanics, [] { return MakeLoader<celebrates::CelebratesLoader>(); }},

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -989,6 +989,10 @@ void BootMudDataBase() {
 	log("Load reset_stats.xml");
 	MUD::CfgManager().LoadCfg("reset_stats");
 
+	boot_profiler.next_step("Loading remort.xml");
+	log("Load remort.xml");
+	MUD::CfgManager().LoadCfg("remort");
+
 	boot_profiler.next_step("Loading mail.xml");
 	log("Load mail.xml");
 	mail::load();

--- a/src/engine/ui/cmd_god/do_reload.cpp
+++ b/src/engine/ui/cmd_god/do_reload.cpp
@@ -205,6 +205,8 @@ void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		MUD::CfgManager().ReloadCfg("noob");
 	} else if (!str_cmp(arg, "resetstats")) {
 		MUD::CfgManager().ReloadCfg("reset_stats");
+	} else if (!str_cmp(arg, "remort")) {
+		MUD::CfgManager().ReloadCfg("remort");
 	} else if (!str_cmp(arg, "digging")) {
 		MUD::CfgManager().ReloadCfg("digging");
 	} else if (!str_cmp(arg, "guards")) {

--- a/src/gameplay/core/remort.cpp
+++ b/src/gameplay/core/remort.cpp
@@ -20,12 +20,15 @@
 #include "gameplay/mechanics/sight.h"
 #include "gameplay/classes/pc_classes.h"
 #include "gameplay/skills/skills.h"
+#include "gameplay/economics/currencies.h"
+#include "engine/db/db.h"                  // world[] for ROOM_FLAGGED
 
 #include "utils/utils_parse.h"               // parse::AttrInt / parse::ReadAsBool
 #include "engine/entities/char_player.h"      // START_STATS_TOTAL
 
 #include <fmt/format.h>
 #include <algorithm>
+#include <cmath>
 
 extern RoomRnum r_frozen_start_room;
 
@@ -35,6 +38,11 @@ namespace remort {
 namespace {
 // Defaults match the legacy hardcoded constants, so behaviour is identical until the file overrides
 // them (and stays sane if the file/tag is missing).
+struct PriceEntry {
+	int remort;           // result remort number this applies to (a 0->1 remort is number 1)
+	std::string currency; // currency text-id as written in remort.xml (resolved when charged)
+	long amount;          // sacrifice amount, >= 0 (0 == free, no sacrifice message)
+};
 struct RemortCfg {
 	bool points_buy = false;
 	int abil_reset_stop = 9;
@@ -43,8 +51,53 @@ struct RemortCfg {
 	int skill_cap_increment = 5;
 	int hp = 10;
 	int moves = 82;
+	// <prices>: cost to perform each remort. Empty table or disabled="Y" => every remort is free.
+	bool prices_disabled = false;
+	int price_increment_percent = 0;
+	std::vector<PriceEntry> prices;  // ascending by remort; gaps filled from the nearest lower entry.
 };
 RemortCfg g_cfg;
+
+// issue.remort-system: resolved sacrifice for performing a given remort number.
+struct ResolvedPrice {
+	bool free;            // true => charge nothing and show no sacrifice message
+	std::string currency; // currency text-id (empty when free)
+	long amount;          // amount to charge (0 when free)
+};
+
+// Cost of performing the `target_remort`-th remort. Exact <price> entries are used verbatim; a target
+// that falls in a gap (or past the last entry) inherits the nearest PRECEDING entry's currency, with
+// the amount raised by price_increment_percent for every step of distance:
+//   amount = round(base.amount * (1 + increment_percent/100 * (target - base.remort))).
+// A target below the first entry, an empty table, disabled="Y", or a computed/explicit 0 => free.
+ResolvedPrice ResolveRemortPrice(int target_remort) {
+	if (g_cfg.prices_disabled || g_cfg.prices.empty()) {
+		return {true, "", 0};
+	}
+	const PriceEntry *exact = nullptr;
+	const PriceEntry *base = nullptr;  // nearest defined entry with remort < target
+	for (const auto &e : g_cfg.prices) {  // ascending
+		if (e.remort == target_remort) { exact = &e; break; }
+		if (e.remort < target_remort) { base = &e; } else { break; }
+	}
+	std::string currency;
+	long amount = 0;
+	if (exact) {
+		currency = exact->currency;
+		amount = exact->amount;
+	} else if (base) {
+		const int gap = target_remort - base->remort;  // >= 1
+		const double mult = 1.0 + (g_cfg.price_increment_percent / 100.0) * gap;
+		currency = base->currency;
+		amount = std::lround(static_cast<double>(base->amount) * mult);
+	} else {
+		return {true, "", 0};  // below the first defined entry
+	}
+	if (amount <= 0) {
+		return {true, "", 0};  // zero cost
+	}
+	return {false, currency, amount};
+}
 } // namespace
 
 bool IsPointsBuy() { return g_cfg.points_buy; }
@@ -117,6 +170,26 @@ void RemortLoader::Load(parser_wrapper::DataNode data) {
 		auto n = data;
 		if (n.GoToChild("moves")) { cfg.moves = parse::AttrInt(n, "val", cfg.moves); }
 	}
+	{
+		auto n = data;
+		if (n.GoToChild("prices")) {
+			cfg.price_increment_percent = parse::AttrInt(n, "increment_percent", 0);
+			const char *dis = n.GetValue("disabled");
+			cfg.prices_disabled = dis && *dis && parse::ReadAsBool(dis);
+			for (auto &pr : n.Children("price")) {
+				PriceEntry e;
+				e.remort = parse::AttrInt(pr, "remort", -1);
+				const char *cur = pr.GetValue("currency");
+				e.currency = cur ? cur : "";
+				e.amount = parse::AttrInt(pr, "amount", 0);
+				if (e.remort >= 0) {
+					cfg.prices.push_back(e);
+				}
+			}
+			std::sort(cfg.prices.begin(), cfg.prices.end(),
+				[](const PriceEntry &a, const PriceEntry &b) { return a.remort < b.remort; });
+		}
+	}
 	g_cfg = cfg;
 }
 
@@ -169,6 +242,39 @@ void ProcessRemort(CharData *ch, char *argument, int subcmd) {
 		}
 	}
 
+	// issue.remort-system: a remort is a sacrifice -- it must be performed in a shrine of one's own
+	// faith and paid in the configured currency. Immortals returned far above, so no faith check is
+	// needed here. Both gates run after every other precondition (and the chosen destination) is
+	// validated and before anything is mutated, so a failure leaves the character untouched.
+	{
+		const bool in_shrine = (GET_RELIGION(ch) == kReligionMono)
+			? ROOM_FLAGGED(ch->in_room, ERoomFlag::kForMono)
+			: ROOM_FLAGGED(ch->in_room, ERoomFlag::kForPoly);
+		if (!in_shrine) {
+			SendMsgToChar("Подобное таинство свершается лишь в святилище вашей веры.\r\n", ch);
+			return;
+		}
+	}
+	{
+		const ResolvedPrice price = ResolveRemortPrice(ch->get_remort() + 1);
+		if (!price.free) {
+			const auto &cur = currencies::FindByTextIdNoCase(price.currency);
+			if (cur.GetId() < 0) {
+				SendMsgToChar("Вы не можете понять, какую жертву для этого требуется принести...\r\n", ch);
+				err_log("remort system: invalid currency identifier '%s' for remort %d",
+						price.currency.c_str(), ch->get_remort() + 1);
+				return;
+			}
+			if (currencies::GetTotal(*ch, cur.GetTextId()) < price.amount) {
+				SendMsgToChar(fmt::format("Вам следует сперва принести достойную жертву - {} {}.\r\n",
+						price.amount, cur.GetNameWithAmount(price.amount, grammar::ECase::kAcc)), ch);
+				return;
+			}
+			currencies::RemoveTotal(*ch, cur.GetTextId(), price.amount);
+			SendMsgToChar(fmt::format("Вы принесли {} {} в жертву.\r\n",
+					price.amount, cur.GetNameWithAmount(price.amount, grammar::ECase::kAcc)), ch);
+		}
+	}
 	log("Remort %s", GET_NAME(ch));
 	ch->remort();
 	act(remort_msg2, false, ch, nullptr, nullptr, kToRoom);

--- a/src/gameplay/core/remort.cpp
+++ b/src/gameplay/core/remort.cpp
@@ -11,6 +11,7 @@
 #include "gameplay/fight/fight.h"
 #include "gameplay/mechanics/follow.h"
 #include "gameplay/mechanics/player_races.h"
+#include "gameplay/mechanics/glory_misc.h"
 #include "engine/core/char_equip_flags.h"
 #include "engine/core/char_handler.h"
 #include "gameplay/mechanics/equipment.h"
@@ -173,12 +174,10 @@ void ProcessRemort(CharData *ch, char *argument, int subcmd) {
 	act(remort_msg2, false, ch, nullptr, nullptr, kToRoom);
 	ch->set_remort(ch->get_remort() + 1);
 	REMOVE_BIT(ch->player_specials->saved.GodsLike, EGf::kRemort);
-	ch->inc_str(1);
-	ch->inc_dex(1);
-	ch->inc_con(1);
-	ch->inc_wis(1);
-	ch->inc_int(1);
-	ch->inc_cha(1);
+	// issue.remort-system: rebuild base stats from the start (creation) stats under the active
+	// system (legacy +1-each or proportional) plus glory -- the SAME path the login parameter
+	// check uses, so a remort and a re-login agree. Replaces the old hardcoded +1 to every stat.
+	GloryMisc::recalculate_stats(ch);
 	if (ch->GetEnemy()) {
 		stop_fighting(ch, true);
 	}

--- a/src/gameplay/core/remort.cpp
+++ b/src/gameplay/core/remort.cpp
@@ -20,11 +20,109 @@
 #include "gameplay/classes/pc_classes.h"
 #include "gameplay/skills/skills.h"
 
+#include "utils/utils_parse.h"               // parse::AttrInt / parse::ReadAsBool
+#include "engine/entities/char_player.h"      // START_STATS_TOTAL
+
 #include <fmt/format.h>
+#include <algorithm>
 
 extern RoomRnum r_frozen_start_room;
 
 namespace remort {
+
+// --- issue.remort-system: cfg/remort.xml ------------------------------------------------------------
+namespace {
+// Defaults match the legacy hardcoded constants, so behaviour is identical until the file overrides
+// them (and stays sane if the file/tag is missing).
+struct RemortCfg {
+	bool points_buy = false;
+	int abil_reset_stop = 9;
+	int abil_reset_period = 3;
+	int skill_cap_start = 80;
+	int skill_cap_increment = 5;
+	int hp = 10;
+	int moves = 82;
+};
+RemortCfg g_cfg;
+} // namespace
+
+bool IsPointsBuy() { return g_cfg.points_buy; }
+int SkillCapStart() { return g_cfg.skill_cap_start; }
+int SkillCapIncrement() { return g_cfg.skill_cap_increment; }
+int CalcSkillCap(int remort_count) { return g_cfg.skill_cap_start + remort_count * g_cfg.skill_cap_increment; }
+int RemortHp() { return g_cfg.hp; }
+int RemortMoves() { return g_cfg.moves; }
+
+bool IsObligatoryResetDue(int remort_count) {
+	return g_cfg.abil_reset_period > 0
+		&& remort_count >= g_cfg.abil_reset_stop
+		&& remort_count % g_cfg.abil_reset_period == 0;
+}
+
+void ApplyRemortStatGains(const int *start, int *out, int remort_count) {
+	if (!g_cfg.points_buy) {
+		// legacy: +1 to every base stat per remort.
+		for (int i = 0; i < START_STATS_TOTAL; ++i) {
+			out[i] = start[i] + remort_count;
+		}
+		return;
+	}
+	// proportional: the highest start stat gains +1/remort; the rest scale to keep their original
+	// ratio to it: out[i] = floor((max_start + remort) * start[i] / max_start).
+	int max_start = 0;
+	for (int i = 0; i < START_STATS_TOTAL; ++i) {
+		max_start = std::max(max_start, start[i]);
+	}
+	if (max_start <= 0) {  // degenerate (shouldn't happen for valid chars) -- fall back to legacy.
+		for (int i = 0; i < START_STATS_TOTAL; ++i) {
+			out[i] = start[i] + remort_count;
+		}
+		return;
+	}
+	for (int i = 0; i < START_STATS_TOTAL; ++i) {
+		out[i] = static_cast<int>(
+			static_cast<long long>(max_start + remort_count) * start[i] / max_start);
+	}
+}
+
+void RemortLoader::Load(parser_wrapper::DataNode data) {
+	RemortCfg cfg;  // start from legacy defaults; only present tags/attrs override.
+	{
+		auto n = data;
+		if (n.GoToChild("system")) {
+			const char *pb = n.GetValue("points_buy");
+			cfg.points_buy = pb && *pb && parse::ReadAsBool(pb);
+		}
+	}
+	{
+		auto n = data;
+		if (n.GoToChild("abilities_reset")) {
+			cfg.abil_reset_stop = parse::AttrInt(n, "stop_obligatory_reset", cfg.abil_reset_stop);
+			cfg.abil_reset_period = parse::AttrInt(n, "period", cfg.abil_reset_period);
+		}
+	}
+	{
+		auto n = data;
+		if (n.GoToChild("skill_cap")) {
+			cfg.skill_cap_start = parse::AttrInt(n, "start_cap", cfg.skill_cap_start);
+			cfg.skill_cap_increment = parse::AttrInt(n, "increment", cfg.skill_cap_increment);
+		}
+	}
+	{
+		auto n = data;
+		if (n.GoToChild("hp")) { cfg.hp = parse::AttrInt(n, "val", cfg.hp); }
+	}
+	{
+		auto n = data;
+		if (n.GoToChild("moves")) { cfg.moves = parse::AttrInt(n, "val", cfg.moves); }
+	}
+	g_cfg = cfg;
+}
+
+void RemortLoader::Reload(parser_wrapper::DataNode data) {
+	Load(std::move(data));
+}
+// --- end issue.remort-system config ----------------------------------------------------------------
 
 const char *remort_msg =
 	"  Если вы так настойчивы в желании начать все заново -\r\n" "наберите <перевоплотиться> полностью.\r\n";
@@ -99,7 +197,7 @@ void ProcessRemort(CharData *ch, char *argument, int subcmd) {
 		ch->UnsetFeat(feat.GetId());
 	}
 
-	if (ch->get_remort() >= 9 && ch->get_remort() % 3 == 0) {
+	if (IsObligatoryResetDue(ch->get_remort())) {
 		ch->clear_skills();
 		for (auto spell_id = ESpell::kFirst; spell_id <= ESpell::kLast; ++spell_id) {
 			GET_SPELL_TYPE(ch, spell_id) = (IS_MANA_CASTER(ch) ? ESpellType::kRunes : 0);
@@ -117,10 +215,10 @@ void ProcessRemort(CharData *ch, char *argument, int subcmd) {
 		}
 	}
 
-	ch->set_max_hit(10);
-	ch->set_hit(10);
-	ch->set_max_move(82);
-	ch->set_move(82);
+	ch->set_max_hit(RemortHp());
+	ch->set_hit(RemortHp());
+	ch->set_max_move(RemortMoves());
+	ch->set_move(RemortMoves());
 	ch->mem_queue.total = ch->mem_queue.stored = 0;
 	ch->set_level(0);
 	GET_WIMP_LEV(ch) = 0;

--- a/src/gameplay/core/remort.h
+++ b/src/gameplay/core/remort.h
@@ -7,6 +7,9 @@
 #ifndef MUD_SRC_GAMEPLAY_CORE_REMORT_H_
 #define MUD_SRC_GAMEPLAY_CORE_REMORT_H_
 
+#include "engine/boot/cfg_manager.h"   // cfg_manager::ICfgLoader
+#include "utils/parser_wrapper.h"      // parser_wrapper::DataNode
+
 #include <memory>
 
 class CharData;
@@ -19,6 +22,39 @@ int GetRealRemort(const CharData *ch);
 int GetRealRemort(const std::shared_ptr<CharData> &ch);
 
 void SetSkillAfterRemort(CharData *ch);
+
+// --- issue.remort-system: parameters from cfg/remort.xml ---
+
+// false: legacy system (+1 to every base stat per remort).
+// true:  proportional system (the highest start stat gains +1/remort, the others scale to keep
+//        their original ratio to it). See ApplyRemortStatGains.
+[[nodiscard]] bool IsPointsBuy();
+
+// The per-character skill cap: SkillCapStart() + remort_count * SkillCapIncrement().
+[[nodiscard]] int SkillCapStart();
+[[nodiscard]] int SkillCapIncrement();
+[[nodiscard]] int CalcSkillCap(int remort_count);
+
+// The obligatory full skill/spell reset gate (remort.cpp): true when
+// remort_count >= stop_obligatory_reset && remort_count % period == 0.
+[[nodiscard]] bool IsObligatoryResetDue(int remort_count);
+
+// Base max-HP / max-moves a character is reset to on remort (remort.cpp).
+[[nodiscard]] int RemortHp();
+[[nodiscard]] int RemortMoves();
+
+// issue.remort-system: compute the base stats a character has for `remort_count` remorts from their
+// six start (creation) stats. Writes out[G_STR..G_CHA]. Legacy: start + remort_count each.
+// Proportional (points_buy): out[i] = floor((max_start + remort_count) * start[i] / max_start).
+// Glory is added by the caller on top. `start`/`out` are indexed by G_STR..G_CHA.
+void ApplyRemortStatGains(const int *start, int *out, int remort_count);
+
+// cfg/remort.xml loader (boot via cfg_manager; `reload remort`).
+class RemortLoader : public cfg_manager::ICfgLoader {
+ public:
+	void Load(parser_wrapper::DataNode data) override;
+	void Reload(parser_wrapper::DataNode data) override;
+};
 
 } // namespace remort
 

--- a/src/gameplay/crafting/im.cpp
+++ b/src/gameplay/crafting/im.cpp
@@ -1120,7 +1120,7 @@ void im_improve_recipe(CharData *ch, im_rskill *rs, int success) {
 			SendMsgToChar(buf, ch);
 			rs->perc += number(1, 2);
 			if (!privilege::IsImmortal(ch))
-				rs->perc = MIN(kZeroRemortSkillCap + remort::GetRealRemort(ch) * 5, rs->perc);
+				rs->perc = MIN(CalcSkillRemortCap(ch), rs->perc);
 		}
 	}
 }

--- a/src/gameplay/mechanics/glory_misc.cpp
+++ b/src/gameplay/mechanics/glory_misc.cpp
@@ -189,22 +189,12 @@ bool bad_start_stats(CharData *ch) {
 }
 
 /**
-* Считаем реальные статы с учетом мортов и влитой славы.
-* \return 0 - все ок, любое другое число - все плохо
-*/
-int bad_real_stats(CharData *ch, int check) {
-	check -= kBaseStatsSum; // стартовые статы у всех по 95
-	check -= 6 * remort::GetRealRemort(ch); // реморты
-	// влитая слава
-	check -= Glory::get_spend_glory(ch);
-	check -= GloryConst::main_stats_count(ch);
-	return check;
-}
-
-/**
 * Проверка стартовых и итоговых статов.
-* Если невалидные стартовые статы - чар отправляется на реролл.
-* Если невалидные только итоговые статы - идет перезапись со стартовых с учетом мортов и славы.
+* Невалидные стартовые статы (вне границ ролла) - чар отправляется на реролл.
+* issue.remort-system: иначе пересчитываем итоговые статы по ТЕКУЩЕЙ системе перевоплощения
+* (recalculate_stats) и, если они изменились (сменились правила перевоплощения или истекла слава),
+* сообщаем игроку и сохраняем чара, чтобы сообщение показалось один раз. Реролл стартовых статов в
+* этом случае НЕ требуется.
 */
 bool check_stats(CharData *ch) {
 	// иммов травмировать не стоит
@@ -212,21 +202,18 @@ bool check_stats(CharData *ch) {
 		return 1;
 	}
 
-	int have_stats = ch->GetInbornStr() + ch->GetInbornDex() + ch->GetInbornInt() + ch->GetInbornWis()
-		+ ch->GetInbornCon() + ch->GetInbornCha();
-
 	// чар со старым роллом статов или после попыток поправить статы в файле
 	if (bad_start_stats(ch)) {
-		snprintf(buf, kMaxStringLength, "\r\n%sВаши параметры за вычетом перевоплощений:\r\n"
+		snprintf(buf, kMaxStringLength, "\r\n%sВаши стартовые параметры:\r\n"
 										 "Сила: %d, Ловкость: %d, Ум: %d, Мудрость: %d, Телосложение: %d, Обаяние: %d\r\n"
 										 "Просим вас заново распределить основные параметры персонажа.%s\r\n",
 				 kColorBoldGrn,
-				 ch->GetInbornStr() - remort::GetRealRemort(ch),
-				 ch->GetInbornDex() - remort::GetRealRemort(ch),
-				 ch->GetInbornInt() - remort::GetRealRemort(ch),
-				 ch->GetInbornWis() - remort::GetRealRemort(ch),
-				 ch->GetInbornCon() - remort::GetRealRemort(ch),
-				 ch->GetInbornCha() - remort::GetRealRemort(ch),
+				 ch->get_start_stat(G_STR),
+				 ch->get_start_stat(G_DEX),
+				 ch->get_start_stat(G_INT),
+				 ch->get_start_stat(G_WIS),
+				 ch->get_start_stat(G_CON),
+				 ch->get_start_stat(G_CHA),
 				 kColorNrm);
 	iosystem::write_to_output(buf, ch->desc);
 
@@ -244,31 +231,43 @@ bool check_stats(CharData *ch) {
 		ch->desc->state = EConState::kResetStats;
 		return false;
 	}
-	// стартовые статы в поряде, но слава не сходится (снялась по времени или иммом)
-	if (bad_real_stats(ch, have_stats)) {
-		recalculate_stats(ch);
+
+	// issue.remort-system: стартовые статы валидны -- пересчитываем итоговые по текущей системе
+	// перевоплощения + текущей славе. Если что-то поменялось -- уведомляем и сохраняем (один раз).
+	const int before_str = ch->GetInbornStr();
+	const int before_dex = ch->GetInbornDex();
+	const int before_int = ch->GetInbornInt();
+	const int before_wis = ch->GetInbornWis();
+	const int before_con = ch->GetInbornCon();
+	const int before_cha = ch->GetInbornCha();
+	recalculate_stats(ch);
+	if (before_str != ch->GetInbornStr() || before_dex != ch->GetInbornDex()
+		|| before_int != ch->GetInbornInt() || before_wis != ch->GetInbornWis()
+		|| before_con != ch->GetInbornCon() || before_cha != ch->GetInbornCha()) {
+		SendMsgToChar(ch,
+			"%sПараметры персонажа были изменены в связи с изменением правил перевоплощения.%s\r\n",
+			kColorBoldGrn, kColorNrm);
+		ch->save_char();
 	}
 	return true;
 }
 
 // * Пересчет статов чара на основании стартовых статов, ремортов и славы.
 void recalculate_stats(CharData *ch) {
-	// стартовые статы
-	ch->set_str(ch->get_start_stat(G_STR));
-	ch->set_dex(ch->get_start_stat(G_DEX));
-	ch->set_con(ch->get_start_stat(G_CON));
-	ch->set_int(ch->get_start_stat(G_INT));
-	ch->set_wis(ch->get_start_stat(G_WIS));
-	ch->set_cha(ch->get_start_stat(G_CHA));
-	// морты
-	if (remort::GetRealRemort(ch)) {
-		ch->inc_str(remort::GetRealRemort(ch));
-		ch->inc_dex(remort::GetRealRemort(ch));
-		ch->inc_con(remort::GetRealRemort(ch));
-		ch->inc_wis(remort::GetRealRemort(ch));
-		ch->inc_int(remort::GetRealRemort(ch));
-		ch->inc_cha(remort::GetRealRemort(ch));
+	// issue.remort-system: стартовые статы + реморты по текущей системе перевоплощения
+	// (старая: +1 ко всем; points_buy: пропорционально -- см. remort::ApplyRemortStatGains).
+	int start[START_STATS_TOTAL];
+	int base[START_STATS_TOTAL];
+	for (int i = 0; i < START_STATS_TOTAL; ++i) {
+		start[i] = ch->get_start_stat(i);
 	}
+	remort::ApplyRemortStatGains(start, base, remort::GetRealRemort(ch));
+	ch->set_str(base[G_STR]);
+	ch->set_dex(base[G_DEX]);
+	ch->set_int(base[G_INT]);
+	ch->set_wis(base[G_WIS]);
+	ch->set_con(base[G_CON]);
+	ch->set_cha(base[G_CHA]);
 	// влитая слава
 	Glory::set_stats(ch);
 	GloryConst::set_stats(ch);

--- a/src/gameplay/skills/skills.cpp
+++ b/src/gameplay/skills/skills.cpp
@@ -33,8 +33,6 @@
 #include <fmt/format.h>
 #include "gameplay/mechanics/sight.h"
 
-const int kZeroRemortSkillCap = 80;
-const int kSkillCapBonusPerRemort = 5;;
 
 //const int kNoviceSkillThreshold = 75;
 const int kNoviceSkillThreshold = 0;
@@ -1976,7 +1974,7 @@ void ImproveSkill(CharData *ch, const ESkill skill, int success, CharData *victi
 		SendMsgToChar(buf, ch);
 		SetSkill(ch, skill, (trained_skill + number(1, 2)));
 		if (!privilege::IsImmortal(ch)) {
-			SetSkill(ch, skill, (std::min(kZeroRemortSkillCap + remort::GetRealRemort(ch) * 5, GetSkillBonus(ch, skill))));
+			SetSkill(ch, skill, (std::min(CalcSkillRemortCap(ch), GetSkillBonus(ch, skill))));
 		}
 		if (victim && victim->IsNpc()) {
 			victim->SetFlag(EMobFlag::kNoSkillTrain);
@@ -2067,7 +2065,7 @@ bool CanGetSkill(CharData *ch, ESkill skill) {
 }
 
 int CalcSkillRemortCap(const CharData *ch) {
-	return kZeroRemortSkillCap + remort::GetRealRemort(ch) * kSkillCapBonusPerRemort;
+	return remort::CalcSkillCap(remort::GetRealRemort(ch));
 }
 
 int CalcSkillWisdomCap(const CharData *ch) {

--- a/src/gameplay/skills/skills.h
+++ b/src/gameplay/skills/skills.h
@@ -21,8 +21,6 @@
 #include "gameplay/fight/fight_constants.h"
 #include "engine/structs/structs.h"
 
-extern const int kZeroRemortSkillCap;
-extern const int kSkillCapBonusPerRemort;
 extern const int kMinTalentLevelDecrement;
 extern const long kMinImprove;
 


### PR DESCRIPTION
  Настраиваемая система перевоплощений

  Параметры перевоплощения вынесены в cfg/remort.xml (загрузка через cfg_manager, поддерживается reload remort). Поведение по умолчанию не меняется — новые механики выключены, пока их не включат в  конфиге.

  Что нового:

  - Конфигурируемые параметры: обязательный сброс умений (abilities_reset), потолок умений (skill_cap = start_cap + реморт × increment), восстанавливаемые хиты и движения (hp/moves). Захардкоженные  константы убраны.
  - Пропорциональный расчёт характеристик (<system points_buy>): по умолчанию false — старая система (+1 ко всем характеристикам за реморт); при true наивысшая стартовая характеристика растёт на +1  за реморт, остальные масштабируются с сохранением исходных пропорций: floor((max_start + remort) × start[i] / max_start). Расчёт един для перевоплощения и для проверки при входе в игру.
  - Плата за перевоплощение (<prices>): стоимость очередного реморта в игровой валюте. Пропуски в таблице заполняются от ближайшей нижней записи с надбавкой increment_percent за каждый недостающий  шаг. Цена 0, пустая таблица или disabled="Y" — перевоплощение бесплатно; неизвестная валюта блокирует реморт и пишет ошибку в лог.
  - Требование святилища: перевоплощение совершается только в святилище своей веры (христианину — в kForMono, язычнику — в kForPoly).

  По умолчанию поставляется с points_buy="false" и prices disabled="Y", поэтому на текущую игру изменения не влияют.
