### PR TITLE
fix(player): free fbgetstring result when loading description (#3574)

### DIFF
--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -1317,6 +1317,7 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 				if (!strcmp(tag, "Desc")) {
 					const auto ptr = fbgetstring(fl);
 					this->player_data.description = ptr ? ptr : "";
+					free(ptr);    // issue #3574: fbgetstring malloc'ит; текст уже скопирован в std::string
 				} else if (!strcmp(tag, "Disp")) {
 					std::bitset<DIS_TOTAL_NUM> tmp_flags(lnum);
 					disposable_flags_ = tmp_flags;


### PR DESCRIPTION
Последняя утечка из отчёта LeakSanitizer по #3574 (53 байта).

## Баг

`Player::load_char_ascii` для тега `Desc`:

```cpp
const auto ptr = fbgetstring(fl);              // malloc внутри fbgetstring
this->player_data.description = ptr ? ptr : ""; // std::string копирует содержимое
// ptr не освобождается -> leak
```

`fbgetstring` (diskio.cpp) выделяет строку через malloc; вызывающий обязан её освободить. Здесь текст копируется в `std::string`, а сам указатель терялся → утечка на каждой загрузке чара с описанием (логин/rent-load).

## Фикс

`free(ptr);` после копирования (`free(nullptr)` безопасен).

После этого LSan на `shutdown die` должен быть **чистым** (SaveInfo — #3577, foreach — #3578, это — последнее).

Closes #3574

🤖 Generated with [Claude Code](https://claude.com/claude-code)