### PR TITLE
fix(trigedit): cancel Lua waits when saving/replacing live trigger — UAF (#3568)

### DIFF
--- a/src/engine/scripting/dg_olc.cpp
+++ b/src/engine/scripting/dg_olc.cpp
@@ -31,6 +31,9 @@
 #include "engine/db/world_data_source_manager.h"
 #include "dg_db_scripts.h"
 #include "gameplay/mechanics/dungeons.h"
+#if defined(WITH_LUAJIT_PROTOTYPE)
+#include "engine/scripting/lua/lua_script_engine.h"   // CancelWaitsForTrigger (issue #3568)
+#endif
 
 extern const char *trig_types[], *otrig_types[], *wtrig_types[];
 extern DescriptorData *descriptor_list;
@@ -562,6 +565,13 @@ void trigedit_save(DescriptorData *d) {
 					free(GET_TRIG_WAIT(trigger).info);    // Причина уже обсуждалась
 					remove_event(GET_TRIG_WAIT(trigger));
 				}
+#if defined(WITH_LUAJIT_PROTOTYPE)
+				// issue #3568: у живого инстанса может висеть приостановленная Lua-корутина
+				// (LuaWaitState хранит Trigger*). Перезапись тела ниже (*trigger = *proto),
+				// особенно при смене Lua->DG, оставила бы вейт-реестр ссылаться на изменённый
+				// триггер -> UAF/порча кучи. Отменяем Lua-вейты, как это делает ExtractTrigger.
+				lua_scripting::LuaScriptEngine::CancelWaitsForTrigger(trigger);
+#endif
 
 				trigger->clear_var_list();
 				*trigger = *proto;


### PR DESCRIPTION
> **Апдейт:** это **латентный фикс, но НЕ подтверждённый корень #3568.** Единственный существующий Lua-триггер отрабатывает за ~2ms без `wait`, значит `LuaWaitState` для него не создаётся и отменять нечего. Так что данный UAF-путь на текущем контенте не стреляет. Оставляю как корректность/хардининг (будущий Lua-триггер с `wait`, отредактированный на живом инстансе, на это напорется). `Closes` снял.

## Проблема (корректность)

`trigedit_save` при коммите правки обновляет живые инстансы триггера и отменяет **только DG-wait**, а Lua-wait — нет:

```cpp
if (GET_TRIG_WAIT(trigger).time_remaining > 0) {  // только DG
    free(GET_TRIG_WAIT(trigger).info);
    remove_event(GET_TRIG_WAIT(trigger));
}
*trigger = *proto;   // перезапись тела
```

`LuaWaitState` хранит сырой `Trigger*` (сравнение по указателю в `CancelForTrigger`). Если у инстанса висит приостановленная Lua-корутина, перезапись тела оставит вейт-реестр ссылаться на изменённый триггер → use-after-free. `ExtractTrigger` (удаление) `CancelWaitsForTrigger` зовёт, а путь обновления в `trigedit_save` — нет.

## Фикс

`LuaScriptEngine::CancelWaitsForTrigger(trigger)` в цикле обновления инстансов, симметрично `ExtractTrigger`. Под `#if defined(WITH_LUAJIT_PROTOTYPE)`. Собрано с `-Dluajit=builtin` и в дефолте.

Related to #3568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
