### PR TITLE
feat(utils): prefix у OutWordsList, уход от костылей -N, перенос syslog богам (#3513)

### DIFF
--- a/src/engine/ui/cmd/do_affects.cpp
+++ b/src/engine/ui/cmd/do_affects.cpp
@@ -33,7 +33,11 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 	aff_copy.sprintbits(affected_bits, buf2, sizeof(buf2), ", ");
 	std::vector<std::string> out_str = utils::Split(buf2, ',');
-	snprintf(buf, kMaxStringLength, "Аффекты: %s%s%s\r\n", kColorYel, utils::OutWordsList(out_str, ch->player_specials->saved.stringLength - 10).c_str(), kColorNrm);
+	// "Аффекты: " передаём префиксом: учитывается в ширине строки, но не
+	// склеивается через ", " (иначе после метки была бы лишняя запятая).
+	snprintf(buf, kMaxStringLength, "%s%s%s\r\n", kColorYel,
+			 utils::OutWordsList(out_str, ch->player_specials->saved.stringLength, ", ", "Аффекты: ").c_str(),
+			 kColorNrm);
 	SendMsgToChar(buf, ch);
 
 	// Routine to show what spells a char is affected by

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -525,12 +525,12 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 	} else {
 		k->char_specials.saved.act.sprintbits(player_bits, smallBuf, sizeof(smallBuf), ", ", 4);
 		std::vector<std::string> out_str = utils::Split(smallBuf, ',');
-		snprintf(buf, sizeof(buf), "PLR: %s%s%s\r\n", kColorCyn, utils::OutWordsList(out_str, ch->player_specials->saved.stringLength - 10).c_str(), kColorNrm);
+		snprintf(buf, sizeof(buf), "%s%s%s\r\n", kColorCyn, utils::OutWordsList(out_str, ch->player_specials->saved.stringLength, ", ", "PLR: ").c_str(), kColorNrm);
 		SendMsgToChar(buf, ch);
 
 		k->player_specials->saved.pref.sprintbits(preference_bits, smallBuf, sizeof(smallBuf), ", ", 4);
 		out_str = utils::Split(smallBuf, ',');
-		snprintf(buf, sizeof(buf), "PRF: %s%s%s\r\n", kColorGrn, utils::OutWordsList(out_str, ch->player_specials->saved.stringLength - 10).c_str(), kColorNrm);
+		snprintf(buf, sizeof(buf), "%s%s%s\r\n", kColorGrn, utils::OutWordsList(out_str, ch->player_specials->saved.stringLength, ", ", "PRF: ").c_str(), kColorNrm);
 		SendMsgToChar(buf, ch);
 
 		if (privilege::IsImpl(ch)) {
@@ -539,7 +539,7 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 				strcpy(smallBuf, "nothing");  // immortal-only command, so a plain English literal is fine
 			}
 			out_str = utils::Split(smallBuf, ',');
-			snprintf(buf, sizeof(buf), "GFL: %s%s%s\r\n", kColorCyn, utils::OutWordsList(out_str, ch->player_specials->saved.stringLength - 10).c_str(), kColorNrm);
+			snprintf(buf, sizeof(buf), "%s%s%s\r\n", kColorCyn, utils::OutWordsList(out_str, ch->player_specials->saved.stringLength, ", ", "GFL: ").c_str(), kColorNrm);
 			SendMsgToChar(buf, ch);
 		}
 	}
