### PR TITLE
feat(yaml): label weapon val[0] as unused hit modifier (#3593)

### DIFF
--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -156,6 +156,7 @@ std::string GetObjValueComment(EObjType type, int slot, int value) {
 
 		case EObjType::kWeapon:
 			switch (slot) {
+				case 0: return "не используется";
 				case 1: return "число бросков кубика";
 				case 2: return "граней кубика";
 				case 3: {

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -647,8 +647,8 @@ void oedit_disp_val1_menu(DescriptorData *d) {
 			break;
 
 		case EObjType::kWeapon:
-			// * This doesn't seem to be used if I remember right.
-			SendMsgToChar("Модификатор попадания : ", d->character.get());
+			// val[0] у оружия в бою не читается (см. fight_hit.cpp).
+			SendMsgToChar("Не используется : ", d->character.get());
 			break;
 
 		case EObjType::kArmor:


### PR DESCRIPTION
Дополнение вслед за #3594 (влит): у оружия `val[0]` оставался без подписи.

## Проверка (по вопросу «точно не hitroll?»)

val[0] оружия — классический Diku-слот hitroll, но в Bylins он **не используется**:
- в `fight_hit.cpp` у надетого оружия читаются только `val[1]`/`val[2]` (урон) и `val[3]` (тип атаки);
- `GET_OBJ_VAL(wielded, 0)` не читается нигде в бою;
- hitroll берётся из `GET_REAL_HR(ch)`, а бонус к попаданию от оружия идёт через **APPLY_HITROLL-аффекты** на объекте, а не через val[0].

Совпадает с комментом в oedit («This doesn't seem to be used»).

## Итог

```yaml
  type: kWeapon
  values:
    - 0  # модификатор попадания (не используется)
    - 2  # число бросков кубика
    - 5  # граней кубика
    - 3  # тип атаки: рубанул
```