### PR TITLE
feat(dg): mob in stun pauses trigger instead of dropping command (#3523)

### DIFF
--- a/src/engine/scripting/dg_mobcmd.cpp
+++ b/src/engine/scripting/dg_mobcmd.cpp
@@ -1548,10 +1548,9 @@ bool mob_script_command_interpreter(CharData *ch, char *argument, Trigger *trig)
 						|| AFF_FLAGGED(ch, EAffect::kStopFight)
 						|| AFF_FLAGGED(ch, EAffect::kMagicStopFight))
 				&& !trig->add_flag) {
-			if (!strcmp(mob_cmd_info[cmd].command, "mload") || (!strcmp(mob_cmd_info[cmd].command, "load"))) {
-				sprintf(buf, "command_interpreter: моб в стане, mload пропущен, команда: %s", argument);
-				mob_log(ch, trig, buf);
-			}
+			// issue #3523: моб в стане -> команду не теряем: вешаем триггеру wait
+			// 1 RL-сек, после стана script_driver повторит её (TRIG_FROM_LINE).
+			hang_trig_wait(ch, trig, MOB_TRIGGER, kPassesPerSec, true);
 			return false;
 		}
 	}

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -828,7 +828,7 @@ EVENT(trig_wait_event) {
 	go = wait_event_obj->go;
 	type = wait_event_obj->type;
 	GET_TRIG_WAIT(trig).time_remaining = 0;
-	script_driver(go, trig, type, TRIG_CONTINUE);
+	script_driver(go, trig, type, wait_event_obj->from_current ? TRIG_FROM_LINE : TRIG_CONTINUE);
 	free(wait_event_obj);
 }
 
@@ -4587,9 +4587,26 @@ cmdlist_element::shared_ptr find_case(Trigger *trig,
 }
 
 // processes any 'wait' commands in a trigger
-void process_wait(void *go, Trigger *trig, int type, char *cmd, const cmdlist_element::shared_ptr &cl) {
-	char *arg;
+// issue #3523: единая точка постановки wait на триггер через штатный
+// trig_wait_event. from_current=true -> возобновление с текущей строки.
+void hang_trig_wait(void *go, Trigger *trig, int type, long time, bool from_current) {
+	if (time <= 0) {
+		return;
+	}
 	struct wait_event_data *wait_event_obj;
+	CREATE(wait_event_obj, 1);
+	wait_event_obj->trigger = trig;
+	wait_event_obj->go = go;
+	wait_event_obj->type = type;
+	wait_event_obj->from_current = from_current;
+	if (GET_TRIG_WAIT(trig).time_remaining > 0) {
+		trig_log(trig, "Wait structure already allocated for trigger");
+	}
+	GET_TRIG_WAIT(trig) = add_event(time, trig_wait_event, wait_event_obj);
+}
+
+void process_wait(void *go, Trigger *trig, int type, char *cmd, const cmdlist_element::shared_ptr &cl, bool from_current = false) {
+	char *arg;
 	long time = 0, hr, min, ntime;
 	char c;
 
@@ -4638,16 +4655,7 @@ void process_wait(void *go, Trigger *trig, int type, char *cmd, const cmdlist_el
 		trig_log(trig, "попытка запустить Wait 0");
 		return;
 	}
-	CREATE(wait_event_obj, 1);
-	wait_event_obj->trigger = trig;
-	wait_event_obj->go = go;
-	wait_event_obj->type = type;
-
-	if (GET_TRIG_WAIT(trig).time_remaining > 0) {
-		trig_log(trig, "Wait structure already allocated for trigger");
-	}
-
-	GET_TRIG_WAIT(trig) = add_event(time, trig_wait_event, wait_event_obj);
+	hang_trig_wait(go, trig, type, time, from_current);
 	trig->wait_line = cl;
 }
 
@@ -6073,6 +6081,14 @@ int timed_script_driver(void *go, Trigger *trig, int type, int mode) {
 						wld_command_interpreter((RoomData *) go, cmd, trig);
 						break;
 				}
+			}
+			// issue #3523: если команда повесила на триггер wait (моб в стане),
+			// выходим из script_driver -- событие позже повторит ту же строку
+			// (TRIG_FROM_LINE). Без этого остаток триггера отработал бы вхолостую.
+			if (trig && GET_TRIG_WAIT(trig).time_remaining > 0) {
+				depth--;
+				cur_trig = prev_trig;
+				return ret_val;
 			}
 			if (trig && trig->is_halted())
 				break;

--- a/src/engine/scripting/dg_scripts.h
+++ b/src/engine/scripting/dg_scripts.h
@@ -131,7 +131,12 @@ struct wait_event_data {
 	Trigger *trigger;
 	void *go;
 	int type;
+	bool from_current = false;  // возобновить с текущей строки (TRIG_FROM_LINE), а не со следующей
 };
+
+// Повесить на триггер wait через штатный trig_wait_event (issue #3523).
+// from_current=true -> по таймеру продолжить с текущей строки (TRIG_FROM_LINE).
+void hang_trig_wait(void *go, Trigger *trig, int type, long time, bool from_current = false);
 
 // one line of the trigger //
 class cmdlist_element {


### PR DESCRIPTION
Closes #3523

## Проблема
Если моб под станом (`kHold`/`kStopFight`/`kMagicStopFight`), DG-диспетчер `mob_script_command_interpreter` просто **пропускал** команду (`return false`). Пока моб в стане, так терялись **все** команды триггера (mload и пр.).

## Решение
Вместо пропуска вешаем на триггер `wait` 1 RL-секунду и после паузы **повторяем ту же строку**:
- стоп-блок (`dg_mobcmd`) зовёт `hang_trig_wait(ch, trig, MOB_TRIGGER, kPassesPerSec, true)`;
- `timed_script_driver` после диспетча команды видит `GET_TRIG_WAIT.time_remaining > 0` и выходит (yield), как ветка `wait ` (`depth--`/`cur_trig`/`return`);
- `trig_wait_event` при `from_current` возобновляет `TRIG_FROM_LINE` = `trig->curr_line` — повторяет ту же строку (`curr_line` хранит исполняемую строку триггера);
- `hang_trig_wait` — единая точка постановки wait через штатный `trig_wait_event`; её же теперь зовёт `process_wait` (дедуп, без нового события).

## Почему без рекурсии/дублей
- Триглист не запускает вторую копию, пока `GET_TRIG_DEPTH != 0` (триггер активен) → максимум одна ждущая копия.
- `wait` событийный: `timed_script_driver` возвращается, статический анти-рекурсивный `depth` корректно уменьшается на yield.
- `GET_TRIG_DEPTH` (вложенность `if/while`) на паузе не трогаем — переживает wait, нужен для `TRIG_FROM_LINE`.

Damage/Death-триггеры по-прежнему исключены (внешний `if (!(CheckScript(...DAMAGE/DEATH)))`).

## Проверка
Сборка проходит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)