### PR TITLE
fix(magic): guard TryBlockByMagicalShield against null victim (#3554)

### DIFF
--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -426,6 +426,10 @@ int LandOneDamageHit(CharData *ch, CharData *victim, ESpell spell_id, int total_
 // The Vityaz magical-shield block: a skill+feat+worn-shield absorption. The chance is
 // (kShieldBlock / 20 + shield_weight / 2) percent. Mass/area/warcry casts bypass the shield.
 bool TryBlockByMagicalShield(CharData *ch, CharData *victim, ESpell spell_id) {
+	// issue #3554: у каста по объекту/комнате нет char-victim (ctx.cvict == nullptr).
+	// Ниже сразу GetSkill(victim,...) -> разыменование nullptr -> краш. Щита-защитника
+	// без цели-персонажа нет, поэтому просто выходим (как делает WardEligible).
+	if (!victim) return false;
 	if (ch == victim) return false;
 	if (!MUD::Spell(spell_id).IsViolentAgainst(ch, victim)) return false;
 	if (MUD::Spell(spell_id).IsFlagged(kMagWarcry)) return false;


### PR DESCRIPTION
Фикс краша из #3554.

## Причина

Каст **violent-заклинания по объекту/комнате** (в репорте — `к !прокл! возв`, проклятие на предмет) идёт с `ctx.cvict == nullptr`. `RunWholeCastWards` **безусловно** зовёт `TryBlockByMagicalShield(caster, victim, spell_id)`, а та первым делом дёргает `GetSkill(victim, kShieldBlock)` → `GetSkillBonus(nullptr)` → `ch->in_room` → разыменование nullptr → краш (`skills.cpp:2143`).

Бэктрейс:
```
#0 GetSkillBonus (ch=0x0, kShieldBlock) skills.cpp:2143
#2 TryBlockByMagicalShield (victim=0x0, kCurse) magic.cpp:434
#3 RunWholeCastWards magic.cpp:533
#7 CallMagic (cvict=0x0, ovict=0x..., spell_id=kCurse)   <- цель — объект
```

Data-ward'ы этот случай уже отсекают через `WardEligible` (там `&& victim &&`), а code-only защита «магический щит» — нет.

## Фикс

Ранний выход в `TryBlockByMagicalShield`: нет цели-персонажа (`!victim`) → щита-защитника быть не может, возвращаем false. Единообразно с `WardEligible`. +4 строки (с комментарием).

Триггерится любым violent-заклинанием по объекту, так что краш лёгкий — стоит в master поскорее.

Closes #3554

🤖 Generated with [Claude Code](https://claude.com/claude-code)