### PR TITLE
fix(identify): «плавающий» урон при опознании моба (#3519)

### DIFF
--- a/src/gameplay/fight/fight_hit.cpp
+++ b/src/gameplay/fight/fight_hit.cpp
@@ -721,7 +721,9 @@ int HitData::CalcDmg(CharData *ch, bool need_dice) {
 		SendMsgToChar(ch, "&YДамага с учетом перков мощная-улучш == %d&n\r\n", dam);
 	// courage
 	if (IsAffectedBySpell(ch, ESpell::kCourage)) {
-		int range = number(1, MUD::Skill(ESkill::kCourage).difficulty + ch->get_real_max_hit() - ch->get_hit());
+		const int courage_range = MUD::Skill(ESkill::kCourage).difficulty + ch->get_real_max_hit() - ch->get_hit();
+		// при показе (need_dice == false) берём среднее, чтобы урон в опознании не "плавал"
+		int range = need_dice ? number(1, courage_range) : (1 + courage_range) / 2;
 		int prob = CalcCurrentSkill(ch, ESkill::kCourage, ch);
 		if (prob > range) {
 			dam += ((GetSkill(ch, ESkill::kCourage) + 19) / 20);
@@ -800,7 +802,10 @@ int HitData::CalcDmg(CharData *ch, bool need_dice) {
 		}
 	}
 	if (ch->IsNpc()) { // урон моба из олц
-		dam += RollDices(ch->mob_specials.damnodice, ch->mob_specials.damsizedice);
+		// при показе (need_dice == false) берём среднее кубиков, иначе урон в опознании "плавает"
+		dam += need_dice
+			? RollDices(ch->mob_specials.damnodice, ch->mob_specials.damsizedice)
+			: ch->mob_specials.damnodice * (ch->mob_specials.damsizedice + 1) / 2;
 	}
 
 	mount::ApplyRiderDamageMult(ch, dam);


### PR DESCRIPTION
Closes #3519

## Симптом
Два опознания чармиса подряд (всё в одной комнате, статы/аффекты идентичны) дают разный урон:
```
Попадание: 64, повреждение: 830, ...
Попадание: 64, повреждение: 754, ...
```

## Причина
Опознание (`MobShowValues`) показывает средний урон через `HitData::CalcDmg(victim, /*need_dice=*/false)`. Путь `need_dice == false` для weapon/barehands/процентов уже считает среднее, но **два слагаемых игнорировали флаг** и брались случайно при каждом вызове:
- кубики урона моба из OLC: `RollDices(damnodice, damsizedice)` (главный разброс — у наёмника крупные кубики);
- блок «доблесть» (`kCourage`): `number(1, range)` (мелкий разброс; у моба есть аффект «доблесть»).

## Решение
Оба места при `need_dice == false` берут среднее:
- кубики моба → `N*(M+1)/2` (как в `AddWeaponDmg`);
- «доблесть» → средний порог `(1 + range) / 2` вместо случайного.

Боевой путь (`need_dice == true`) не изменился — урон в бою по-прежнему случайный.

## Проверка
Сборка проходит. Изменения только в ветке `need_dice == false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)