### PR TITLE
chore(build): fix all -Wall -Wextra warnings (unity=off)

### DIFF
--- a/src/engine/core/char_movement.cpp
+++ b/src/engine/core/char_movement.cpp
@@ -583,7 +583,10 @@ bool PerformSimpleMove(CharData *ch, int dir, int following, CharData *leader, E
 	// issue.room-affect-trigger-improve: AFTER placement on the walk path -- run the non-blocking
 	// on-entry effects (e.g. kHypnoticPattern's sleep) in the destination room. The blocking-capable
 	// actions already ran (and possibly refused the move) before placement, above.
-	room_spells::RunRoomEntryTriggers(ch, world[ch->in_room],
+	// Result is intentionally ignored here: only non-blocking on-entry effects
+	// run (the blocking pass already decided the move above). See magic_rooms.cpp
+	// for the same (void) pattern.
+	(void) room_spells::RunRoomEntryTriggers(ch, world[ch->in_room],
 			room_spells::EEntryTriggerPhase::kEffectsNonBlocking);
 
 	if (deathtrap::check_death_trap(ch)) {

--- a/src/engine/entities/obj_data.cpp
+++ b/src/engine/entities/obj_data.cpp
@@ -660,7 +660,7 @@ void ObjData::attach_triggers(const triggers_list_t &trigs) {
 * Помимо таймера самой шмотки снимается таймер ее временного обкаста.
 * \param time по дефолту 1.
 */
-void ObjData::dec_timer(int time, bool ignore_utimer, bool exchange) {
+void ObjData::dec_timer(int time, bool ignore_utimer, bool /*exchange*/) {
 	*buf2 = '\0';
 	if (!m_timed_spell.empty()) {
 		m_timed_spell.dec_timer(this, time);

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -2257,8 +2257,7 @@ void oedit_parse(DescriptorData *d, char *arg) {
 						}
 					}
 					// * No break - drop into default case.
-
-					// fall through
+					[[fallthrough]];
 				}
 				default: oedit_disp_extradesc_menu(d);
 					return;

--- a/src/gameplay/abilities/talents_actions.cpp
+++ b/src/gameplay/abilities/talents_actions.cpp
@@ -32,6 +32,7 @@ const char *ActionTargetName(EActionTarget t) {
 		case EActionTarget::kTarMinions: return "kTarMinions";
 		case EActionTarget::kTarActor: return "kTarActor";
 		case EActionTarget::kTarRoomThis: return "kTarRoomThis";
+		case EActionTarget::kTarMaster: return "kTarMaster";
 	}
 	return "?";
 }

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -1941,7 +1941,6 @@ EStageResult CastToPoints(ActionContext &ctx) {
 		return EStageResult::kSuccess;
 	}
 
-	const auto &potency_roll = MUD::Spell(spell_id).GetPotencyRoll();
 	// Shared roll: dice + competencies are rolled once per cast (not per
 	// category), so heal and moves restored on the same cast scale together
 	// with the same skill check.
@@ -4490,7 +4489,6 @@ bool room_spells::DispelExitAffects(CharData *caster, int dir, ESpell spell_id) 
 		if (rev && rev->to_room() == caster->in_room) { hosts.push_back(rev); }
 	}
 	ActionContext ctx = BuildActionContext(caster, spell_id, GetRealLevel(caster));
-	const auto &roll = MUD::Spell(spell_id).GetPotencyRoll();
 	bool any = false;
 	for (const auto &ex : hosts) {
 		for (auto it = ex->affected.begin(); it != ex->affected.end();) {


### PR DESCRIPTION
## What & why

Unity build (`unity=on` — default in `meson.build`) hides per-file warnings by concatenating translation units, so `-Wall -Wextra` never shows them in CI or local builds. After switching `build_yaml2` to `-Dunity=off` for cleaner diagnostics, **6 pre-existing warnings** surfaced. This PR fixes all of them — the project now compiles with **zero warnings** under `-Wall -Wextra` (C++20, release).

None of these are related to #3568 — they are pre-existing and surfaced only because unity was hiding them.

## Fixes

| File | Warning | Fix |
|---|---|---|
| `char_movement.cpp:586` | `-Wunused-result` (nodiscard) | `RunRoomEntryTriggers` is `[[nodiscard]]`; the call in `PerformSimpleMove` intentionally runs only the non-blocking on-entry effects (the blocking pass already decided the move above). Added `(void)` matching the existing pattern in `magic_rooms.cpp:1370`, plus an explanatory comment. |
| `magic.cpp:1944` | `-Wunused-variable` | Leftover `potency_roll` after the `CastToPoints` refactor — the math now goes through `ctx.potency()`. Removed. |
| `magic.cpp:4493` | `-Wunused-variable` | Same — leftover `roll` in `DispelExitAffects`. Removed. |
| `obj_data.cpp:663` | `-Wunused-parameter` | `dec_timer`'s `exchange` parameter is declared but never read and never passed explicitly by any caller (verified). Renamed to `/*exchange*/` — keeps the API unchanged, just silences the warning. |
| `oedit.cpp:2257` | `-Wimplicit-fallthrough=` | The prose comment `// fall through` is not in gcc's recognised marker set; replaced with the standard `[[fallthrough]];` attribute (C++17+, project is C++20). Kept the explanatory `// No break - drop into default case.` |
| `talents_actions.cpp:24` | `-Wswitch` | `ActionTargetName` switch didn't cover `kTarMaster` (added in `issue.soullink-affect-patching`). Added the case mirroring the other entries. |

## Verification

- **Build:** `ninja -C build_yaml2 -Dunity=off` → **0 warnings**
- **Tests:** 589 PASSED / 3 SKIPPED / 0 FAILED
- 5 files changed, 7 insertions(+), 6 deletions(-)

## Note on `unity=off`

The `unity=off` switch was applied **only** to my local `build_yaml2` build directory (via `meson configure`) — it is **not** part of this PR. Default project options in `meson.build` are unchanged. I'd recommend a follow-up discussion (separate PR) on whether CI should also flip unity off to catch warnings going forward, but that's out of scope here.

---

Generated with ZCode. Co-authored cleanup.
