### PR TITLE
fix(frenzy): do not mutate affect list while iterating (SIGSEGV)

### DIFF
--- a/src/gameplay/skills/frenzy.cpp
+++ b/src/gameplay/skills/frenzy.cpp
@@ -10,6 +10,8 @@
 #include "engine/db/global_objects.h"
 #include "gameplay/fight/common.h"
 
+#include <vector>
+
 void do_frenzy(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	if (!GetSkill(ch, ESkill::kFrenzy)) {
 		SendMsgToChar(MUD::SkillMessages().GetMessage(ESkill::kFrenzy, ESkillMsg::kDontKnowSkill) + "\r\n", ch);
@@ -55,28 +57,34 @@ void do_frenzy(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	af[1].battleflag = kAfPulsedec;
 	bool has_frenzy = false;
 	bool can_be_angrier = false;
+	// В цикле только СНИМАЕМ старые frenzy-аффекты и СОБИРАЕМ обновлённые копии.
+	// affect_to_char нельзя звать внутри: он меняет ch->affected и зовёт
+	// affect_total()/EmitAffectEvent, что инвалидирует итератор it (краш).
+	std::vector<Affect<EApply>> readd;
 
 	for (auto it = ch->affected.begin(); it != ch->affected.end();) {
-		auto a = *(*it);  // копия данных эффекта (НЕ ссылка!)
-
-		if (a.type == ESpell::kFrenzy) {
-			has_frenzy = true;
-
-			if (a.location == EApply::kHpRegen && a.modifier < af[0].modifier * 5) {
-				a.modifier += af[0].modifier;
-				can_be_angrier = true;
-			}
-			if (a.location == EApply::kPhysicDamagePercent && a.modifier < af[1].modifier * 5) {
-				a.modifier += af[1].modifier;
-				can_be_angrier = true;
-			}
-			a.duration = duration;
-			it = RemoveAffect(ch, it);
-			affect_to_char(ch, a);
-			// continue не обязателен: it уже установлен на следующий
-		} else {
+		if ((*it)->type != ESpell::kFrenzy) {
 			++it;
+			continue;
 		}
+		auto a = *(*it);  // копия данных эффекта (НЕ ссылка!)
+		has_frenzy = true;
+
+		if (a.location == EApply::kHpRegen && a.modifier < af[0].modifier * 5) {
+			a.modifier += af[0].modifier;
+			can_be_angrier = true;
+		}
+		if (a.location == EApply::kPhysicDamagePercent && a.modifier < af[1].modifier * 5) {
+			a.modifier += af[1].modifier;
+			can_be_angrier = true;
+		}
+		a.duration = duration;
+		readd.push_back(a);
+		it = RemoveAffect(ch, it);  // только erase, возвращает валидный следующий
+	}
+	// Применяем собранные аффекты уже вне итерации по списку.
+	for (const auto &a : readd) {
+		affect_to_char(ch, a);
 	}
 
 	if (!has_frenzy) {


### PR DESCRIPTION
## Краш
```
SIGSEGV в do_frenzy (frenzy.cpp:60), разыменование битого shared_ptr<Affect<EApply>>
#3 do_frenzy ... frenzy.cpp:60
#4 command_interpreter ... "исс"
```
Падает при использовании бешенства, когда на персонаже уже висят frenzy-аффекты.

## Причина
В цикле `for (auto it = ch->affected.begin(); ...)` внутри тела вызывался `affect_to_char(ch, a)`. `affect_to_char` меняет `ch->affected` (push_front) и зовёт `affect_total()` + `EmitAffectEvent` — это инвалидирует итератор `it`, и на следующей итерации `*(*it)` обращается к освобождённой памяти → SIGSEGV.

(`ch->affected` — `std::list`, сам `RemoveAffect`=`erase` безопасен и возвращает валидный следующий; проблема именно во вставке/пересчёте посреди итерации.)

## Фикс
В цикле теперь только снимаем старые frenzy-аффекты и собираем обновлённые копии в `std::vector`; `affect_to_char` вызываем уже **после** цикла, вне итерации. Логика (бамп hp_regen/phys_dmg до кратности ×5, обновление duration, ветки has_frenzy/can_be_angrier) сохранена.

## Проверка
Сборка проходит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)