### PR TITLE
perf(clans): skip disbanded clans and unchanged files on clan save

### DIFF
--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -687,12 +687,9 @@ void Clan::HconShow(CharData *ch) {
 	SendMsgToChar(buffer.str().c_str(), ch);
 }
 
-void Clan::save_clan_file(const std::string &filename) const {
-	std::ofstream file(filename.c_str());
-	if (!file.is_open()) {
-		log("Error open file: %s! (%s %s %d)", filename.c_str(), __FILE__, __func__, __LINE__);
-		return;
-	}
+// формирование содержимого основного файла клана
+std::string Clan::build_clan_file() const {
+	std::ostringstream file;
 
 	file << "Abbrev: " << abbrev << "\n"
 		 << "Name: " << name << "\n"
@@ -753,7 +750,48 @@ void Clan::save_clan_file(const std::string &filename) const {
 		}
 	}
 	file << "~\n";
+	return file.str();
+}
+
+// формирование содержимого пкл/дрл файла клана
+std::string Clan::build_pk_file() const {
+	std::ostringstream file;
+
+	for (auto it = pkList.begin(); it != pkList.end(); ++it)
+		file << it->second->author << " " << it->first << " " << (*it).
+			second->time << " " << "0\n" << it->second->text << "\n~\n";
+	for (auto it = frList.begin(); it != frList.end(); ++it)
+		file << it->second->author << " " << it->first << " " << (*it).
+			second->time << " " << "1\n" << it->second->text << "\n~\n";
+
+	return file.str();
+}
+
+namespace {
+
+// запись файла, если его содержимое изменилось с прошлого сохранения
+bool write_if_changed(const std::string &filename, const std::string &contents,
+					  std::optional<std::string> &cache) {
+	if (cache.has_value() && *cache == contents) {
+		return true;
+	}
+
+	std::ofstream file(filename.c_str());
+	if (!file.is_open()) {
+		log("Error open file: %s! (%s %s %d)", filename.c_str(), __FILE__, __func__, __LINE__);
+		return false;
+	}
+	file.write(contents.data(), static_cast<std::streamsize>(contents.size()));
 	file.close();
+
+	cache = contents;
+	return true;
+}
+
+}  // namespace
+
+void Clan::save_clan_file(const std::string &filename) const {
+	write_if_changed(filename, build_clan_file(), saved_clan_file_);
 }
 
 // сохранение кланов в файлы
@@ -768,7 +806,13 @@ void Clan::ClanSave() {
 		// именем файла для клана служит его аббревиатура (английский и нижний регистр)
 		std::string buffer = clan->abbrev;
 		CreateFileName(buffer);
+		// в индексе дружина остается всегда, иначе она пропадет из игры после перезагрузки
 		index << buffer << "\n";
+
+		// дружина без игроков считается распущенной: ее файлы больше не трогаем
+		if (clan->m_members.empty()) {
+			continue;
+		}
 
 		std::string filepath = LIB_HOUSE + buffer + "/" + buffer;
 		std::string path = LIB_HOUSE + buffer;
@@ -782,18 +826,7 @@ void Clan::ClanSave() {
 		// основной файл клана
 		clan->save_clan_file(filepath);
 		// пкл/дрл
-		std::ofstream pkFile((filepath + ".pkl").c_str());
-		if (!pkFile.is_open()) {
-			log("Error open file: %s! (%s %s %d)", (filepath + ".pkl").c_str(), __FILE__, __func__, __LINE__);
-			return;
-		}
-		for (auto it = clan->pkList.begin(); it != clan->pkList.end(); ++it)
-			pkFile << it->second->author << " " << it->first << " " << (*it).
-				second->time << " " << "0\n" << it->second->text << "\n~\n";
-		for (auto it = clan->frList.begin(); it != clan->frList.end(); ++it)
-			pkFile << it->second->author << " " << it->first << " " << (*it).
-				second->time << " " << "1\n" << it->second->text << "\n~\n";
-		pkFile.close();
+		write_if_changed(filepath + ".pkl", clan->build_pk_file(), clan->saved_pk_file_);
 	}
 	index.close();
 }

--- a/src/gameplay/clans/house.h
+++ b/src/gameplay/clans/house.h
@@ -19,6 +19,7 @@
 #include <map>
 #include <unordered_map>
 #include <bitset>
