### PR TITLE
refactor(obj): drop dead spell + spell-level fields from world serialization (#3581)

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -645,9 +645,8 @@ void ObjectFile::parse_object(const int nr) {
 		timer = 99999;
 	}
 	tobj->set_timer(timer);
-	// issue #3581: obj->spell -- мёртвое поле, ни одна механика его не читает.
-	// t[2] всё ещё разбирается (формат легаси-строки = 4 поля), но объекту не присваивается.
-	tobj->set_level(t[3]);
+	// issue #3581: obj->spell и его уровень -- мёртвая пара, ни одна механика их не читает.
+	// t[2]/t[3] всё ещё разбираются (формат легаси-строки = 4 поля), но объекту не присваиваются.
 
 	if (!get_line(file(), m_line)) {
 		fatal_log("SYSERR: Expecting *3th* numeric line of %s, but file ended!", m_buffer);

--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -645,7 +645,8 @@ void ObjectFile::parse_object(const int nr) {
 		timer = 99999;
 	}
 	tobj->set_timer(timer);
-	tobj->set_spell(t[2]);
+	// issue #3581: obj->spell -- мёртвое поле, ни одна механика его не читает.
+	// t[2] всё ещё разбирается (формат легаси-строки = 4 поля), но объекту не присваивается.
 	tobj->set_level(t[3]);
 
 	if (!get_line(file(), m_line)) {

--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -310,7 +310,7 @@ ObjData::shared_ptr read_one_object_new(char **data, int *error) {
 				}
 			} else if (!strcmp(read_line, "Spll")) {
 				*error = 21;
-				object->set_spell(atoi(buffer));
+				// issue #3581: obj->spell -- мёртвое поле; тег игнорируем (совместимость со старыми рентами).
 			} else if (!strcmp(read_line, "Levl")) {
 				*error = 22;
 				object->set_level(atoi(buffer));
@@ -734,9 +734,7 @@ void write_one_object(std::stringstream &out, ObjData *object, int location) {
 		if (obj_timer != proto_timer) {
 			out << "Tmer: " << obj_timer << "~\n";
 		}
-		if (object->get_spell() != p->get_spell()) {
-			out << "Spll: " << object->get_spell() << "~\n";
-		}
+		// issue #3581: obj->spell -- мёртвое поле, в рент больше не пишем.
 		if (object->get_level() != p->get_level()) {
 			out << "Levl: " << object->get_level() << "~\n";
 		}

--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -313,7 +313,7 @@ ObjData::shared_ptr read_one_object_new(char **data, int *error) {
 				// issue #3581: obj->spell -- мёртвое поле; тег игнорируем (совместимость со старыми рентами).
 			} else if (!strcmp(read_line, "Levl")) {
 				*error = 22;
-				object->set_level(atoi(buffer));
+				// issue #3581: obj->spell/level -- мёртвая пара; тег игнорируем (совместимость со старыми рентами).
 			} else if (!strcmp(read_line, "Affs")) {
 				*error = 23;
 				object->SetWeaponAffectFlags(clear_flags);
@@ -734,10 +734,7 @@ void write_one_object(std::stringstream &out, ObjData *object, int location) {
 		if (obj_timer != proto_timer) {
 			out << "Tmer: " << obj_timer << "~\n";
 		}
-		// issue #3581: obj->spell -- мёртвое поле, в рент больше не пишем.
-		if (object->get_level() != p->get_level()) {
-			out << "Levl: " << object->get_level() << "~\n";
-		}
+		// issue #3581: obj->spell/level -- мёртвая пара, в рент больше не пишем.
 		if (object->get_is_rename()) {
 			out << "Rnme: 1~\n";
 		}

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -2160,7 +2160,7 @@ LoadedObject SqliteWorldDataSource::LoadObjectRow(sqlite3_stmt *stmt)
 	}
 	if (timer > 99999) timer = 99999;  // Cap timer like Legacy
 	obj->set_timer(timer);
-	obj->set_spell(sqlite3_column_int(stmt, 24));
+	// issue #3581: obj->spell -- мёртвое поле; колонку 24 не присваиваем (индексы ниже не сдвигаем).
 	obj->set_level(sqlite3_column_int(stmt, 25));
 	obj->set_sex(static_cast<EGender>(sqlite3_column_int(stmt, 26)));
 	obj->set_max_in_world(sqlite3_column_type(stmt, 27) == SQLITE_NULL ? -1 : sqlite3_column_int(stmt, 27));

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -2160,8 +2160,7 @@ LoadedObject SqliteWorldDataSource::LoadObjectRow(sqlite3_stmt *stmt)
 	}
 	if (timer > 99999) timer = 99999;  // Cap timer like Legacy
 	obj->set_timer(timer);
-	// issue #3581: obj->spell -- мёртвое поле; колонку 24 не присваиваем (индексы ниже не сдвигаем).
-	obj->set_level(sqlite3_column_int(stmt, 25));
+	// issue #3581: obj->spell/level -- мёртвая пара; колонки 24/25 не присваиваем (индексы ниже не сдвигаем).
 	obj->set_sex(static_cast<EGender>(sqlite3_column_int(stmt, 26)));
 	obj->set_max_in_world(sqlite3_column_type(stmt, 27) == SQLITE_NULL ? -1 : sqlite3_column_int(stmt, 27));
 	obj->set_minimum_remorts(sqlite3_column_int(stmt, 28));

--- a/src/engine/db/world_checksum.cpp
+++ b/src/engine/db/world_checksum.cpp
@@ -449,7 +449,7 @@ std::string SerializeObject(const CObjectPrototype::shared_ptr &obj)
 	oss << obj->get_max_in_world() << "|";
 	oss << obj->get_timer() << "|";
 	oss << static_cast<int>(obj->get_sex()) << "|";
-	oss << static_cast<int>(obj->get_spell()) << "|";
+	// issue #3581: obj->spell -- мёртвое поле, из чексуммы исключено.
 	oss << obj->get_maximum_durability() << "|";
 	oss << obj->get_current_durability() << "|";
 	oss << obj->get_minimum_remorts() << "|";

--- a/src/engine/db/world_checksum.cpp
+++ b/src/engine/db/world_checksum.cpp
@@ -444,7 +444,7 @@ std::string SerializeObject(const CObjectPrototype::shared_ptr &obj)
 	oss << obj->get_cost() << "|";
 	oss << obj->get_rent_on() << "|";
 	oss << obj->get_rent_off() << "|";
-	oss << obj->get_level() << "|";
+	// issue #3581: obj->level (уровень спелла) -- мёртвое поле, из чексуммы исключено.
 	oss << static_cast<int>(obj->get_material()) << "|";
 	oss << obj->get_max_in_world() << "|";
 	oss << obj->get_timer() << "|";

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -2125,7 +2125,7 @@ CObjectPrototype* YamlWorldDataSource::ParseObjectNode(const YAML::Node &root, i
 			if (timer > 99999) timer = 99999;
 			obj_ptr->set_timer(timer);
 
-			obj_ptr->set_spell(GetInt(root, "spell", -1));
+			// issue #3581: obj->spell -- мёртвое поле, из мировой сериализации выпилено; ключ "spell" в старых yaml игнорируется.
 			obj_ptr->set_level(GetInt(root, "level", 0));
 			obj_ptr->set_sex(static_cast<EGender>(ParseGender(root["sex"])));
 
@@ -4290,13 +4290,7 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 	yaml.Key("timer");
 	yaml.Value(obj->get_timer());
 
-	// Spell (with comment)
-	if (to_underlying(obj->get_spell()) >= 0)
-	{
-		int spell_id = to_underlying(obj->get_spell());
-		yaml.Key("spell");
-		yaml.Value(spell_id, GetSpellNameComment(static_cast<ESpell>(spell_id)));
-	}
+	// issue #3581: obj->spell -- мёртвое поле, в yaml больше не пишем.
 
 	// Level and sex
 	yaml.Key("level");

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -2125,8 +2125,7 @@ CObjectPrototype* YamlWorldDataSource::ParseObjectNode(const YAML::Node &root, i
 			if (timer > 99999) timer = 99999;
 			obj_ptr->set_timer(timer);
 
-			// issue #3581: obj->spell -- мёртвое поле, из мировой сериализации выпилено; ключ "spell" в старых yaml игнорируется.
-			obj_ptr->set_level(GetInt(root, "level", 0));
+			// issue #3581: obj->spell и его уровень (level) -- мёртвая пара, из мировой сериализации выпилены; ключи "spell"/"level" в старых yaml игнорируются.
 			obj_ptr->set_sex(static_cast<EGender>(ParseGender(root["sex"])));
 
 			if (root["max_in_world"])
@@ -4290,11 +4289,7 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 	yaml.Key("timer");
 	yaml.Value(obj->get_timer());
 
-	// issue #3581: obj->spell -- мёртвое поле, в yaml больше не пишем.
-
-	// Level and sex
-	yaml.Key("level");
-	yaml.Value(obj->get_level());
+	// issue #3581: obj->spell и его уровень (level) -- мёртвая пара, в yaml больше не пишем.
 
 	yaml.Key("sex");
 	yaml.Value(ReverseLookupEnum("genders", static_cast<int>(obj->get_sex())));


### PR DESCRIPTION
По итогам разбора в #3581: `obj->m_spell` **и его уровень** `obj->m_level` — вестигиальная **пара** из старого формата CircleMUD (поля t[2]/t[3] легаси-строки, `level` = уровень того самого спелла).

## Почему выпиливаем

Проверил все использования по коду. Ни `m_spell`, ни `m_level` **не читает ни одна механика**:
- нет боевого/носильного/юзательного эффекта;
- **DG-доступа нет** (`%obj.spell%`/`%obj.level%` в dg_variables отсутствуют);
- `init_ilvl` считает **отдельное** поле `m_ilevel` (item level для баланса), а не `m_level`;
- реально живут только в **недоделанном** `craft.cpp` (load/save прототипа).

Поэтому **сами поля `m_spell`/`m_level` + get/set + craft.cpp + Lua-аксессоры — оставляем**. Когда крафт доделают, перенесут в нормальное место. Убираем только мёртвую **мировую сериализацию** объекта.

## Что сделано (для обоих полей)

| Формат | Правка |
|---|---|
| legacy loader (`boot_data_files.cpp`) | не присваиваем t[2]/t[3]; строка формата остаётся 4-польной (`sscanf` цел) |
| yaml (`yaml_world_data_source.cpp`) | не читаем и не пишем ключи `spell`/`level`; в существующих yaml они игнорируются и уходят при пересейве |
| rent (`obj_save.cpp`) | не пишем теги `Spll`/`Levl`; на чтении — no-op-ветки ради совместимости старых рент-файлов |
| sqlite (`sqlite_world_data_source.cpp`) | не присваиваем колонки 24/25 (индексы ниже **не** сдвигаем — схема цела) |
| world checksum (`world_checksum.cpp`) | исключаем оба из хэша объекта |

Позиционные слоты (легаси-строка, sqlite-колонки) **оставлены** ради совместимости формата/схемы — в них пишется значение по умолчанию.

## Совместимость / риски

- Существующие yaml/rent со `spell:`/`level:`/`Spll`/`Levl` грузятся без ошибок (ключ/тег игнорируется), поля уходят при следующем сейве.
- Чексумма мира меняет базовое значение (поля исключены), но кросс-форматное сравнение в `run_load_tests` симметрично — расхождений не даёт.
- Тесты не задеты: в `world_checksum_serialization.cpp` «spell» — это potion-значения (`kPotionSpell1Num`), не `m_spell`; в `obj.copy.cpp` проверки закомментированы.

Сборка `build` (yaml, default) — зелёная. Sqlite локально не собрать (нет sqlite-subproject/wrap), но правки там — механическое снятие присвоения, `obj` используется на соседних строках.

Closes #3581
