### PR TITLE
fix(player-index): free player timers on shutdown — LSan cleanup (#3574)

### DIFF
--- a/src/engine/db/player_index.cpp
+++ b/src/engine/db/player_index.cpp
@@ -40,6 +40,14 @@ const std::size_t PlayersIndex::NOT_FOUND = ~static_cast<std::size_t>(0);
 
 PlayersIndex::~PlayersIndex() {
 	log("~PlayersIndex()");
+	// issue #3574: timer -- сырой SaveInfo*, аллоцируется при boot и живёт весь ран.
+	// Освобождаем в деструкторе контейнера (один раз, безопасно). В деструкторе
+	// элемента нельзя -- при росте вектора элементы копируются/перемещаются и был бы
+	// double-free. Без этого LeakSanitizer репортит таймеры как утечку на shutdown.
+	for (auto &element : *this) {
+		delete element.timer;
+		element.timer = nullptr;
+	}
 }
 
 std::size_t PlayersIndex::Append(const PlayerIndexElement &element) {


### PR DESCRIPTION
Косметика #3574 — почистить LeakSanitizer на `shutdown die`, чтобы в ASAN-прогонах (охота за #3568) он не заглушал реальные находки.

## Что течёт

`PlayerIndexElement::timer` — сырой `SaveInfo*`, аллоцируется при boot (`ReadCrashTimerFile` → `Crash_create_timer` → `RecreateSaveinfo`) и живёт весь ран, но при выходе не освобождался. LSan репортил **~205 КБ** (196 таймеров + их `SaveTimeInfo`-векторы) — это **99% всего отчёта**.

Не растущая утечка: `RecreateSaveinfo` уже `delete`-ит старый таймер перед realloc. Чисто «не освобождено при выходе».

## Фикс

Освобождаем таймеры в деструкторе **контейнера** `PlayersIndex` (один раз):
```cpp
PlayersIndex::~PlayersIndex() {
    log("~PlayersIndex()");
    for (auto &element : *this) { delete element.timer; element.timer = nullptr; }
}
```

- В деструкторе **элемента** нельзя — при росте вектора элементы копируются/перемещаются, был бы double-free (элемент тривиально копируемый, dtor'а нет).
- `GlobalObjects` (владелец `player_table`) — глобальный синглтон, его dtor отрабатывает **до** LSan-чека, так что репорт по таймерам уходит.

Остаются мелкие строковые leak'и (<1 КБ суммарно: `diskio`/`track`/DG-`foreach`) — по желанию добью отдельно.

Проверить на вашем ASAN-билде (`build_debug`): `shutdown die` больше не должен показывать SaveInfo-утечки.

Closes #3574

🤖 Generated with [Claude Code](https://claude.com/claude-code)