### PR TITLE
build(hunt): label build as "Hunt" in version string (#3568)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,11 @@ if build_profile == 'hunt'
 endif
 
 buildtype = {'release': 'Release', 'debug': 'Debug', 'dev': 'Dev', 'fasttest': 'FastTest', 'custom': 'Custom'}[build_profile]
+if fortify_source
+    # hunt ведёт себя как release, но в версии/summary помечаем отдельно, чтобы было
+    # видно, что бинарь собран с _FORTIFY_SOURCE (иначе писал бы "Release").
+    buildtype = 'Hunt'
+endif
 
 if build_profile in ['dev', 'fasttest']
     project_args += ['-DTEST_BUILD']


### PR DESCRIPTION
Догоняющий к #3571.

Профиль `hunt` внутри переназначается в `release` (чтобы вести себя как релиз), из-за чего в строке версии писалось **`(Release)`** — и hunt-бинарь было не отличить от обычного релиза.

Помечаем `buildtype = 'Hunt'` при `fortify_source`. Теперь:
```
const char* revision = "c92d83516 (Hunt)";
```
видно в игре (`revision`), в стартовом логе и в meson-summary (`Build Type: Hunt`).

Проверено на `build_hunt` — `version.cpp` содержит `(Hunt)`.

Связано с #3568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)