### PR TITLE
fix(trigedit): bound DG cmdlist copy into OLC storage — heap overflow (#3568)

### DIFF
--- a/src/engine/scripting/dg_olc.cpp
+++ b/src/engine/scripting/dg_olc.cpp
@@ -81,9 +81,24 @@ void TrigeditLoadStorageFromTrigger(Trigger *trig, char *storage)
 		return;
 	}
 	if (trig->cmdlist) {
+		// issue #3568: storage -- heap-буфер размера MAX_CMD_LENGTH. Раньше strcat всех
+		// команд шёл БЕЗ границы, и при DG-скрипте длиннее буфера переполнял кучу
+		// (crash-save потом ловил "corrupted top size"). Ограничиваем по размеру буфера.
+		size_t used = strlen(storage);
 		for (auto c = *trig->cmdlist; c; c = c->next) {
+			const size_t need = c->cmd.size() + 2;    // команда + "\r\n"
+			if (used + need >= MAX_CMD_LENGTH) {
+				char m[256];
+				snprintf(m, sizeof(m),
+						"SYSERR: TrigeditLoadStorageFromTrigger: DG-скрипт триггера #%d не влез "
+						"в буфер %d байт -- обрезан (предотвращено переполнение)",
+						GET_TRIG_VNUM(trig), MAX_CMD_LENGTH);
+				mudlog(m, NRM, kLvlGod, SYSLOG, true);
+				break;
+			}
 			strcat(storage, c->cmd.c_str());
 			strcat(storage, "\r\n");
+			used += need;
 		}
 	}
 }


### PR DESCRIPTION
> **Апдейт:** это **НЕ причина #3568** (root cause — Lua-wait UAF в trigedit_save, см. #3575). Таких больших триггеров (>32768) нет, и при их наличии крешило бы на любом trigedit/tstat, а не только при переключении Lua↔DG. Оставляю как **хардининг** (реальный latent overflow), но `Closes` снял.

Хардининг парсинга в OLC-редакторе триггеров.

## Баг (latent)

`TrigeditLoadStorageFromTrigger` (dg_olc.cpp) грузит DG-скрипт в буфер редактора `OLC_STORAGE` (heap, `MAX_CMD_LENGTH = 32768`) через `strcat` **всех команд подряд без границы**:

```cpp
if (TrigeditIsLuaTrigger(trig)) {
    strncat(storage, ..., MAX_CMD_LENGTH - 1);  // ограничено
    return;
}
if (trig->cmdlist) {
    for (auto c = *trig->cmdlist; c; c = c->next) {
        strcat(storage, c->cmd.c_str());   // ← без границы
        strcat(storage, "\r\n");
    }
}
```

Lua-ветку ограничили, DG — нет. При DG-скрипте > 32768 байт — переполнение кучи. Сейчас таких триггеров нет, поэтому не стреляет, но дыра реальная.

## Фикс

Ограничиваем DG-ветку размером буфера + `mudlog` при обрезке (какой триггер #vnum слишком большой).

Related to #3568 (root cause — #3575).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
