### PR TITLE
fix(dg): log stun-lag resume only when trigger actually continues (#3523)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -829,12 +829,26 @@ EVENT(trig_wait_event) {
 	type = wait_event_obj->type;
 	GET_TRIG_WAIT(trig).time_remaining = 0;
 	// issue #3523: from_current выставляется только при паузе триггера из-за стана
-	// моба -- логируем возобновление, чтобы видеть, что механизм действительно работает.
-	if (wait_event_obj->from_current && type == MOB_TRIGGER && go) {
+	// моба. Логируем возобновление лишь когда триггер РЕАЛЬНО продолжится, иначе
+	// лог о "продолжил работу" был бы ложным. Проверять надо ДО script_driver:
+	// после него trig может быть уже удалён (remove_trigger -> ExtractTrigger).
+	//  - цикл script_driver зайдёт только если есть строка (curr_line), триггер
+	//    не свёрнут (GET_TRIG_DEPTH) и не остановлен (is_halted);
+	//  - моб не выведен из мира (in_room != kNowhere: extract_char уже вынул бы
+	//    его из комнаты, а script_driver ничего не выполнит);
+	//  - моб вышел из стана: иначе интерпретатор снова повесит wait и команда
+	//    опять не выполнится.
+	if (wait_event_obj->from_current && type == MOB_TRIGGER && go && trig
+			&& trig->curr_line && GET_TRIG_DEPTH(trig) && !trig->is_halted()) {
 		auto *mob = reinterpret_cast<CharData *>(go);
-		mudlog(fmt::format("DG: триггер {} #{} продолжил работу после лага моба {} #{}",
-						   GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), GET_SHORT(mob), GET_MOB_VNUM(mob)),
-			   NRM, kLvlGod, SYSLOG, true);
+		if (mob->in_room != kNowhere
+				&& !AFF_FLAGGED(mob, EAffect::kHold)
+				&& !AFF_FLAGGED(mob, EAffect::kStopFight)
+				&& !AFF_FLAGGED(mob, EAffect::kMagicStopFight)) {
+			mudlog(fmt::format("DG: триггер {} #{} продолжил работу после лага моба {} #{}",
+							   GET_TRIG_NAME(trig), GET_TRIG_VNUM(trig), GET_SHORT(mob), GET_MOB_VNUM(mob)),
+				   NRM, kLvlGod, SYSLOG, true);
+		}
 	}
 	script_driver(go, trig, type, wait_event_obj->from_current ? TRIG_FROM_LINE : TRIG_CONTINUE);
 	free(wait_event_obj);


### PR DESCRIPTION
Догоняющий фикс к #3532: диагностический лог печатал «триггер продолжил работу после лага» там, где триггер на самом деле **не** продолжается.

## Две лжи

**1. Моб мёртв.** Отложенное `trig_wait_event` срабатывает раньше реального удаления; `extract_char` к этому моменту уже вынул моба из комнаты (`in_room == kNowhere`), а `script_driver` ниже ничего не выполняет ([комментарий](https://github.com/bylins/mud/issues/3523#issuecomment-4877512874)):

```
10:38:01.339 :: [Extract char] Start function for char торговец рыбой VNUM: 98510
10:38:01.419 :: DG: триггер триггер торговца рыбой #98500 продолжил работу после лага моба торговец рыбой #98510
```

**2. Моб ещё в стане.** Событие раз в секунду перезапускает строку через `TRIG_FROM_LINE`. Если стан не прошёл — `mob_script_command_interpreter` снова вешает `wait` и команда опять не выполняется: триггер стоит на паузе, а лог кричал «продолжил работу» на каждом тике паузы.

## Фикс

Логируем только когда триггер **реально продолжится**:
- моб жив (`in_room != kNowhere`);
- моб вышел из стана (нет `kHold`/`kStopFight`/`kMagicStopFight`) — то же условие, по которому интерпретатор решает выполнять команду.

Флаг `purged` не используем — устарел, оставлен для совместимости. UAF нет: успей удаление первым, `ExtractTrigger` снял бы событие через `remove_event`.

Closes #3523

🤖 Generated with [Claude Code](https://claude.com/claude-code)
