### PR TITLE
feat(dg): log trigger resume after mob stun-lag (#3523)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -828,6 +828,18 @@ EVENT(trig_wait_event) {
 	go = wait_event_obj->go;
 	type = wait_event_obj->type;
 	GET_TRIG_WAIT(trig).time_remaining = 0;
+	// issue #3523: from_current выставляется только при паузе триггера из-за стана
+	// моба -- логируем возобновление, чтобы видеть, что механизм действительно работает.
+	// Выведенного из мира моба пропускаем: extract_char вынимает моба из комнаты
+	// (in_room = kNowhere) раньше, чем событие успевает сработать, а script_driver
+	// ниже всё равно ничего не выполнит -- лог о "продолжил работу" был бы ложным.
+	if (wait_event_obj->from_current && type == MOB_TRIGGER && go
+			&& reinterpret_cast<CharData *>(go)->in_room != kNowhere) {
+		auto *mob = reinterpret_cast<CharData *>(go);
+		mudlog(fmt::format("DG: триггер {} #{} продолжил работу после лага моба {} #{}",
+						   GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), GET_SHORT(mob), GET_MOB_VNUM(mob)),
+			   NRM, kLvlGod, SYSLOG, true);
+	}
 	script_driver(go, trig, type, wait_event_obj->from_current ? TRIG_FROM_LINE : TRIG_CONTINUE);
 	free(wait_event_obj);
 }


### PR DESCRIPTION
Вся диагностика по #3523 одним коммитом — удобно ревьюить целиком.

> Порядок мёржа: сначала revert #3537, затем этот PR. База временно указана на ветку `revert/dg-stun-resume-3532`, чтобы дифф показывал полный блок как добавление. После мёржа #3537 переключу базу на master.

## Что

После #3524 моб в стане не теряет DG-команду, а вешает на триггер `wait` 1 RL-сек и продолжает с той же строки (`TRIG_FROM_LINE`). Не было видно, срабатывает ли механизм на практике — добавлен диагностический лог в `trig_wait_event`.

## Детали

- Пишем в мудлог только на **реальном** возобновлении: `from_current` выставляется исключительно стан-паузой моба (`hang_trig_wait(..., true)` из #3524); обычный `wait N` идёт с `from_current=false`.
- **Мёртвого моба пропускаем** (`in_room != kNowhere`). `extract_char` вынимает моба из комнаты раньше, чем срабатывает отложенное событие, а `script_driver` ниже всё равно ничего не выполнит по выходу из мира — иначе лог печатал бы ложное «продолжил работу после лага» уже после смерти моба (см. https://github.com/bylins/mud/issues/3523#issuecomment-4877512874). Флаг `purged` не используем — устарел, оставлен для совместимости.
- Формат идентификатора — `имя #номер`, и для триггера, и для моба.
- Через `mudlog(SYSLOG)` на уровне бога, а не `script_log`/`ERRLOG` — иначе не читается.

Пример строки:
```
DG: триггер имя #98500 продолжил работу после лага моба моб #98510
```

Closes #3523

🤖 Generated with [Claude Code](https://claude.com/claude-code)