### PR TITLE
Revert "feat(dg): log trigger resume after mob stun-lag (#3532)"

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -828,14 +828,6 @@ EVENT(trig_wait_event) {
 	go = wait_event_obj->go;
 	type = wait_event_obj->type;
 	GET_TRIG_WAIT(trig).time_remaining = 0;
-	// issue #3523: from_current выставляется только при паузе триггера из-за стана
-	// моба -- логируем возобновление, чтобы видеть, что механизм действительно работает.
-	if (wait_event_obj->from_current && type == MOB_TRIGGER && go) {
-		auto *mob = reinterpret_cast<CharData *>(go);
-		mudlog(fmt::format("DG: триггер {} #{} продолжил работу после лага моба {} #{}",
-						   GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), GET_SHORT(mob), GET_MOB_VNUM(mob)),
-			   NRM, kLvlGod, SYSLOG, true);
-	}
 	script_driver(go, trig, type, wait_event_obj->from_current ? TRIG_FROM_LINE : TRIG_CONTINUE);
 	free(wait_event_obj);
 }


### PR DESCRIPTION
Механический откат #3532 из master.

Диагностический лог из #3532 был вмёржен без гарда на выведенного из мира моба, из-за чего печатал ложное «триггер продолжил работу после лага» уже после смерти моба (см. #3523).

Откатываем, чтобы собрать всю диагностику одним самодостаточным PR (лог + формат `имя #номер` + гард `in_room != kNowhere`) — так удобнее ревьюить. Полная версия придёт отдельным PR поверх этого отката.

🤖 Generated with [Claude Code](https://claude.com/claude-code)