### PR TITLE
diag(obj): log obj_from_char for player charmices too (#3563)

### DIFF
--- a/src/gameplay/mechanics/inventory.cpp
+++ b/src/gameplay/mechanics/inventory.cpp
@@ -258,6 +258,12 @@ void RemoveObjFromChar(ObjData *object) {
 	if (!object->get_carried_by()->IsNpc()) {
 		object->get_carried_by()->SetFlag(EPlrFlag::kCrashSave);
 		log("obj_from_char: %s -> %d", object->get_carried_by()->get_name().c_str(), GET_OBJ_VNUM(object));
+	} else {
+		// issue #3563: трейс ухода из инвентаря чармиса игрока (игрок -- ветка выше)
+		const std::string who = ObjHolderLogDesc(object->get_carried_by());
+		if (!who.empty()) {
+			log("obj_from_char: %s -> %d", who.c_str(), GET_OBJ_VNUM(object));
+		}
 	}
 
 	IS_CARRYING_W(object->get_carried_by()) -= object->get_weight();


### PR DESCRIPTION
Догоняющий к #3566.

`obj_from_char` (в `RemoveObjFromChar`) трейсил уход вещи из инвентаря только у **игрока** (`!IsNpc`), у **чармисов** — нет. Именно поэтому пропажа из инвентаря чармиса не светилась в сислоге.

Добавляем: для NPC-держателя пишем через `ObjHolderLogDesc`, так что уход вещи из инвентаря чармиса игрока тоже попадает в лог — с именем чармиса и владельца. Обычные мобы не логируются (desc пустой). Флаг `kCrashSave` остаётся только у игрока.

```
obj_from_char: чармиса 'скелет' игрока Марея -> 1234
```

Связано с #3563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)