### PR TITLE
perf(observability): drop pulse-counter label from mob.activity.duration

### DIFF
--- a/src/gameplay/ai/mobact.cpp
+++ b/src/gameplay/ai/mobact.cpp
@@ -895,9 +895,7 @@ bool allow_enter(RoomData *room, CharData *ch) {
 
 void mobile_activity(int activity_level, int missed_pulses) {
 	auto activity_span = tracing::TraceManager::Instance().StartSpan("mob.activity");
-	observability::ScopedMetric activity_metric("mob.activity.duration", {
-		{"activity_level", std::to_string(activity_level)}
-	});
+	observability::ScopedMetric activity_metric("mob.activity.duration");
 
 	utils::CExecutionTimer mobact_timer;
 	int processed_mobs = 0;


### PR DESCRIPTION
## Проблема

`mob.activity.duration` (histogram длительности обработки mob-AI) навешивал метку **`activity_level`**. Но `mobile_activity()` вызывается из heartbeat как `mobile_activity(pulse_number, 10)` ([heartbeat.cpp](../blob/master/src/engine/core/heartbeat.cpp)), т.е. `activity_level` — это **счётчик пульса игры**, монотонно растущий integer.

В роли метки он порождал новую серию Prometheus на каждое значение пульса: на проде получилось **~20 000+ серий** (`mob_activity_duration_bucket{activity_level=...}`), которые продолжали расти. Аналитической ценности ноль — гистограмму нельзя агрегировать по неограниченному счётчику.

Это вторая по величине причина раздувания TSDB мониторинга (после боевых спанов `Combat: X vs Y`, которых в master уже нет).

## Что сделано

- Убрана метка `activity_level` из метрики.
- **Спан `mob.activity` и сама гистограмма `mob.activity.duration` сохранены** — метрика теперь корректно агрегируется по всем пульсам.

Метрика не удаляется, а оптимизируется: теряется только бесполезная метка-бомба.

## Проверка

```promql
# было: тысячи серий, по одной на пульс
count by (activity_level) (mob_activity_duration_bucket)
# станет: одна серия histogram-набора, агрегируемая нормально
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)