### PR TITLE
fix(meson): restore template-only configs in small world

### DIFF
--- a/tools/meson/setup_world.py
+++ b/tools/meson/setup_world.py
@@ -42,6 +42,29 @@ def copy_dirs(src_root, names, what):
         shutil.copytree(s, d, ignore=_IGNORE)
 
 
+def fill_missing(src_root, names):
+    """Докладывает файлы, которых нет в lib.
+
+    Часть конфигов (system_msg.xml, cases.xml, celebrates.xml, guards.xml, obj_sets.xml,
+    quests/, class.*) существует только в lib.template, и без них мир не работает: игрока
+    выкидывает на входе с "ERROR: message not found". Уже скопированные из lib файлы
+    не перезаписываем — там актуальная конфигурация.
+    """
+    for name in names:
+        src_dir = os.path.join(src_root, name)
+        if not os.path.isdir(src_dir):
+            continue
+        for root, dirs, files in os.walk(src_dir):
+            dirs[:] = [d for d in dirs if d != ".git"]
+            rel = os.path.relpath(root, src_root)
+            dst_root = os.path.join(small_world_dir, rel)
+            os.makedirs(dst_root, exist_ok=True)
+            for f in files:
+                dst = os.path.join(dst_root, f)
+                if not os.path.exists(dst):
+                    shutil.copy2(os.path.join(root, f), dst)
+
+
 if not os.path.exists(lib_src):
     print(f"ERROR: Source 'lib' not found at {lib_src}")
     sys.exit(1)
@@ -54,6 +77,7 @@ os.makedirs(small_world_dir, exist_ok=True)
 
 copy_dirs(lib_src, LIB_DIRS, "lib")
 copy_dirs(template_src, TEMPLATE_DIRS, "lib.template")
+fill_missing(template_src, LIB_DIRS)
 
 print(f"Small world configured at: {small_world_dir}")
 


### PR DESCRIPTION
Регрессия от #3609 (уже в master): собранный small world не пускает игрока — после выбора кодировки на экране входа вылезает `ERROR: message not found` и следует дисконнект.

## Причина

#3609 стал копировать `cfg`/`text`/`misc` только из `lib`, исходя из того, что в `lib.template` лежит только мир. Это оказалось неверно — часть конфигов существует **исключительно** в `lib.template`, в репозиторном `lib/` их нет вовсе:

```
cfg/messages/ru/system_msg.xml          ← отсюда "ERROR: message not found"
cfg/mechanics/{cases,celebrates,guards,obj_sets}.xml
cfg/quests/
misc/class.{basestatlimits.xml,features.lst,skills.xml,spells.lst,recipies.lst}
misc/{stop_offtop,stuff.lst.template}
```

## Что изменилось

После копирования `cfg`/`text`/`misc` из `lib` недостающие файлы докладываются из `lib.template`. Уже скопированное из `lib` не перезаписывается — актуальная боевая конфигурация остаётся в приоритете, а мир при этом получается работоспособным.

Замысел #3609 сохраняется: мир по-прежнему берётся только из `lib.template/world`, а устаревшие шаблонные версии тех конфигов, что есть в `lib`, в сборку не попадают.

## Проверка

Мир собран скриптом заново, все ранее отсутствовавшие файлы на месте, `cfg/configuration.xml` побайтово совпадает с версией из `lib` (шаблоном не перетёрт).

Симптом воспроизведён и устранён напрямую: подключение к свежесобранному миру, ввод `2` на выбор кодировки — вместо `ERROR: message not found` идёт нормальный экран приветствия.

🤖 Generated with [Claude Code](https://claude.com/claude-code)