### PR TITLE
fix(mem): stop leaking str_dup into player_data std::string fields

### DIFF
--- a/src/gameplay/ai/spec_procs.cpp
+++ b/src/gameplay/ai/spec_procs.cpp
@@ -1355,8 +1355,9 @@ int pet_shops(CharData *ch, void * /*me*/, int cmd, char *argument) {
 			sprintf(buf,
 					"%sA small sign on a chain around the neck says 'My name is %s'\r\n",
 					pet->player_data.description.c_str(), pet_name);
-			// free(pet->player_data.description); don't free the prototype!
-			pet->player_data.description = str_dup(buf);
+			// player_data.description -- std::string со своим владением: прямое
+			// присваивание заменяет собственную копию, прототип не затрагивается.
+			pet->player_data.description = buf;
 		}
 		PlaceCharToRoom(pet, ch->in_room);
 		follow::AddFollower(ch, pet);

--- a/src/gameplay/handlers/summon_tutelar.cpp
+++ b/src/gameplay/handlers/summon_tutelar.cpp
@@ -112,8 +112,8 @@ EStageResult SummonTutelar(ActionContext &ctx) {
 		mob->player_data.PNames[grammar::ECase::kIns] = "Небесным защитником";
 		mob->player_data.PNames[grammar::ECase::kPre] = "Небесном защитнике";
 		mob->set_npc_name("Небесный защитник");
-		mob->player_data.long_descr = str_dup("Небесный защитник летает тут.\r\n");
-		mob->player_data.description = str_dup("Сияющая призрачная фигура о двух крылах.\r\n");
+		mob->player_data.long_descr = "Небесный защитник летает тут.\r\n";
+		mob->player_data.description = "Сияющая призрачная фигура о двух крылах.\r\n";
 	} else {
 		mob->set_sex(EGender::kFemale);
 		mob->SetCharAliases("Небесная защитница");
@@ -124,8 +124,8 @@ EStageResult SummonTutelar(ActionContext &ctx) {
 		mob->player_data.PNames[grammar::ECase::kIns] = "Небесной защитницей";
 		mob->player_data.PNames[grammar::ECase::kPre] = "Небесной защитнице";
 		mob->set_npc_name("Небесная защитница");
-		mob->player_data.long_descr = str_dup("Небесная защитница летает тут.\r\n");
-		mob->player_data.description = str_dup("Сияющая призрачная фигура о двух крылах.\r\n");
+		mob->player_data.long_descr = "Небесная защитница летает тут.\r\n";
+		mob->player_data.description = "Сияющая призрачная фигура о двух крылах.\r\n";
 	}
 
 	float additional_str_for_charisma = 0.6875;


### PR DESCRIPTION
## Что

`player_data.long_descr` и `player_data.description` — `std::string`. В нескольких местах в них присваивался `str_dup(...)`: `str_dup` возвращает `char*`, он копируется в строку, а сам выделенный буфер **утекает**.

## Где

- `summon_tutelar.cpp` — `long_descr`/`description` призванного небесного защитника (обе ветки пола, 4 присваивания);
- `spec_procs.cpp` — `description` питомца при навешивании таблички с именем.

## Правка

Прямое присваивание строки/буфера вместо `str_dup`.

Комментарий `// free(pet->player_data.description); don't free the prototype!` в `spec_procs.cpp` устарел ещё до этого PR: поле давно `std::string` со своим владением, никакого `char*` от прототипа там нет, прямое присваивание безопасно.

Это тот же класс утечки, что чинился ранее в corpse/house/do_put.

## Проверка

- сборка чистая.
