### PR TITLE
fix(dg): do not log stun-lag resume for an extracted mob (#3523)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -830,7 +830,11 @@ EVENT(trig_wait_event) {
 	GET_TRIG_WAIT(trig).time_remaining = 0;
 	// issue #3523: from_current выставляется только при паузе триггера из-за стана
 	// моба -- логируем возобновление, чтобы видеть, что механизм действительно работает.
-	if (wait_event_obj->from_current && type == MOB_TRIGGER && go) {
+	// Выведенного из мира моба пропускаем: extract_char вынимает моба из комнаты
+	// (in_room = kNowhere) раньше, чем событие успевает сработать, а script_driver
+	// ниже всё равно ничего не выполнит -- лог о "продолжил работу" был бы ложным.
+	if (wait_event_obj->from_current && type == MOB_TRIGGER && go
+			&& reinterpret_cast<CharData *>(go)->in_room != kNowhere) {
 		auto *mob = reinterpret_cast<CharData *>(go);
 		mudlog(fmt::format("DG: триггер {} #{} продолжил работу после лага моба {} #{}",
 						   GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), GET_SHORT(mob), GET_MOB_VNUM(mob)),


### PR DESCRIPTION
## Проблема

В логе после #3532 появлялись строки вида ([комментарий](https://github.com/bylins/mud/issues/3523#issuecomment-4877512874)):

```
10:38:01.339 :: [Extract char] Start function for char торговец рыбой VNUM: 98510
10:38:01.419 :: DG: триггер триггер торговца рыбой #98500 продолжил работу после лага моба торговец рыбой #98510
```

То есть «триггер продолжил работу» **после смерти моба**.

## Причина

Это ложный лог, а не реальное выполнение триггера на мёртвом мобе:

- отложенное `trig_wait_event` (wait от стан-паузы) успевает сработать **раньше**, чем моба реально удалят;
- `extract_char` к этому моменту уже вынул моба из комнаты (`RemoveCharFromRoom` → `in_room == kNowhere`), а `script_driver` ниже ничего не выполнит;
- но лог печатался ДО этого, поэтому врал про «продолжил работу».

UAF тут нет: если бы удаление прошло первым, `ExtractTrigger` снял бы wait-событие через `remove_event` — оно бы просто не сработало.

## Фикс

Печатаем лог только если моб ещё в мире (`in_room != kNowhere`). Признак «моб выведен из мира / готовится к удалению» — именно `in_room == kNowhere`; флаг `purged` для этого не используем, он устарел и оставлен для совместимости.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
