### PR TITLE
refactor(obj): set_ex_description takes std::string, not const char*

### DIFF
--- a/src/engine/entities/obj_data.cpp
+++ b/src/engine/entities/obj_data.cpp
@@ -621,7 +621,7 @@ void ObjData::swap(ObjData &object, bool swap_trig) {
 
 void ObjData::set_tag(const char *tag) {
 	if (!get_ex_description()) {
-		set_ex_description(get_aliases().c_str(), tag);
+		set_ex_description(get_aliases(), tag);
 	} else {
 		// По уму тут надо бы стереть старое описапние если оно не с прототипа
 		detach_ex_description();
@@ -827,10 +827,8 @@ void ObjData::del_timed_spell(const ESpell spell_id, const bool message) {
 	m_timed_spell.del(this, spell_id, message);
 }
 
-void CObjectPrototype::set_ex_description(const char *keyword, const char *description) {
+void CObjectPrototype::set_ex_description(const std::string &keyword, const std::string &description) {
 	ExtraDescription::shared_ptr d(new ExtraDescription());
-	// keyword/description -- std::string, присваиваем напрямую (strdup утёк бы:
-	// строка копирует контент, а выделенный буфер терялся).
 	d->keyword = keyword;
 	d->description = description;
 	m_ex_description = d;

--- a/src/engine/entities/obj_data.h
+++ b/src/engine/entities/obj_data.h
@@ -352,7 +352,7 @@ class CObjectPrototype {
 	void set_rent_off(int x);
 	auto get_rent_on() const { return m_rent_on; }
 	void set_rent_on(int x);
-	void set_ex_description(const char *keyword, const char *description);
+	void set_ex_description(const std::string &keyword, const std::string &description);
 	void set_minimum_remorts(const int _) { m_minimum_remorts = _; }
 	void set_dgscript_field(const std::string _) { m_dgscript_field = _; }
 	int get_auto_mort_req() const;

--- a/src/gameplay/mechanics/stuff.cpp
+++ b/src/gameplay/mechanics/stuff.cpp
@@ -417,7 +417,7 @@ void create_charmice_stuff(CharData *ch, const ESkill skill_id, int diff) {
 	const std::string descr = std::string("острые когти ") + ch->get_pad(1);
 	obj->set_short_description(descr);
 	obj->set_description("Острые когти лежат здесь.");
-	obj->set_ex_description(descr.c_str(), "Острые когти лежат здесь.");
+	obj->set_ex_description(descr, "Острые когти лежат здесь.");
 	obj->set_PName(grammar::ECase::kNom, "острые когти");
 	obj->set_PName(grammar::ECase::kGen, "острых когтей");
 	obj->set_PName(grammar::ECase::kDat, "острым когтям");
@@ -524,7 +524,7 @@ void create_charmice_stuff(CharData *ch, const ESkill skill_id, int diff) {
 	case ESkill::kShieldBlock: // блок щитом ? делаем щит
 		obj->set_type(EObjType::kArmor);
 		obj->set_description("Роговые пластины лежат здесь.");
-		obj->set_ex_description(descr.c_str(), "Роговые пластины лежат здесь.");
+		obj->set_ex_description(descr, "Роговые пластины лежат здесь.");
 		obj->set_aliases("роговые пластины");
 		obj->set_short_description("роговые пластины");
 		obj->set_PName(grammar::ECase::kNom, "роговые пластины");
@@ -546,7 +546,7 @@ void create_charmice_stuff(CharData *ch, const ESkill skill_id, int diff) {
 			obj->set_sex(EGender::kPoly);
 			obj->set_weight(50);
 			obj->set_description("Оторванная лапа зверя лежит здесь.");
-			obj->set_ex_description(descr.c_str(), "Оторванная лапа зверя лежит здесь.");
+			obj->set_ex_description(descr, "Оторванная лапа зверя лежит здесь.");
 			obj->set_aliases("огромные лапы");
 			obj->set_short_description("огромные лапы");
 			obj->set_PName(grammar::ECase::kNom, "огромные лапы");
@@ -561,7 +561,7 @@ void create_charmice_stuff(CharData *ch, const ESkill skill_id, int diff) {
 		obj->set_type(EObjType::kArmor);
 		obj->set_sex(EGender::kFemale);
 		obj->set_description("Прочная шкура лежит здесь.");
-		obj->set_ex_description(descr.c_str(), "Прочная шкура лежит здесь.");
+		obj->set_ex_description(descr, "Прочная шкура лежит здесь.");
 		obj->set_aliases("прочная шкура");
 		obj->set_short_description("прочная шкура");
 		obj->set_PName(grammar::ECase::kNom, "прочная шкура");


### PR DESCRIPTION
Продолжение рефактора ExtraDescription (#3598, уже влит).

`CObjectPrototype::set_ex_description(const char *keyword, const char *description)` → `(const std::string &keyword, const std::string &description)`.

- Тело просто присваивает в std::string-поля (никаких `strdup`).
- Вызывающие: в `stuff.cpp` (×4) и `obj_data.cpp` убраны лишние `.c_str()`; остальные (`craft.cpp` — pugixml `child_value()` → `const char*`) работают через неявное преобразование в `std::string`.

Сборка зелёная (base + tests + admin_api локально), 16 профильных тестов проходят.

Завершает переход ExtraDescription на `std::string`: теперь и поля, и сеттеры, и этот метод — без сырых `char*`.