### PR TITLE
fix: vnum trig не работает на YAML/SQLite мире

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -12,8 +12,6 @@
 
 #include <fmt/format.h>
 
-#include <regex>
-
 extern int scheck;                        // TODO: get rid of this line
 CharData *mob_proto;                    // TODO: get rid of this global variable
 
@@ -240,37 +238,22 @@ void DiscreteFile::dg_read_trigger(void *proto, int type, int proto_vnum) {
 
 class DataFileFactoryImpl : public DataFileFactory {
  public:
-	using regex_ptr_t = std::shared_ptr<std::regex>;
-
-	DataFileFactoryImpl() : m_load_obj_exp(std::make_shared<std::regex>(
-		"^\\s*(?:%load%|load|oload|mload|wload)\\s+obj\\s+(\\d+)")) {}
-
 	virtual BaseDataFile::shared_ptr get_file(const EBootType mode, const std::string &file_name) override;
-
- private:
-	const regex_ptr_t m_load_obj_exp;
 };
 
 class TriggersFile : public DiscreteFile {
  public:
-	TriggersFile(const std::string &file_name, const DataFileFactoryImpl::regex_ptr_t &expression) : DiscreteFile(
-		file_name), m_load_obj_exp(expression) {}
+	TriggersFile(const std::string &file_name) : DiscreteFile(file_name) {}
 
 	virtual EBootType mode() const override { return DB_BOOT_TRG; }
 
-	static shared_ptr create(const std::string &file_name,
-							 const DataFileFactoryImpl::regex_ptr_t &expression) {
-		return shared_ptr(new TriggersFile(file_name,
-										   expression));
-	}
+	static shared_ptr create(const std::string &file_name) { return shared_ptr(new TriggersFile(file_name)); }
 
  private:
 	virtual void read_entry(const int nr) override;
 	void parse_trigger(int nr);
 	void LoadDgTriggerScript(Trigger *trig, const std::string &cmds, int vnum);
 	void LoadLuaTriggerScript(Trigger *trig, const std::string &cmds);
-
-	const DataFileFactoryImpl::regex_ptr_t m_load_obj_exp;
 };
 
 void TriggersFile::read_entry(const int nr) {
@@ -349,23 +332,6 @@ void TriggersFile::LoadDgTriggerScript(Trigger *trig, const std::string &cmds, i
 			while (it != (*ptr)->cmd.end() && (*it == ' ' || *it == '\t')) ++it;
 			while (it != (*ptr)->cmd.end() && *it != ' ') { *it = LOWER(*it); ++it; }
 			ptr = &(*ptr)->next;
-
-			std::smatch match;
-			if (std::regex_search(line, match, *m_load_obj_exp)) {
-				ObjVnum obj_num = std::stoi(match.str(1));
-				const auto tlist_it = obj2triggers.find(obj_num);
-				if (tlist_it != obj2triggers.end()) {
-					//const auto trig_f = std::find(tlist_it->second.begin(), tlist_it->second.end(), top_of_trigt);
-					const auto trig_f = std::find(tlist_it->second.begin(), tlist_it->second.end(), vnum);
-					if (trig_f == tlist_it->second.end()) {
-						//tlist_it->second.push_back(top_of_trigt);
-						tlist_it->second.push_back(vnum);
-					}
-				} else {
-					std::list<TrgVnum> tlist = {vnum};
-					obj2triggers.emplace(obj_num, tlist);
-				}
-			}
 		}
 		if (pos_end != std::string::npos)
 			pos_end = pos_end + 1;
@@ -1830,7 +1796,7 @@ BaseDataFile::shared_ptr DataFileFactoryImpl::get_file(const EBootType mode, con
 
 		case DB_BOOT_HLP:return HelpFile::create(file_name);
 
-		case DB_BOOT_TRG:return TriggersFile::create(file_name, m_load_obj_exp);
+		case DB_BOOT_TRG:return TriggersFile::create(file_name);
 
 
 		default:return nullptr;

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -119,14 +119,7 @@ Rooms &world = GlobalObjects::world();
 RoomRnum top_of_world = 0;    // ref to top element of world
 
 void AddTrigIndexEntry(int nr, Trigger *trig) {
-	IndexData *index;
-	CREATE(index, 1);
-	index->vnum = nr;
-	index->total_online = 0;
-	index->func = nullptr;
-	index->proto = trig;
-
-	trig_index[top_of_trigt++] = index;
+	world_loader::WorldDataSourceBase::CreateTriggerIndex(nr, trig);
 }
 
 IndexData **trig_index;    // index table for triggers

--- a/src/engine/db/world_data_source_base.cpp
+++ b/src/engine/db/world_data_source_base.cpp
@@ -115,6 +115,11 @@ IndexData* WorldDataSourceBase::CreateTriggerIndex(int vnum, Trigger *trig)
 	index->proto = trig;
 
 	trig_index[top_of_trigt++] = index;
+
+	// Индекс для 'vnum trig': какие триггеры грузят данный предмет. Строим его
+	// здесь -- через эту функцию проходит каждый триггер любого формата мира.
+	IndexTriggerObjLoads(vnum, trig);
+
 	return index;
 }
 

--- a/src/engine/scripting/dg_db_scripts.cpp
+++ b/src/engine/scripting/dg_db_scripts.cpp
@@ -23,11 +23,11 @@
 #include "gameplay/magic/magic_temp_spells.h"
 #include "engine/db/global_objects.h"
 #include "trigger_indenter.h"
-#include "utils/utils_string.h"
 
 #include <algorithm>
-#include <cstring>
+#include <charconv>
 #include <stack>
+#include <string_view>
 
 //External functions
 extern void ExtractTrigger(Trigger *trig);
@@ -41,54 +41,65 @@ extern IndexData *mob_index;
 
 namespace {
 
-// Разбирает строку триггера вида "<load|oload|mload|wload|%load%> obj <внум>".
-// Вызывается для каждой строки каждого триггера при загрузке мира, поэтому
-// разбор посимвольный, без regex.
-bool ParseObjLoadCommand(const std::string &command, ObjVnum &obj_vnum) {
-	static const char *const kLoadCommands[] = {"%load%", "oload", "mload", "wload", "load"};
+constexpr std::string_view kSpaces = " \t";
+constexpr std::string_view kLoadCommands[] = {"%load%", "oload", "mload", "wload", "load"};
+constexpr std::string_view kObjArgument = "obj";
 
-	auto is_space = [](const char c) { return c == ' ' || c == '\t'; };
-	auto skip_spaces = [&is_space](const char *&pos) {
-		while (is_space(*pos)) {
-			++pos;
+std::string_view SkipSpaces(std::string_view text) {
+	const auto pos = text.find_first_not_of(kSpaces);
+	return pos == std::string_view::npos ? std::string_view{} : text.substr(pos);
+}
+
+std::string_view FirstWord(std::string_view text) {
+	return text.substr(0, text.find_first_of(kSpaces));
+}
+
+// utils::IsAbbr() для string_view: непустое сокращение слова без учета регистра.
+bool IsAbbrOf(std::string_view abbr, std::string_view word) {
+	if (abbr.empty() || abbr.size() > word.size()) {
+		return false;
+	}
+
+	for (std::size_t i = 0; i < abbr.size(); ++i) {
+		if (LOWER(abbr[i]) != LOWER(word[i])) {
+			return false;
 		}
-	};
-
-	const char *pos = command.c_str();
-	skip_spaces(pos);
-
-	const char *args = nullptr;
-	for (const auto *load_command : kLoadCommands) {
-		const auto len = std::strlen(load_command);
-		if (!strn_cmp(pos, load_command, len) && is_space(pos[len])) {
-			args = pos + len;
-			break;
-		}
 	}
-	if (!args) {
-		return false;
-	}
-
-	// Первый аргумент разбираем так же, как рантайм в do_dgoload()/do_mload():
-	// IsAbbr(arg, "obj") -- без учета регистра и с сокращениями ("o", "ob", "obj").
-	pos = args;
-	skip_spaces(pos);
-	const char *arg = pos;
-	while (*pos && !is_space(*pos)) {
-		++pos;
-	}
-	const auto arg_len = static_cast<std::size_t>(pos - arg);
-	if (arg_len < 1 || arg_len > std::strlen("obj") || strn_cmp(arg, "obj", arg_len)) {
-		return false;
-	}
-
-	skip_spaces(pos);
-	if (*pos < '0' || *pos > '9') {
-		return false;
-	}
-	obj_vnum = std::atoi(pos);
 
 	return true;
+}
+
+bool IsSameWord(std::string_view lhs, std::string_view rhs) {
+	return lhs.size() == rhs.size() && IsAbbrOf(lhs, rhs);
+}
+
+// Разбирает строку скрипта вида "<load|oload|mload|wload|%load%> obj <внум>".
+bool ParseObjLoadCommand(std::string_view line, ObjVnum &obj_vnum) {
+	line = SkipSpaces(line);
+	const auto command = FirstWord(line);
+	if (std::none_of(std::begin(kLoadCommands), std::end(kLoadCommands),
+					 [command](const auto load_command) { return IsSameWord(command, load_command); })) {
+		return false;
+	}
+
+	// Аргументы сверяем так же, как рантайм в do_dgoload()/do_mload():
+	// IsAbbr(arg, "obj") -- без учета регистра и с сокращениями ("o", "ob", "obj"),
+	// внум -- строго число (иначе рантайм ругнется на синтаксис и ничего не загрузит).
+	line = SkipSpaces(line.substr(command.size()));
+	const auto argument = FirstWord(line);
+	if (!IsAbbrOf(argument, kObjArgument)) {
+		return false;
+	}
+
+	const auto number = FirstWord(SkipSpaces(line.substr(argument.size())));
+	if (number.empty() || number.front() == '-') {
+		return false;
+	}
+
+	const auto number_end = number.data() + number.size();
+	const auto parsed = std::from_chars(number.data(), number_end, obj_vnum);
+
+	return parsed.ec == std::errc() && parsed.ptr == number_end;
 }
 
 } // namespace

--- a/src/engine/scripting/dg_db_scripts.cpp
+++ b/src/engine/scripting/dg_db_scripts.cpp
@@ -23,7 +23,10 @@
 #include "gameplay/magic/magic_temp_spells.h"
 #include "engine/db/global_objects.h"
 #include "trigger_indenter.h"
+#include "utils/utils_string.h"
 
+#include <algorithm>
+#include <cstring>
 #include <stack>
 
 //External functions
@@ -35,6 +38,95 @@ trigger_to_owners_map_t owner_trig;
 extern int top_of_trigt;
 
 extern IndexData *mob_index;
+
+namespace {
+
+// Разбирает строку триггера вида "<load|oload|mload|wload|%load%> obj <внум>".
+// Вызывается для каждой строки каждого триггера при загрузке мира, поэтому
+// разбор посимвольный, без regex.
+bool ParseObjLoadCommand(const std::string &command, ObjVnum &obj_vnum) {
+	static const char *const kLoadCommands[] = {"%load%", "oload", "mload", "wload", "load"};
+
+	auto is_space = [](const char c) { return c == ' ' || c == '\t'; };
+	auto skip_spaces = [&is_space](const char *&pos) {
+		while (is_space(*pos)) {
+			++pos;
+		}
+	};
+
+	const char *pos = command.c_str();
+	skip_spaces(pos);
+
+	const char *args = nullptr;
+	for (const auto *load_command : kLoadCommands) {
+		const auto len = std::strlen(load_command);
+		if (!strn_cmp(pos, load_command, len) && is_space(pos[len])) {
+			args = pos + len;
+			break;
+		}
+	}
+	if (!args) {
+		return false;
+	}
+
+	// Первый аргумент разбираем так же, как рантайм в do_dgoload()/do_mload():
+	// IsAbbr(arg, "obj") -- без учета регистра и с сокращениями ("o", "ob", "obj").
+	pos = args;
+	skip_spaces(pos);
+	const char *arg = pos;
+	while (*pos && !is_space(*pos)) {
+		++pos;
+	}
+	const auto arg_len = static_cast<std::size_t>(pos - arg);
+	if (arg_len < 1 || arg_len > std::strlen("obj") || strn_cmp(arg, "obj", arg_len)) {
+		return false;
+	}
+
+	skip_spaces(pos);
+	if (*pos < '0' || *pos > '9') {
+		return false;
+	}
+	obj_vnum = std::atoi(pos);
+
+	return true;
+}
+
+} // namespace
+
+// Индекс "внум предмета -> триггеры, грузящие этот предмет" для команды 'vnum trig'.
+// Строится при загрузке мира -- одинаково для всех форматов (YAML/SQLite/Legacy).
+void IndexTriggerObjLoads(TrgVnum trig_vnum, const Trigger *trig) {
+	if (!trig->cmdlist) {
+		return;
+	}
+
+	for (auto cmd = *trig->cmdlist; cmd; cmd = cmd->next) {
+		ObjVnum obj_vnum = 0;
+		if (!ParseObjLoadCommand(cmd->cmd, obj_vnum)) {
+			continue;
+		}
+
+		auto &triggers = obj2triggers[obj_vnum];
+		if (std::find(triggers.begin(), triggers.end(), trig_vnum) == triggers.end()) {
+			triggers.push_back(trig_vnum);
+		}
+	}
+}
+
+// То же, но с предварительной чисткой старых записей триггера: скрипт мог
+// перестать грузить предмет, который грузил до правки в trigedit.
+void ReindexTriggerObjLoads(TrgVnum trig_vnum, const Trigger *trig) {
+	for (auto it = obj2triggers.begin(); it != obj2triggers.end();) {
+		it->second.remove(trig_vnum);
+		if (it->second.empty()) {
+			it = obj2triggers.erase(it);
+		} else {
+			++it;
+		}
+	}
+
+	IndexTriggerObjLoads(trig_vnum, trig);
+}
 
 // TODO: Get rid of me
 char *dirty_indent_trigger(char *cmd, int *level) {

--- a/src/engine/scripting/dg_olc.cpp
+++ b/src/engine/scripting/dg_olc.cpp
@@ -628,6 +628,11 @@ void trigedit_save(DescriptorData *d) {
 		}
 	}
 	
+	// Индекс "предмет -> грузящие его триггеры" строится при загрузке мира,
+	// так что для правленого скрипта его надо пересчитать -- иначе 'vnum trig'
+	// будет показывать старую картину до ближайшей перезагрузки.
+	ReindexTriggerObjLoads(OLC_NUM(d), trig_index[trig_rnum]->proto);
+
 	// Save trigger to disk using data source abstraction (YAML/SQLite/Legacy)
 	TriggerDistribution(d);
 	int notify_level = MAX(kLvlBuilder, GET_INVIS_LEV(d->character));

--- a/src/engine/scripting/dg_scripts.h
+++ b/src/engine/scripting/dg_scripts.h
@@ -413,6 +413,11 @@ void trig_log(Trigger *trig, std::string msg, LogMode type = LogMode::OFF);
 using obj2triggers_t = std::unordered_map<ObjVnum, std::list<TrgVnum>>;
 extern obj2triggers_t &obj2triggers;
 
+// Добавляет в obj2triggers предметы, которые грузит скрипт триггера (см. 'vnum trig').
+void IndexTriggerObjLoads(TrgVnum trig_vnum, const Trigger *trig);
+// То же, но сначала убирает прежние записи триггера -- для правки скрипта в trigedit.
+void ReindexTriggerObjLoads(TrgVnum trig_vnum, const Trigger *trig);
+
 class GlobalTriggersStorage {
  public:
 	~GlobalTriggersStorage();

--- a/src/engine/ui/cmd_god/do_tabulate.cpp
+++ b/src/engine/ui/cmd_god/do_tabulate.cpp
@@ -9,6 +9,7 @@
 #include "engine/db/obj_prototypes.h"
 #include "engine/olc/olc.h"
 #include "engine/db/global_objects.h"
+#include "utils/logger.h"
 #include "utils/utils_string.h"
 #include "utils/utils_time.h"
 
@@ -319,6 +320,16 @@ int TabulateTrigsByObjLoad(char *searchname, CharData *ch) {
 	int found = 0;
 	for (const auto &t : trigger->second) {
 		TrgRnum rnum = GetTriggerRnum(t);
+		if (rnum < 0) {
+			// Инвариант: триггеры из trig_index никогда не удаляются, так что
+			// внум из obj2triggers обязан существовать. Если сюда попали --
+			// индекс разошелся с trig_index (напр., в OLC добавили удаление
+			// триггера, не почистив obj2triggers). Читать trig_index[rnum]
+			// нельзя, продолжаем -- но это ошибка, а не штатная ситуация.
+			log("SYSERR: obj2triggers references trigger #%d with no rnum "
+				"(index out of sync with trig_index)", t);
+			continue;
+		}
 		SendMsgToChar(fmt::format("{:<3}. [{:>5}] {}\r\n",
 								  ++found, trig_index[rnum]->vnum, trig_index[rnum]->proto->get_name()), ch);
 	}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -54,6 +54,7 @@ test_sources = files(
     'extra_description.cpp',
     'trigger_indenter.cpp',
     'trigger_script_parser.cpp',
+    'trigger_obj_load_index.cpp',
     'yaml_loader_flag_packing.cpp',
     'yaml_mob_saves_resistances.cpp',
     'world_checksum_serialization.cpp',

--- a/tests/trigger_obj_load_index.cpp
+++ b/tests/trigger_obj_load_index.cpp
@@ -1,0 +1,141 @@
+// Part of Bylins http://www.mud.ru
+// Unit tests for the obj2triggers index (IndexTriggerObjLoads /
+// ReindexTriggerObjLoads), which backs the `vnum trig <obj vnum>` command:
+// "which triggers load this object".
+//
+// The index used to be built only by the legacy trigger parser, so on a
+// YAML/SQLite world `vnum trig` found nothing. It is now built for every
+// trigger of every world format, and refreshed when a script is edited in
+// trigedit.
+
+#include "engine/db/world_data_source_base.h"
+#include "engine/scripting/dg_scripts.h"
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <string>
+
+namespace {
+
+// Build a trigger whose cmdlist is parsed from the given script, exactly as
+// the world loaders do, and index the objects it loads.
+void IndexScript(Trigger &trig, TrgVnum trig_vnum, const std::string &script) {
+	world_loader::WorldDataSourceBase::ParseTriggerScript(&trig, script);
+	IndexTriggerObjLoads(trig_vnum, &trig);
+}
+
+bool Indexed(ObjVnum obj_vnum, TrgVnum trig_vnum) {
+	const auto it = obj2triggers.find(obj_vnum);
+	if (it == obj2triggers.end()) {
+		return false;
+	}
+	return std::find(it->second.begin(), it->second.end(), trig_vnum) != it->second.end();
+}
+
+} // namespace
+
+TEST(TriggerObjLoadIndex, IndexesEveryLoadCommandForm) {
+	Trigger trig;
+	IndexScript(trig, 5001,
+				"load obj 1001\n"
+				"oload obj 1002\n"
+				"mload obj 1003\n"
+				"wload obj 1004\n"
+				"%load% obj 1005\n");
+
+	EXPECT_TRUE(Indexed(1001, 5001));
+	EXPECT_TRUE(Indexed(1002, 5001));
+	EXPECT_TRUE(Indexed(1003, 5001));
+	EXPECT_TRUE(Indexed(1004, 5001));
+	EXPECT_TRUE(Indexed(1005, 5001));
+}
+
+// Trigger scripts are indented, and builders type commands in any case.
+TEST(TriggerObjLoadIndex, IgnoresIndentationAndCase) {
+	Trigger trig;
+	IndexScript(trig, 5002,
+				"if %actor.level% > 10\n"
+				"  MLOAD OBJ 1010\n"
+				"end\n");
+
+	EXPECT_TRUE(Indexed(1010, 5002));
+}
+
+// do_dgoload()/do_mload() match the argument with IsAbbr(arg, "obj"), so an
+// abbreviated "o"/"ob" really does load an object at runtime.
+TEST(TriggerObjLoadIndex, IndexesAbbreviatedObjArgument) {
+	Trigger trig;
+	IndexScript(trig, 5010,
+				"mload o 1070\n"
+				"oload ob 1071\n");
+
+	EXPECT_TRUE(Indexed(1070, 5010));
+	EXPECT_TRUE(Indexed(1071, 5010));
+}
+
+TEST(TriggerObjLoadIndex, SkipsCommandsThatDoNotLoadObjects) {
+	Trigger trig;
+	IndexScript(trig, 5003,
+				"mload mob 1020\n"
+				"say load obj 1021\n"
+				"mload obj\n"
+				"mloadobj 1022\n"
+				"mload obj vasya\n");
+
+	EXPECT_FALSE(Indexed(1020, 5003)) << "'mload mob' loads a mob, not an object";
+	EXPECT_FALSE(Indexed(1021, 5003)) << "load command must be the first word";
+	EXPECT_FALSE(Indexed(1022, 5003)) << "command name must be followed by whitespace";
+	EXPECT_EQ(obj2triggers.end(), obj2triggers.find(1022));
+}
+
+TEST(TriggerObjLoadIndex, ListsTriggerOnceEvenIfItLoadsObjectTwice) {
+	Trigger trig;
+	IndexScript(trig, 5004,
+				"mload obj 1030\n"
+				"mload obj 1030\n");
+
+	const auto it = obj2triggers.find(1030);
+	ASSERT_NE(obj2triggers.end(), it);
+	EXPECT_EQ(1u, std::count(it->second.begin(), it->second.end(), 5004));
+}
+
+TEST(TriggerObjLoadIndex, ListsEveryTriggerLoadingTheSameObject) {
+	Trigger first;
+	Trigger second;
+	IndexScript(first, 5005, "mload obj 1040\n");
+	IndexScript(second, 5006, "oload obj 1040\n");
+
+	EXPECT_TRUE(Indexed(1040, 5005));
+	EXPECT_TRUE(Indexed(1040, 5006));
+}
+
+// After a trigedit save the script may no longer load what it used to.
+TEST(TriggerObjLoadIndex, ReindexDropsObjectsTheScriptNoLongerLoads) {
+	Trigger trig;
+	IndexScript(trig, 5007, "mload obj 1050\n");
+	ASSERT_TRUE(Indexed(1050, 5007));
+
+	Trigger edited;
+	world_loader::WorldDataSourceBase::ParseTriggerScript(&edited, "mload obj 1051\n");
+	ReindexTriggerObjLoads(5007, &edited);
+
+	EXPECT_FALSE(Indexed(1050, 5007)) << "stale entry must be dropped";
+	EXPECT_TRUE(Indexed(1051, 5007));
+}
+
+// Reindexing one trigger must not evict other triggers loading the same object.
+TEST(TriggerObjLoadIndex, ReindexKeepsOtherTriggersOfTheSameObject) {
+	Trigger keeper;
+	Trigger edited;
+	IndexScript(keeper, 5008, "mload obj 1060\n");
+	IndexScript(edited, 5009, "mload obj 1060\n");
+
+	Trigger rewritten;
+	world_loader::WorldDataSourceBase::ParseTriggerScript(&rewritten, "say nothing to load here\n");
+	ReindexTriggerObjLoads(5009, &rewritten);
+
+	EXPECT_TRUE(Indexed(1060, 5008));
+	EXPECT_FALSE(Indexed(1060, 5009));
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/trigger_obj_load_index.cpp
+++ b/tests/trigger_obj_load_index.cpp
@@ -73,6 +73,22 @@ TEST(TriggerObjLoadIndex, IndexesAbbreviatedObjArgument) {
 	EXPECT_TRUE(Indexed(1071, 5010));
 }
 
+// do_dgoload() refuses to load anything unless the vnum is a plain number, so
+// neither must the index accept one -- otherwise `vnum trig` reports a trigger
+// that in fact loads nothing.
+TEST(TriggerObjLoadIndex, SkipsVnumsThatAreNotPlainNumbers) {
+	Trigger trig;
+	IndexScript(trig, 5011,
+				"mload obj %loaditem%\n"
+				"mload obj 1080abc\n"
+				"mload obj -1081\n"
+				"mload obj 99999999999999999999\n");
+
+	EXPECT_EQ(obj2triggers.end(), obj2triggers.find(1080)) << "trailing garbage is not a vnum";
+	EXPECT_EQ(obj2triggers.end(), obj2triggers.find(-1081)) << "negative vnum is refused by the runtime";
+	EXPECT_FALSE(Indexed(0, 5011)) << "an overflowing vnum must not be indexed as anything";
+}
+
 TEST(TriggerObjLoadIndex, SkipsCommandsThatDoNotLoadObjects) {
 	Trigger trig;
 	IndexScript(trig, 5003,


### PR DESCRIPTION
Fixes #3556

## Проблема

`vnum trig <внум предмета>` (из каких триггеров грузится предмет) на YAML-мире всегда отвечал «Нет триггеров, загружающих такой объект». На SQLite — то же; работало только в Legacy-сборке.

Команда читает индекс `obj2triggers`, а заполнял его ровно один загрузчик — legacy-парсер триггеров (`boot_data_files.cpp`), прогонявший каждую строку скрипта через regex `^\s*(?:%load%|load|oload|mload|wload)\s+obj\s+(\d+)`. YAML/SQLite разбирают скрипты общим кодом `WorldDataSourceBase::ParseTriggerScript()`, который ничего не индексировал. Так как YAML — формат мира по умолчанию, команда не работала ни у кого.

## Что сделано

**1. Индекс строится для всех форматов мира** (`c27b6fe`)

Индексация переехала в `WorldDataSourceBase::CreateTriggerIndex()` — единую точку, через которую регистрируется каждый триггер любого формата. `AddTrigIndexEntry()` (legacy-путь) теперь делегирует туда, дублирующее тело убрано. Из legacy-парсера удалена вся regex-машинерия (`m_load_obj_exp`, лишний параметр конструктора `TriggersFile`, `#include <regex>`).

Разбор строки — посимвольный, без regex. Заодно исправлено расхождение с рантаймом: `do_dgoload()`/`do_mload()` сверяют первый аргумент через `IsAbbr(arg, "obj")`, то есть без учёта регистра и с сокращениями, поэтому `MLOAD OBJ 100` и `mload o 100` реально грузят предмет — прежний regex такие строки не видел.

**2. Индекс обновляется при сохранении триггера в trigedit** (`73ad0bd`)

Раньше индекс строился только на загрузке мира, и после правки скрипта `vnum trig` до перезагрузки показывал устаревшую картину (пропавшие загрузки числились, новые не появлялись). Это ломалось и в Legacy.

## Проверка

- Новый юнит-тест `tests/trigger_obj_load_index.cpp` (8 кейсов): все формы команд загрузки, регистр и отступы, сокращения аргумента, отсев `mload mob`/`say load obj`/`mloadobj`, дедупликация, несколько триггеров на один предмет, чистка устаревших записей при реиндексе.
- Загрузка small YAML-мира: индекс покрывает **262 предмета** (до фикса — пусто), сервер входит в игровой цикл без SYSERR.
- `tests/tests` (затронутые сьюты) — зелёные.