@@ -573,24 +573,24 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 	if (god_level >= kLvlGreatGod) {
 		std::string fl_str;
 
-		SendMsgToChar(ch, "Ведущий: %s, Ведомые: ", (k->has_master() ? GET_NAME(k->get_master()) : "<нет>"));
+		// "Ведущий: X, Ведомые: " передаём префиксом -- его длина (с именем
+		// ведущего) учитывается в ширине строки автоматически, без магического -30.
+		const std::string lead_prefix =
+			fmt::format("Ведущий: {}, Ведомые: ", (k->has_master() ? GET_NAME(k->get_master()) : "<нет>"));
 		for (auto &it : k->followers) {
-			if (!it->IsNpc()) { 
+			if (!it->IsNpc()) {
 				fl_str += " " + it->get_name();
 			} else {
-				fl_str += " " + it->get_name() + "_#" + std::to_string(GET_MOB_VNUM(it)); 
+				fl_str += " " + it->get_name() + "_#" + std::to_string(GET_MOB_VNUM(it));
 			}
 		}
-		SendMsgToChar(ch, "%s\r\n", utils::OutWordsList(fl_str, ch->player_specials->saved.stringLength - 30).c_str());
+		SendMsgToChar(ch, "%s\r\n", utils::OutWordsList(fl_str, ch->player_specials->saved.stringLength, ", ", lead_prefix).c_str());
 		if (ch->IsNpc()) {
-			SendMsgToChar(ch, "Помогают: ");
-			if (!k->summon_helpers.empty()) {
-				fl_str.clear();
-				for (auto &helper : k->summon_helpers) {
-					fl_str += " " +  std::to_string(helper);
-				}
-				SendMsgToChar(ch, "%s\r\n", utils::OutWordsList(fl_str, ch->player_specials->saved.stringLength - 30).c_str());
+			fl_str.clear();
+			for (auto &helper : k->summon_helpers) {
+				fl_str += " " +  std::to_string(helper);
 			}
+			SendMsgToChar(ch, "%s\r\n", utils::OutWordsList(fl_str, ch->player_specials->saved.stringLength, ", ", "Помогают: ").c_str());
 		}
 	}
 	// Showing the bitvector

--- a/src/gameplay/mechanics/identify.cpp
+++ b/src/gameplay/mechanics/identify.cpp
@@ -523,9 +523,10 @@ void MobShowValues(CharData *ch, CharData *victim, int skill) {
 	}
 	if (skill > 249) {
 		victim->char_specials.saved.affected_by.sprintbits(affected_bits, buf2, sizeof(buf2), " ", 4);
-		std::string line = std::string("Аффекты: ") + buf2;
-
-		ss << fmt::format("&G{}&n\r\n", utils::OutWordsList(line, ch->player_specials->saved.stringLength, ", "));
+		// "Аффекты: " передаём префиксом: учитывается в ширине строки, но не
+		// склеивается через ", " (иначе после метки была бы лишняя запятая).
+		ss << fmt::format("&G{}&n\r\n",
+				utils::OutWordsList(buf2, ch->player_specials->saved.stringLength, ", ", "Аффекты: "));
 	}
 	SendMsgToChar(ch, "%s", ss.str().c_str());
 }

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -6,6 +6,7 @@
 #include "gameplay/mechanics/minions.h"
 #include "engine/entities/char_data.h"
 #include "utils/utils_encoding.h"
+#include "utils/utils_string.h"
 #include "engine/ui/color.h"
 #include "backtrace.h"
 
@@ -379,7 +380,8 @@ void mudlog(const char *str, LogMode type, int level, EOutputStream channel, boo
 	char time_buf[20];
 	time_t ct = time(0);
 	strftime(time_buf, sizeof(time_buf), "%d-%m-%y %H:%M:%S", localtime(&ct));
-	snprintf(tmpbuf, sizeof(tmpbuf), "[%s][ %s ]\r\n", time_buf, str);
+	// \r\n добавляем после переноса по ширине; в файл строка уже ушла сырой выше
+	snprintf(tmpbuf, sizeof(tmpbuf), "[%s][ %s ]", time_buf, str);
 	for (i = descriptor_list; i; i = i->next) {
 		if  (i->state != EConState::kPlaying || i->character->IsNpc())    // switch
 			continue;
@@ -393,7 +395,9 @@ void mudlog(const char *str, LogMode type, int level, EOutputStream channel, boo
 			continue;
 
 		SendMsgToChar(kColorGrn, i->character.get());
-		SendMsgToChar(tmpbuf, i->character.get());
+		// переносим строку лога по ширине вывода бога (stringLength == 0 -- без переноса)
+		SendMsgToChar(utils::WrapText(tmpbuf, i->character->player_specials->saved.stringLength) + "\r\n",
+				i->character.get());
 		SendMsgToChar(kColorNrm, i->character.get());
 	}
 }

--- a/src/utils/utils_string.cpp
+++ b/src/utils/utils_string.cpp
@@ -1047,9 +1047,12 @@ void kill_ems(std::string &str) {
 }
 
 std::string utils::OutWordsList(const std::vector<std::string> &words, size_t max_length,
-		const std::string &separator) {
-	std::string result;
-	size_t line_length = 0;
+		const std::string &separator, const std::string &prefix) {
+	// prefix печатается один раз и занимает место на первой строке, но не
+	// склеивается через separator (first остаётся true -- первое слово идёт
+	// сразу за префиксом без ", "). Видимую длину считаем без цветокодов.
+	std::string result = prefix;
+	size_t line_length = GetStringWithoutColors(prefix).size();
 	bool first = true;
 	// separator -- это и есть то, что стоит между словами на одной строке
 	// (", " для списка, " " для обычного переноса по словам). На переносе
@@ -1081,14 +1084,14 @@ std::string utils::OutWordsList(const std::vector<std::string> &words, size_t ma
 }
 
 std::string utils::OutWordsList(const std::string &words_str, size_t max_length,
-		const std::string &separator) {
+		const std::string &separator, const std::string &prefix) {
 	std::vector<std::string> words;
 	std::istringstream stream(words_str);
 	std::string word;
 	while (stream >> word) {
 		words.push_back(word);
 	}
-	return OutWordsList(words, max_length, separator);
+	return OutWordsList(words, max_length, separator, prefix);
 }
 
 std::string utils::WrapText(const std::string &text, size_t max_length) {

--- a/src/utils/utils_string.h
+++ b/src/utils/utils_string.h
@@ -299,12 +299,15 @@ std::string CAP(const std::string txt);
 // формирует строку из списка слов, разделенных separator (то, что стоит
 // между словами на строке: ", " для списка, " " для переноса по словам)
 // при превышении max_length переносит на новую строку, срезая хвостовой
-// пробел разделителя перед \r\n. separator по умолчанию ", " -- прежнее поведение
+// пробел разделителя перед \r\n. separator по умолчанию ", " -- прежнее поведение.
+// prefix печатается один раз в начале первой строки и учитывается в её длине
+// (по видимой длине, без цветокодов), но НЕ участвует в склейке через separator
+// (т.е. после него не ставится ", "). На строках-продолжениях префикса нет.
 std::string OutWordsList(const std::vector<std::string> &words, size_t max_length,
-		const std::string &separator = ", ");
+		const std::string &separator = ", ", const std::string &prefix = "");
 // то же, но на вход строка со словами через пробелы
 std::string OutWordsList(const std::string &words_str, size_t max_length,
-		const std::string &separator = ", ");
+		const std::string &separator = ", ", const std::string &prefix = "");
 // переносит многострочный текст по словам на ширину max_length, сохраняя
 // авторские переносы строк и пустые строки (абзацы): каждая исходная строка
 // переносится независимо через OutWordsList(line, max_length, " ").


### PR DESCRIPTION
Closes #3513

## Суть бага (#3513)
В `MobShowValues` (`identify.cpp`) метку «Аффекты: » приклеивали к строке слов, после чего `OutWordsList(..., ", ")` резал её по пробелам и склеивал запятыми:
```
Аффекты:, определение, невидимости
```

## Решение
`utils::OutWordsList` получил необязательный `prefix`:
- печатается один раз в начале первой строки;
- учитывается в её длине (по видимой длине, без `&`-цветокодов);
- НЕ участвует в склейке через `separator` (после него нет `", "`);
- на строках-продолжениях отсутствует.

Обе перегрузки проброшены, дефолт `prefix=""` сохраняет поведение всех существующих вызовов.

## Что поправлено
- **`MobShowValues`** (`identify.cpp`) — собственно баг #3513, метка ушла в `prefix`.
- Убраны магические `stringLength - N` в выводах списков флагов: `do_affects` (Аффекты) и `do_stat` (`PLR/PRF/GFL/Аффекты`, а также `Ведомые/Помогают` — там префикс динамический, с именем ведущего; теперь длина считается точно, без `-30`).
- **mudlog**: вывод syslog онлайн-богам переносится по ширине их вывода (`WrapText` по `stringLength`); запись в файл остаётся сырой, без переноса — формат в логах не страдает.

## Замечание про цвет
`GetStringWithoutColors` срезает только `&`-коды, а не сырой ANSI (`kColorYel`). Поэтому в выводах с цветом метка теперь внутри общей окраски (точность цвета некритична); если положить ANSI прямо в префикс, он съест пару символов ширины.

## Проверка
Сборка проходит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)