### PR TITLE
fix(glory): меню «слава2 изменить» — формат строки стата и выравнивание

### DIFF
--- a/src/gameplay/mechanics/glory_const.cpp
+++ b/src/gameplay/mechanics/glory_const.cpp
@@ -327,7 +327,7 @@ std::string olc_print_stat(CharData *ch, int stat) {
 		stat_add = fmt::format("+{}", ch->desc->glory_const->stat_add[stat]);
 	}
 
-	return fmt::format("  {:<16} :  {}(+{:<5}){}  ({}{}{}) %4d ({}{}{})  {}(-{:<5})  | {:+}{}\r\n",
+	return fmt::format("  {:<17} :  {}(+{:<5}){}  ({}{}{}) {:4} ({}{}{})  {}(-{:<5})  | {}{}\r\n",
 					   olc_stat_name[stat],
 					   kColorBoldBlk, remove_stat_cost(stat, ch->desc->glory_const), kColorNrm,
 					   kColorBoldGrn, olc_del_name[stat], kColorNrm,
@@ -341,7 +341,7 @@ std::string olc_print_stat(CharData *ch, int stat) {
 // * Распечатка олц меню.
 void spend_glory_menu(CharData *ch) {
 	std::ostringstream out;
-	out << "\r\n                         -      +\r\n";
+	out << "\r\n                                  -        +\r\n";
 
 	out << olc_print_stat(ch, GLORY_STR)
 		<< olc_print_stat(ch, GLORY_DEX)


### PR DESCRIPTION
Меню `слава2 изменить` (`olc_print_stat` / `spend_glory_menu`, `glory_const.cpp`).

## Проблемы
```
                         -      +
  Сила             :  (+0    )  (А) %4d (92О)  (-)  | +1000
```
1. торчит литерал `%4d`;
2. `(92О)`/`(91П)` — значение стата слиплось с буквой кнопки «+»;
3. строка `Сила заклинаний %` (17 символов) не влезает в поле и едет;
4. заголовок `- +` не над колонками.

## Причина
`olc_print_stat` собирается через `fmt::format`, но в шаблоне остались артефакты конвертации из `sprintf`:
- printf-овский `%4d` — `fmt` его не подставляет, печатает буквально; из-за этого аргумент со значением стата съезжает в следующий `{}` и слипается с буквой кнопки;
- `{:+}` стоял на аргументе-строке `stat_add` (а `{:+}` — только для чисел; из-за сдвига от `%4d` он случайно попадал на число, поэтому компилировалось).

Плюс поле имени было `{:<16}`, а самое длинное имя — 17 символов.

## Решение
- `%4d` → `{:4}` (значение стата);
- `{:+}` → `{}` (у `stat_add` знак уже в строке);
- поле имени `{:<16}` → `{:<17}` (влезает «Сила заклинаний %», все строки выровнены);
- заголовок `- +` пересчитан: `-` над буквой-кнопкой уменьшения (кол. 35), `+` над буквой увеличения (кол. 44).

## Проверка
Сборка проходит; выравнивание сверено моделью вывода (буквы кнопок встают точно под `-`/`+`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)