### PR TITLE
fix(give): винительный падеж валюты при передаче денег

### DIFF
--- a/src/engine/ui/cmd/do_give.cpp
+++ b/src/engine/ui/cmd/do_give.cpp
@@ -107,9 +107,9 @@ void perform_give_gold(CharData *ch, CharData *vict, int amount) {
 			false, ch, nullptr, nullptr, kToChar);
 		return;
 	}
-	sprintf(buf, "Вы дали %d %s $N2.", amount, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kNom).c_str());
+	sprintf(buf, "Вы дали %d %s $N2.", amount, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kAcc).c_str());
 	act(buf, false, ch, nullptr, vict, kToChar);
-	sprintf(buf, "$n дал$g вам %d %s.", amount, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kNom).c_str());
+	sprintf(buf, "$n дал$g вам %d %s.", amount, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kAcc).c_str());
 	act(buf, false, ch, nullptr, vict, kToVict);
 	sprintf(buf, "$n дал$g %s $N2.",
 			MUD::Currency(currencies::kGoldVnum).GetObjCName(amount, grammar::ECase::kAcc));


### PR DESCRIPTION
## Проблема
```
Вы дали 1 куна черному василиску.
```
Название валюты в именительном падеже вместо винительного. «Дали что? — куну».

## Причина
`perform_give_gold` (do_give.cpp) выводил валюту через `GetNameWithAmount(amount, grammar::ECase::kNom)` — именительный. Передача требует винительного (`kAcc`).

## Решение
Заменил `kNom` → `kAcc` в двух сообщениях (себе и получателю). Третье лицо там уже было на `kAcc`. Новый `perform_give_currency` давно использует `kAcc` — золотой путь просто не обновили.

Теперь: `Вы дали 1 куну черному василиску.` (склонение по числу — «куну/куны/кун» — отрабатывает `GetNameWithAmount`).

## Проверка
Сборка проходит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)