### PR TITLE
feat(yaml): annotate scroll/wand/staff spell values with spell name (#3583)

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -671,6 +671,17 @@ void GameLoader::BootWorld(std::unique_ptr<world_loader::IWorldDataSource> data_
 		MUD::CfgManager().LoadCfg("skills");
 	}
 
+	// issue #3583: имена спеллов (MUD::Spell().GetName()) нужны, чтобы подписывать
+	// спелл-значения свитков/палочек/посохов в objects.yaml. Как и skills выше,
+	// конфиг спеллов грузит BootMudDataBase для боевого сервера, но путь `-S`
+	// resave / scheck его пропускает -- иначе имена спеллов остаются "!undefined!".
+	// Guarded, чтобы обычный boot не перезагружал уже загруженное.
+	if (!MUD::Spells().IsInitizalized())
+	{
+		MUD::CfgManager().LoadCfg("spell_msg");   // имена спеллов (spell_msg.xml), читаются при загрузке spells
+		MUD::CfgManager().LoadCfg("spells");
+	}
+
 	// Create data source if none provided. Runtime selection comes from
 	// <world_loader><sources> (ordered = priority); several sources combine into
 	// a CompositeWorldDataSource. An empty/absent block falls back to the

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -119,6 +119,22 @@ std::string GetSpellNameComment(ESpell spell_id) {
 	return MUD::Spell(spell_id).GetName();
 }
 
+// issue #3583: имя спелла для values-слотов, которые хранят номер заклинания.
+// Свиток -- спеллы в val[1..3]; палочка/посох -- в val[3]. Зелья держат спеллы в
+// ObjVal-ключах (а не в val[]), поэтому их values не аннотируем.
+std::string GetObjValueSpellComment(EObjType type, int slot, int value) {
+	bool is_spell_slot = false;
+	if (type == EObjType::kScroll) {
+		is_spell_slot = (slot >= 1 && slot <= 3);
+	} else if (type == EObjType::kWand || type == EObjType::kStaff) {
+		is_spell_slot = (slot == 3);
+	}
+	if (!is_spell_slot || value <= 0 || value > to_underlying(ESpell::kLast)) {
+		return "";
+	}
+	return GetSpellNameComment(static_cast<ESpell>(value));
+}
+
 // Get material name by ID (for material comments)
 std::string GetMaterialNameComment(int material_id) {
 	return ::material_name[material_id];
@@ -4253,10 +4269,12 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 	yaml.BeginSequence();
 	yaml.IncreaseIndent();
 
-	yaml.SequenceItem(obj->get_val(0));
-	yaml.SequenceItem(obj->get_val(1));
-	yaml.SequenceItem(obj->get_val(2));
-	yaml.SequenceItem(obj->get_val(3));
+	// issue #3583: у свитков/палочек/посохов values-слоты со спеллами подписываем именем заклинания.
+	const auto obj_type = obj->get_type();
+	yaml.SequenceItem(obj->get_val(0), GetObjValueSpellComment(obj_type, 0, obj->get_val(0)));
+	yaml.SequenceItem(obj->get_val(1), GetObjValueSpellComment(obj_type, 1, obj->get_val(1)));
+	yaml.SequenceItem(obj->get_val(2), GetObjValueSpellComment(obj_type, 2, obj->get_val(2)));
+	yaml.SequenceItem(obj->get_val(3), GetObjValueSpellComment(obj_type, 3, obj->get_val(3)));
 
 	yaml.DecreaseIndent();
 

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -135,6 +135,20 @@ std::string GetObjValueSpellComment(EObjType type, int slot, int value) {
 	return GetSpellNameComment(static_cast<ESpell>(value));
 }
 
+// issue #3583: имя спелла для потионных ключей extra_values вида POTION_SPELL<n>_NUM
+// (у зелий заклинания лежат в ObjVal-ключах, а не в val[]). Ключи *_LVL не трогаем.
+std::string GetExtraValueSpellComment(const std::string &key, int value) {
+	static const std::string kPrefix = "POTION_SPELL";
+	static const std::string kSuffix = "_NUM";
+	const bool is_spell_key = key.size() > kPrefix.size() + kSuffix.size()
+		&& key.compare(0, kPrefix.size(), kPrefix) == 0
+		&& key.compare(key.size() - kSuffix.size(), kSuffix.size(), kSuffix) == 0;
+	if (!is_spell_key || value <= 0 || value > to_underlying(ESpell::kLast)) {
+		return "";
+	}
+	return GetSpellNameComment(static_cast<ESpell>(value));
+}
+
 // Get material name by ID (for material comments)
 std::string GetMaterialNameComment(int material_id) {
 	return ::material_name[material_id];
@@ -4579,7 +4593,7 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 			for (const auto &kv : sorted_vals)
 			{
 				yaml.Key(kv.first);
-				yaml.Value(kv.second);
+				yaml.Value(kv.second, GetExtraValueSpellComment(kv.first, kv.second));
 			}
 			yaml.EndBlock();
 		}

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -4284,8 +4284,9 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 	yaml.IncreaseIndent();
 
 	// issue #3583: у свитков/палочек/посохов values-слоты со спеллами подписываем именем заклинания.
+	// val[0] -- это уровень/сила заклинания, а не номер спелла, поэтому его не подписываем.
 	const auto obj_type = obj->get_type();
-	yaml.SequenceItem(obj->get_val(0), GetObjValueSpellComment(obj_type, 0, obj->get_val(0)));
+	yaml.SequenceItem(obj->get_val(0));
 	yaml.SequenceItem(obj->get_val(1), GetObjValueSpellComment(obj_type, 1, obj->get_val(1)));
 	yaml.SequenceItem(obj->get_val(2), GetObjValueSpellComment(obj_type, 2, obj->get_val(2)));
 	yaml.SequenceItem(obj->get_val(3), GetObjValueSpellComment(obj_type, 3, obj->get_val(3)));


### PR DESCRIPTION
Из #3583: у свитков/зелий/палочек номера спеллов в YAML не подписаны именем (в отличие от `material: 11 # СТЕКЛО`). Подписываем.

## Что сделано

**Свитки/палочки/посохи** — спелл-слоты `values`:

```yaml
  type: kScroll
  values:
    - 20
    - 109  # медлительность
    - -1
    - -1
```

| Тип | Спелл-слоты |
|---|---|
| `kScroll` | val[1..3] (цикл каста `for i=1..3`) |
| `kWand` / `kStaff` | val[3] |

**Зелья** — заклинания у них в ObjVal-ключах `extra_values`, а не в `val[]`:

```yaml
  extra_values:
    POTION_SPELL1_NUM: 97  # восстановление
    POTION_SPELL2_NUM: 20  # определение магии
```

Матч по префиксу `POTION_SPELL` + суффиксу `_NUM` — ключи `*_LVL`/`SKILL`/`STAT`/`PROTO_VNUM` не трогаем.

Везде имя берётся из **реальной таблицы спеллов** (`MUD::Spell().GetName()`); guard по диапазону `[1, kLast]`, так что `-1`/`0`-слоты, не-спелл-типы и мусорные номера остаются без коммента.

## Побочно: имена спеллов в resave-режиме

Путь `-S` (resave / массовая перегенерация мира) и `scheck` вызывают `BootWorld` напрямую, **минуя** `BootMudDataBase`, поэтому конфиг спеллов там не грузился — без фикса все имена вышли бы `!undefined!`. Добавил guard-подгрузку `spell_msg` + `spells` (ровно как уже сделано для skills в #3391; имя живёт в `spell_msg.xml`, читается при загрузке `spells`). Guarded по `IsInitizalized()`, обычный boot не перезагружает.

## Проверка

Ресейв small-мира (`circle -d small -S resave_out -T yaml`), `errors=0`:
- свиток `val[1]=109` → `# медлительность`;
- палочка `val[3]=356` → `# ослепить`;
- зелье `POTION_SPELL1_NUM=97` → `# восстановление`, мульти-спелл (SPELL1/2/3) подписаны;
- `val[0]`/уровень, `-1`-слоты, `_LVL`/`SKILL`/`STAT` — без коммента.

Legacy Python-конвертер не трогал (перешли на YAML, canonical path — C++ ресейв/OLC).

Closes #3583
