### PR TITLE
feat(dg): log trigger resume after mob stun-lag (#3523)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -828,6 +828,14 @@ EVENT(trig_wait_event) {
 	go = wait_event_obj->go;
 	type = wait_event_obj->type;
 	GET_TRIG_WAIT(trig).time_remaining = 0;
+	// issue #3523: from_current выставляется только при паузе триггера из-за стана
+	// моба -- логируем возобновление, чтобы видеть, что механизм действительно работает.
+	if (wait_event_obj->from_current && type == MOB_TRIGGER && go) {
+		auto *mob = reinterpret_cast<CharData *>(go);
+		mudlog(fmt::format("DG: триггер '{}' (внум {}) продолжил работу после лага моба '{}' (внум {})",
+						   GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), GET_SHORT(mob), GET_MOB_VNUM(mob)),
+			   NRM, kLvlGod, SYSLOG, true);
+	}
 	script_driver(go, trig, type, wait_event_obj->from_current ? TRIG_FROM_LINE : TRIG_CONTINUE);
 	free(wait_event_obj);
 }

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -832,7 +832,7 @@ EVENT(trig_wait_event) {
 	// моба -- логируем возобновление, чтобы видеть, что механизм действительно работает.
 	if (wait_event_obj->from_current && type == MOB_TRIGGER && go) {
 		auto *mob = reinterpret_cast<CharData *>(go);
-		mudlog(fmt::format("DG: триггер '{}' (внум {}) продолжил работу после лага моба '{}' (внум {})",
+		mudlog(fmt::format("DG: триггер {} #{} продолжил работу после лага моба {} #{}",
 						   GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), GET_SHORT(mob), GET_MOB_VNUM(mob)),
 			   NRM, kLvlGod, SYSLOG, true);
 	}


### PR DESCRIPTION
## Что

По просьбе из #3523 ([комментарий](https://github.com/bylins/mud/issues/3523#issuecomment-4867645576)): после #3524 моб в стане не теряет DG-команду, а вешает на триггер `wait` 1 RL-сек и продолжает с той же строки. Не было видно, срабатывает ли механизм на практике — добавлена диагностика.

## Как

В `trig_wait_event` (`src/engine/scripting/dg_scripts.cpp`) при возобновлении триггера с текущей строки (`from_current`) пишем в мудлог имя+внум триггера и моба.

`from_current == true` выставляется **только** стан-паузой моба (`hang_trig_wait(..., true)` из #3524); обычный `wait N` идёт с `from_current=false`, поэтому ложных срабатываний нет.

Пишем через `mudlog(..., SYSLOG)` на уровне бога, а не через `script_log`/`ERRLOG` — иначе сообщение фактически не читается.

Пример строки:
```
DG: триггер 'имя' (внум 12345) продолжил работу после лага моба 'моб' (внум 200)
```

Closes #3523

🤖 Generated with [Claude Code](https://claude.com/claude-code)