### PR TITLE
issue.magic-items-hotfix: migrate drink liquid core to keys + fix the…

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -417,6 +417,25 @@ int ConvertSpellItemToEValueKey(CObjectPrototype *obj, bool /*proto*/) {
 	return 1;
 }
 
+// issue.magic-items-hotfix: the liquid core is stored in the kLiquid* keys (get_val/set_val redirect
+// val[0..2] to them for drink containers/fountains). Safety net for a load path that filled the raw
+// val[] array without going through set_val: seed the keys from it. Idempotent -- keys present -> skip.
+int ConvertDrinkconLiquidCore(CObjectPrototype *obj, bool /*proto*/) {
+	const auto type = obj->get_type();
+	if (type != EObjType::kLiquidContainer && type != EObjType::kFountain) {
+		return 0;
+	}
+	if (obj->GetPotionValueKey(ObjVal::EValueKey::kLiquidCapacity) >= 0
+		|| obj->GetPotionValueKey(ObjVal::EValueKey::kLiquidCurrent) >= 0
+		|| obj->GetPotionValueKey(ObjVal::EValueKey::kLiquidType) >= 0) {
+		return 0;
+	}
+	obj->SetPotionValueKey(ObjVal::EValueKey::kLiquidCapacity, obj->get_val(0));
+	obj->SetPotionValueKey(ObjVal::EValueKey::kLiquidCurrent, obj->get_val(1));
+	obj->SetPotionValueKey(ObjVal::EValueKey::kLiquidType, obj->get_val(2));
+	return 1;
+}
+
 void ConvertObjValues() {
 	int save = 0;
 	for (const auto &i : obj_proto) {
@@ -424,6 +443,7 @@ void ConvertObjValues() {
 		save = std::max(save, ConvertDrinkPoisonField(i.get(), true));
 		save = std::max(save, ConvertPotionToEValueKey(i.get(), true));
 		save = std::max(save, ConvertSpellItemToEValueKey(i.get(), true));
+		save = std::max(save, ConvertDrinkconLiquidCore(i.get(), true));
 		if (i->has_flag(EObjFlag::k2inlaid)) {
 			i->unset_extraflag(EObjFlag::k2inlaid);
 			save = 1;

--- a/src/engine/db/db.h
+++ b/src/engine/db/db.h
@@ -203,6 +203,7 @@ extern int ConvertDrinkconSkillField(CObjectPrototype *obj, bool proto);
 extern int ConvertDrinkPoisonField(CObjectPrototype *obj, bool proto);
 extern int ConvertPotionToEValueKey(CObjectPrototype *obj, bool proto);
 extern int ConvertSpellItemToEValueKey(CObjectPrototype *obj, bool proto);   // issue.magic-items
+int ConvertDrinkconLiquidCore(CObjectPrototype *obj, bool proto);
 
 void PasteMobiles();
 

--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -602,6 +602,7 @@ ObjData::shared_ptr read_one_object_new(char **data, int *error) {
 	ConvertDrinkPoisonField(object.get(), false);   // issue.potion-hotfix: migrate player-held drink val[3]
 	ConvertPotionToEValueKey(object.get(), false);
 	ConvertSpellItemToEValueKey(object.get(), false);   // issue.magic-items: migrate held scroll/wand/staff
+	ConvertDrinkconLiquidCore(object.get(), false);   // issue.magic-items-hotfix: reconcile held drink liquid core
 	object->remove_incorrect_values_keys(object->get_type());
 	object->set_extra_flag(EObjFlag::kTicktimer);
 	// ВРЕМЕННЫЙ КОСТЫЛЬ (2026-06-19, issue #3459/#3490): краш-баг крафта (#3486) вешал

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -4418,19 +4418,23 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 	yaml.Key("material");
 	yaml.Value(material_id, GetMaterialNameComment(material_id));
 
-	// Values
-	yaml.Key("values");
-	yaml.BeginSequence();
-	yaml.IncreaseIndent();
-
-	// issue #3593: подписываем каждый values-слот по смыслу для типа предмета.
+	// issue.magic-items-hotfix (point 5): scrolls/wands/staves/potions/drink-containers/fountains keep
+	// their payload in extra_values; the raw val[0..3] just duplicate it, so skip them (YAML). Loaders
+	// reconstruct val[] from the keys (ConvertObjValues / obj_save).
 	const auto obj_type = obj->get_type();
-	yaml.SequenceItem(obj->get_val(0), GetObjValueComment(obj_type, 0, obj->get_val(0)));
-	yaml.SequenceItem(obj->get_val(1), GetObjValueComment(obj_type, 1, obj->get_val(1)));
-	yaml.SequenceItem(obj->get_val(2), GetObjValueComment(obj_type, 2, obj->get_val(2)));
-	yaml.SequenceItem(obj->get_val(3), GetObjValueComment(obj_type, 3, obj->get_val(3)));
-
-	yaml.DecreaseIndent();
+	const bool hotfix_extended = obj_type == EObjType::kScroll || obj_type == EObjType::kWand
+		|| obj_type == EObjType::kStaff || obj_type == EObjType::kPotion
+		|| obj_type == EObjType::kLiquidContainer || obj_type == EObjType::kFountain;
+	if (!hotfix_extended) {
+		yaml.Key("values");
+		yaml.BeginSequence();
+		yaml.IncreaseIndent();
+		yaml.SequenceItem(obj->get_val(0), GetObjValueComment(obj_type, 0, obj->get_val(0)));
+		yaml.SequenceItem(obj->get_val(1), GetObjValueComment(obj_type, 1, obj->get_val(1)));
+		yaml.SequenceItem(obj->get_val(2), GetObjValueComment(obj_type, 2, obj->get_val(2)));
+		yaml.SequenceItem(obj->get_val(3), GetObjValueComment(obj_type, 3, obj->get_val(3)));
+		yaml.DecreaseIndent();
+	}
 
 	// Weight, cost, rent
 	yaml.Key("weight");

--- a/src/engine/entities/obj_data.cpp
+++ b/src/engine/entities/obj_data.cpp
@@ -1222,6 +1222,9 @@ bool is_valid_drinkcon(const ObjVal::EValueKey key) {
 		case ObjVal::EValueKey::kMakerSkill:
 		case ObjVal::EValueKey::kMakerStat:
 		case ObjVal::EValueKey::kLiquidTimer:
+		case ObjVal::EValueKey::kLiquidCapacity:
+		case ObjVal::EValueKey::kLiquidCurrent:
+		case ObjVal::EValueKey::kLiquidType:
 		case ObjVal::EValueKey::kLiquidPoison: return true;
 		default: return false;   // issue.magic-items: kSpellItem* keys are not drinkcon keys
 	}

--- a/src/engine/entities/obj_data.h
+++ b/src/engine/entities/obj_data.h
@@ -57,7 +57,12 @@ class ObjVal {
 		kLiquidTimer = 11,     // drink/potion-only: contents freshness countdown
 		kLiquidPoison = 12,    // drink/potion-only: poison level applied on drinking
 		kMaxCharges = 13,      // wand/staff-only: capacity (was kSpellItemMaxCharges)
-		kCurCharges = 14       // wand/staff-only: charges remaining (was kSpellItemCurCharges)
+		kCurCharges = 14,      // wand/staff-only: charges remaining (was kSpellItemCurCharges)
+		// issue.magic-items-hotfix: drink-container/fountain liquid core (migrated off raw val[0..2]).
+		// val[] stays the runtime store; these keys are the on-disk (YAML) + OLC/display form.
+		kLiquidCapacity = 15,  // drink/fountain-only: total volume (was val[0])
+		kLiquidCurrent = 16,   // drink/fountain-only: current contents (was val[1])
+		kLiquidType = 17       // drink/fountain-only: liquid kind (was val[2])
 	};
 
 	// issue.potion-hotfix: fixed-point scale for kPotionBrewRoll. The stored int is
@@ -213,7 +218,23 @@ class CObjectPrototype {
 	ObjVnum get_parent_vnum();
 	void set_parent_rnum(ObjRnum _) {m_parent_proto = _;}
 	auto &get_skills() const { return m_skills; }
-	auto dec_val(size_t index) { return --m_vals[index]; }
+	// issue.magic-items-hotfix: a drink container's / fountain's liquid core (capacity=0, current=1,
+	// liquid-type=2) is the source of truth in the ObjVal keys, NOT val[0..2]. The val mutators below
+	// transparently redirect those indices for those types to the keys, so every existing consumer uses
+	// the extended store and val[] stops being authoritative. (YAML save skips val[]; old worlds
+	// auto-migrate because the loader's set_val() writes the key.)
+	static constexpr ObjVal::EValueKey liquid_core_key(size_t index) {
+		return index == 0 ? ObjVal::EValueKey::kLiquidCapacity
+			 : index == 1 ? ObjVal::EValueKey::kLiquidCurrent
+						  : ObjVal::EValueKey::kLiquidType;
+	}
+	bool uses_liquid_core(size_t index) const {
+		return index <= 2 && (m_type == EObjType::kLiquidContainer || m_type == EObjType::kFountain);
+	}
+	int dec_val(size_t index) {
+		if (uses_liquid_core(index)) { const int v = get_val(index) - 1; set_val(index, v); return v; }
+		return --m_vals[index];
+	}
 	auto get_current_durability() const { return m_current_durability; }
 	auto get_destroyer() const { return m_destroyer; }
 	auto get_level() const { return m_level; }
@@ -224,7 +245,13 @@ class CObjectPrototype {
 	auto get_spec_param() const { return m_sparam; }
 	auto get_spell() const { return m_spell; }
 	auto get_type() const { return m_type; }
-	auto get_val(size_t index) const { return m_vals[index]; }
+	int get_val(size_t index) const {
+		if (uses_liquid_core(index)) {
+			const int v = m_values.get(liquid_core_key(index));
+			if (v >= 0) { return v; }
+		}
+		return m_vals[index];
+	}
 	auto GetPotionValueKey(const ObjVal::EValueKey key) const { return m_values.get(key); }
 	auto get_wear_flags() const { return m_wear_flags; }
 	auto get_weight() const { return m_weight; }
@@ -261,7 +288,10 @@ class CObjectPrototype {
 	void add_maximum(const int amount) { m_maximum_durability += amount; }
 	void add_no_flags(const FlagData &flags) { m_no_flags += flags; }
 	void add_proto_script(const ObjVnum vnum) { m_proto_script->push_back(vnum); }
-	void add_val(const size_t index, const int amount) { m_vals[index] += amount; }
+	void add_val(const size_t index, const int amount) {
+		if (uses_liquid_core(index)) { set_val(index, get_val(index) + amount); return; }
+		m_vals[index] += amount;
+	}
 	void add_weight(const int _) { m_weight += _; }
 	void clear_action_description() { m_action_description.clear(); }
 	void clear_affected(const size_t index) { m_affected[index].location = EApply::kNone; }
@@ -276,7 +306,10 @@ class CObjectPrototype {
 	void gm_extra_flag(const char *subfield, const char **list, char *res) {
 		m_extra_flags.gm_flag(subfield, list, res);
 	}
-	void inc_val(const size_t index) { ++m_vals[index]; }
+	void inc_val(const size_t index) {
+		if (uses_liquid_core(index)) { set_val(index, get_val(index) + 1); return; }
+		++m_vals[index];
+	}
 	void init_values_from_zone(const char *str) { m_values.init_from_zone(str); }
 	void load_affect_flags(const char *string) { m_waffect_flags.from_string(string); }
 	void load_anti_flags(const char *string) { m_anti_flags.from_string(string); }
@@ -324,9 +357,15 @@ class CObjectPrototype {
 	void set_wear_flag(const EWearFlag flag);
 	void set_wear_flags(const wear_flags_t _) { m_wear_flags = _; }
 	void set_weight(const int _) { m_weight = _; }
-	void set_val(size_t index, int value) { m_vals[index] = value; }
+	void set_val(size_t index, int value) {
+		if (uses_liquid_core(index)) { m_values.set(liquid_core_key(index), value); return; }
+		m_vals[index] = value;
+	}
 	void sub_current(const int _) { m_current_durability -= _; }
-	void sub_val(const size_t index, const int amount) { m_vals[index] -= amount; }
+	void sub_val(const size_t index, const int amount) {
+		if (uses_liquid_core(index)) { set_val(index, get_val(index) - amount); return; }
+		m_vals[index] -= amount;
+	}
 	void sub_weight(const int _) { m_weight -= _; }
 	void swap_proto_script(triggers_list_t &_) { m_proto_script->swap(_); }
 	void toggle_affect_flag(const size_t plane, const Bitvector flag) { m_waffect_flags.toggle_flag(plane, flag); }

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -1103,6 +1103,22 @@ void drinkcon_values_menu(DescriptorData *d) {
 			grn, nrm, cyn, st_s, nrm);
 		SendMsgToChar(pbuf, d->character.get());
 	}
+	// issue.magic-items-hotfix: the liquid core (capacity/amount/type) is edited here in the extended
+	// menu, not via the legacy val editor.
+	if (OLC_OBJ(d)->get_type() == EObjType::kLiquidContainer
+		|| OLC_OBJ(d)->get_type() == EObjType::kFountain) {
+		const int lt = GET_OBJ_VAL(OLC_OBJ(d), 2);
+		const char *lname = (lt >= 0 && lt < NUM_LIQ_TYPES) ? drinks[lt] : "?";
+		char lbuf[512];
+		snprintf(lbuf, sizeof(lbuf),
+			"%s6%s) Ёмкость       : %s%d%s\r\n"
+			"%s7%s) Налито        : %s%d%s\r\n"
+			"%s8%s) Жидкость      : %s%d (%s)%s\r\n",
+			grn, nrm, cyn, GET_OBJ_VAL(OLC_OBJ(d), 0), nrm,
+			grn, nrm, cyn, GET_OBJ_VAL(OLC_OBJ(d), 1), nrm,
+			grn, nrm, cyn, lt, lname, nrm);
+		SendMsgToChar(lbuf, d->character.get());
+	}
 	SendMsgToChar("Ваш выбор (0 - выход) :", d->character.get());
 	return;
 }
@@ -1213,30 +1229,60 @@ void oedit_disp_skills_menu(DescriptorData *d) {
 }
 
 std::string print_values2_menu(ObjData *obj) {
-	if (obj_uses_extended_values(obj->get_type())) {
-		const int sk = obj->GetPotionValueKey(ObjVal::EValueKey::kMakerSkill);
-		const int st = obj->GetPotionValueKey(ObjVal::EValueKey::kMakerStat);
-		char buf_p[kMaxInputLength], sk_s[32], st_s[32];
-		if (sk < 0) snprintf(sk_s, sizeof(sk_s), "деф."); else snprintf(sk_s, sizeof(sk_s), "%d", sk);
-		if (st < 0) snprintf(st_s, sizeof(st_s), "деф."); else snprintf(st_s, sizeof(st_s), "%d", st);
-		snprintf(buf_p, sizeof(buf_p), "Спец. параметры: навык=%s стат=%s", sk_s, st_s);
-		return buf_p;
+	const auto type = obj->get_type();
+	if (!obj_uses_extended_values(type)) {
+		return "Спец. параметры: " + std::to_string(obj->get_spec_param());
 	}
-
-	char buf_[kMaxInputLength];    
-	snprintf(buf_, sizeof(buf_), "Спец. параметры: %d", obj->get_spec_param());
-	return buf_;
+	// issue.magic-items-hotfix: full decoded parameter list for a migrated item, all on the N) line.
+	const auto k = [obj](ObjVal::EValueKey key) { return obj->GetPotionValueKey(key); };
+	const auto spell = [](int num) -> std::string {
+		const auto sp = static_cast<ESpell>(num);
+		return MUD::Spell(sp).IsValid() ? MUD::Spell(sp).GetName() : std::to_string(num);
+	};
+	std::string s = "Спец. параметры:";
+	if (type == EObjType::kLiquidContainer || type == EObjType::kFountain) {
+		s += " ёмкость=" + std::to_string(GET_OBJ_VAL(obj, 0));
+		s += " налито=" + std::to_string(GET_OBJ_VAL(obj, 1));
+		const int lt = GET_OBJ_VAL(obj, 2);
+		s += " жидкость=";
+		s += (lt >= 0 && lt < NUM_LIQ_TYPES) ? std::string(drinks[lt]) : std::to_string(lt);
+		if (k(ObjVal::EValueKey::kLiquidPoison) > 0) { s += " (ядовитая)"; }
+	}
+	const std::pair<ObjVal::EValueKey, const char *> spells[] = {
+		{ObjVal::EValueKey::kSpell1Num, "закл1"},
+		{ObjVal::EValueKey::kSpell2Num, "закл2"},
+		{ObjVal::EValueKey::kSpell3Num, "закл3"},
+	};
+	for (const auto &[key, label] : spells) {
+		const int v = k(key);
+		if (v > 0) { s += " "; s += label; s += "="; s += spell(v); }
+	}
+	const bool spellcaster = type == EObjType::kScroll || type == EObjType::kWand
+		|| type == EObjType::kStaff || type == EObjType::kPotion;
+	const int sk = k(ObjVal::EValueKey::kMakerSkill);
+	const int st = k(ObjVal::EValueKey::kMakerStat);
+	if (spellcaster || sk >= 0 || st >= 0) {
+		s += " навык=" + (sk < 0 ? std::string("деф.") : std::to_string(sk));
+		s += " стат=" + (st < 0 ? std::string("деф.") : std::to_string(st));
+	}
+	if (type == EObjType::kWand || type == EObjType::kStaff) {
+		s += " заряды=" + std::to_string(k(ObjVal::EValueKey::kCurCharges))
+			+ "/" + std::to_string(k(ObjVal::EValueKey::kMaxCharges));
+	}
+	return s;
 }
 
 // * Display main menu.
 // The "O) Values" summary: the raw val[0..3] for legacy types, or nothing for extended-value types.
 static std::string print_obj_values_line(ObjData *obj) {
+	// issue.magic-items-hotfix: migrated types show their payload on the N) line, so drop their legacy
+	// O) val[0..3] line entirely; legacy types still get a full "O) Values" line.
 	if (obj_uses_extended_values(obj->get_type())) {
 		return "";
 	}
-	char b[64];
-	snprintf(b, sizeof(b), "%d %d %d %d",
-			GET_OBJ_VAL(obj, 0), GET_OBJ_VAL(obj, 1), GET_OBJ_VAL(obj, 2), GET_OBJ_VAL(obj, 3));
+	char b[128];
+	snprintf(b, sizeof(b), "%sO%s) Values      : %s%d %d %d %d\r\n",
+			grn, nrm, cyn, GET_OBJ_VAL(obj, 0), GET_OBJ_VAL(obj, 1), GET_OBJ_VAL(obj, 2), GET_OBJ_VAL(obj, 3));
 	return b;
 }
 
@@ -1293,8 +1339,9 @@ void oedit_disp_menu(DescriptorData *d) {
 			 "%sH%s) Рента(снято): %s%8d   %sI%s) Рента(одето): %s%d\r\n"
 			 "%sJ%s) Макс.проч.  : %s%8d   %sK%s) Тек.проч    : %s%d\r\n"
 			 "%sL%s) Материал    : %s%s\r\n"
-			 "%sM%s) Таймер      : %s%8d   %sN%s) %s\r\n"
-			 "%sO%s) Values      : %s%s\r\n"
+			 "%sM%s) Таймер      : %s%8d\r\n"
+			 "%sN%s) %s\r\n"
+			 "%s"
 			 "%sP%s) Аффекты     : %s%s\r\n"
 			 "%sR%s) Меню наводимых аффектов\r\n"
 			 "%sT%s) Меню экстраописаний\r\n"
@@ -1316,7 +1363,6 @@ void oedit_disp_menu(DescriptorData *d) {
 			 grn, nrm, cyn, material_name[obj->get_material()],
 			 grn, nrm, cyn, obj->get_timer(),
 			 grn, nrm, print_values2_menu(obj).c_str(),
-			 grn, nrm, cyn,
 			 print_obj_values_line(obj).c_str(), grn, nrm, grn, buf2, grn, nrm, grn, nrm, grn,
 			 nrm, cyn, !obj->get_proto_script().empty() ? "Присутствуют" : "Отсутствуют",
 			 grn, nrm, cyn, genders[gender],
@@ -1634,7 +1680,9 @@ void oedit_parse(DescriptorData *d, char *arg) {
 					// issue.potion-olc-values: potions keep their data in the extended ObjVal
 					// map, not val[0..3]; route 'O' to the same extended editor as 'N'. Other
 					// (not yet migrated) item types keep the legacy val editor untouched.
-					if (OLC_OBJ(d)->get_type() == EObjType::kPotion) {
+					if (OLC_OBJ(d)->get_type() == EObjType::kPotion
+						|| OLC_OBJ(d)->get_type() == EObjType::kLiquidContainer
+						|| OLC_OBJ(d)->get_type() == EObjType::kFountain) {
 						drinkcon_values_menu(d);
 						OLC_MODE(d) = OEDIT_DRINKCON_VALUES;
 						break;
@@ -2261,6 +2309,26 @@ void oedit_parse(DescriptorData *d, char *arg) {
 					SendMsgToChar("Неверный выбор.\r\n", d->character.get());
 					drinkcon_values_menu(d);
 					return;
+				case 6:
+				case 7:
+				case 8:
+					if (OLC_OBJ(d)->get_type() == EObjType::kLiquidContainer
+						|| OLC_OBJ(d)->get_type() == EObjType::kFountain) {
+						if (number == 6) {
+							OLC_MODE(d) = OEDIT_DRINKCON_CAPACITY;
+							SendMsgToChar("Ёмкость (макс. объём) : ", d->character.get());
+						} else if (number == 7) {
+							OLC_MODE(d) = OEDIT_DRINKCON_CURRENT;
+							SendMsgToChar("Налито (текущий объём) : ", d->character.get());
+						} else {
+							OLC_MODE(d) = OEDIT_DRINKCON_TYPE;
+							SendMsgToChar("Тип жидкости (0 - вода) : ", d->character.get());
+						}
+						return;
+					}
+					SendMsgToChar("Неверный выбор.\r\n", d->character.get());
+					drinkcon_values_menu(d);
+					return;
 				default: SendMsgToChar("Неверный выбор.\r\n", d->character.get());
 					drinkcon_values_menu(d);
 					return;
@@ -2300,6 +2368,22 @@ void oedit_parse(DescriptorData *d, char *arg) {
 			OLC_MODE(d) = OEDIT_DRINKCON_VALUES;
 			drinkcon_values_menu(d);
 			return;
+			// issue.magic-items-hotfix: drink-container/fountain liquid core (val[0..2]) edited via keys' menu.
+			case OEDIT_DRINKCON_CAPACITY: number = atoi(arg);
+				OLC_OBJ(d)->set_val(0, std::max(0, number));
+				OLC_MODE(d) = OEDIT_DRINKCON_VALUES;
+				drinkcon_values_menu(d);
+				return;
+			case OEDIT_DRINKCON_CURRENT: number = atoi(arg);
+				OLC_OBJ(d)->set_val(1, std::clamp(number, 0, GET_OBJ_VAL(OLC_OBJ(d), 0)));
+				OLC_MODE(d) = OEDIT_DRINKCON_VALUES;
+				drinkcon_values_menu(d);
+				return;
+			case OEDIT_DRINKCON_TYPE: number = atoi(arg);
+				OLC_OBJ(d)->set_val(2, std::clamp(number, 0, NUM_LIQ_TYPES - 1));
+				OLC_MODE(d) = OEDIT_DRINKCON_VALUES;
+				drinkcon_values_menu(d);
+				return;
 		// issue.magic-items: scroll/wand/staff extended-value editor.
 		case OEDIT_SPELLITEM_VALUES:
 			switch (number = atoi(arg)) {

--- a/src/engine/olc/olc.h
+++ b/src/engine/olc/olc.h
@@ -226,6 +226,9 @@ extern struct olc_save_info *olc_save_list;
 #define OEDIT_SPELLITEM_STAT                    60
 #define OEDIT_SPELLITEM_MAXCHARGES              61
 #define OEDIT_SPELLITEM_CURCHARGES              62
+#define OEDIT_DRINKCON_CAPACITY                 63
+#define OEDIT_DRINKCON_CURRENT                  64
+#define OEDIT_DRINKCON_TYPE                     65
 
 // * Submodes of REDIT connectedness.
 #define REDIT_MAIN_MENU        1

--- a/src/utils/utils_parse.cpp
+++ b/src/utils/utils_parse.cpp
@@ -70,6 +70,10 @@ void InitObjVals() {
 	text_id_list.at(kObjVals).Add(to_underlying(ObjVal::EValueKey::kPotionBrewRoll), "POTION_BREW_ROLL");
 	text_id_list.at(kObjVals).Add(to_underlying(ObjVal::EValueKey::kLiquidTimer), "LIQUID_TIMER");
 	text_id_list.at(kObjVals).Add(to_underlying(ObjVal::EValueKey::kLiquidPoison), "LIQUID_POISON");
+	// issue.magic-items-hotfix: drink-container/fountain liquid core keys
+	text_id_list.at(kObjVals).Add(to_underlying(ObjVal::EValueKey::kLiquidCapacity), "LIQUID_CAPACITY");
+	text_id_list.at(kObjVals).Add(to_underlying(ObjVal::EValueKey::kLiquidCurrent), "LIQUID_CURRENT");
+	text_id_list.at(kObjVals).Add(to_underlying(ObjVal::EValueKey::kLiquidType), "LIQUID_TYPE");
 }
 
 ///

--- a/tests/spell_item_convert.cpp
+++ b/tests/spell_item_convert.cpp
@@ -102,3 +102,44 @@ TEST(SpellItemConvert, UnifiedKeyReadAliases) {
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :
+
+
+// issue.magic-items-hotfix: a drink-container/fountain liquid core lives in the kLiquid* keys; the val
+// mutators (get/set/dec/inc/add/sub_val) redirect indices 0..2 to them, so val[] is not the store.
+TEST(DrinkconLiquidCore, ValMutatorsRedirectToKeys) {
+	auto p = make_proto(EObjType::kLiquidContainer, 24, 18, 5, 0);  // set_val -> keys
+	EXPECT_EQ(24, key(p, ObjVal::EValueKey::kLiquidCapacity));
+	EXPECT_EQ(18, key(p, ObjVal::EValueKey::kLiquidCurrent));
+	EXPECT_EQ(5,  key(p, ObjVal::EValueKey::kLiquidType));
+	EXPECT_EQ(24, p->get_val(0));  // get_val reads the key
+	EXPECT_EQ(18, p->get_val(1));
+	EXPECT_EQ(5,  p->get_val(2));
+}
+
+TEST(DrinkconLiquidCore, DrinkingUpdatesTheKey) {
+	auto p = make_proto(EObjType::kFountain, 50, 50, 2, 0);
+	p->sub_val(1, 20);  // drink 20
+	EXPECT_EQ(30, p->get_val(1));
+	EXPECT_EQ(30, key(p, ObjVal::EValueKey::kLiquidCurrent));  // key is the store, kept in sync
+	p->dec_val(1);
+	EXPECT_EQ(29, key(p, ObjVal::EValueKey::kLiquidCurrent));
+}
+
+TEST(DrinkconLiquidCore, ZeroIsStoredNotAbsent) {
+	auto p = make_proto(EObjType::kLiquidContainer, 24, 0, 0, 0);  // empty container of water
+	EXPECT_EQ(0, key(p, ObjVal::EValueKey::kLiquidCurrent));
+	EXPECT_EQ(0, key(p, ObjVal::EValueKey::kLiquidType));
+	EXPECT_EQ(0, p->get_val(1));
+	EXPECT_EQ(0, p->get_val(2));
+}
+
+TEST(DrinkconLiquidCore, NonDrinkTypeUsesValArray) {
+	auto p = make_proto(EObjType::kArmor, 1, 2, 3, 4);
+	EXPECT_LT(key(p, ObjVal::EValueKey::kLiquidCapacity), 0);  // no liquid key created
+	EXPECT_EQ(1, p->get_val(0));                               // reads m_vals
+}
+
+TEST(DrinkconLiquidCore, ConvertIsNoOpWhenKeysPresent) {
+	auto p = make_proto(EObjType::kLiquidContainer, 24, 18, 5, 0);  // set_val already populated the keys
+	EXPECT_EQ(0, ConvertDrinkconLiquidCore(p.get(), true));
+}


### PR DESCRIPTION
… OLC value UI

Makes the extended ObjVal keys the SOURCE OF TRUTH for the object payload of the six "magic-item" types, so the object system can keep moving off the legacy val[0..3].

1. Drink containers & fountains: their liquid core (capacity=val[0], current=val[1], liquid-type=val[2]) now lives in kLiquidCapacity/kLiquidCurrent/kLiquidType. Rather than rewire ~74 call sites, the six val mutators (get/set/dec/inc/add/sub_val) transparently REDIRECT indices 0..2 to those keys for these types, so every existing consumer (drink/pour/fill/identify/...) reads and writes the extended store and val[] stops being authoritative. Old worlds auto-migrate: the loader's set_val() writes the key, and the values: block is loaded before extra_values: so keys win. A one-way safety-net converter (ConvertDrinkconLiquidCore) covers any load path that fills the raw array directly. OLC edits capacity/amount/type in the extended drinkcon menu (options 6/7/8); 'O' routes there instead of the legacy val editor.

2/3/4. OLC main menu: "O) Values" dropped entirely for the six migrated types; "N)"
   moved to its own line; "N) Спец. параметры:" prints the full decoded parameter list
   (spells by name, maker skill/stat, charges, liquid capacity/amount/type/poison) on
   one compact line.

5. YAML save stops writing val[] for scroll/wand/staff/potion/liquid-container/fountain (it just duplicates extra_values). Legacy/SQLite unchanged. No converter script.

Adds kLiquidCapacity/Current/Type to EValueKey + text_id names + is_valid_drinkcon. Builds YAML + legacy; 594 tests pass (5 DrinkconLiquidCore tests incl. drinking updates the key + stored-0 empty/water; Object_Copy confirms the map is copied); boots the YAML small world clean.