### PR TITLE
fix(obj-save): bound get_buf_line/get_buf_lines to buffer size (#3568)

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -113,8 +113,13 @@ enum {
 	RENT_TIMEDOUT, // заренчен после idle_rent_time
 };
 
+// issue #3568: все вызывающие передают буфер размера kMaxStringLength, поэтому
+// пишем не дальше него -- иначе строка из файла длиннее буфера затирала память
+// за границей (порча кучи/стека). При переполнении обрезаем и пишем в лог.
 int get_buf_line(char **source, char *target) {
 	char *otarget = target;
+	char *const limit = target + kMaxStringLength - 1;    // резерв под '\0'
+	bool truncated = false;
 	int empty = true;
 
 	*target = '\0';
@@ -130,6 +135,17 @@ int get_buf_line(char **source, char *target) {
 			(*source)++;
 			return (true);
 		}
+		if (target >= limit) {    // граница буфера: дочитываем строку, но не пишем
+			if (!truncated) {
+				truncated = true;
+				char msg[256];
+				snprintf(msg, sizeof(msg),
+						"SYSERR: get_buf_line: строка обрезана до %d байт (предотвращено переполнение буфера)",
+						kMaxStringLength);
+				mudlog(msg, NRM, kLvlGod, SYSLOG, true);   // #3568: в mudlog -- боги видят сразу
+			}
+			continue;
+		}
 		*target = **source;
 		if (!isspace(static_cast<unsigned char>(*target++)))
 			empty = false;
@@ -139,8 +155,10 @@ int get_buf_line(char **source, char *target) {
 }
 
 int get_buf_lines(char **source, char *target) {
-	*target = '\0';
+	char *const limit = target + kMaxStringLength - 1;    // резерв под '\0'
+	bool truncated = false;
 
+	*target = '\0';
 	for (; **source && **source != DIV_CHAR && **source != END_CHAR; (*source)++) {
 		if (**source == END_LINES) {
 			(*source)++;
@@ -149,6 +167,17 @@ int get_buf_lines(char **source, char *target) {
 			if (**source == END_LINE)
 				(*source)++;
 			return (true);
+		}
+		if (target >= limit) {    // граница буфера: дочитываем блок, но не пишем
+			if (!truncated) {
+				truncated = true;
+				char msg[256];
+				snprintf(msg, sizeof(msg),
+						"SYSERR: get_buf_lines: блок обрезан до %d байт (предотвращено переполнение буфера)",
+						kMaxStringLength);
+				mudlog(msg, NRM, kLvlGod, SYSLOG, true);   // #3568: в mudlog -- боги видят сразу
+			}
+			continue;
 		}
 		*(target++) = **source;
 		*target = '\0';


### PR DESCRIPTION
Хардининг парсеров рент-файлов, найденных при разборе #3568.

## Проблема

`get_buf_line` (obj_save.cpp:116) и `get_buf_lines` (141) писали каждый символ в `target` **без проверки длины**:

```cpp
*target = **source;
... *target++ ...
*target = '\0';   // растёт без ограничения
```

Все вызывающие (`obj_save.cpp`, `exchange.cpp`, `parcel.cpp`) передают `char buffer[kMaxStringLength]` (32768). Строка/блок из файла длиннее буфера → запись **за границу** → латентное переполнение (порча кучи/стека).

## Фикс

Ограничиваем запись `kMaxStringLength - 1`. При переполнении:
- дочитываем строку/блок до конца (парсинг остаётся в синхроне),
- но не пишем за границу буфера,
- один раз пишем `SYSERR` в syslog, чтобы такие файлы было видно.

Сигнатуру не меняем — все вызывающие используют буфер ровно `kMaxStringLength`, так что граница едина.

## Про #3568

Само падение (`malloc(): corrupted top size` в crash-save) — **отложенное** обнаружение порчи, и у конкретного игрока (Скегги) строк >32768 в ренте нет, так что этот фикс, возможно, не прямая причина именно того крэша. Но это **реальный overflow-баг** в пути сериализации предметов — чиним независимо. Точную причину #3568 добьёт ASAN.

Связано с #3568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)