### PR TITLE
fix(dg): free str_dup'd vars on all foreach-done paths (#3574)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -4417,6 +4417,8 @@ int process_foreach_done(const char *cond, void *, Script *, Trigger *trig, int)
 
 	if (!var_list_value || !var_list_pos_value) {
 		trig_log(trig, "foreach utility vars not found");
+		free(var_list_value);       // issue #3574: str_dup выше -- освобождаем на всех выходах
+		free(var_list_pos_value);
 		return 0;
 	}
 
@@ -4430,6 +4432,8 @@ int process_foreach_done(const char *cond, void *, Script *, Trigger *trig, int)
 		snprintf(value, kMaxTrglineLength, "%s%s", name, FOREACH_LIST_POS_GUID);
 		remove_var_cntx(trig->var_list, value, 0);
 
+		free(var_list_value);       // issue #3574: str_dup выше течёт на завершении foreach
+		free(var_list_pos_value);
 		return 0;
 	}
 


### PR DESCRIPTION
Реальная (растущая) утечка, всплывшая в LeakSanitizer после #3577 — не только shutdown.

## Баг

`process_foreach_done` (dg_scripts.cpp) делает `str_dup` двух служебных переменных и освобождает их **только на главном пути** (`return 1`):

```cpp
char *var_list_value     = str_dup(...);
char *var_list_pos_value = str_dup(...);
...
if (!p || !*p) {           // конец списка -- КАЖДЫЙ раз при завершении foreach
    remove_var_cntx(...);
    return 0;              // ← утечка обоих str_dup
}
...
free(var_list_pos_value);  // только тут
free(var_list_value);
return 1;
```

Ветка `!p || !*p` — это нормальное завершение foreach-цикла (список кончился), срабатывает **каждый раз**. Плюс ветка «vars not found». На них str_dup'ы не освобождались → утечка на каждом foreach в DG-скриптах (горячий путь).

## Фикс

`free(var_list_value); free(var_list_pos_value);` на обоих ранних выходах.

Related to #3574 (после #3577 SaveInfo-утечка ушла, это следующий по значимости — и он растущий, а не shutdown-only).

Остаётся мелочь: `fbgetstring` при `load_char_ascii` (login) и пара str в DG — добью, если нужно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)