### PR TITLE
fix(dg): do not log stun-lag resume for a purged mob (#3523)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -830,7 +830,11 @@ EVENT(trig_wait_event) {
 	GET_TRIG_WAIT(trig).time_remaining = 0;
 	// issue #3523: from_current выставляется только при паузе триггера из-за стана
 	// моба -- логируем возобновление, чтобы видеть, что механизм действительно работает.
-	if (wait_event_obj->from_current && type == MOB_TRIGGER && go) {
+	// Мёртвого (purged) моба пропускаем: событие срабатывает раньше отложенного
+	// purge, но script_driver ниже всё равно выйдет по is_purged() -- триггер не
+	// продолжится, и лог о "продолжил работу" был бы ложным.
+	if (wait_event_obj->from_current && type == MOB_TRIGGER && go
+			&& !reinterpret_cast<CharData *>(go)->purged()) {
 		auto *mob = reinterpret_cast<CharData *>(go);
 		mudlog(fmt::format("DG: триггер {} #{} продолжил работу после лага моба {} #{}",
 						   GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), GET_SHORT(mob), GET_MOB_VNUM(mob)),


### PR DESCRIPTION
Событие trig_wait_event срабатывает раньше отложенного purge моба, поэтому после смерти моба лог печатал «продолжил работу после лага», хотя реально script_driver тут же выходит по is_purged() и триггер не продолжается.

Пропускаем лог, если моб уже purged -- сообщение теперь соответствует реальному возобновлению.