### PR TITLE
fix(msdp): do not leak another group's state to a mere follower (#3586)

### DIFF
--- a/src/engine/network/msdp/msdp_reporters.cpp
+++ b/src/engine/network/msdp/msdp_reporters.cpp
@@ -290,27 +290,35 @@ void GroupReporter::get(Variable::shared_ptr &response) {
 	*/
 	const auto group_descriptor = std::make_shared<ArrayValue>();
 	const auto ch = descriptor()->character.get();
-	const auto master = ch->has_master() ? ch->get_master() : ch;
-	append_char(group_descriptor, ch, master, true);
-	for (auto *f : master->followers) {
-		if (!AFF_FLAGGED(f, EAffect::kGroup)
-			&& !(f->IsFlagged(EMobFlag::kCompanion))) {
-			continue;
-		}
-
-		append_char(group_descriptor, ch, f, false);
-
-		// followers of a ch
-		if (!AFF_FLAGGED(f, EAffect::kGroup)) {
-			continue;
-		}
-
-		for (auto *ff : f->followers) {
-			if (!(ff->IsFlagged(EMobFlag::kCompanion))) {
+	// issue #3586: не раскрывать группу того, за кем персонаж просто следует.
+	// Членство в группе -- это флаг kGroup (ставится и лидеру, и согруппникам,
+	// см. group::perform_group), а не follow-отношение. Без этой проверки
+	// заследовавшийся не-член получал полное состояние чужой группы. Гейт тот же,
+	// что в group::print_list_group ("Но вы же не член группы!"). Не в группе --
+	// отдаём пустой GROUP.
+	if (ch && AFF_FLAGGED(ch, EAffect::kGroup)) {
+		const auto master = ch->has_master() ? ch->get_master() : ch;
+		append_char(group_descriptor, ch, master, true);
+		for (auto *f : master->followers) {
+			if (!AFF_FLAGGED(f, EAffect::kGroup)
+				&& !(f->IsFlagged(EMobFlag::kCompanion))) {
 				continue;
 			}
 
-			append_char(group_descriptor, ch, ff, false);
+			append_char(group_descriptor, ch, f, false);
+
+			// followers of a ch
+			if (!AFF_FLAGGED(f, EAffect::kGroup)) {
+				continue;
+			}
+
+			for (auto *ff : f->followers) {
+				if (!(ff->IsFlagged(EMobFlag::kCompanion))) {
+					continue;
+				}
+
+				append_char(group_descriptor, ch, ff, false);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Баг

Подписавшись на MSDP `GROUP` и заследовав (`сл`) за кем-то, игрок начинал получать полное состояние группы того, за кем следует — лидера и всех согруппников — хотя в группу его не принимали:

```
груп
-:- [msdp] {"GROUP":[{"NAME":"Берест",...,"ROLE":"leader",...}]}
Но вы же не член (в лучшем смысле этого слова) группы!
```

## Причина

`GroupReporter::get` (`src/engine/network/msdp/msdp_reporters.cpp`) строил `GROUP` из `ch->get_master()` **безусловно** — т.е. по follow-отношению, а не по членству:

```cpp
const auto master = ch->has_master() ? ch->get_master() : ch;
append_char(group_descriptor, ch, master, true);   // мастер как лидер
for (auto *f : master->followers) { ... }           // вся его группа
```

`follow` (`сл`) делает тебя последователем, но **не членом группы**. Членство — это affect `kGroup` (ставится и лидеру через `perform_group(ch, ch)`, и согруппникам). `print_group` вдобавок шлёт MSDP-репорт **до** проверки членства, поэтому утечка приходила прямо при `груп`.

## Фикс

Строим `GROUP` только если `ch` реально в группе — гейт `AFF_FLAGGED(ch, EAffect::kGroup)`, та же проверка, что в каноничном `group::print_list_group` («Но вы же не член группы!»). Не в группе → отдаём **пустой** `GROUP`. Фикс на источнике (репортере), так что все вызовы (в т.ч. преждевременный репорт в `print_group`) автоматически безопасны. Заодно null-guard на `ch`.

Поведение для реальных членов/лидеров не меняется (у них `kGroup` стоит). Соло-игрок теперь корректно получает пустой `GROUP` (раньше видел «группу» из себя одного).

Сборка зелёная.

Closes #3586