### PR TITLE
build: add 'hunt' profile (release + _FORTIFY_SOURCE=2)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,16 @@ project_args = []
 dependencies = []
 
 build_profile = get_option('build_profile')
+
+# hunt: собираем ровно как release, но с -D_FORTIFY_SOURCE=2 -- дешёвый (околонулевой
+# оверхед) ловец переполнений фиксированных буферов в sprintf/strcpy/memcpy и т.п.,
+# падает в момент записи за границу с бэктрейсом. Дальше ведём себя как release.
+fortify_source = false
+if build_profile == 'hunt'
+    build_profile = 'release'
+    fortify_source = true
+endif
+
 buildtype = {'release': 'Release', 'debug': 'Debug', 'dev': 'Dev', 'fasttest': 'FastTest', 'custom': 'Custom'}[build_profile]
 
 if build_profile in ['dev', 'fasttest']
@@ -37,6 +47,10 @@ if cpp.get_argument_syntax() == 'gcc'
         project_args += ['-Ofast']
     endif
     project_args += ['-Wno-format-truncation']
+    if fortify_source
+        # -U на случай, если тулчейн уже определил _FORTIFY_SOURCE (иначе redefine-варнинг)
+        project_args += ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=2']
+    endif
     if host_system != 'windows' and build_profile != 'fasttest'
         add_project_link_arguments('-rdynamic', language: 'cpp')
     endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('build_profile', type: 'combo',choices: ['release', 'debug', 'dev', 'fasttest', 'custom'],value: 'release',description: 'Build profile: release/debug - ggdb3 O0, debug adds ASAN; dev - O3 + TEST_BUILD; fasttest - Ofast + TEST_BUILD; custom - no specific flags')
+option('build_profile', type: 'combo',choices: ['release', 'debug', 'dev', 'fasttest', 'custom', 'hunt'],value: 'release',description: 'Build profile: release/debug - ggdb3 O0, debug adds ASAN; dev - O3 + TEST_BUILD; fasttest - Ofast + TEST_BUILD; custom - no specific flags; hunt - как release + _FORTIFY_SOURCE=2 (дешёвый ловец переполнений буферов)')
 
 option('linker', type: 'string', value: '', description: 'Linker to use: gold, mold, lld, bfd, or empty for system default')
 option('build_tests', type: 'boolean', value: true, description: 'Build and run tests.')


### PR DESCRIPTION
Новый build-профиль **`hunt`** для охоты за порчей кучи (#3568), где ASAN на проде неприемлем по производительности (лаг 5-7 сек раз в минуту).

## Что

`hunt` собирается **ровно как release** (`-Og`, ggdb3), но добавляет `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2`:
- **околонулевой оверхед** (не ASAN) — можно держать на проде/зеркале;
- компилятор вставляет проверки в `sprintf`/`snprintf`/`strcpy`/`strcat`/`memcpy`/`memset` с известным размером буфера;
- при записи за границу — падение **в момент** с `*** buffer overflow detected ***` и бэктрейсом на виноватой функции (а не отложенно на crash-save, как сейчас).

## Реализация

При `build_profile == 'hunt'` переназначаем его в `'release'` (чтобы вести себя как релиз во всех веток meson) и поднимаем `fortify_source`, который добавляет флаг в gcc-ветке. `-U` — на случай, если тулчейн уже определил `_FORTIFY_SOURCE`.

## Проверено

Локально `meson setup build_hunt -Dbuild_profile=hunt` + полная сборка — компилится чисто при `-Og`, никаких fortify-варнингов, `_FORTIFY_SOURCE=2` в compile_commands подтверждён.

Использование:
```bash
meson setup build_hunt -Dbuild_profile=hunt -Dbuild_tests=false
ninja -C build_hunt -j$(($(nproc)/2))
```

Связано с #3568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)