### PR TITLE
fix(extra-desc): empty oedit keyword + diff extra-desc by key in rent (followup #3601)

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -407,15 +407,30 @@ ObjData::shared_ptr read_one_object_new(char **data, int *error) {
 				*error = 46;
 				ExtraDescription new_descr;
 				new_descr.keyword = buffer;
-				if (new_descr.keyword == "None") {
-					object->set_ex_description(nullptr);
-				} else {
+				// Маркер "None" в старых рентах означал "описаний нет"; больше не
+				// пишется -- просто пропускаем (описания прототипа не трогаем).
+				if (new_descr.keyword != "None") {
 					if (!get_buf_lines(data, buffer)) {
 						*error = 47;
 						return (object);
 					}
 					new_descr.description = buffer;
-					object->ex_descriptions().push_back(std::move(new_descr));
+					// Мерж по ключу: объект -- копия прототипа, в ренте лежат только
+					// отличия. Есть описание с таким ключом -- меняем его текст,
+					// нет -- добавляем новое.
+					auto &descs = object->ex_descriptions();
+					ExtraDescription *same_key = nullptr;
+					for (auto &d : descs) {
+						if (!str_cmp(d.keyword.c_str(), new_descr.keyword.c_str())) {
+							same_key = &d;
+							break;
+						}
+					}
+					if (same_key) {
+						same_key->description = std::move(new_descr.description);
+					} else {
+						descs.push_back(std::move(new_descr));
+					}
 				}
 			} else if (!strcmp(read_line, "Ouid")) {
 				*error = 48;
@@ -621,10 +636,16 @@ ObjData::shared_ptr read_one_object_new(char **data, int *error) {
 	return (object);
 }
 
+// Есть ли в прототипе точно такое же экстра-описание. Если да -- в ренте его не
+// пишем: при загрузке оно приходит из копии прототипа. Ключ сравниваем
+// регистронезависимо (как матчинг ключей в игре), а текст -- точно, побайтно
+// (== короче str_cmp: сначала сверяет длину, при равной делает memcmp, и не
+// даункейсит по 2-3 сотни символов). Иначе описание, отличающееся хотя бы
+// регистром, ошибочно считалось бы совпавшим и терялось при сохранении.
 inline bool proto_has_descr(const ExtraDescription &odesc, const std::vector<ExtraDescription> &pdesc) {
 	for (const auto &desc : pdesc) {
 		if (!str_cmp(odesc.keyword.c_str(), desc.keyword.c_str())
-			&& !str_cmp(odesc.description.c_str(), desc.description.c_str())) {
+			&& odesc.description == desc.description) {
 			return true;
 		}
 	}
@@ -811,15 +832,16 @@ void write_one_object(std::stringstream &out, ObjData *object, int location) {
 				out << "Afc" << j << ": " << oaff.location << " " << oaff.modifier << "~\n";
 			}
 		}
+		// Диф экстра-описаний против прототипа: описания, совпадающие с
+		// прототипом (ключ + текст), в ренте не пишем -- при загрузке они
+		// приходят из копии прототипа. Пишем только новые/изменённые; при
+		// загрузке мерж идёт по ключу (см. read_one_object_new).
 		for (const auto &descr : object->get_ex_description()) {
 			if (proto_has_descr(descr, p->get_ex_description())) {
 				continue;
 			}
 			out << "Edes: " << descr.keyword << "~\n"
 				<< descr.description << "~\n";
-		}
-		if (object->get_ex_description().empty() && !p->get_ex_description().empty()) {
-			out << "Edes: None~\n";
 		}
 		if (object->get_auto_mort_req() > 0) {
 			out << "Mort: " << object->get_auto_mort_req() << "~\n";

--- a/src/engine/entities/obj_data.h
+++ b/src/engine/entities/obj_data.h
@@ -332,8 +332,6 @@ class CObjectPrototype {
 	void set_current_durability(const int _) { m_current_durability = _; }
 	void set_description(const std::string &_) { m_description = _; }
 	void set_destroyer(const int _) { m_destroyer = _; }
-	void set_ex_description(std::nullptr_t) { m_ex_description.clear(); }
-	void add_ex_description(const ExtraDescription &ed) { m_ex_description.push_back(ed); }
 	void set_extra_flag(const EObjFlag packed_flag) { m_extra_flags.set(packed_flag); }
 	void set_extra_flag(const size_t plane, const Bitvector flag) { m_extra_flags.set_flag(plane, flag); }
 	void set_extra_flags(const FlagData &flags) { m_extra_flags = flags; }

--- a/src/engine/network/admin_api/parsers.cpp
+++ b/src/engine/network/admin_api/parsers.cpp
@@ -638,7 +638,7 @@ void ParseObjectUpdate(CObjectPrototype* obj, const nlohmann::json& data)
 	if (data.contains("extra_descriptions") && data["extra_descriptions"].is_array())
 	{
 		// Clear existing extra descriptions
-		obj->set_ex_description(nullptr);
+		obj->ex_descriptions().clear();
 
 		// Заполняем вектор в порядке массива (push_back)
 		for (const auto &ed_data : data["extra_descriptions"])

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -2208,7 +2208,9 @@ void oedit_parse(DescriptorData *d, char *arg) {
 			return;
 
 		case OEDIT_EXTRADESC_KEY:
-			OLC_OBJ(d)->ex_descriptions()[OLC_DESC(d)].keyword = (arg && *arg) ? arg : "undefined";
+			// пустой ключ оставляем пустым (<NONE>), а не пишем "undefined":
+			// на выходе из меню незаполненное экстра-описание удаляется.
+			OLC_OBJ(d)->ex_descriptions()[OLC_DESC(d)].keyword = (arg && *arg) ? arg : "";
 			oedit_disp_extradesc_menu(d);
 			return;
 

--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -194,7 +194,7 @@ void ItemNode::replace_descs(ObjData *obj, const int vnum) const {
 		obj->attach_triggers(desc.trigs);
 	}
 
-	obj->set_ex_description(nullptr); //Пока в конфиге нельзя указать экстраописания - убираем нафиг
+	obj->ex_descriptions().clear(); //Пока в конфиге нельзя указать экстраописания - убираем нафиг
 
 	if ((obj->get_type() == EObjType::kLiquidContainer)
 		&& (GET_OBJ_VAL(obj, 1) > 0)) //Если работаем с непустой емкостью...


### PR DESCRIPTION
Хвост к #3601: два коммита не попали в master, т.к. PR был смержен сразу после первого пуша, а эти доработки запушены позже. Переношу их отдельным PR.

## 1. fix(oedit): пустой ключ экстра-описания

При правке ключа экстра-описания в oedit пустой ввод записывал в ключ литерал `undefined`. Теперь пустой ключ остаётся пустым (`<NONE>`), как уже сделано в redit; при выходе из меню незаполненное экстра-описание (пустой ключ или пустое описание) удаляется из вектора.

## 2. refactor(obj_save): диф экстра-описаний по ключу, без None

- убран костыль `set_ex_description(std::nullptr_t)` и неиспользуемый `add_ex_description` из API; очистка вектора — родным `ex_descriptions().clear()` прямо в call-site (shops, admin_api);
- формат рент остаётся дифом против прототипа, но семантика приведена к вектору:
  - **запись**: пишем только описания, отличающиеся от прототипа (`proto_has_descr` сравнивает ключ + текст); совпадающие не пишем — рент не раздувается описаниями прототипа. Маркер `Edes: None` больше не пишем;
  - **чтение**: объект — копия прототипа, поэтому мерж идёт **по ключу**: если описание с таким ключом уже есть (из прототипа) — меняем его текст, иначе добавляем новое. Изменённое описание не задваивается;
  - старые ренты с `Edes: None` при чтении просто пропускаются.

Заодно чинит прежний баг: старый список делал `set_ex_description(node)` (assign одного узла, затирал прототип и предыдущие), а промежуточный `push_back` наоборот задваивал совпадающие описания. Мерж по ключу корректен в обоих случаях.

## Проверка

- сборка (yaml + admin_api + tests) на актуальном master — чисто;
- 592 юнит-теста зелёные;
- буст small-мира без ошибок.

⚠️ Правки OLC (добавление/редактирование/удаление экстра-описаний в oedit) требуют интерактивной проверки в игре.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
