### PR TITLE
refactor(extra-desc): ExtraDescription keyword/description -> std::string

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -450,7 +450,7 @@ void WorldFile::parse_room(int virtual_nr) {
 				const ExtraDescription::shared_ptr new_descr(new ExtraDescription);
 				new_descr->set_keyword(fread_string());
 				new_descr->set_description(fread_string());
-				if (new_descr->keyword && new_descr->description) {
+				if (!new_descr->keyword.empty() && !new_descr->description.empty()) {
 					new_descr->next = world[room_realnum]->ex_description;
 					world[room_realnum]->ex_description = new_descr;
 				} else {
@@ -733,7 +733,7 @@ void ObjectFile::parse_object(const int nr) {
 				const ExtraDescription::shared_ptr new_descr(new ExtraDescription());
 				new_descr->set_keyword(fread_string());
 				new_descr->set_description(fread_string());
-				if (new_descr->keyword && new_descr->description) {
+				if (!new_descr->keyword.empty() && !new_descr->description.empty()) {
 					new_descr->next = tobj->get_ex_description();
 					tobj->set_ex_description(new_descr);
 				} else {

--- a/src/engine/core/char_handler.cpp
+++ b/src/engine/core/char_handler.cpp
@@ -55,7 +55,7 @@ void DoReturn(CharData *ch, char *argument, int cmd, int subcmd);
 //extern std::vector<City> Cities;
 extern int global_uid;
 extern void change_leader(CharData *ch, CharData *vict);
-char *sight::find_exdesc(const char *word, const ExtraDescription::shared_ptr &list);
+const char *sight::find_exdesc(const char *word, const ExtraDescription::shared_ptr &list);
 extern void SetSkillCooldown(CharData *ch, ESkill skill, int pulses);
 
 

--- a/src/engine/core/obj_handler.cpp
+++ b/src/engine/core/obj_handler.cpp
@@ -56,7 +56,7 @@ void DoReturn(CharData *ch, char *argument, int cmd, int subcmd);
 //extern std::vector<City> Cities;
 extern int global_uid;
 extern void change_leader(CharData *ch, CharData *vict);
-char *sight::find_exdesc(const char *word, const ExtraDescription::shared_ptr &list);
+const char *sight::find_exdesc(const char *word, const ExtraDescription::shared_ptr &list);
 extern void SetSkillCooldown(CharData *ch, ESkill skill, int pulses);
 
 

--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -406,8 +406,8 @@ ObjData::shared_ptr read_one_object_new(char **data, int *error) {
 			} else if (!strcmp(read_line, "Edes")) {
 				*error = 46;
 				ExtraDescription::shared_ptr new_descr(new ExtraDescription());
-				new_descr->keyword = str_dup(buffer);
-				if (!strcmp(new_descr->keyword, "None")) {
+				new_descr->keyword = buffer;
+				if (new_descr->keyword == "None") {
 					object->set_ex_description(nullptr);
 				} else {
 					if (!get_buf_lines(data, buffer)) {
@@ -814,8 +814,8 @@ void write_one_object(std::stringstream &out, ObjData *object, int location) {
 			if (proto_has_descr(descr, p->get_ex_description())) {
 				continue;
 			}
-			out << "Edes: " << (descr->keyword ? descr->keyword : "") << "~\n"
-				<< (descr->description ? descr->description : "") << "~\n";
+			out << "Edes: " << descr->keyword << "~\n"
+				<< descr->description << "~\n";
 		}
 		if (!object->get_ex_description() && p->get_ex_description()) {
 			out << "Edes: None~\n";

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -3169,8 +3169,8 @@ void SqliteWorldDataSource::SaveRoomRecord(RoomData *room)
 		if (sqlite3_prepare_v2(m_db, extra_sql, -1, &stmt, nullptr) == SQLITE_OK)
 		{
 			sqlite3_bind_int(stmt, 1, room_vnum);
-			BindTextKoi(stmt, 2, exdesc->keyword);
-			BindTextKoi(stmt, 3, exdesc->description);
+			BindTextKoi(stmt, 2, exdesc->keyword.c_str());
+			BindTextKoi(stmt, 3, exdesc->description.c_str());
 			sqlite3_step(stmt);
 			sqlite3_finalize(stmt);
 		}
@@ -3879,8 +3879,8 @@ void SqliteWorldDataSource::SaveObjectRecord(int obj_vnum, CObjectPrototype *obj
 		if (sqlite3_prepare_v2(m_db, extra_sql, -1, &stmt, nullptr) == SQLITE_OK)
 		{
 			sqlite3_bind_int(stmt, 1, obj_vnum);
-			BindTextKoi(stmt, 2, exdesc->keyword);
-			BindTextKoi(stmt, 3, exdesc->description);
+			BindTextKoi(stmt, 2, exdesc->keyword.c_str());
+			BindTextKoi(stmt, 3, exdesc->description.c_str());
 			sqlite3_step(stmt);
 			sqlite3_finalize(stmt);
 		}

--- a/src/engine/db/world_checksum.cpp
+++ b/src/engine/db/world_checksum.cpp
@@ -203,11 +203,11 @@ std::string SerializeRoom(const RoomData *room)
 	// the room's ex_description list (see boot_data_files.cpp:463-475).
 	for (auto ed = room->ex_description; ed; ed = ed->next)
 	{
-		if (ed->keyword)
+		if (!ed->keyword.empty())
 		{
 			oss << ed->keyword << ":";
 		}
-		if (ed->description)
+		if (!ed->description.empty())
 		{
 			oss << ed->description;
 		}
@@ -521,11 +521,11 @@ std::string SerializeObject(const CObjectPrototype::shared_ptr &obj)
 	// Extra descriptions
 	for (auto ed = obj->get_ex_description(); ed; ed = ed->next)
 	{
-		if (ed->keyword)
+		if (!ed->keyword.empty())
 		{
 			oss << ed->keyword << ":";
 		}
-		if (ed->description)
+		if (!ed->description.empty())
 		{
 			oss << ed->description;
 		}

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -3560,8 +3560,8 @@ void YamlWorldDataSource::EmitRoomBody(Koi8rYamlEmitter &yaml, std::ostream &out
 	std::vector<ExtraDescription *> exdescs;
 	for (auto exdesc = room->ex_description; exdesc; exdesc = exdesc->next)
 	{
-		if (exdesc->keyword && exdesc->description
-			&& std::string(exdesc->description).find_first_not_of(" \t\r\n") != std::string::npos)
+		if (!exdesc->keyword.empty()
+			&& exdesc->description.find_first_not_of(" \t\r\n") != std::string::npos)
 		{
 			exdescs.push_back(exdesc.get());
 		}
@@ -3585,11 +3585,11 @@ void YamlWorldDataSource::EmitRoomBody(Koi8rYamlEmitter &yaml, std::ostream &out
 			// IncreaseIndent so yaml.Value's literal-block branch emits content
 			// lines at the correct column for indicator "2" (parent_indent + 2).
 			yaml.IncreaseIndent();
-			yaml.Value(std::string(exdesc->keyword));
+			yaml.Value(exdesc->keyword);
 			yaml.DecreaseIndent();
 			out << yaml.GetIndent() << "  description:";
 			yaml.IncreaseIndent();
-			yaml.Value(std::string(exdesc->description), true);
+			yaml.Value(exdesc->description, true);
 			yaml.DecreaseIndent();
 		}
 
@@ -4656,8 +4656,8 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 	std::vector<ExtraDescription *> exdescs;
 	for (auto exdesc = obj->get_ex_description(); exdesc; exdesc = exdesc->next)
 	{
-		if (exdesc->keyword && exdesc->description
-			&& std::string(exdesc->description).find_first_not_of(" \t\r\n") != std::string::npos)
+		if (!exdesc->keyword.empty()
+			&& exdesc->description.find_first_not_of(" \t\r\n") != std::string::npos)
 		{
 			exdescs.push_back(exdesc.get());
 		}
@@ -4680,11 +4680,11 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 			// IncreaseIndent so yaml.Value's literal-block branch emits content
 			// lines at the correct column for indicator "2" (parent_indent + 2).
 			yaml.IncreaseIndent();
-			yaml.Value(std::string(exdesc->keyword));
+			yaml.Value(exdesc->keyword);
 			yaml.DecreaseIndent();
 			out << yaml.GetIndent() << "  description:";
 			yaml.IncreaseIndent();
-			yaml.Value(std::string(exdesc->description), true);
+			yaml.Value(exdesc->description, true);
 			yaml.DecreaseIndent();
 		}
 

--- a/src/engine/entities/obj_data.cpp
+++ b/src/engine/entities/obj_data.cpp
@@ -829,8 +829,10 @@ void ObjData::del_timed_spell(const ESpell spell_id, const bool message) {
 
 void CObjectPrototype::set_ex_description(const char *keyword, const char *description) {
 	ExtraDescription::shared_ptr d(new ExtraDescription());
-	d->keyword = strdup(keyword);
-	d->description = strdup(description);
+	// keyword/description -- std::string, присваиваем напрямую (strdup утёк бы:
+	// строка копирует контент, а выделенный буфер терялся).
+	d->keyword = keyword;
+	d->description = description;
 	m_ex_description = d;
 }
 

--- a/src/engine/entities/obj_data.cpp
+++ b/src/engine/entities/obj_data.cpp
@@ -90,12 +90,8 @@ void ObjData::zero_init() {
 void ObjData::detach_ex_description() {
 	const auto old_description = get_ex_description();
 	const auto new_description = std::make_shared<ExtraDescription>();
-	if (nullptr != old_description->keyword) {
-		new_description->keyword = str_dup(old_description->keyword);
-	}
-	if (nullptr != old_description->keyword) {
-		new_description->description = str_dup(old_description->description);
-	}
+	new_description->keyword = old_description->keyword;
+	new_description->description = old_description->description;
 	set_ex_description(new_description);
 }
 
@@ -306,7 +302,7 @@ void CObjectPrototype::set_vnum(const ObjVnum vnum) {
 }
 
 void CObjectPrototype::tag_ex_description(const char *tag) {
-	m_ex_description->description = str_add(m_ex_description->description, tag);
+	m_ex_description->description += tag;
 }
 
 CObjectPrototype &CObjectPrototype::operator=(const CObjectPrototype &from) {
@@ -563,8 +559,8 @@ void ObjData::copy_from(const CObjectPrototype *src) {
 		auto sdd = src->get_ex_description();
 		while (sdd) {
 			pddd->reset(new ExtraDescription());
-			(*pddd)->keyword = str_dup(sdd->keyword);
-			(*pddd)->description = str_dup(sdd->description);
+			(*pddd)->keyword = sdd->keyword;
+			(*pddd)->description = sdd->description;
 			pddd = &(*pddd)->next;
 			sdd = sdd->next;
 		}

--- a/src/engine/network/admin_api/serializers.cpp
+++ b/src/engine/network/admin_api/serializers.cpp
@@ -284,8 +284,8 @@ json SerializeObject(const CObjectPrototype& obj, int vnum)
 	for (auto ed = obj.get_ex_description(); ed; ed = ed->next)
 	{
 		json extra;
-		extra["keywords"] = Koi8rToUtf8(ed->keyword ? ed->keyword : "");
-		extra["description"] = Koi8rToUtf8(ed->description ? ed->description : "");
+		extra["keywords"] = Koi8rToUtf8(ed->keyword);
+		extra["description"] = Koi8rToUtf8(ed->description);
 		extra_descs.push_back(extra);
 	}
 	obj_data["extra_descriptions"] = extra_descs;
@@ -365,11 +365,11 @@ json SerializeRoom(RoomData& room, int vnum)
 	for (auto ed = room.ex_description; ed; ed = ed->next)
 	{
 		json ed_obj;
-		if (ed->keyword)
+		if (!ed->keyword.empty())
 		{
 			ed_obj["keyword"] = Koi8rToUtf8(ed->keyword);
 		}
-		if (ed->description)
+		if (!ed->description.empty())
 		{
 			ed_obj["description"] = Koi8rToUtf8(ed->description);
 		}

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -370,15 +370,15 @@ void oedit_save_to_disk(ZoneRnum zone_num) {
 			{
 				for (auto ex_desc = obj->get_ex_description(); ex_desc; ex_desc = ex_desc->next) {
 					// * Sanity check to prevent nasty protection faults.
-					if (!ex_desc->keyword
-						|| !ex_desc->description) {
+					if (ex_desc->keyword.empty()
+						|| ex_desc->description.empty()) {
 						mudlog("SYSERR: OLC: oedit_save_to_disk: Corrupt ex_desc!",
 							   BRF, kLvlBuilder, SYSLOG, true);
 						continue;
 					}
-					snprintf(buf1, sizeof(buf1), "%s", ex_desc->description);
+					snprintf(buf1, sizeof(buf1), "%s", ex_desc->description.c_str());
 					strip_string(buf1);
-					fprintf(fp, "E\n" "%s~\n" "%s~\n", ex_desc->keyword, buf1);
+					fprintf(fp, "E\n" "%s~\n" "%s~\n", ex_desc->keyword.c_str(), buf1);
 				}
 			}
 			// * Do we have affects?
@@ -459,8 +459,8 @@ void oedit_disp_extradesc_menu(DescriptorData *d) {
 			 "%s3%s) Следующий дескриптор: %s\r\n"
 			 "%s0%s) Выход\r\n"
 			 "Ваш выбор : ",
-			 grn, nrm, yel, (extra_desc->keyword && *extra_desc->keyword) ? extra_desc->keyword : "<NONE>",
-			 grn, nrm, yel, (extra_desc->description && *extra_desc->description) ? extra_desc->description : "<NONE>",
+			 grn, nrm, yel, !extra_desc->keyword.empty() ? extra_desc->keyword.c_str() : "<NONE>",
+			 grn, nrm, yel, !extra_desc->description.empty() ? extra_desc->description.c_str() : "<NONE>",
 			 grn, nrm, buf1, grn, nrm);
 	SendMsgToChar(buf, d->character.get());
 	OLC_MODE(d) = OEDIT_EXTRADESC_MENU;
@@ -2160,16 +2160,14 @@ void oedit_parse(DescriptorData *d, char *arg) {
 			return;
 
 		case OEDIT_EXTRADESC_KEY:
-			if (OLC_DESC(d)->keyword)
-				free(OLC_DESC(d)->keyword);
-			OLC_DESC(d)->keyword = str_dup((arg && *arg) ? arg : "undefined");
+			OLC_DESC(d)->keyword = (arg && *arg) ? arg : "undefined";
 			oedit_disp_extradesc_menu(d);
 			return;
 
 		case OEDIT_EXTRADESC_MENU:
 			switch ((number = atoi(arg))) {
 				case 0:
-					if (!OLC_DESC(d)->keyword || !OLC_DESC(d)->description) {
+					if (OLC_DESC(d)->keyword.empty() || OLC_DESC(d)->description.empty()) {
 						OLC_DESC(d).reset();
 						OLC_OBJ(d)->set_ex_description(nullptr);
 					}
@@ -2182,11 +2180,11 @@ void oedit_parse(DescriptorData *d, char *arg) {
 				case 2: OLC_MODE(d) = OEDIT_EXTRADESC_DESCRIPTION;
 				iosystem::write_to_output("Enter the extra description: (/s saves /h for help)\r\n\r\n", d);
 					d->backstr = nullptr;
-					if (OLC_DESC(d)->description) {
-					iosystem::write_to_output(OLC_DESC(d)->description, d);
-						d->backstr = str_dup(OLC_DESC(d)->description);
+					if (!OLC_DESC(d)->description.empty()) {
+					iosystem::write_to_output(OLC_DESC(d)->description.c_str(), d);
+						d->backstr = str_dup(OLC_DESC(d)->description.c_str());
 					}
-					d->writer.reset(new utils::DelegatedStringWriter(OLC_DESC(d)->description));
+					d->writer.reset(new utils::DelegatedStdStringWriter(OLC_DESC(d)->description));
 					d->max_str = 4096;
 					d->mail_to = 0;
 					OLC_VAL(d) = 1;
@@ -2194,7 +2192,7 @@ void oedit_parse(DescriptorData *d, char *arg) {
 
 				case 3:
 					// * Only go to the next description if this one is finished.
-					if (OLC_DESC(d)->keyword && OLC_DESC(d)->description) {
+					if (!OLC_DESC(d)->keyword.empty() && !OLC_DESC(d)->description.empty()) {
 						if (OLC_DESC(d)->next) {
 							OLC_DESC(d) = OLC_DESC(d)->next;
 						} else    // Make new extra description and attach at end.

--- a/src/engine/olc/redit.cpp
+++ b/src/engine/olc/redit.cpp
@@ -348,10 +348,10 @@ void redit_save_to_disk(ZoneRnum zone_num) {
 			// * Home straight, just deal with extra descriptions.
 			if (room->ex_description) {
 				for (auto ex_desc = room->ex_description; ex_desc; ex_desc = ex_desc->next) {
-					if (ex_desc->keyword && ex_desc->description) {
-						snprintf(buf1, sizeof(buf1), "%s", ex_desc->description);
+					if (!ex_desc->keyword.empty() && !ex_desc->description.empty()) {
+						snprintf(buf1, sizeof(buf1), "%s", ex_desc->description.c_str());
 						strip_string(buf1);
-						fprintf(fp, "E\n%s~\n%s~\n", ex_desc->keyword, buf1);
+						fprintf(fp, "E\n%s~\n%s~\n", ex_desc->keyword.c_str(), buf1);
 					}
 				}
 			}
@@ -390,8 +390,8 @@ void redit_disp_extradesc_menu(DescriptorData *d) {
 			"&g1&n) Ключ: &y%s\r\n"
 			"&g2&n) Описание:\r\n&y%s\r\n"
 			"&g3&n) Следующее описание: ",
-			extra_desc->keyword ? extra_desc->keyword : "<NONE>",
-			extra_desc->description ? extra_desc->description : "<NONE>");
+			!extra_desc->keyword.empty() ? extra_desc->keyword.c_str() : "<NONE>",
+			!extra_desc->description.empty() ? extra_desc->description.c_str() : "<NONE>");
 
 	strncat(buf, !extra_desc->next ? "<NOT SET>\r\n" : "Set.\r\n", sizeof(buf) - strlen(buf) - 1);
 	strncat(buf, "Enter choice (0 to quit) : ", sizeof(buf) - strlen(buf) - 1);
@@ -800,7 +800,7 @@ void redit_parse(DescriptorData *d, char *arg) {
 			OLC_MODE(d) = REDIT_EXIT_DOORFLAGS;
 			redit_disp_exit_flag_menu(d);
 			return;
-		case REDIT_EXTRADESC_KEY: OLC_DESC(d)->keyword = ((arg && *arg) ? str_dup(arg) : nullptr);
+		case REDIT_EXTRADESC_KEY: OLC_DESC(d)->keyword = (arg && *arg) ? arg : "";
 			redit_disp_extradesc_menu(d);
 			return;
 
@@ -809,7 +809,7 @@ void redit_parse(DescriptorData *d, char *arg) {
 				case 0:
 					// * If something got left out, delete the extra description
 					// * when backing out to the menu.
-					if (!OLC_DESC(d)->keyword || !OLC_DESC(d)->description) {
+					if (OLC_DESC(d)->keyword.empty() || OLC_DESC(d)->description.empty()) {
 						auto &desc = OLC_DESC(d);
 						desc.reset();
 					}
@@ -822,17 +822,17 @@ void redit_parse(DescriptorData *d, char *arg) {
 				case 2: OLC_MODE(d) = REDIT_EXTRADESC_DESCRIPTION;
 				iosystem::write_to_output("Введите экстраописание: (/s сохранить /h помощь)\r\n\r\n", d);
 					d->backstr = nullptr;
-					if (OLC_DESC(d)->description) {
-					iosystem::write_to_output(OLC_DESC(d)->description, d);
-						d->backstr = str_dup(OLC_DESC(d)->description);
+					if (!OLC_DESC(d)->description.empty()) {
+					iosystem::write_to_output(OLC_DESC(d)->description.c_str(), d);
+						d->backstr = str_dup(OLC_DESC(d)->description.c_str());
 					}
-					d->writer.reset(new utils::DelegatedStringWriter(OLC_DESC(d)->description));
+					d->writer.reset(new utils::DelegatedStdStringWriter(OLC_DESC(d)->description));
 					d->max_str = 4096;
 					d->mail_to = 0;
 					return;
 
 				case 3:
-					if (!OLC_DESC(d)->keyword || !OLC_DESC(d)->description) {
+					if (OLC_DESC(d)->keyword.empty() || OLC_DESC(d)->description.empty()) {
 						SendMsgToChar("Вы не можете редактировать следующее экстраописание, не завершив текущее.\r\n",
 									 d->character.get());
 						redit_disp_extradesc_menu(d);
@@ -925,8 +925,8 @@ void CopyRoom(RoomData *dst, RoomData *src) {
 
 	while (sdd) {
 		*pddd = std::make_shared<ExtraDescription>();
-		(*pddd)->keyword = sdd->keyword ? str_dup(sdd->keyword) : nullptr;
-		(*pddd)->description = sdd->description ? str_dup(sdd->description) : nullptr;
+		(*pddd)->keyword = sdd->keyword;
+		(*pddd)->description = sdd->description;
 		pddd = &((*pddd)->next);
 		sdd = sdd->next;
 	}

--- a/src/engine/structs/extra_description.cpp
+++ b/src/engine/structs/extra_description.cpp
@@ -9,26 +9,11 @@
 #include "utils/utils.h"
 
 void ExtraDescription::set_keyword(std::string const &value) {
-	if (keyword != nullptr)
-		free(keyword);
-	keyword = str_dup(value.c_str());
+	keyword = value;
 }
 
 void ExtraDescription::set_description(std::string const &value) {
-	if (description != nullptr)
-		free(description);
-	description = str_dup(value.c_str());
-}
-
-ExtraDescription::~ExtraDescription() {
-	if (nullptr != keyword) {
-		free(keyword);
-	}
-
-	if (nullptr != description) {
-		free(description);
-	}
-	// we don't take care of items in list. So, we don't do anything with the next field.
+	description = value;
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/structs/extra_description.h
+++ b/src/engine/structs/extra_description.h
@@ -13,13 +13,11 @@
 // Extra description: used in objects, mobiles, and rooms //
 struct ExtraDescription {
 	using shared_ptr = std::shared_ptr<ExtraDescription>;
-	ExtraDescription() : keyword(nullptr), description(nullptr), next(nullptr) {}
-	~ExtraDescription();
 	void set_keyword(std::string const &keyword);
 	void set_description(std::string const &description);
 
-	char *keyword;        // Keyword in look/examine          //
-	char *description;    // What to see                      //
+	std::string keyword;        // Keyword in look/examine          //
+	std::string description;    // What to see                      //
 	shared_ptr next;    // Next in list                     //
 };
 

--- a/src/engine/ui/cmd/do_get.cpp
+++ b/src/engine/ui/cmd/do_get.cpp
@@ -16,7 +16,7 @@
 #include <fmt/format.h>
 
 extern bool CanTakeObj(CharData *ch, ObjData *obj);
-extern char *sight::find_exdesc(const char *word, const ExtraDescription::shared_ptr &list);
+extern const char *sight::find_exdesc(const char *word, const ExtraDescription::shared_ptr &list);
 
 /// считаем сколько у ch в группе еще игроков (не мобов)
 int other_pc_in_group(CharData *ch) {

--- a/src/gameplay/crafting/craft.cpp
+++ b/src/gameplay/crafting/craft.cpp
@@ -538,9 +538,9 @@ bool CObject::save_to_node(pugi::xml_node *node) const {
 		CHelper::save_string(description, "action", get_action_description().c_str(),
 							 [&]() { throw std::runtime_error("WARNING: Failed to save action description"); });
 		if (get_ex_description()) {
-			CHelper::save_string(description, "keyword", get_ex_description()->keyword,
+			CHelper::save_string(description, "keyword", get_ex_description()->keyword.c_str(),
 								 [&]() { throw std::runtime_error("WARNING: Failed to save keyword"); });
-			CHelper::save_string(description, "extended", get_ex_description()->description,
+			CHelper::save_string(description, "extended", get_ex_description()->description.c_str(),
 								 [&]() { throw std::runtime_error("WARNING: Failed to save extended description"); });
 		}
 

--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -37,7 +37,7 @@ extern int invalid_unique(CharData *ch, const ObjData *obj);    // implemented i
 extern int invalid_no_class(CharData *ch, const ObjData *obj);    // implemented in class.cpp
 extern int invalid_anti_class_proto(CharData *ch, const CObjectPrototype *obj);    // implemented in class.cpp
 extern int invalid_no_class_proto(CharData *ch, const CObjectPrototype *obj);    // implemented in class.cpp
-char *sight::find_exdesc(const char *word, const ExtraDescription::shared_ptr &list); // implemented in act.informative.cpp
+const char *sight::find_exdesc(const char *word, const ExtraDescription::shared_ptr &list); // implemented in act.informative.cpp
 namespace ShopExt {
 const int IDENTIFY_COST = 110;
 

--- a/src/gameplay/mechanics/dungeons.cpp
+++ b/src/gameplay/mechanics/dungeons.cpp
@@ -914,11 +914,8 @@ void RoomDataFree(ZoneRnum zrn) {
 		}
 		ExtraDescription::shared_ptr sdd = room->ex_description;
 		if (sdd) {
-			while (sdd) {
-				free(sdd->keyword);
-				free(sdd->description);
-				sdd = sdd->next;
-			}
+			// строки keyword/description теперь std::string -- освобождаются
+			// автоматически при разрушении ExtraDescription, ручной free не нужен.
 			sdd.reset();
 		}
 	}

--- a/src/gameplay/mechanics/sight.cpp
+++ b/src/gameplay/mechanics/sight.cpp
@@ -398,7 +398,8 @@ bool look_at_target(CharData *ch, char *arg, int subcmd) {
 	int bits, found = false, fnum, i = 0;
 	CharData *found_char = nullptr;
 	ObjData *found_obj = nullptr;
-	char *desc, *what, whatp[kMaxInputLength], where[kMaxInputLength];
+	const char *desc;
+	char *what, whatp[kMaxInputLength], where[kMaxInputLength];
 	int where_bits = EFind::kObjInventory | EFind::kObjRoom | EFind::kObjEquip | EFind::kCharInRoom | EFind::kObjExtraDesc;
 
 	if (!ch->desc) {
@@ -489,7 +490,7 @@ bool look_at_target(CharData *ch, char *arg, int subcmd) {
 	i = 0;
 	// Does the argument match an extra desc in the room?
 	if ((desc = find_exdesc(what, world[ch->in_room]->ex_description)) != nullptr && ++i == fnum) {
-		page_string(ch->desc, desc, false);
+		page_string(ch->desc, const_cast<char *>(desc), false);
 		return false;
 	}
 
@@ -1464,10 +1465,10 @@ bool put_delim(std::stringstream &out, bool delim) {
 	return true;
 }
 
-char *find_exdesc(const char *word, const ExtraDescription::shared_ptr &list) {
+const char *find_exdesc(const char *word, const ExtraDescription::shared_ptr &list) {
 	for (auto i = list; i; i = i->next) {
 		if (isname(word, i->keyword)) {
-			return i->description;
+			return i->description.c_str();
 		}
 	}
 

--- a/src/gameplay/mechanics/sight.h
+++ b/src/gameplay/mechanics/sight.h
@@ -29,7 +29,7 @@ void look_in_obj(CharData *ch, char *arg);
 void look_in_direction(CharData *ch, int dir, int info_is);
 void list_obj_to_char(ObjData *list, CharData *ch, int mode, int show);
 void print_zone_info(CharData *ch);
-char *find_exdesc(const char *word, const ExtraDescription::shared_ptr &list);
+const char *find_exdesc(const char *word, const ExtraDescription::shared_ptr &list);
 const char *show_obj_to_char(ObjData *object, CharData *ch, int mode, int show_state, int how);
 void obj_info(CharData *ch, ObjData *obj, char buf[kMaxStringLength]);
 void print_zone_info(CharData *ch);

--- a/tests/extra_description.cpp
+++ b/tests/extra_description.cpp
@@ -11,8 +11,8 @@
 
 TEST(ExtraDescription, DefaultConstruction_AllFieldsNull) {
 	ExtraDescription ed;
-	EXPECT_EQ(nullptr, ed.keyword);
-	EXPECT_EQ(nullptr, ed.description);
+	EXPECT_TRUE(ed.keyword.empty());
+	EXPECT_TRUE(ed.description.empty());
 	EXPECT_EQ(nullptr, ed.next);
 }
 
@@ -21,22 +21,20 @@ TEST(ExtraDescription, DefaultConstruction_AllFieldsNull) {
 TEST(ExtraDescription, SetKeyword_StoresValue) {
 	ExtraDescription ed;
 	ed.set_keyword("door");
-	ASSERT_NE(nullptr, ed.keyword);
-	EXPECT_STREQ("door", ed.keyword);
+	EXPECT_EQ("door", ed.keyword);
 }
 
 TEST(ExtraDescription, SetKeyword_Twice_UpdatesValue) {
 	ExtraDescription ed;
 	ed.set_keyword("first");
 	ed.set_keyword("second");
-	EXPECT_STREQ("second", ed.keyword);
+	EXPECT_EQ("second", ed.keyword);
 }
 
 TEST(ExtraDescription, SetKeyword_EmptyString_Stores) {
 	ExtraDescription ed;
 	ed.set_keyword("");
-	ASSERT_NE(nullptr, ed.keyword);
-	EXPECT_STREQ("", ed.keyword);
+	EXPECT_EQ("", ed.keyword);
 }
 
 // --- set_description ---
@@ -44,15 +42,14 @@ TEST(ExtraDescription, SetKeyword_EmptyString_Stores) {
 TEST(ExtraDescription, SetDescription_StoresValue) {
 	ExtraDescription ed;
 	ed.set_description("A heavy oak door.");
-	ASSERT_NE(nullptr, ed.description);
-	EXPECT_STREQ("A heavy oak door.", ed.description);
+	EXPECT_EQ("A heavy oak door.", ed.description);
 }
 
 TEST(ExtraDescription, SetDescription_Twice_UpdatesValue) {
 	ExtraDescription ed;
 	ed.set_description("old desc");
 	ed.set_description("new desc");
-	EXPECT_STREQ("new desc", ed.description);
+	EXPECT_EQ("new desc", ed.description);
 }
 
 // --- Both keyword and description ---
@@ -61,8 +58,8 @@ TEST(ExtraDescription, SetBoth_Independent) {
 	ExtraDescription ed;
 	ed.set_keyword("window");
 	ed.set_description("A cracked glass window.");
-	EXPECT_STREQ("window", ed.keyword);
-	EXPECT_STREQ("A cracked glass window.", ed.description);
+	EXPECT_EQ("window", ed.keyword);
+	EXPECT_EQ("A cracked glass window.", ed.description);
 }
 
 // --- Linked list via shared_ptr ---
@@ -85,9 +82,9 @@ TEST(ExtraDescription, LinkedList_CanChain) {
 	second->next = third;
 
 	// Traverse
-	EXPECT_STREQ("head", head->keyword);
-	EXPECT_STREQ("second", head->next->keyword);
-	EXPECT_STREQ("third", head->next->next->keyword);
+	EXPECT_EQ("head", head->keyword);
+	EXPECT_EQ("second", head->next->keyword);
+	EXPECT_EQ("third", head->next->next->keyword);
 	EXPECT_EQ(nullptr, head->next->next->next);
 }
 
@@ -100,7 +97,7 @@ TEST(ExtraDescription, LinkedList_DropHead_SecondBecomesReachable) {
 
 	// Drop head - second should still be alive
 	head.reset();
-	EXPECT_STREQ("second", second->keyword);
+	EXPECT_EQ("second", second->keyword);
 }
 
 // --- Memory management (no leaks - verified by ASAN/valgrind) ---


### PR DESCRIPTION
Заменил сырые `char*` на `std::string` в `ExtraDescription` — RAII вместо ручных `strdup`/`free`, нормальный `empty()`, без утечек по забытому `free`.

## Структура
```cpp
struct ExtraDescription {
    std::string keyword;      // было char*
    std::string description;  // было char*
    shared_ptr next;
};
```
Убраны кастомный `~ExtraDescription()` и `strdup`/`free` в сеттерах (теперь тривиальное присваивание, дефолтный деструктор).

## Потребители (~17 файлов)
- проверки указателя `if (ed->keyword)` → `if (!ed->keyword.empty())`;
- передача в C-API/printf/fprintf → `.c_str()`;
- копирование дескрипторов → прямое присваивание (без `str_dup`);
- **OLC** (oedit/redit): строковый редактор пишет через `DelegatedStdStringWriter(std::string&)` вместо `DelegatedStringWriter(char*&)`;
- `sight::find_exdesc` теперь возвращает `const char*` (`.c_str()`), объявления обновлены во всех местах;
- **dungeons**: убран ручной `free(keyword)/free(description)` — теперь RAII (это заодно чинило потенциальный double-free со строками, ещё живущими в списке комнаты).

## Проверка
- Сборка зелёная (circle + mud-sim).
- Ресейв small-мира: `errors=0`, extra_descriptions грузятся и пишутся корректно (round-trip сохранён), валидные многострочные описания на месте.

Часть общего курса на замену сырых `char*` на `std::string`.