### PR TITLE
refactor(extra-desc): drop unused ExtraDescription::shared_ptr alias

### DIFF
--- a/src/engine/structs/extra_description.h
+++ b/src/engine/structs/extra_description.h
@@ -7,14 +7,13 @@
 #ifndef BYLINS_SRC_STRUCTS_EXTRA_DESCRIPTION_H_
 #define BYLINS_SRC_STRUCTS_EXTRA_DESCRIPTION_H_
 
-#include <memory>
 #include <string>
 
-// Extra description: used in objects, mobiles, and rooms.
-// Хранятся в std::vector<ExtraDescription> у объекта/комнаты (без ручной
-// next-цепочки). shared_ptr оставлен для совместимости отдельных мест.
+// Extra description: набор пар "ключ -> текст" у объекта и комнаты (look по
+// под-ключам). Хранятся в std::vector<ExtraDescription> у самой сущности, без
+// ручной next-цепочки. У моба "описание" -- отдельное одиночное поле
+// player_data.description (std::string), эту структуру не использует.
 struct ExtraDescription {
-	using shared_ptr = std::shared_ptr<ExtraDescription>;
 	void set_keyword(std::string const &keyword);
 	void set_description(std::string const &description);
 


### PR DESCRIPTION
## Что

После перехода экстра-описаний на `std::vector<ExtraDescription>` по значению (#3601) алиас `ExtraDescription::shared_ptr` больше **не используется нигде** (0 вхождений `ExtraDescription::shared_ptr` по всему дереву).

## Правка

- убрал мёртвый `using shared_ptr = std::shared_ptr<ExtraDescription>;`;
- убрал ставший ненужным `#include <memory>` (в структуре теперь только `std::string`-поля); полная сборка это подтвердила — транзитивно `<memory>` ни на что не завязан;
- уточнил комментарий: структура — набор пар «ключ → текст» у объектов и комнат; у моба «описание» — отдельное одиночное поле `player_data.description` (`std::string`), эту структуру не использует.

Чистая уборка, поведение не меняется.

## Проверка

- сборка (yaml + admin_api + tests) чистая;
- 592 юнит-теста зелёные.
