### PR TITLE
feat(yaml): annotate LIQUID_TYPE extra_value with liquid name

### DIFF
--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -290,6 +290,16 @@ std::string GetExtraValueSpellComment(const std::string &key, int value) {
 	return GetSpellNameComment(static_cast<ESpell>(value));
 }
 
+// issue.magic-items-hotfix: подпись значения для extra_values-ключей, чей смысл --
+// enum из кода. LIQUID_TYPE (бывший val[2] у питья/фонтанов, теперь ключ) -- название
+// жидкости из drinks[] (enum LIQ_*). Прочее делегируем на спелл-подпись.
+std::string GetExtraValueComment(const std::string &key, int value) {
+	if (key == "LIQUID_TYPE") {
+		return (value >= 0 && value < NUM_LIQ_TYPES) ? std::string(drinks[value]) : "";
+	}
+	return GetExtraValueSpellComment(key, value);
+}
+
 // Get material name by ID (for material comments)
 std::string GetMaterialNameComment(int material_id) {
 	return ::material_name[material_id];
@@ -4712,7 +4722,7 @@ void YamlWorldDataSource::EmitObjectBody(Koi8rYamlEmitter &yaml, std::ostream &o
 			for (const auto &kv : sorted_vals)
 			{
 				yaml.Key(kv.first);
-				yaml.Value(kv.second, GetExtraValueSpellComment(kv.first, kv.second));
+				yaml.Value(kv.second, GetExtraValueComment(kv.first, kv.second));
 			}
 			yaml.EndBlock();
 		}


### PR DESCRIPTION
## Что

После сегодняшней миграции питья/фонтанов на ObjVal-ключи (issue.magic-items-hotfix) тип жидкости пишется в `extra_values` ключом `LIQUID_TYPE` голым числом, без подписи:

```
LIQUID_TYPE: 17
```

Добавил комментарий с названием жидкости из `drinks[]` (enum `LIQ_*`):

```
LIQUID_TYPE: 17  # красного колдовского зелья
```

Ровно так же, как уже подписан val[2] в `GetObjValueComment` и спелл-ключи в `GetExtraValueSpellComment`.

## Как

- ввёл `GetExtraValueComment(key, value)` — тонкий диспетчер: для `LIQUID_TYPE` возвращает `drinks[value]` (с проверкой границ `NUM_LIQ_TYPES`), иначе делегирует на `GetExtraValueSpellComment`;
- заменил вызов в сериализации `extra_values` на новый диспетчер.

Значение остаётся числом — round-trip не меняется, меняется только комментарий.

## Проверка

- сборка чистая, 592 юнит-теста зелёные;
- `drinks[]`/`NUM_LIQ_TYPES` уже подключены и используются в этом же файле (val[2]-подпись), новых зависимостей нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
