### PR TITLE
fix(put): разрешить укладку kRepopDecay-предметов в контейнеры (#3559)

### DIFF
--- a/src/engine/ui/cmd/do_put.cpp
+++ b/src/engine/ui/cmd/do_put.cpp
@@ -70,7 +70,15 @@ int perform_put(CharData *ch, ObjData::shared_ptr obj, ObjData *cont) {
 	else if (obj->has_flag(EObjFlag::kNodrop)) {
 		act("Неведомая сила помешала положить $o3 в $O3.", false, ch, obj.get(), cont, kToChar);
 	}
-	else if (obj->is_unrentable()) {
+	// Обычный контейнер в комнате -- не постоянное хранилище, поэтому
+	// нерентуемость предмета (kRepopDecay/kNorent/rent_off<0 -> is_unrentable())
+	// не должна мешать положить его внутрь. Постоянные хранилища (рент/depot/
+	// сундук клана) обработаны выше и сами применяют is_unrentable(). Здесь
+	// возвращаем прежнюю узкую проверку: блокируем только zone-decay и ключи
+	// (анти-стеш). См. issue #3371: в квесте зоны 65 гнездо (obj 6505,
+	// kRepopDecay) нужно положить в молодое дерево (obj 6504) -- расширенная
+	// проверка is_unrentable() это сломала.
+	else if (obj->has_flag(EObjFlag::kZonedecay) || obj->get_type() == EObjType::kKey) {
 		act("Неведомая сила помешала положить $o3 в $O3.", false, ch, obj.get(), cont, kToChar);
 	}
 	else {


### PR DESCRIPTION
## Проблема

`do_put` (`perform_put`) с коммита `6eb087f0a` блокирует укладку предмета в контейнер по `is_unrentable()`, которая истинна в т.ч. для **`kRepopDecay`**. В итоге такие предметы нельзя положить ни в один контейнер, включая обычные контейнеры в комнате.

Проявление (#3559): квест «Сказка для охотника» (зона 65) — гнездо `6505` (kRepopDecay) нельзя положить в молодое дерево `6504` → «Неведомая сила помешала...», птичка улетает, квест не завершается. Подтверждено логами боевого сервера.

## Почему блок стал избыточным

Repop-decay держали вне контейнеров, чтобы ускорить очистку репопа (она не искала предметы внутри контейнеров). Причина снята текущим алгоритмом:

- `DecayObjectsOnRepop()` (`game_limits.cpp`) обходит зону через `WorldObjects::foreach_in_zone()` → `m_zone_to_object_ptr`, индексирующий все объекты зоны независимо от места (земля/инвентарь/контейнер), и удаляет все `kRepopDecay`;
- рассыпание в контейнере не беззвучно — `ExtractRepopDecayObject()` сообщает владельцу.

Постоянные хранилища (рент/склад/сундук клана) обрабатываются в `do_put` выше и сами зовут `is_unrentable()` — их поведение не меняется.

## Фикс

Возвращаем прежнюю узкую проверку для обычных контейнеров: блокируем только zone-decay и ключи.

```diff
-	else if (obj->is_unrentable()) {
+	else if (obj->has_flag(EObjFlag::kZonedecay) || obj->get_type() == EObjType::kKey) {
```

`is_unrentable()` остальные вызыватели (rent/depot/clan/parcel/exchange/shops) не тронуты.

## Связь

- Closes #3559
- Refs #3371 / #3372 — недетерминированная укладка гнезда на ресете (движок починен в #3372). Точечная правка данных зоны 65 (`P 0 6505 6510 6503`) — в `bylins/world`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
