### PR TITLE
feat(yaml): annotate every values slot by object type (#3593)

### DIFF
--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -26,6 +26,7 @@
 #include "gameplay/mechanics/dungeons.h"
 #include "gameplay/mechanics/liquid.h"          // issue #3593: drinks[]/NUM_LIQ_TYPES
 #include "gameplay/economics/currencies.h"       // issue #3593: MUD::Currency().GetName()
+#include "gameplay/fight/fight_messages.h"        // issue #3593: GetAttackTypeDescription
 #include "engine/scripting/dg_olc.h"
 #include "gameplay/affects/affect_contants.h"
 #include "gameplay/skills/skills.h"
@@ -157,7 +158,11 @@ std::string GetObjValueComment(EObjType type, int slot, int value) {
 			switch (slot) {
 				case 1: return "число бросков кубика";
 				case 2: return "граней кубика";
-				case 3: return "тип атаки";   // enum-номер; расшифровку см. в oedit/medit
+				case 3: {
+					// тип удара -- из кода (fight-сообщения); в oedit save all они загружены
+					const std::string &n = fight::GetAttackTypeDescription(value);
+					return n.empty() ? "тип атаки" : "тип атаки: " + n;
+				}
 			}
 			return "";
 

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -226,9 +226,13 @@ std::string GetObjValueComment(EObjType type, int slot, int value) {
 			return "";
 
 		case EObjType::kMagicComponent:
-			// В OLC у магкомпонента доступен только val[0]; val[1..3] заполняются
-			// при загрузке мада из lib/misc/im.lst (сила/тип/индекс), в objects.yaml
-			// это плейсхолдеры -- поэтому их не подписываем, чтобы не вводить в заблуждение.
+			// Единственное авторское значение -- класс ингредиента; OLC пишет его в
+			// val[3] (set_val(3) через меню класса), im.cpp читает GET_OBJ_VAL(...,3).
+			// val[0..2] заполняются при загрузке из lib/misc/im.lst -- их не подписываем.
+			if (slot == 3) {
+				const char *n = GetIngredientClassName(static_cast<EIngredientClass>(value));
+				return (n && *n) ? std::string("класс ингредиента: ") + n : "класс ингредиента";
+			}
 			return "";
 
 		case EObjType::kCraftMaterial:

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -226,15 +226,9 @@ std::string GetObjValueComment(EObjType type, int slot, int value) {
 			return "";
 
 		case EObjType::kMagicComponent:
-			// слоты магкомпонента: см. IM_POWER_SLOT/IM_TYPE_SLOT/IM_INDEX_SLOT (im.h)
-			switch (slot) {
-				case 1: return "сила ингредиента";             // IM_POWER_SLOT
-				case 2: return "номер типа (из im.lst)";       // IM_TYPE_SLOT
-				case 3: {                                       // IM_INDEX_SLOT: в прото -- класс
-					const char *n = GetIngredientClassName(static_cast<EIngredientClass>(value));
-					return (n && *n) ? std::string("класс ингредиента: ") + n : "класс ингредиента";
-				}
-			}
+			// В OLC у магкомпонента доступен только val[0]; val[1..3] заполняются
+			// при загрузке мада из lib/misc/im.lst (сила/тип/индекс), в objects.yaml
+			// это плейсхолдеры -- поэтому их не подписываем, чтобы не вводить в заблуждение.
 			return "";
 
 		case EObjType::kCraftMaterial:

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -226,9 +226,14 @@ std::string GetObjValueComment(EObjType type, int slot, int value) {
 			return "";
 
 		case EObjType::kMagicComponent:
-			if (slot == 3) {
-				const char *n = GetIngredientClassName(static_cast<EIngredientClass>(value));
-				return (n && *n) ? std::string("класс ингредиента: ") + n : "класс ингредиента";
+			// слоты магкомпонента: см. IM_POWER_SLOT/IM_TYPE_SLOT/IM_INDEX_SLOT (im.h)
+			switch (slot) {
+				case 1: return "сила ингредиента";             // IM_POWER_SLOT
+				case 2: return "номер типа (из im.lst)";       // IM_TYPE_SLOT
+				case 3: {                                       // IM_INDEX_SLOT: в прото -- класс
+					const char *n = GetIngredientClassName(static_cast<EIngredientClass>(value));
+					return (n && *n) ? std::string("класс ингредиента: ") + n : "класс ингредиента";
+				}
 			}
 			return "";
 

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -208,13 +208,15 @@ std::string GetObjValueComment(EObjType type, int slot, int value) {
 			return "";
 
 		case EObjType::kBook:
+			// значения из enum EBook (entities_constants.h) -- при его переопределении/
+			// переименовании компилятор поймает, а числа-подсказки не разъедутся.
 			if (slot == 0) {
-				switch (value) {
-					case 0: return "книга заклинаний";
-					case 1: return "книга умений";
-					case 2: return "улучшение умения";
-					case 3: return "книга рецептов";
-					case 4: return "книга способностей";
+				switch (static_cast<EBook>(value)) {
+					case EBook::kSpell:        return "книга заклинаний";
+					case EBook::kSkill:        return "книга умений";
+					case EBook::kSkillUpgrade: return "улучшение умения";
+					case EBook::kReceipt:      return "книга рецептов";
+					case EBook::kFeat:         return "книга способностей";
 				}
 				return "тип книги";
 			}

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -25,6 +25,7 @@
 #include "gameplay/mechanics/dead_load.h"
 #include "gameplay/mechanics/dungeons.h"
 #include "gameplay/mechanics/liquid.h"          // issue #3593: drinks[]/NUM_LIQ_TYPES
+#include "gameplay/economics/currencies.h"       // issue #3593: MUD::Currency().GetName()
 #include "engine/scripting/dg_olc.h"
 #include "gameplay/affects/affect_contants.h"
 #include "gameplay/skills/skills.h"
@@ -197,28 +198,17 @@ std::string GetObjValueComment(EObjType type, int slot, int value) {
 		case EObjType::kMoney:
 			if (slot == 0) return "сумма";
 			if (slot == 1) {
-				switch (value) {
-					case 0: return "куны";
-					case 1: return "слава";
-					case 2: return "гривны";
-					case 3: return "снежинки";
-				}
-				return "тип валюты";
+				// валюта -- из кода: money val[1] == vnum валюты (kGoldVnum=0 и т.д.).
+				const std::string &n = MUD::Currency(value).GetName();
+				return (n.empty() || n == "!undefined!") ? "тип валюты" : n;
 			}
 			return "";
 
 		case EObjType::kBook:
-			// значения из enum EBook (entities_constants.h) -- при его переопределении/
-			// переименовании компилятор поймает, а числа-подсказки не разъедутся.
+			// название типа книги -- из единого источника GetBookTypeName (enum EBook).
 			if (slot == 0) {
-				switch (static_cast<EBook>(value)) {
-					case EBook::kSpell:        return "книга заклинаний";
-					case EBook::kSkill:        return "книга умений";
-					case EBook::kSkillUpgrade: return "улучшение умения";
-					case EBook::kReceipt:      return "книга рецептов";
-					case EBook::kFeat:         return "книга способностей";
-				}
-				return "тип книги";
+				const char *n = GetBookTypeName(static_cast<EBook>(value));
+				return (n && *n) ? n : "тип книги";
 			}
 			return "";
 

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -24,6 +24,7 @@
 #include "engine/structs/flag_data.h"
 #include "gameplay/mechanics/dead_load.h"
 #include "gameplay/mechanics/dungeons.h"
+#include "gameplay/mechanics/liquid.h"          // issue #3593: drinks[]/NUM_LIQ_TYPES
 #include "engine/scripting/dg_olc.h"
 #include "gameplay/affects/affect_contants.h"
 #include "gameplay/skills/skills.h"
@@ -119,20 +120,151 @@ std::string GetSpellNameComment(ESpell spell_id) {
 	return MUD::Spell(spell_id).GetName();
 }
 
-// issue #3583: имя спелла для values-слотов, которые хранят номер заклинания.
-// Свиток -- спеллы в val[1..3]; палочка/посох -- в val[3]. Зелья держат спеллы в
-// ObjVal-ключах (а не в val[]), поэтому их values не аннотируем.
-std::string GetObjValueSpellComment(EObjType type, int slot, int value) {
-	bool is_spell_slot = false;
-	if (type == EObjType::kScroll) {
-		is_spell_slot = (slot >= 1 && slot <= 3);
-	} else if (type == EObjType::kWand || type == EObjType::kStaff) {
-		is_spell_slot = (slot == 3);
+// issue #3593 (расширяет #3583): подпись values-слота по типу предмета -- смысл
+// слота и, где уместно, расшифровка enum-значения (заклинание/тип атаки/жидкость/
+// валюта/книга/класс компонента). Смысл слотов взят из OLC-меню
+// (oedit_disp_val1..4_menu). slot 0-индексный (= val[0..3]); "" -- нет осмысленной
+// подписи для данного типа/слота.
+std::string GetObjValueComment(EObjType type, int slot, int value) {
+	// заклинание по номеру (для спелл-слотов свитков/палочек/посохов/зелий)
+	auto spell = [](int v) -> std::string {
+		return (v > 0 && v <= to_underlying(ESpell::kLast)) ? GetSpellNameComment(static_cast<ESpell>(v)) : "";
+	};
+	switch (type) {
+		case EObjType::kLightSource:
+			return slot == 2 ? "длительность горения (0=погасла, -1=вечный)" : "";
+
+		case EObjType::kScroll:
+			return slot == 0 ? "уровень заклинания" : spell(value);   // val[1..3] -- заклинания
+
+		case EObjType::kPotion:
+			if (slot == 0) return "уровень заклинания";
+			if (slot == 3) return "сила зелья (potency)";
+			return spell(value);   // val[1..2] -- заклинания
+
+		case EObjType::kWand:
+		case EObjType::kStaff:
+			switch (slot) {
+				case 0: return "уровень заклинания";
+				case 1: return "всего зарядов";
+				case 2: return "осталось зарядов";
+				case 3: return spell(value);
+			}
+			return "";
+
+		case EObjType::kWeapon:
+			switch (slot) {
+				case 1: return "число бросков кубика";
+				case 2: return "граней кубика";
+				case 3: return "тип атаки";   // enum-номер; расшифровку см. в oedit/medit
+			}
+			return "";
+
+		case EObjType::kArmor:
+		case EObjType::kLightArmor:
+		case EObjType::kMediumArmor:
+		case EObjType::kHeavyArmor:
+			if (slot == 0) return "изменяет AC";
+			if (slot == 1) return "изменяет броню";
+			return "";
+
+		case EObjType::kContainer:
+			switch (slot) {
+				case 0: return "макс. вместимый вес";
+				case 1: return "флаги контейнера";
+				case 2: return "vnum ключа (-1 нет)";
+				case 3: return "сложность замка (0-1000)";
+			}
+			return "";
+
+		case EObjType::kLiquidContainer:
+		case EObjType::kFountain:
+			switch (slot) {
+				case 0: return "объём, глотков";
+				case 1: return "налито, глотков";
+				case 2:
+					return (value >= 0 && value < NUM_LIQ_TYPES)
+						? "тип жидкости: " + std::string(drinks[value]) : "тип жидкости";
+				case 3: return "отравлено (0 нет, 1 да, >1 таймер)";
+			}
+			return "";
+
+		case EObjType::kFood:
+			if (slot == 0) return "насыщает, часов";
+			if (slot == 3) return "отравлено (0 нет, 1 да, >1 таймер)";
+			return "";
+
+		case EObjType::kMoney:
+			if (slot == 0) return "сумма";
+			if (slot == 1) {
+				switch (value) {
+					case 0: return "куны";
+					case 1: return "слава";
+					case 2: return "гривны";
+					case 3: return "снежинки";
+				}
+				return "тип валюты";
+			}
+			return "";
+
+		case EObjType::kBook:
+			if (slot == 0) {
+				switch (value) {
+					case 0: return "книга заклинаний";
+					case 1: return "книга умений";
+					case 2: return "улучшение умения";
+					case 3: return "книга рецептов";
+					case 4: return "книга способностей";
+				}
+				return "тип книги";
+			}
+			return "";
+
+		case EObjType::kMagicIngredient:
+			switch (slot) {
+				case 0: return "лаг применения, сек + уровень (6 бит)";
+				case 1: return "vnum прототипа";
+				case 2: return "число использований";
+			}
+			return "";
+
+		case EObjType::kMagicComponent:
+			return slot == 3 ? "класс ингредиента (0 РОСЛЬ, 1 ЖИВЬ, 2 ТВЕРДЬ)" : "";
+
+		case EObjType::kCraftMaterial:
+			switch (slot) {
+				case 0: return "уровень игрока + морт*2";
+				case 1: return "vnum прототипа";
+				case 2: return "сила ингредиента";
+				case 3: return "условный уровень";
+			}
+			return "";
+
+		case EObjType::kBandage:
+			return slot == 0 ? "хитов в секунду" : "";
+
+		case EObjType::kEnchant:
+			return slot == 0 ? "изменяет вес" : "";
+
+		case EObjType::kMagicContaner:
+			switch (slot) {
+				case 0: return spell(value);
+				case 1: return "объём колчана";
+				case 2: return "количество стрел";
+			}
+			return "";
+
+		case EObjType::kMagicArrow:
+			switch (slot) {
+				case 0: return spell(value);
+				case 1: return "размер пучка";
+				case 2: return "количество стрел";
+			}
+			return "";
+
+		default:
+			return "";
 	}
-	if (!is_spell_slot || value <= 0 || value > to_underlying(ESpell::kLast)) {
-		return "";
-	}
-	return GetSpellNameComment(static_cast<ESpell>(value));
 }
 
 // issue #3583: имя спелла для потионных ключей extra_values вида POTION_SPELL<n>_NUM
@@ -4282,13 +4414,12 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 	yaml.BeginSequence();
 	yaml.IncreaseIndent();
 
-	// issue #3583: у свитков/палочек/посохов values-слоты со спеллами подписываем именем заклинания.
-	// val[0] -- это уровень/сила заклинания, а не номер спелла, поэтому его не подписываем.
+	// issue #3593: подписываем каждый values-слот по смыслу для типа предмета.
 	const auto obj_type = obj->get_type();
-	yaml.SequenceItem(obj->get_val(0));
-	yaml.SequenceItem(obj->get_val(1), GetObjValueSpellComment(obj_type, 1, obj->get_val(1)));
-	yaml.SequenceItem(obj->get_val(2), GetObjValueSpellComment(obj_type, 2, obj->get_val(2)));
-	yaml.SequenceItem(obj->get_val(3), GetObjValueSpellComment(obj_type, 3, obj->get_val(3)));
+	yaml.SequenceItem(obj->get_val(0), GetObjValueComment(obj_type, 0, obj->get_val(0)));
+	yaml.SequenceItem(obj->get_val(1), GetObjValueComment(obj_type, 1, obj->get_val(1)));
+	yaml.SequenceItem(obj->get_val(2), GetObjValueComment(obj_type, 2, obj->get_val(2)));
+	yaml.SequenceItem(obj->get_val(3), GetObjValueComment(obj_type, 3, obj->get_val(3)));
 
 	yaml.DecreaseIndent();
 

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -226,7 +226,11 @@ std::string GetObjValueComment(EObjType type, int slot, int value) {
 			return "";
 
 		case EObjType::kMagicComponent:
-			return slot == 3 ? "класс ингредиента (0 РОСЛЬ, 1 ЖИВЬ, 2 ТВЕРДЬ)" : "";
+			if (slot == 3) {
+				const char *n = GetIngredientClassName(static_cast<EIngredientClass>(value));
+				return (n && *n) ? std::string("класс ингредиента: ") + n : "класс ингредиента";
+			}
+			return "";
 
 		case EObjType::kCraftMaterial:
 			switch (slot) {

--- a/src/engine/entities/entities_constants.cpp
+++ b/src/engine/entities/entities_constants.cpp
@@ -788,5 +788,16 @@ const char *GetBookTypeName(EBook type) {
 	return "";
 }
 
+// Единый источник названий классов магингредиентов (см. enum EIngredientClass).
+// Используется OLC-меню и подсказками в yaml. TODO: перенести в конфиги.
+const char *GetIngredientClassName(EIngredientClass type) {
+	switch (type) {
+		case EIngredientClass::kRosl:  return "РОСЛЬ";
+		case EIngredientClass::kJiv:   return "ЖИВЬ";
+		case EIngredientClass::kTverd: return "ТВЕРДЬ";
+	}
+	return "";
+}
+
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/entities/entities_constants.cpp
+++ b/src/engine/entities/entities_constants.cpp
@@ -775,5 +775,18 @@ std::vector<EWearFlag> ParseWearPositions(const std::string &val) {
 	return out;
 }
 
+// Единый источник названий типов книг (см. enum EBook). Используется OLC-меню
+// и подсказками в yaml. TODO: перенести в конфиги.
+const char *GetBookTypeName(EBook type) {
+	switch (type) {
+		case EBook::kSpell:        return "Книга заклинаний";
+		case EBook::kSkill:        return "Книга умений";
+		case EBook::kSkillUpgrade: return "Улучшение умения";
+		case EBook::kReceipt:      return "Книга рецептов";
+		case EBook::kFeat:         return "Книга способностей";
+	}
+	return "";
+}
+
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/entities/entities_constants.h
+++ b/src/engine/entities/entities_constants.h
@@ -665,6 +665,10 @@ EObjMaterial ITEM_BY_NAME<EObjMaterial>(const std::string &name);
 	kFeat = 4
 };
 
+// Название типа книги (единый источник для OLC-меню и подсказок в yaml).
+// TODO: перенести в конфиги. Возвращает "" для неизвестного типа.
+const char *GetBookTypeName(EBook type);
+
 /**
  * Take/Wear flags: used by obj_data.obj_flags.wear_flags
  */

--- a/src/engine/entities/entities_constants.h
+++ b/src/engine/entities/entities_constants.h
@@ -669,6 +669,16 @@ EObjMaterial ITEM_BY_NAME<EObjMaterial>(const std::string &name);
 // TODO: перенести в конфиги. Возвращает "" для неизвестного типа.
 const char *GetBookTypeName(EBook type);
 
+// Классы магических ингредиентов (kMagicComponent val[3]) -- нормальный тип
+// взамен старых #define IM_CLASS_ROSL/JIV/TVERD. Единый источник имён для OLC и
+// yaml. TODO: перенести в конфиги.
+enum class EIngredientClass {
+	kRosl = 0,    // РОСЛЬ (растения)
+	kJiv = 1,     // ЖИВЬ (животные)
+	kTverd = 2    // ТВЕРДЬ (минералы)
+};
+const char *GetIngredientClassName(EIngredientClass type);
+
 /**
  * Take/Wear flags: used by obj_data.obj_flags.wear_flags
  */

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -891,7 +891,13 @@ void oedit_disp_val4_menu(DescriptorData *d) {
 			}
 			break;
 
-		case EObjType::kMagicComponent: SendMsgToChar("Класс ингредиента (0-РОСЛЬ,1-ЖИВЬ,2-ТВЕРДЬ): ", d->character.get());
+		case EObjType::kMagicComponent:
+			// названия классов -- из единого источника GetIngredientClassName
+			snprintf(buf, sizeof(buf), "Класс ингредиента (0-%s, 1-%s, 2-%s): ",
+					GetIngredientClassName(EIngredientClass::kRosl),
+					GetIngredientClassName(EIngredientClass::kJiv),
+					GetIngredientClassName(EIngredientClass::kTverd));
+			SendMsgToChar(buf, d->character.get());
 			break;
 
 		case EObjType::kCraftMaterial: SendMsgToChar("Введите условный уровень: ", d->character.get());

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -674,32 +674,17 @@ void oedit_disp_val1_menu(DescriptorData *d) {
 			// * This is supposed to be language, but it's unused.
 			break;
 
-		case EObjType::kBook:
-			snprintf(buf, sizeof(buf),
-					"%s0%s) %sКнига заклинаний\r\n"
-					"%s1%s) %sКнига умений\r\n"
-					"%s2%s) %sУлучшение умения\r\n"
-					"%s3%s) %sКнига рецептов\r\n"
-					"%s4%s) %sКнига способностей\r\n"
-					"%sВыберите тип книги : ",
-					grn,
-					nrm,
-					yel,
-					grn,
-					nrm,
-					yel,
-					grn,
-					nrm,
-					yel,
-					grn,
-					nrm,
-					yel,
-					grn,
-					nrm,
-					yel,
-					nrm);
+		case EObjType::kBook: {
+			// названия типов книг -- из единого источника GetBookTypeName (enum EBook)
+			buf[0] = '\0';
+			for (int bt = EBook::kSpell; bt <= EBook::kFeat; ++bt) {
+				snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%s%d%s) %s%s\r\n",
+						grn, bt, nrm, yel, GetBookTypeName(static_cast<EBook>(bt)));
+			}
+			snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%sВыберите тип книги : ", nrm);
 			SendMsgToChar(buf, d->character.get());
 			break;
+		}
 
 		case EObjType::kMagicIngredient:
 			SendMsgToChar("Первый байт - лаг после применения в сек, 6 бит - уровень : ",

--- a/src/gameplay/crafting/im.cpp
+++ b/src/gameplay/crafting/im.cpp
@@ -314,7 +314,7 @@ int im_assign_power(ObjData *obj)
 	onum = GetObjRnum(imtypes[rind].proto_vnum);
 	if (onum < 0)
 		return 4;
-	if (GET_OBJ_VAL(obj_proto[onum], 3) == IM_CLASS_JIV) {
+	if (GET_OBJ_VAL(obj_proto[onum], 3) == static_cast<int>(EIngredientClass::kJiv)) {
 		if (GET_OBJ_VAL(obj, IM_INDEX_SLOT) == -1)
 			return 3;
 		rnum = GetMobRnum(GET_OBJ_VAL(obj, IM_INDEX_SLOT));

--- a/src/gameplay/crafting/im.h
+++ b/src/gameplay/crafting/im.h
@@ -17,10 +17,8 @@
 class ObjData;    // forward declaration to avoid inclusion of obj.hpp and any dependencies of that header.
 struct RoomData;    //
 
-// Определение основных классов ингредиентов: росль, живь, твердь
-#define        IM_CLASS_ROSL        0
-#define        IM_CLASS_JIV        1
-#define        IM_CLASS_TVERD        2
+// Классы ингредиентов (росль/живь/твердь) -- см. enum EIngredientClass в
+// entities_constants.h (заменил старые #define IM_CLASS_*).
 
 #define    IM_POWER_SLOT        1
 #define        IM_TYPE_SLOT        2

--- a/src/gameplay/crafting/im.h
+++ b/src/gameplay/crafting/im.h
@@ -20,9 +20,13 @@ struct RoomData;    //
 // Классы ингредиентов (росль/живь/твердь) -- см. enum EIngredientClass в
 // entities_constants.h (заменил старые #define IM_CLASS_*).
 
-#define    IM_POWER_SLOT        1
-#define        IM_TYPE_SLOT        2
-#define     IM_INDEX_SLOT       3
+// Слоты значений магингредиента (индексы в values). Plain enum: имена
+// по-прежнему используются как int-индексы в GET_OBJ_VAL/set_val.
+enum EIngredientSlot {
+	IM_POWER_SLOT = 1,   // val[1] -- уровень (сила) ингредиента
+	IM_TYPE_SLOT = 2,    // val[2] -- номер типа (из im.lst)
+	IM_INDEX_SLOT = 3    // val[3] -- уровень ингредиента или VNUM моба
+};
 
 #define        IM_NPARAM            3
 


### PR DESCRIPTION
Расширяет #3583: подписываем **каждый** слот `values` по смыслу для типа предмета, а не только спелл-слоты. Смысл слотов взят из OLC-меню (`oedit_disp_val1..4_menu`) — авторитетный источник.

## Пример (из issue)

```yaml
  type: kWeapon
  values:
    - 0
    - 5  # число бросков кубика
    - 3  # граней кубика
    - 2  # тип атаки
```

## Покрытие

`GetObjValueSpellComment` заменён общим `GetObjValueComment(type, slot, value)`:

| Тип | Слоты |
|---|---|
| оружие | число бросков кубика / граней / тип атаки |
| броня (все) | изменяет AC / изменяет броню |
| контейнер | вес / флаги / vnum ключа / сложность замка |
| сосуд/фонтан | объём / налито / **тип жидкости** (декод `drinks[]`) / отравлено |
| еда | насыщает часов / отравлено |
| деньги | сумма / **валюта** (куны/слава/гривны/снежинки) |
| книга | **тип книги** (заклинаний/умений/улучшение/рецептов/способностей) |
| свет | длительность горения (0=погасла, -1=вечный) |
| свиток/палочка/посох/зелье | уровень заклинания, заряды, **имена спеллов** (из #3583) |
| магингредиент/крафт/бандаж/зачар/колчан/стрелы | по OLC |

Enum-значения расшифровываются: жидкость (`drinks[]`), валюта, тип книги, класс магкомпонента. **Тип атаки оружия** оставлен без расшифровки — она зависит от fight-сообщений, которые в `-S` resave не загружены (в `oedit save all` на полном boot загружены, но чтобы не плодить guard-подгрузку и не ловить `ERROR: message not found`, оставил просто метку `тип атаки`). Жидкость декодится всегда — `drinks[]` статичный.

## Проверка

Ресейв small-мира (`errors=0`): оружие, броня, контейнер, сосуд (`тип жидкости: молока`), еда, свет, деньги (`куны`), книга (`книга заклинаний`), свиток (`уровень заклинания` + `медлительность`) — все подписаны корректно. Спелл-слоты из #3583 не сломаны.

Сборка зелёная.

Closes #3593