### PR TITLE
feat(stat): comma-separate wrapped mob skills/spells/feats lists (#3429)

### DIFF
--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -450,7 +450,7 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 					parts.push_back(fmt::sprintf("%s:[%d]", skill.GetName(), GetSkill(k, skill.GetId())));
 				}
 			}
-			SendMsgToChar(utils::OutWordsList(parts, list_width, " ", "&GУмения:&c ") + "&n\r\n", ch);
+			SendMsgToChar(utils::OutWordsList(parts, list_width, ", ", "&GУмения:&c ") + "&n\r\n", ch);
 		}
 		if (!k->mob_specials.have_spell) {
 			SendMsgToChar(ch, "&GЗаклинания: &Rнет&n\r\n");
@@ -464,7 +464,7 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 					parts.push_back(fmt::sprintf("%s:[%d]", MUD::Spell(spell_id).GetCName(), GET_SPELL_MEM(k, spell_id)));
 				}
 			}
-			SendMsgToChar(utils::OutWordsList(parts, list_width, " ", "&GЗаклинания:&c ") + "&n\r\n", ch);
+			SendMsgToChar(utils::OutWordsList(parts, list_width, ", ", "&GЗаклинания:&c ") + "&n\r\n", ch);
 		}
 		{
 			std::vector<std::string> parts;
@@ -476,7 +476,7 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 					parts.push_back(fmt::sprintf("'%s'", feat.GetCName()));
 				}
 			}
-			SendMsgToChar(utils::OutWordsList(parts, list_width, " ", "&GСпособности:&c ") + "&n\r\n", ch);
+			SendMsgToChar(utils::OutWordsList(parts, list_width, ", ", "&GСпособности:&c ") + "&n\r\n", ch);
 		}
 		// информация о маршруте моба
 		if (k->mob_specials.dest_count > 0 && k->in_room != kNowhere) {


### PR DESCRIPTION
Догоняющий штрих к #3546 (тот уже влит): в переносе по ширине списков **Умения / Заклинания / Способности** в `stat` моба ставим разделитель `", "` вместо пробела — **как в списке аффектов**.

Меняется только разделитель в трёх вызовах `utils::OutWordsList` (+3/−3). `OutWordsList` при переносе срезает хвостовой пробел разделителя, так что на конце строки получается `",\r\n"`, а не висящая запятая с пробелом.

Пример:
```
Способности: 'предсмертная ярость', 'отбить стрелу', 'слепой бой', 'непробиваемый',
'ночное зрение', 'щитоносец', 'изворотливость', ...
```

Связано с #3429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)