### PR TITLE
diag(sign): log custom-label set/erase to syslog (#3568)

### DIFF
--- a/src/engine/ui/cmd/do_sign.cpp
+++ b/src/engine/ui/cmd/do_sign.cpp
@@ -66,6 +66,10 @@ void DoSign(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		} else {
 			if (erase_only) {
 				target->remove_custom_label();
+				// issue #3568: логируем операции с метками -- для корреляции в Loki
+				// (custom_label нарушает rule-of-3, подозреваем double-free).
+				log("[Custom label] %s стёр метку с %s #%d",
+						GET_NAME(ch), target->get_short_description().c_str(), GET_OBJ_VNUM(target));
 				act("Вы затерли надписи на $o5.", false, ch, target, nullptr, kToChar);
 			} else if (labels) {
 				if (strlen(labels) > kMaxLabelLength)
@@ -87,6 +91,11 @@ void DoSign(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					msg = "Вы покрыли $o3 каракулями, понятными разве что вашим соратникам.";
 				}
 				target->set_custom_label(label);
+				// issue #3568: логируем операции с метками -- для корреляции в Loki
+				// (custom_label нарушает rule-of-3, подозреваем double-free).
+				log("[Custom label] %s нанёс метку '%s'%s на %s #%d",
+						GET_NAME(ch), labels, clan ? " (клан)" : "",
+						target->get_short_description().c_str(), GET_OBJ_VNUM(target));
 				act(msg, false, ch, target, nullptr, kToChar);
 			}
 		}


### PR DESCRIPTION
По идее Квирунда — залогировать операции с кастомными метками, чтобы их было видно в Loki и коррелировать с крэшами #3568.

## Что

Команда **«нацарапать»** (`DoSign`) раньше писала только сообщения игроку, в syslog — ничего. Добавляем `log()` в двух точках:
- **нанесение метки** (`set_custom_label`): кто, текст метки, личная/клановая, вещь + vnum;
- **стирание** (`remove_custom_label`): кто, вещь + vnum.

```
[Custom label] Марея нанёс метку 'моё' на меч #1234
[Custom label] Марея стёр метку с меч #1234
```

## Зачем

`custom_label` нарушает rule-of-3 (сырые `char*` + деструктор `free`, без copy-ctor) — подозрение на double-free при копировании структуры по значению → могло дать `corrupted top size` из #3568. Теперь по Loki видно, кто делал метки рядом с крэшем.

Логируем через `log()` (→ syslog → Loki). Related to #3568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)