### PR TITLE
fix(stat): tidy mob/PC stat lists — feats quotes + wrap quests (#3429)

### DIFF
--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -475,7 +475,7 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 					continue;
 				}
 				if (k->HaveFeat(feat.GetId())) {
-					parts.push_back(fmt::sprintf("'%s'", feat.GetCName()));
+					parts.push_back(feat.GetCName());
 				}
 			}
 			SendMsgToChar(utils::OutWordsList(parts, list_width, ", ", "&GСпособности:&c ") + "&n\r\n", ch);

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -679,8 +679,13 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 		}
 
 		std::string quested(k->quested_print());
-		if (!quested.empty())
-			SendMsgToChar(ch, "Выполнил квесты:\r\n%s\r\n", quested.c_str());
+		if (!quested.empty()) {
+			// issue #3429: список выполненных квестов бывает очень длинным --
+			// переносим каждую строку (зону) по ширине экрана через WrapText.
+			const size_t width = (!ch->IsNpc() && ch->player_specials->saved.stringLength > 0)
+					? ch->player_specials->saved.stringLength : 120;
+			SendMsgToChar(ch, "Выполнил квесты:\r\n%s\r\n", utils::WrapText(quested, width).c_str());
+		}
 
 		if (NORENTABLE(k)) {
 			snprintf(buf, sizeof(buf), "Не может уйти на постой %ld\r\n",


### PR DESCRIPTION
Доводка вывода `stat` по #3429 (после переноса списков в #3546/#3547).

## Что сделано

1. **Способности без кавычек.** Были в кавычках (`'предсмертная ярость'`), а умения/заклинания — без. С разделителем `", "` кавычки не нужны, рассинхрон резал глаз. Теперь все три списка единообразны.
2. **Список «Выполнил квесты» переносится по ширине.** Бывал строкой на пол-экрана и шире; оборачиваем через `utils::WrapText` (переносит каждую строку-зону по словам, сохраняя разбивку).

## Пример

```
Способности: предсмертная ярость, отбить стрелу, слепой бой, непробиваемый, ...

Выполнил квесты:
203 @26718 1672065833 20334 1673628141 30914 1714392777 77436 1724605062 204
1724670022 82003 1728389328 ...
205 @3000402 1 3000302 2 ...
```

Связано с #3429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
