### PR TITLE
fix(observability): не терять обращения к богам (окно [5m])

### DIFF
--- a/tools/observability/grafana/provisioning/alerting/god-appeals.yaml
+++ b/tools/observability/grafana/provisioning/alerting/god-appeals.yaml
@@ -23,6 +23,12 @@ apiVersion: 1
 # Время — .StartsAt (момент срабатывания, ~≤1 мин от события); TZ=Europe/Moscow
 # у контейнера grafana → .Local печатает МСК.
 #
+# Окно count_over_time — [5m] (НЕ [1m]!) при оценке раз в минуту. Причина: строку,
+# залогированную за ~10с до тика оценки, Loki ещё не успевает принять (otel батчит
+# ~5с), а к следующему тику она уже выпадает из узкого [1m]-окна → событие терялось
+# навсегда. С [5m] у события ~5 попыток попасть в оценку. Дублей нет: алёрт срабатывает
+# один раз, держится, пока строка в окне (~5 мин), и резолвится (disableResolveMessage).
+#
 # Токен бота — из env (${BYLINS_ROOSTER_TOKEN}; tools/observability/.env, gitignored).
 # chatid — литералом строкой: не секрет, а через env нельзя (Grafana при подстановке
 # ${...} теряет кавычки, число ломает провижининг). Так же сделан deadman.yaml.
@@ -80,7 +86,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 60
+              from: 300
               to: 0
             datasourceUid: loki
             model:
@@ -88,14 +94,14 @@ groups:
                 type: loki
                 uid: loki
               editorMode: code
-              expr: 'sum by (who, room, text) (count_over_time({service_name="bylins-bylins-new-4000"} |~ `\[возз` | regexp `^<(?P<who>[^>]+)> \{\s*(?P<room>\d+)\} \[возз\S*\s*(?P<msg>.*)\]` | who =~ `.+` | who !~ `^(Стрибог|Сквиз|Сварог|Магни|Свентовит|Переплут|Бодрич|Числобог|Спорыш|Хорс|Белун|Руевит|Купала|Бальдр|Хмель)$` | label_format text=`{{ regexReplaceAll ">" (regexReplaceAll "<" (regexReplaceAll "&" .msg "&amp;") "&lt;") "&gt;" }}` [1m]))'
+              expr: 'sum by (who, room, text) (count_over_time({service_name="bylins-bylins-new-4000"} |~ `\[возз` | regexp `^<(?P<who>[^>]+)> \{\s*(?P<room>\d+)\} \[возз\S*\s*(?P<msg>.*)\]` | who =~ `.+` | who !~ `^(Стрибог|Сквиз|Сварог|Магни|Свентовит|Переплут|Бодрич|Числобог|Спорыш|Хорс|Белун|Руевит|Купала|Бальдр|Хмель)$` | label_format text=`{{ regexReplaceAll ">" (regexReplaceAll "<" (regexReplaceAll "&" .msg "&amp;") "&lt;") "&gt;" }}` [5m]))'
               queryType: instant
               intervalMs: 1000
               maxDataPoints: 43200
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 60
+              from: 300
               to: 0
             datasourceUid: __expr__
             model:
@@ -108,7 +114,7 @@ groups:
                 uid: __expr__
           - refId: C
             relativeTimeRange:
-              from: 60
+              from: 300
               to: 0
             datasourceUid: __expr__
             model:
@@ -144,7 +150,7 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 60
+              from: 300
               to: 0
             datasourceUid: loki
             model:
@@ -152,14 +158,14 @@ groups:
                 type: loki
                 uid: loki
               editorMode: code
-              expr: 'sum by (who, to, room, text) (count_over_time({service_name="bylins-bylins-new-4000"} |~ `\[возз` | regexp `^<(?P<who>[^>]+)> \{\s*(?P<room>\d+)\} \[возз\S*\s+(?P<to>\S+)\s+(?P<msg>.*)\]` | who =~ `^(Стрибог|Сквиз|Сварог|Магни|Свентовит|Переплут|Бодрич|Числобог|Спорыш|Хорс|Белун|Руевит|Купала|Бальдр|Хмель)$` | label_format text=`{{ regexReplaceAll ">" (regexReplaceAll "<" (regexReplaceAll "&" .msg "&amp;") "&lt;") "&gt;" }}` [1m]))'
+              expr: 'sum by (who, to, room, text) (count_over_time({service_name="bylins-bylins-new-4000"} |~ `\[возз` | regexp `^<(?P<who>[^>]+)> \{\s*(?P<room>\d+)\} \[возз\S*\s+(?P<to>\S+)\s+(?P<msg>.*)\]` | who =~ `^(Стрибог|Сквиз|Сварог|Магни|Свентовит|Переплут|Бодрич|Числобог|Спорыш|Хорс|Белун|Руевит|Купала|Бальдр|Хмель)$` | label_format text=`{{ regexReplaceAll ">" (regexReplaceAll "<" (regexReplaceAll "&" .msg "&amp;") "&lt;") "&gt;" }}` [5m]))'
               queryType: instant
               intervalMs: 1000
               maxDataPoints: 43200
               refId: A
           - refId: B
             relativeTimeRange:
-              from: 60
+              from: 300
               to: 0
             datasourceUid: __expr__
             model:
@@ -172,7 +178,7 @@ groups:
                 uid: __expr__
           - refId: C
             relativeTimeRange:
-              from: 60
+              from: 300
               to: 0
             datasourceUid: __expr__
             model:


### PR DESCRIPTION
## Проблема

Правила пересылки обращений/ответов богов (влиты в #3558) теряли часть событий: воззвание или ответ, залогированные за ~10с до тика поминутной оценки, не пересылались в канал.

## Причина

Окно `count_over_time(... [1m])` при оценке раз в минуту. Строку, попавшую в Loki за ~10с до тика, otel ещё не успевал доставить (батч ~5с + сеть), поэтому в оценке она отсутствовала. К следующему тику (через минуту) строка уже выпадала из узкого `[1m]`-окна → событие терялось навсегда.

Подтверждено на реальном инциденте: ответ бога с меткой Loki `21:36:28` не попал ни в оценку `21:36:35` (ещё не принят), ни в `21:37:35` (уже вне окна). Соседний ответ с меткой `21:38:22` (13с до тика) успел приняться и прошёл.

## Фикс

Окно `[1m]` → `[5m]` (оценка по-прежнему раз в минуту). Событие попадает в ~5 оценок подряд — лаг приёма Loki перестаёт его ронять. Дублей нет: алёрт срабатывает один раз при первом попадании и держится, пока строка в окне (~5 мин), затем резолвится молча (`disableResolveMessage`).

Проверено пушем в Loki: оба правила ловят события (`framesLength≥1`), доставка без ошибок.