+#include <optional>
 #include <string>
 
 namespace ClanSystem {
@@ -340,6 +341,12 @@ class Clan {
   void HouseStat(CharData *ch, std::string &buffer);
   void remove_member(const ClanMembersList::key_type &it, char *reason);
   void save_clan_file(const std::string &filename) const;
+  std::string build_clan_file() const;
+  std::string build_pk_file() const;
+  // последнее записанное на диск содержимое: если не изменилось, файл не переписываем
+  // пустое значение означает "на диск еще не писали", а не "записали пустой файл"
+  mutable std::optional<std::string> saved_clan_file_;
+  mutable std::optional<std::string> saved_pk_file_;
   void house_web_url(CharData *ch, const std::string &buffer);
 
   // house аля олц


### PR DESCRIPTION
Шаг пульса `Clan: clan save` на боевом занимал до **0.152 с** — 98% длины самого долгого пульса:

```
Longest pulse: 614960; duration: 0.155165 seconds; steps:
        38. Clan: clan save       0.152648 seconds.
```

## Причина

`Clan::ClanSave()` синхронно, в главном потоке, переписывал файлы всех дружин из `ClanList` целиком — безусловно, независимо от того, менялось ли в них хоть что-нибудь. По логам с прода в этом шаге писалось 10 дружин × 2 файла + `index` = 21 файл, а полезных данных там меньше килобайта (67 игроков во всех дружинах, `.pkl` активных дружин пустые). То есть время уходило не на сериализацию, а на сам факт открытия/записи/закрытия файлов по одному — ~7 мс на файл. Для сравнения, соседний шаг сохранения сундуков в том же пульсе укладывается в 0.25 мс на 5 файлов за счёт dirty-tracking и пула потоков.

## Что изменилось

- **Дружина без игроков считается распущенной** и на диск больше не пишется. В `index` она при этом остаётся — иначе пропала бы из игры после перезагрузки вместе с сундуком и гвардами.
- **Файл пишется только если изменился.** Содержимое формируется в память (`build_clan_file()` / `build_pk_file()`) и сравнивается с тем, что было записано в прошлый раз.

Кэш хранится в `std::optional`: пустая строка должна означать «записали пустой файл», а не «на диск ещё не писали» — иначе пустой `.pkl` при старте не перезаписал бы устаревшие данные на диске.

## Насколько это помогает

Честная оценка по результатам замеров: **основной файл активной дружины меняется почти каждый цикл** — капают налоги и опыт, — поэтому на нём экономии почти нет. Выигрыш дают две другие вещи:

- распущенные дружины не пишутся вовсе (на проде это 4 из 10, то есть ~40% файлов шага);
- `.pkl` не переписывается, пока в нём ничего не меняется, а у активных дружин он обычно пустой и статичный.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов; **592 теста проходят**.

Функционально — на живом сервере (`small` world, две тестовые дружины: `tst1` с игроками, `tst2` без). Важно: без единого подключения главный цикл уходит в `epoll_wait(..., -1)` и встаёт (`comm.cpp:1533`), поэтому замеры делались с вошедшим игроком, а период сохранения на время теста был сокращён до 1 минуты.

Шесть последовательных циклов:

```
16:33:38  tst1=16:33:18  pkl=16:31:48  tst2=не тронут
16:34:23  tst1=16:34:18  pkl=16:31:48  tst2=не тронут
16:35:08  tst1=16:34:18  pkl=16:31:48  tst2=не тронут   ← цикл без записи
16:35:53  tst1=16:35:19  pkl=16:31:48  tst2=не тронут
16:36:38  tst1=16:36:18  pkl=16:31:48  tst2=не тронут
16:37:23  tst1=16:37:18  pkl=16:31:48  tst2=не тронут
```

| Ситуация | Ожидание | Факт |
|---|---|---|
| Данные дружины изменились (игрок введён воеводой) | файл перезаписывается | `Owner: 786321`, запись в 16:36:18 |
| `.pkl` не менялся | не трогаем | mtime неизменен 6 циклов подряд |
| Дружина без игроков | не трогаем вовсе | mtime `tst2` не менялся ни разу |
| `index` | распущенная дружина остаётся | обе в `index` |

Сохранение осталось синхронным, в главном потоке — переносить клановые файлы в пул потоков этот PR не трогает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
