### PR TITLE
dot-death-exp: credit self-inflicted DoT kills to the affect's author

### DIFF
--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -392,8 +392,12 @@ namespace {
 int LandOneDamageHit(CharData *ch, CharData *victim, ESpell spell_id, int total_dmg,
 					 EPosition ch_start_pos, EPosition victim_start_pos, int count,
 					 const std::string &aff_msg_char, const std::string &aff_msg_vict,
-					 const std::string &aff_msg_room) {
+					 const std::string &aff_msg_room, long author_uid) {
 	Damage dmg(SpellDmg(spell_id), total_dmg, fight::kMagicDmg);
+	// issue.dot-death-exp: carry the self-damage author (a DoT/affect tick's caster_id) so a kill
+	// dealt by the bearer's OWN tick credits the responsible character, exactly like the poison
+	// branch above. 0 = no author (a normal offensive hit sets nothing; ch != victim credits ch).
+	dmg.author_uid = author_uid;
 	dmg.ch_start_pos = ch_start_pos;
 	dmg.victim_start_pos = victim_start_pos;
 	// issue.character-affect-triggers: affect-owned damage flavor (empty for ordinary spell damage).
@@ -725,7 +729,7 @@ EStageResult CastDamage(ActionContext &ctx) {
 			rand = LandOneDamageHit(ch, victim, spell_id, total_dmg,
 									ch_start_pos, victim_start_pos, count,
 									ctx.AffectDamageMsgChar(), ctx.AffectDamageMsgVict(),
-									ctx.AffectDamageMsgRoom());
+									ctx.AffectDamageMsgRoom(), ctx.DamageAuthorUid());
 			// accumulate the ACTUAL HP removed this hit (post-resist/save, capped
 			// at the target's HP) so a chained action scales off real damage. On death the victim is
 			// extracted -> count the HP it had; otherwise the HP it actually lost.

--- a/src/gameplay/mechanics/damage.cpp
+++ b/src/gameplay/mechanics/damage.cpp
@@ -374,6 +374,34 @@ void Damage::DealReflectPool(CharData *ch, CharData *victim) {
 	reflect_pool_.clear();
 }
 
+// issue.dot-death-exp: choose who to credit for a SELF-inflicted death (a DoT/poison affect tick, or
+// suffering) among the victim's room occupants `people`. A DoT/poison author is identified by UID (the
+// affect's stored caster_id) -- never a live pointer -- so a DoT whose author has ALREADY DIED finds no
+// live match and returns nullptr: nobody is credited and nothing stale is dereferenced. author_uid == 0
+// (self-inflicted with no author, e.g. eating poisoned food) or == the victim's own uid also yields
+// nullptr. Extracted from ProcessDeath so the attribution is unit-testable (tests/dot.death.credit.cpp).
+CharData *SelectSelfInflictedKiller(const std::list<CharData *> &people, const CharData *victim,
+								   long author_uid, fight::EDamageSource damage_source) {
+	if (author_uid != 0 && author_uid != victim->get_uid()) {
+		for (const auto author : people) {
+			if (author != victim && author->get_uid() == author_uid) {
+				return author;
+			}
+		}
+		return nullptr;   // the author is gone (their DoT outlived them) -- credit nobody, do not deref
+	}
+	if (damage_source == fight::EDamageSource::kSuffering) {
+		CharData *attacker = nullptr;
+		for (const auto a : people) {
+			if (a->GetEnemy() == victim) {
+				attacker = a;
+			}
+		}
+		return attacker;
+	}
+	return nullptr;
+}
+
 void Damage::ProcessDeath(CharData *ch, CharData *victim) const {
 	CharData *killer = nullptr;
 
@@ -383,20 +411,8 @@ void Damage::ProcessDeath(CharData *ch, CharData *victim) const {
 			// урона (author_uid -- обычно caster_id аффекта), если он рядом. Нет автора (0) или
 			// автор сам victim -- не засчитывается. Любой будущий повреждающий аффект просто
 			// выставляет author_uid, отдельная ветка тут не нужна.
-			if (author_uid != 0 && author_uid != victim->get_uid()) {
-				for (const auto author : world[victim->in_room]->people) {
-					if (author != victim && author->get_uid() == author_uid) {
-						killer = author;
-						break;
-					}
-				}
-			} else if (damage_source == fight::EDamageSource::kSuffering) {
-				for (const auto attacker : world[victim->in_room]->people) {
-					if (attacker->GetEnemy() == victim) {
-						killer = attacker;
-					}
-				}
-			}
+			killer = SelectSelfInflictedKiller(world[victim->in_room]->people, victim,
+											   author_uid, damage_source);
 		}
 
 		if (ch != victim) {

--- a/src/gameplay/mechanics/damage.h
+++ b/src/gameplay/mechanics/damage.h
@@ -14,7 +14,16 @@
 #include "engine/entities/entities_constants.h"
 
 #include <bitset>
+#include <list>
 #include <vector>
+
+class CharData;
+
+// issue.dot-death-exp: pick the character to credit for a self-inflicted death (DoT/poison tick or
+// suffering) among `people` (the victim's room). Author looked up by UID, so a dead author -> nullptr.
+// Defined in damage.cpp; exposed here for ProcessDeath and unit tests.
+CharData *SelectSelfInflictedKiller(const std::list<CharData *> &people, const CharData *victim,
+								   long author_uid, fight::EDamageSource damage_source);
 
 /**
  * Для входа со скила без инита остальных полей:

--- a/tests/dot.death.credit.cpp
+++ b/tests/dot.death.credit.cpp
@@ -1,0 +1,80 @@
+// issue.dot-death-exp: regression tests for crediting a self-inflicted DoT/poison kill.
+//
+// When a damage-over-time affect ticks, the bearer damages ITSELF (target=kTarFightSelf), so the
+// death is attributed via the Damage's author_uid -- the affect's stored caster_id (a UID, not a
+// live pointer). SelectSelfInflictedKiller is the attribution ProcessDeath uses; it decides who (if
+// anyone) gets the experience. The bug was that the general <damage> DoT path never fed author_uid,
+// so kBurning-style DoTs credited nobody. These tests lock the attribution contract, including the
+// case the user flagged: a DoT can still tick after its author has died.
+
+#include "gameplay/mechanics/damage.h"
+
+#include "char.utilities.hpp"   // test_utils::CharacterBuilder
+
+#include <gtest/gtest.h>
+
+#include <list>
+
+namespace {
+
+CharData *make_char(test_utils::CharacterBuilder &b, int uid) {
+	b.create_new();
+	CharData *c = b.get().get();
+	c->set_uid(uid);
+	return c;
+}
+
+}  // namespace
+
+// A self-inflicted DoT kill credits the author when they are present in the room -- looked up by the
+// affect's stored uid, exactly like a weapon/spell kill credits the attacker.
+TEST(DotDeathCredit, AuthorInRoomIsCredited) {
+	test_utils::CharacterBuilder vb, ab, bystb;
+	CharData *victim = make_char(vb, 101);
+	CharData *author = make_char(ab, 202);
+	CharData *bystander = make_char(bystb, 303);
+
+	std::list<CharData *> people{victim, bystander, author};
+
+	EXPECT_EQ(author, SelectSelfInflictedKiller(people, victim, /*author_uid*/ 202,
+												fight::EDamageSource::kUndefined));
+}
+
+// The user's constraint: a DoT can still deal damage after the character that applied it has died.
+// The author is then no longer in the room, so no live char matches the stored uid -- nobody is
+// credited, and (crucially) no stale pointer is dereferenced.
+TEST(DotDeathCredit, DeadAuthorCreditsNobody) {
+	test_utils::CharacterBuilder vb, bystb;
+	CharData *victim = make_char(vb, 101);
+	CharData *bystander = make_char(bystb, 303);
+
+	std::list<CharData *> people{victim, bystander};   // author (uid 202) already extracted
+
+	EXPECT_EQ(nullptr, SelectSelfInflictedKiller(people, victim, /*author_uid*/ 202,
+												 fight::EDamageSource::kUndefined));
+}
+
+// No author (a self-poison with caster_id 0, e.g. eating poisoned food): the victim is blamed for
+// their own death -- credit nobody.
+TEST(DotDeathCredit, NoAuthorCreditsNobody) {
+	test_utils::CharacterBuilder vb;
+	CharData *victim = make_char(vb, 101);
+
+	std::list<CharData *> people{victim};
+
+	EXPECT_EQ(nullptr, SelectSelfInflictedKiller(people, victim, /*author_uid*/ 0,
+												 fight::EDamageSource::kUndefined));
+}
+
+// A stale author_uid equal to the victim's OWN uid must not credit the victim for killing itself.
+TEST(DotDeathCredit, SelfAuthorCreditsNobody) {
+	test_utils::CharacterBuilder vb;
+	CharData *victim = make_char(vb, 101);
+
+	std::list<CharData *> people{victim};
+
+	EXPECT_EQ(nullptr, SelectSelfInflictedKiller(people, victim, /*author_uid*/ 101,
+												 fight::EDamageSource::kUndefined));
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -27,6 +27,7 @@ test_sources = files(
     'msdp.parser.cpp',
     'msdp.builder.cpp',
     'char.affects.cpp',
+    'dot.death.credit.cpp',
     'affects.loader.cpp',
     'random.noise.cpp',
     'potion.duration.cpp',


### PR DESCRIPTION
A data-driven DoT ticks as self-damage (the bearer damages itself via target=kTarFightSelf), so the kill is attributed through Damage::author_uid -- the affect's stored caster_id, a UID rather than a live pointer. Only the poison branch of CastDamage set author_uid; the general <damage> delivery (LandOneDamageHit) never did, so a non-poison DoT (kBurning and any future <damage> DoT) killed with author_uid == 0 and credited nobody -- no exp for the player who effectively defeated the mob.

- LandOneDamageHit takes an author_uid and sets it on its Damage; CastDamage feeds it ctx.DamageAuthorUid(), so every DoT tick carries its author.
- Extract the self-inflicted killer pick from ProcessDeath into a pure, unit-testable SelectSelfInflictedKiller(). It resolves the author by UID at death time, so a DoT whose author has ALREADY DIED finds no live match and credits nobody -- nothing stale is dereferenced (no crash).
- tests/dot.death.credit.cpp: author-in-room credited; dead author -> nobody; no author (caster_id 0) -> nobody; stale self-uid -> nobody.

Grouping is unchanged: once a killer is resolved, ProcessDeath routes through group_gain/perform_group_gain as for a weapon or spell kill.