### PR TITLE
fix(magic-items): read spell/charges from extra_values, not raw val[]

### DIFF
--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -2,3 +2,11 @@ exclude = ^subprojects/
 exclude = ^src/third_party_libs/
 exclude = ^tests/
 exclude = ^build/
+
+# Инлайновый метод из заголовка попадает в несколько unity-блоков, и gcov
+# приписывает его то к строке объявления, то к следующей. При строгом режиме
+# (по умолчанию) gcovr падает на таком расхождении:
+#   AssertionError: Got function utils::CExecutionTimer::CExecutionTimer()
+#   on multiple lines: 19, 20.
+# Берем наименьшую строку -- расхождение чисто в атрибуции, покрытие то же.
+merge-mode-functions = merge-use-line-min

--- a/src/engine/entities/obj_data.h
+++ b/src/engine/entities/obj_data.h
@@ -253,6 +253,16 @@ class CObjectPrototype {
 		return m_vals[index];
 	}
 	auto GetPotionValueKey(const ObjVal::EValueKey key) const { return m_values.get(key); }
+	// issue.magic-items: номер заклинания в позиции 1..3. У свитков, зелий, посохов и жезлов
+	// заклинания живут в extra_values, сырые val[] у них нулевые.
+	int GetSpellItemSpellNum(int pos) const {
+		switch (pos) {
+			case 1: return m_values.get(ObjVal::EValueKey::kSpell1Num);
+			case 2: return m_values.get(ObjVal::EValueKey::kSpell2Num);
+			case 3: return m_values.get(ObjVal::EValueKey::kSpell3Num);
+			default: return -1;
+		}
+	}
 	auto get_wear_flags() const { return m_wear_flags; }
 	auto get_weight() const { return m_weight; }
 	auto serialize_values() const { return m_values.print_to_file(); }

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -953,18 +953,19 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 			break;
 
 		case EObjType::kScroll: {
+			// issue.magic-items: заклинания свитка лежат в extra_values, сила -- умение мастера
 			std::ostringstream out;
-			out << "Заклинания: (Уровень - " << GET_OBJ_VAL(j, 0) << ") ";
-			for (auto val = 1; val < 4; ++val) {
-				auto spell_id = static_cast<ESpell>(GET_OBJ_VAL(j, val));
+			out << "Заклинания:";
+			for (auto pos = 1; pos < 4; ++pos) {
+				const auto spell_id = static_cast<ESpell>(j->GetSpellItemSpellNum(pos));
 				if (MUD::Spell(spell_id).IsValid()) {
-					out << MUD::Spell(spell_id).GetName();
-					if (val < 3) {
-						out << ", ";
-					} else {
-						out << ".";
-					}
+					const int potency = static_cast<int>(MagicItemPotency(j, spell_id) + 0.5f);
+					out << " " << MUD::Spell(spell_id).GetName()
+						<< " (сила " << potency << "),";
 				}
+			}
+			if (out.str().back() == ',') {
+				out.seekp(-1, out.end);
 			}
 			snprintf(buf, sizeof(buf), "%s", out.str().c_str());
 			break;
@@ -992,11 +993,16 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 		}
 		case EObjType::kWand:
 		case EObjType::kStaff:
-			snprintf(buf, sizeof(buf), "Заклинание: %s уровень %d, %d (из %d) зарядов осталось",
-					MUD::Spell(static_cast<ESpell>(GET_OBJ_VAL(j, 3))).GetCName(),
-					GET_OBJ_VAL(j, 0),
-					GET_OBJ_VAL(j, 2),
-					GET_OBJ_VAL(j, 1));
+			// issue.magic-items: заклинание и заряды берем из extra_values, val[] у посохов нулевые
+			{
+				const auto staff_spell = static_cast<ESpell>(j->GetSpellItemSpellNum(1));
+				const int potency = static_cast<int>(MagicItemPotency(j, staff_spell) + 0.5f);
+				snprintf(buf, sizeof(buf), "Заклинание: %s (сила %d), %d (из %d) зарядов осталось",
+						MUD::Spell(staff_spell).GetCName(),
+						potency,
+						j->GetPotionValueKey(ObjVal::EValueKey::kCurCharges),
+						j->GetPotionValueKey(ObjVal::EValueKey::kMaxCharges));
+			}
 			break;
 
 		case EObjType::kWeapon:

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -954,11 +954,13 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 
 		case EObjType::kScroll: {
 			// issue.magic-items: заклинания свитка лежат в extra_values, сила -- умение мастера
-			snprintf(buf, sizeof(buf), "Заклинания: %s", SpellItemSpellsWithPotency(j).c_str());
+			snprintf(buf, sizeof(buf), "%s", utils::OutWordsList(SpellItemSpellsWithPotency(j),
+					ch->player_specials->saved.stringLength, ", ", "Заклинания: ").c_str());
 			break;
 		}
 		case EObjType::kPotion: {
-			snprintf(buf, sizeof(buf), "Заклинания: %s", SpellItemSpellsWithPotency(j).c_str());
+			snprintf(buf, sizeof(buf), "%s", utils::OutWordsList(SpellItemSpellsWithPotency(j),
+					ch->player_specials->saved.stringLength, ", ", "Заклинания: ").c_str());
 			break;
 		}
 		case EObjType::kWand:

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -954,41 +954,11 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 
 		case EObjType::kScroll: {
 			// issue.magic-items: заклинания свитка лежат в extra_values, сила -- умение мастера
-			std::ostringstream out;
-			out << "Заклинания:";
-			for (auto pos = 1; pos < 4; ++pos) {
-				const auto spell_id = static_cast<ESpell>(j->GetSpellItemSpellNum(pos));
-				if (MUD::Spell(spell_id).IsValid()) {
-					const int potency = static_cast<int>(MagicItemPotency(j, spell_id) + 0.5f);
-					out << " " << MUD::Spell(spell_id).GetName()
-						<< " (сила " << potency << "),";
-				}
-			}
-			if (out.str().back() == ',') {
-				out.seekp(-1, out.end);
-			}
-			snprintf(buf, sizeof(buf), "%s", out.str().c_str());
+			snprintf(buf, sizeof(buf), "Заклинания: %s", SpellItemSpellsWithPotency(j).c_str());
 			break;
 		}
 		case EObjType::kPotion: {
-			std::ostringstream out;
-			out << "Заклинания:";
-			const ObjVal::EValueKey spell_keys[3] = {
-				ObjVal::EValueKey::kSpell1Num,
-				ObjVal::EValueKey::kSpell2Num,
-				ObjVal::EValueKey::kSpell3Num};
-			for (const auto key : spell_keys) {
-				const auto spell_id = static_cast<ESpell>(j->GetPotionValueKey(key));
-				if (MUD::Spell(spell_id).IsValid()) {
-					const int potency = static_cast<int>(MagicItemPotency(j, spell_id) + 0.5f);
-					out << " " << MUD::Spell(spell_id).GetName()
-						<< " (сила " << potency << "),";
-				}
-			}
-			if (out.str().back() == ',') {
-				out.seekp(-1, out.end);
-			}
-			snprintf(buf, sizeof(buf), "%s", out.str().c_str());
+			snprintf(buf, sizeof(buf), "Заклинания: %s", SpellItemSpellsWithPotency(j).c_str());
 			break;
 		}
 		case EObjType::kWand:

--- a/src/gameplay/ai/spec_procs.cpp
+++ b/src/gameplay/ai/spec_procs.cpp
@@ -163,18 +163,19 @@ bool item_nouse(ObjData *obj) {
 			}
 			break;
 
+		// issue.magic-items: заклинания и заряды переехали в extra_values, val[] у этих типов нулевые
 		case EObjType::kScroll:
 		case EObjType::kPotion:
-			if (!GET_OBJ_VAL(obj, 1)
-				&& !GET_OBJ_VAL(obj, 2)
-				&& !GET_OBJ_VAL(obj, 3)) {
+			if (obj->GetPotionValueKey(ObjVal::EValueKey::kSpell1Num) <= 0
+				&& obj->GetPotionValueKey(ObjVal::EValueKey::kSpell2Num) <= 0
+				&& obj->GetPotionValueKey(ObjVal::EValueKey::kSpell3Num) <= 0) {
 				return true;
 			}
 			break;
 
 		case EObjType::kStaff:
 		case EObjType::kWand:
-			if (!GET_OBJ_VAL(obj, 2)) {
+			if (obj->GetPotionValueKey(ObjVal::EValueKey::kCurCharges) <= 0) {
 				return true;
 			}
 			break;

--- a/src/gameplay/economics/auction.cpp
+++ b/src/gameplay/economics/auction.cpp
@@ -396,7 +396,8 @@ bool auction_drive(CharData *ch, char *argument) {
 			sprintf(buf, "Предмет \"%s\", ", obj->get_short_description().c_str());
 			if ((obj->get_type() == EObjType::kWand)
 				|| (obj->get_type() == EObjType::kStaff)) {
-				if (GET_OBJ_VAL(obj, 2) < GET_OBJ_VAL(obj, 1)) {
+				if (obj->GetPotionValueKey(ObjVal::EValueKey::kCurCharges)
+					< obj->GetPotionValueKey(ObjVal::EValueKey::kMaxCharges)) {
 					strcat(buf, "(б/у), ");
 				}
 			}

--- a/src/gameplay/economics/exchange.cpp
+++ b/src/gameplay/economics/exchange.cpp
@@ -445,7 +445,8 @@ int exchange_information(CharData *ch, char *arg) {
 	out += fmt::sprintf("Предмет \"%s\", ", GET_EXCHANGE_ITEM(item)->get_short_description().c_str());
 	if (GET_EXCHANGE_ITEM(item)->get_type() == EObjType::kWand
 		|| GET_EXCHANGE_ITEM(item)->get_type() == EObjType::kStaff) {
-		if (GET_OBJ_VAL(GET_EXCHANGE_ITEM(item), 2) < GET_OBJ_VAL(GET_EXCHANGE_ITEM(item), 1)) {
+		if (GET_EXCHANGE_ITEM(item)->GetPotionValueKey(ObjVal::EValueKey::kCurCharges)
+			< GET_EXCHANGE_ITEM(item)->GetPotionValueKey(ObjVal::EValueKey::kMaxCharges)) {
 			out += "(б/у), ";
 		}
 	}

--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -928,7 +928,7 @@ void shop_node::do_shop_cmd(CharData *ch, CharData *keeper, ObjData *obj, std::s
 		return;
 	}
 
-	if (GET_OBJ_VAL(obj, 2) == 0
+	if (obj->GetPotionValueKey(ObjVal::EValueKey::kCurCharges) <= 0
 		&& (obj->get_type() == EObjType::kWand
 			|| obj->get_type() == EObjType::kStaff)) {
 		tell_to_char(keeper, ch, ShopMsg(ESM::kNoUsedItems).c_str());

--- a/src/gameplay/fight/fight.cpp
+++ b/src/gameplay/fight/fight.cpp
@@ -1110,24 +1110,28 @@ void mob_casting(CharData *ch) {
 		switch (item->get_type()) {
 			case EObjType::kWand:
 			case EObjType::kStaff: {
-				const auto spell_id = static_cast<ESpell>(GET_OBJ_VAL(item, 3));
+				// issue.magic-items: заклинание и заряды лежат в extra_values, val[] у этих типов нулевые
+				const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(1));
 				if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
-					log("SYSERR: Неверно указано значение спела в стафе vnum: %d %s, позиция: 3, значение: %d ",
-						GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VAL(item, 3));
+					log("SYSERR: Неверно указано значение спела в стафе vnum: %d %s, позиция: 1, значение: %d ",
+						GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(),
+						item->GetSpellItemSpellNum(1));
 					break;
 				}
 
-				if (GET_OBJ_VAL(item, 2) > 0 && MUD::Spell(spell_id).IsFlagged(NPC_CALCULATE)) {
+				if (item->GetPotionValueKey(ObjVal::EValueKey::kCurCharges) > 0
+					&& MUD::Spell(spell_id).IsFlagged(NPC_CALCULATE)) {
 					battle_spells[spells++] = spell_id;
 				}
 				break;
 			}
 			case EObjType::kPotion: {
 				for (int i = 1; i <= 3; i++) {
-					const auto spell_id = static_cast<ESpell>(GET_OBJ_VAL(item, i));
+					const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(i));
 					if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
 						log("SYSERR: Неверно указано значение спела в напитке vnum %d %s, позиция: %d, значение: %d ",
-							GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(), i, GET_OBJ_VAL(item, i));
+							GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(), i,
+							item->GetSpellItemSpellNum(i));
 						continue;
 					}
 					if (MUD::Spell(spell_id).IsFlagged(kNpcAffectNpc | kNpcUnaffectNpc | kNpcUnaffectNpcCaster)) {
@@ -1138,10 +1142,11 @@ void mob_casting(CharData *ch) {
 			}
 			case EObjType::kScroll: {
 				for (int i = 1; i <= 3; i++) {
-					const auto spell_id = static_cast<ESpell>(GET_OBJ_VAL(item, i));
+					const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(i));
 					if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
 						log("SYSERR: Не верно указано значение спела в свитке %d %s, позиция: %d, значение: %d ",
-							GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(), i, GET_OBJ_VAL(item, i));
+							GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(), i,
+							item->GetSpellItemSpellNum(i));
 						continue;
 					}
 
@@ -1227,8 +1232,8 @@ void mob_casting(CharData *ch) {
 			switch (item->get_type()) {
 				case EObjType::kWand:
 				case EObjType::kStaff:
-					if (GET_OBJ_VAL(item, 2) > 0
-						&& static_cast<ESpell>(GET_OBJ_VAL(item, 3)) == spell_id_2) {
+					if (item->GetPotionValueKey(ObjVal::EValueKey::kCurCharges) > 0
+						&& static_cast<ESpell>(item->GetSpellItemSpellNum(1)) == spell_id_2) {
 						EmployMagicItem(ch, item, GET_NAME(victim));
 						return;
 					}
@@ -1236,7 +1241,7 @@ void mob_casting(CharData *ch) {
 
 				case EObjType::kPotion:
 					for (int i = 1; i <= 3; i++) {
-						if (static_cast<ESpell>(GET_OBJ_VAL(item, i)) == spell_id_2) {
+						if (static_cast<ESpell>(item->GetSpellItemSpellNum(i)) == spell_id_2) {
 							if (ch != victim) {
 								RemoveObjFromChar(item);
 								act("$n передал$g $o3 $N2.", false, ch, item, victim, kToRoom | kToArenaListen);
@@ -1252,7 +1257,7 @@ void mob_casting(CharData *ch) {
 
 				case EObjType::kScroll:
 					for (int i = 1; i <= 3; i++) {
-						if (static_cast<ESpell>(GET_OBJ_VAL(item, i)) == spell_id_2) {
+						if (static_cast<ESpell>(item->GetSpellItemSpellNum(i)) == spell_id_2) {
 							EmployMagicItem(ch, item, GET_NAME(victim));
 							return;
 						}

--- a/src/gameplay/fight/fight.cpp
+++ b/src/gameplay/fight/fight.cpp
@@ -1113,9 +1113,9 @@ void mob_casting(CharData *ch) {
 				// issue.magic-items: заклинание и заряды лежат в extra_values, val[] у этих типов нулевые
 				const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(1));
 				if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
-					log("SYSERR: Неверно указано значение спела в стафе vnum: %d %s, позиция: 1, значение: %d ",
-						GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(),
-						item->GetSpellItemSpellNum(1));
+					mudlog(fmt::format("SYSERR: неверное заклинание в посохе {} #{}, позиция 1, значение {}",
+							item->get_PName(grammar::ECase::kNom), GET_OBJ_VNUM(item),
+							item->GetSpellItemSpellNum(1)), BRF, kLvlImmortal, SYSLOG, true);
 					break;
 				}
 
@@ -1129,9 +1129,9 @@ void mob_casting(CharData *ch) {
 				for (int i = 1; i <= 3; i++) {
 					const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(i));
 					if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
-						log("SYSERR: Неверно указано значение спела в напитке vnum %d %s, позиция: %d, значение: %d ",
-							GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(), i,
-							item->GetSpellItemSpellNum(i));
+						mudlog(fmt::format("SYSERR: неверное заклинание в напитке {} #{}, позиция {}, значение {}",
+								item->get_PName(grammar::ECase::kNom), GET_OBJ_VNUM(item), i,
+								item->GetSpellItemSpellNum(i)), BRF, kLvlImmortal, SYSLOG, true);
 						continue;
 					}
 					if (MUD::Spell(spell_id).IsFlagged(kNpcAffectNpc | kNpcUnaffectNpc | kNpcUnaffectNpcCaster)) {
@@ -1144,9 +1144,9 @@ void mob_casting(CharData *ch) {
 				for (int i = 1; i <= 3; i++) {
 					const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(i));
 					if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
-						log("SYSERR: Не верно указано значение спела в свитке %d %s, позиция: %d, значение: %d ",
-							GET_OBJ_VNUM(item), item->get_PName(grammar::ECase::kNom).c_str(), i,
-							item->GetSpellItemSpellNum(i));
+						mudlog(fmt::format("SYSERR: неверное заклинание в свитке {} #{}, позиция {}, значение {}",
+								item->get_PName(grammar::ECase::kNom), GET_OBJ_VNUM(item), i,
+								item->GetSpellItemSpellNum(i)), BRF, kLvlImmortal, SYSLOG, true);
 						continue;
 					}
 

--- a/src/gameplay/magic/magic_utils.cpp
+++ b/src/gameplay/magic/magic_utils.cpp
@@ -18,12 +18,14 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <vector>
 #include "administration/privilege.h"
 
 #include "gameplay/mechanics/groups.h"
 #include "engine/db/global_objects.h"
 #include "engine/entities/char_data.h"
 #include "gameplay/mechanics/equipment.h"
+#include "utils/utils.h"      // joinList
 #include "utils/utils_parse.h"
 #include "engine/core/target_resolver.h"
 #include "engine/ui/color.h"
@@ -367,6 +369,24 @@ int MagicItemSkill(const ObjData *item) {
 int MagicItemStat(const ObjData *item) {
 	const int stored = item->GetPotionValueKey(ObjVal::EValueKey::kMakerStat);
 	return (stored >= 0) ? stored : kAuthoredPotionKeyStat;   // absent (-1) -> authored; a stored 0 stays 0
+}
+
+// issue.magic-items: перечень заклинаний предмета с их силой -- один формат для stat и опознания.
+// Заклинания лежат в extra_values (сырые val[] у свитков, зелий, посохов и жезлов нулевые).
+std::string SpellItemSpellsWithPotency(const ObjData *item) {
+	std::vector<std::string> spells;
+	for (int pos = 1; pos <= 3; ++pos) {
+		const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(pos));
+		if (!MUD::Spell(spell_id).IsValid()) {
+			continue;
+		}
+		const int potency = static_cast<int>(MagicItemPotency(item, spell_id) + 0.5f);
+		spells.push_back(fmt::format("{} (сила {})", MUD::Spell(spell_id).GetName(), potency));
+	}
+
+	std::string result;
+	joinList(spells, result);
+	return result;
 }
 
 float CalcCastPotency(const RollResult &potency) {

--- a/src/gameplay/magic/magic_utils.cpp
+++ b/src/gameplay/magic/magic_utils.cpp
@@ -25,7 +25,6 @@
 #include "engine/db/global_objects.h"
 #include "engine/entities/char_data.h"
 #include "gameplay/mechanics/equipment.h"
-#include "utils/utils.h"      // joinList
 #include "utils/utils_parse.h"
 #include "engine/core/target_resolver.h"
 #include "engine/ui/color.h"
@@ -373,7 +372,7 @@ int MagicItemStat(const ObjData *item) {
 
 // issue.magic-items: перечень заклинаний предмета с их силой -- один формат для stat и опознания.
 // Заклинания лежат в extra_values (сырые val[] у свитков, зелий, посохов и жезлов нулевые).
-std::string SpellItemSpellsWithPotency(const ObjData *item) {
+std::vector<std::string> SpellItemSpellsWithPotency(const ObjData *item) {
 	std::vector<std::string> spells;
 	for (int pos = 1; pos <= 3; ++pos) {
 		const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(pos));
@@ -384,9 +383,7 @@ std::string SpellItemSpellsWithPotency(const ObjData *item) {
 		spells.push_back(fmt::format("{} (сила {})", MUD::Spell(spell_id).GetName(), potency));
 	}
 
-	std::string result;
-	joinList(spells, result);
-	return result;
+	return spells;
 }
 
 float CalcCastPotency(const RollResult &potency) {

--- a/src/gameplay/magic/magic_utils.h
+++ b/src/gameplay/magic/magic_utils.h
@@ -2,6 +2,7 @@
 #define SPELL_PARSER_HPP_
 
 #include <limits>
+#include <string>
 
 #include "gameplay/abilities/feats.h"
 #include "engine/entities/entities_constants.h"
@@ -99,6 +100,11 @@ int CalcNoisyAmount(double floor_val, double scaled, double sigma, int cap,
 // the item acts on its own.
 [[nodiscard]] int MagicItemSkill(const ObjData *item);
 [[nodiscard]] int MagicItemStat(const ObjData *item);
+
+// issue.magic-items: перечень заклинаний свитка/зелья/посоха с их силой, вида
+// "исцеление (сила 42), защита (сила 30)". Пустая строка, если заклинаний нет.
+// Заклинания берутся из extra_values -- сырые val[] у этих типов нулевые.
+[[nodiscard]] std::string SpellItemSpellsWithPotency(const ObjData *item);
 
 int CalcCastSuccess(CharData *ch, CharData *victim, ESaving saving, ESpell spell_id);
 

--- a/src/gameplay/magic/magic_utils.h
+++ b/src/gameplay/magic/magic_utils.h
@@ -3,6 +3,7 @@
 
 #include <limits>
 #include <string>
+#include <vector>
 
 #include "gameplay/abilities/feats.h"
 #include "engine/entities/entities_constants.h"
@@ -101,10 +102,10 @@ int CalcNoisyAmount(double floor_val, double scaled, double sigma, int cap,
 [[nodiscard]] int MagicItemSkill(const ObjData *item);
 [[nodiscard]] int MagicItemStat(const ObjData *item);
 
-// issue.magic-items: перечень заклинаний свитка/зелья/посоха с их силой, вида
-// "исцеление (сила 42), защита (сила 30)". Пустая строка, если заклинаний нет.
-// Заклинания берутся из extra_values -- сырые val[] у этих типов нулевые.
-[[nodiscard]] std::string SpellItemSpellsWithPotency(const ObjData *item);
+// issue.magic-items: заклинания свитка/зелья/посоха с их силой, по одному на элемент,
+// вида "исцеление (сила 42)" -- на выход в utils::OutWordsList. Пустой список, если
+// заклинаний нет. Берутся из extra_values -- сырые val[] у этих типов нулевые.
+[[nodiscard]] std::vector<std::string> SpellItemSpellsWithPotency(const ObjData *item);
 
 int CalcCastSuccess(CharData *ch, CharData *victim, ESaving saving, ESpell spell_id);
 

--- a/src/gameplay/mechanics/groups.cpp
+++ b/src/gameplay/mechanics/groups.cpp
@@ -619,12 +619,8 @@ void do_report(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 							skills.emplace_back(skill.GetName());
 						}
 					}
-					std::string str;
-					joinList(skills, str);
-					if (!str.empty()) {
-						str = " " + str + ".";
-					}
-					SendMsgToChar(ch, "&C%s&n\r\n", str.c_str());
+					SendMsgToChar(ch, "&C %s&n\r\n",
+							utils::OutWordsList(skills, ch->player_specials->saved.stringLength).c_str());
 				} else {
 					SendMsgToChar(ch, "%s не подчиняется вам, и не хочет ничего докладывать.\r\n", utils::CAP(f->get_name()).c_str());
 				}

--- a/src/gameplay/mechanics/groups.cpp
+++ b/src/gameplay/mechanics/groups.cpp
@@ -611,17 +611,18 @@ void do_report(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			}
 			for (auto *f : ch->followers) {
 				if (IsCharmice(f)) {
-					std::string str;
+					std::vector<std::string> skills;
 
 					SendMsgToChar(ch, "%s доложил%s свои умения:", utils::CAP(f->get_name()).c_str(), grammar::SexEnding((f)->get_sex(), 1));
 					for (const auto &skill : MUD::Skills()) {
 						if (skill.IsValid() && GetSkill(f, skill.GetId())) {
-							str += fmt::format(" {},", skill.GetName());
+							skills.emplace_back(skill.GetName());
 						}
 					}
-					if (str.back() == ',') {
-						str.pop_back();
-						str.push_back('.');
+					std::string str;
+					joinList(skills, str);
+					if (!str.empty()) {
+						str = " " + str + ".";
 					}
 					SendMsgToChar(ch, "&C%s&n\r\n", str.c_str());
 				} else {

--- a/src/gameplay/mechanics/identify.cpp
+++ b/src/gameplay/mechanics/identify.cpp
@@ -79,49 +79,15 @@ static void ShowObjTypeSpecificValues(const ObjData *obj, CharData *ch) {
 	(void) i; (void) j; (void) li;  // some branches do not touch all of them
 switch (obj->get_type()) {
 	case EObjType::kScroll: {
-		std::ostringstream out;
-		out << "Содержит заклинание:";
-		const ObjVal::EValueKey spell_keys[3] = {
-			ObjVal::EValueKey::kSpell1Num,
-			ObjVal::EValueKey::kSpell2Num,
-			ObjVal::EValueKey::kSpell3Num};
-		for (const auto key : spell_keys) {
-			const auto spell_id = static_cast<ESpell>(obj->GetPotionValueKey(key));
-			if (MUD::Spell(spell_id).IsValid()) {
-				const int potency = static_cast<int>(MagicItemPotency(obj, spell_id) + 0.5f);
-				out << " " << MUD::Spell(spell_id).GetName()
-					<< " (сила " << potency << "),";
-			}
-		}
-		if (out.str().back() == ',') {
-			out.seekp(-1, out.end);
-		}
-		out << "\r\n";
-		SendMsgToChar(out.str(), ch);
+		SendMsgToChar(fmt::format("Содержит заклинание: {}\r\n",
+				SpellItemSpellsWithPotency(obj)), ch);
 		break;
 	}
 		// issue.potion-hotfix: a potion reads its spells from the ObjVal keys and shows its maker-derived
 	// POTENCY (Сила), never a per-spell level -- the drinker's own skill/stats are irrelevant.
 	case EObjType::kPotion: {
-		std::ostringstream out;
-		out << "Содержит заклинание:";
-		const ObjVal::EValueKey spell_keys[3] = {
-			ObjVal::EValueKey::kSpell1Num,
-			ObjVal::EValueKey::kSpell2Num,
-			ObjVal::EValueKey::kSpell3Num};
-		for (const auto key : spell_keys) {
-			const auto spell_id = static_cast<ESpell>(obj->GetPotionValueKey(key));
-			if (MUD::Spell(spell_id).IsValid()) {
-				const int potency = static_cast<int>(MagicItemPotency(obj, spell_id) + 0.5f);
-				out << " " << MUD::Spell(spell_id).GetName()
-					<< " (сила " << potency << "),";
-			}
-		}
-		if (out.str().back() == ',') {
-			out.seekp(-1, out.end);
-		}
-		out << "\r\n";
-		SendMsgToChar(out.str(), ch);
+		SendMsgToChar(fmt::format("Содержит заклинание: {}\r\n",
+				SpellItemSpellsWithPotency(obj)), ch);
 		break;
 	}
 	case EObjType::kWand:

--- a/src/gameplay/mechanics/identify.cpp
+++ b/src/gameplay/mechanics/identify.cpp
@@ -79,15 +79,15 @@ static void ShowObjTypeSpecificValues(const ObjData *obj, CharData *ch) {
 	(void) i; (void) j; (void) li;  // some branches do not touch all of them
 switch (obj->get_type()) {
 	case EObjType::kScroll: {
-		SendMsgToChar(fmt::format("Содержит заклинание: {}\r\n",
-				SpellItemSpellsWithPotency(obj)), ch);
+		SendMsgToChar(utils::OutWordsList(SpellItemSpellsWithPotency(obj),
+				ch->player_specials->saved.stringLength, ", ", "Содержит заклинание: ") + "\r\n", ch);
 		break;
 	}
 		// issue.potion-hotfix: a potion reads its spells from the ObjVal keys and shows its maker-derived
 	// POTENCY (Сила), never a per-spell level -- the drinker's own skill/stats are irrelevant.
 	case EObjType::kPotion: {
-		SendMsgToChar(fmt::format("Содержит заклинание: {}\r\n",
-				SpellItemSpellsWithPotency(obj)), ch);
+		SendMsgToChar(utils::OutWordsList(SpellItemSpellsWithPotency(obj),
+				ch->player_specials->saved.stringLength, ", ", "Содержит заклинание: ") + "\r\n", ch);
 		break;
 	}
 	case EObjType::kWand:

--- a/src/gameplay/skills/dazzle.cpp
+++ b/src/gameplay/skills/dazzle.cpp
@@ -74,8 +74,9 @@ void GoDazzle(CharData *ch, CharData *vict) {
 	bool has_pepper = false;
 
 	for (auto i = ch->carrying;i; i = i->get_next_content()) {
-		if (i->get_type() == EObjType::kWand && GET_OBJ_VAL(i,3) == 356 && GET_OBJ_VAL(i,2) > 0) {
-			int charges = GET_OBJ_VAL(i,2);
+		if (i->get_type() == EObjType::kWand && i->GetSpellItemSpellNum(1) == 356
+			&& i->GetPotionValueKey(ObjVal::EValueKey::kCurCharges) > 0) {
+			int charges = i->GetPotionValueKey(ObjVal::EValueKey::kCurCharges);
 			if (charges > 0) {
 				i->set_val(2, charges - 1);
 				has_pepper = true;

--- a/tests/spell_item_convert.cpp
+++ b/tests/spell_item_convert.cpp
@@ -143,3 +143,35 @@ TEST(DrinkconLiquidCore, ConvertIsNoOpWhenKeysPresent) {
 	auto p = make_proto(EObjType::kLiquidContainer, 24, 18, 5, 0);  // set_val already populated the keys
 	EXPECT_EQ(0, ConvertDrinkconLiquidCore(p.get(), true));
 }
+
+// issue.magic-items: a world already saved in the new format carries the payload ONLY in
+// extra_values -- the yaml serializer skips the values block for these types, so val[] stays zero.
+// Consumers must read the keys; reading raw val[] made every staff look discharged and every scroll
+// spell-less (mob scavengers threw such items on the floor, shops refused them, stat printed zeros).
+TEST(SpellItemAccessor, StaffLoadedFromExtraValuesOnly) {
+	auto p = std::make_shared<CObjectPrototype>(60700);
+	p->set_type(EObjType::kStaff);
+	// exactly what the yaml loader does for: CUR_CHARGES 1 / MAX_CHARGES 1 / SPELL1_NUM 28
+	p->init_values_from_zone("SPELL1_NUM 28");
+	p->init_values_from_zone("MAX_CHARGES 1");
+	p->init_values_from_zone("CUR_CHARGES 1");
+
+	EXPECT_EQ(0, p->get_val(2)) << "raw val[] is empty for a new-format world";
+	EXPECT_EQ(28, p->GetSpellItemSpellNum(1));
+	EXPECT_EQ(1, key(p, ObjVal::EValueKey::kCurCharges));
+	EXPECT_EQ(1, key(p, ObjVal::EValueKey::kMaxCharges));
+}
+
+// A scroll's three spell slots are readable by position through the accessor.
+TEST(SpellItemAccessor, ScrollSpellsByPosition) {
+	auto p = std::make_shared<CObjectPrototype>(60701);
+	p->set_type(EObjType::kScroll);
+	p->init_values_from_zone("SPELL1_NUM 28");
+	p->init_values_from_zone("SPELL2_NUM 84");
+
+	EXPECT_EQ(28, p->GetSpellItemSpellNum(1));
+	EXPECT_EQ(84, p->GetSpellItemSpellNum(2));
+	EXPECT_LT(p->GetSpellItemSpellNum(3), 0) << "an unset slot stays absent";
+	EXPECT_LT(p->GetSpellItemSpellNum(0), 0) << "out-of-range position is not a slot";
+	EXPECT_LT(p->GetSpellItemSpellNum(4), 0);
+}


### PR DESCRIPTION
Closes #3611

## Что происходило

Моб выбрасывал на пол гусли (`#60700`), надев при этом броню. Причина не в мобе.

Мир, сохранённый в новом формате, **не содержит блока `values`** для свитков, зелий, посохов и жезлов — сериализатор его намеренно пропускает (`yaml_world_data_source.cpp:4443`), а payload уезжает в `extra_values`:

```yaml
  extra_values:
    CUR_CHARGES: 1
    MAX_CHARGES: 1
    SPELL1_NUM: 28  # исцеление
```

Загрузчик (`:2504`) читает `extra_values` в `ObjVal`-ключи, но сырые `val[0..3]` остаются нулевыми — обратной реконструкции нет (комментарий в коде утверждает обратное: «loaders reconstruct val[] from the keys»; `ConvertObjValues` мигрирует только `val[] → ключи` и только при `num > 0`, то есть для уже пересохранённого мира ему нечего мигрировать).

Часть потребителей на ключи так и не перевели — они видели нули.

## Что чинится

| Файл | Симптом |
|---|---|
| `spec_procs.cpp` `item_nouse()` | моб-сборщик считал разряженным **любой** посох и жезл и выбрасывал их на пол (#3611); свитки и зелья считал пустыми |
| `do_stat.cpp` | `Заклинание: !undefined! уровень 0, 0 (из 0) зарядов`, у свитков `Заклинания: (Уровень - 0)` |
| `fight.cpp` | мобы не применяли жезлы, зелья и свитки в бою — заклинание не опознавалось, заряды нулевые |
| `dazzle.cpp` | жезл ослепления не срабатывал |
| `auction.cpp`, `exchange.cpp` | пометка `(б/у)` не работала |
| `shops_implementation.cpp` | магазин отказывался принимать любой посох |

Все переведены на `GetPotionValueKey`. Для чтения заклинания по позиции добавлен `GetSpellItemSpellNum(1..3)` рядом с `GetPotionValueKey` в `obj_data.h`.

## Отдельным решением: мёртвый «уровень» в stat

После перехода на `extra_values` сила свитка/посоха определяется умением мастера (`MagicItemPotency`) — так уже сделано для зелий, см. комментарий в `magic_items.cpp:31`. Уровень (`val[0]`) у этих типов никуда не мигрировал и всегда ноль, поэтому в `stat` он заменён на силу, а вывод свитков приведён к формату зелий:

```
было:  Заклинания: (Уровень - 0) исцеление.
стало: Заклинания: исцеление (сила 42)

было:  Заклинание: !undefined! уровень 0, 0 (из 0) зарядов осталось
стало: Заклинание: исцеление (сила 42), 1 (из 1) зарядов осталось
```

Если предпочитаешь оставить прежний формат строки — скажи, откачу эту часть, она независима от основного фикса.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов. **594 теста проходят** (было 592 — добавлены два новых).

Добавлены регрессионные тесты в `tests/spell_item_convert.cpp`. `SpellItemAccessor.StaffLoadedFromExtraValuesOnly` воспроизводит исходный баг в чистом виде: объект собирается ровно так, как его строит YAML-загрузчик (`init_values_from_zone` с `SPELL1_NUM`/`MAX_CHARGES`/`CUR_CHARGES`), после чего проверяется, что `val[2] == 0`, а ключи читаются корректно. То есть тест падал бы на старом коде в `item_nouse`.

Отдельно проверено, что обращений к сырым `val[1..3]` в ветках `kStaff`/`kWand`/`kScroll`/`kPotion` больше не осталось.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
