### PR TITLE
fix(poison): credit the poisoner when the victim dies from a DoT tick

### DIFF
--- a/src/gameplay/affects/affect_data.cpp
+++ b/src/gameplay/affects/affect_data.cpp
@@ -416,6 +416,23 @@ void player_affect_update() {
 	player_affect_update_profiler::record_run(profile);
 }
 
+// issue #3610: см. описание правила в affect_data.h.
+long SelectAffectAuthorUid(const std::list<Affect<EApply>::shared_ptr> &affects,
+						   const Affect<EApply>::shared_ptr &ticking) {
+	if (!ticking) {
+		return 0;
+	}
+	if (ticking->caster_id != 0) {
+		return ticking->caster_id;
+	}
+	for (const auto &other : affects) {
+		if (other && other->affect_type == ticking->affect_type && other->caster_id != 0) {
+			return other->caster_id;
+		}
+	}
+	return 0;
+}
+
 // This file update battle affects only
 void battle_affect_update(CharData *ch) {
 	bool need_recalc = false;

--- a/src/gameplay/affects/affect_data.h
+++ b/src/gameplay/affects/affect_data.h
@@ -114,6 +114,14 @@ void mobile_affect_update();
 // (kPulse always, kBattlePulse only while fighting). Defined in magic.cpp. Returns true if any fired.
 bool RunCharAffectTick(CharData *ch, const Affect<EApply>::shared_ptr &aff);
 
+// issue #3610: кому засчитывать урон тика повреждающего аффекта. Узлов одного типа на персонаже
+// может быть несколько, с разными авторами или вовсе без автора (отравленная еда, dg-триггер,
+// врожденный флаг моба), а тик достается наложенному последним. Если у него автора нет, берем его
+// у любого другого узла того же типа -- иначе отравитель терял опыт за смерть жертвы от яда.
+// Вынесено отдельно, чтобы правило проверялось тестами (tests/dot.death.credit.cpp).
+long SelectAffectAuthorUid(const std::list<Affect<EApply>::shared_ptr> &affects,
+						   const Affect<EApply>::shared_ptr &ticking);
+
 // issue.character-affect-triggers: run an affect TYPE's <actions> matching `trig` on the bearer `ch`,
 // with event.actor = `actor` (nullptr for actor-less triggers). Used for kExpired (from the affect-update
 // loops, actor=null) and kDispell (from RemoveAffectAndAnnounce, actor=dispeller). Defined in magic.cpp;

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -4005,6 +4005,8 @@ bool RunCharAffectTick(CharData *ch, const Affect<EApply>::shared_ptr &aff) {
 	}
 	const int phase = aff->apply_time > 0 ? aff->apply_time - 1 : 0;
 	int dur = aff->duration;
+	// issue #3610: автора тика ищем по всем узлам этого типа, см. SelectAffectAuthorUid.
+	const long author_uid = SelectAffectAuthorUid(ch->affected, aff);
 	// Spell-free tick on the affect's stored potency (ctx_spell kUndefined); the bearer is the caster, so
 	// a <damage> action targeting kTarFightSelf damages the bearer (a lone action's default kTarSame
 	// resolves to the previous action's targets -- empty -- so it must be explicit). Room = bearer's room.
@@ -4014,13 +4016,13 @@ bool RunCharAffectTick(CharData *ch, const Affect<EApply>::shared_ptr &aff) {
 			affects::AffectMsgRaw(aff->affect_type, affects::EAffectMsgType::kDamageToChar),
 			affects::AffectMsgRaw(aff->affect_type, affects::EAffectMsgType::kDamageToVict),
 			affects::AffectMsgRaw(aff->affect_type, affects::EAffectMsgType::kDamageToRoom),
-			aff->caster_id);   // issue.damage-over-time: poison <damage> credits the poisoner
+			author_uid);   // issue.damage-over-time: poison <damage> credits the poisoner
 	aff->duration = dur;
 	// issue.affect-action-patch-improve: run the affect's ADDITIVE talent-patches this tick (fresh ctx with
 	// the tick's potency/author), matching the pulse triggers -- e.g. a perk that adds an effect each DoT tick.
 	if (!ch->purged() && !feats::AffectTalentPatches(aff->affect_type).empty()) {
 		ActionContext pctx = BuildActionContext(ch, ESpell::kUndefined, GetRealLevel(ch), aff->potency);
-		pctx.SetDamageAuthorUid(aff->caster_id);
+		pctx.SetDamageAuthorUid(author_uid);
 		RunAdditiveAffectPatches(pctx, ch, world[ch->in_room], aff->affect_type,
 				[combat](const talents_actions::Action &a) {
 					const auto &tt = a.GetTrigger();

--- a/src/gameplay/mechanics/poison.cpp
+++ b/src/gameplay/mechanics/poison.cpp
@@ -246,6 +246,10 @@ namespace {
 // * Крит при отравлении с пушек.
 	void ProcessCritWeaponPoison(CharData *ch, CharData *vict, ESpell/* spell_num*/) {
 		Affect<EApply> af;
+		// issue #3610: крит-яд вешает свои узлы kPoisoned поверх основного, а тик берет из списка
+		// первый узел этого типа. Без автора весь урон яда переставал кому-либо засчитываться,
+		// и моб, умерший от яда, не давал опыта отравителю.
+		af.caster_id = ch->get_uid();
 		if (number(1, 100) <= 15) {
 			switch (number(1, 3)) {
 				case 1:

--- a/tests/dot.death.credit.cpp
+++ b/tests/dot.death.credit.cpp
@@ -8,6 +8,7 @@
 // case the user flagged: a DoT can still tick after its author has died.
 
 #include "gameplay/mechanics/damage.h"
+#include "gameplay/affects/affect_data.h"
 
 #include "char.utilities.hpp"   // test_utils::CharacterBuilder
 
@@ -22,6 +23,13 @@ CharData *make_char(test_utils::CharacterBuilder &b, int uid) {
 	CharData *c = b.get().get();
 	c->set_uid(uid);
 	return c;
+}
+
+Affect<EApply>::shared_ptr make_poison(long caster_id, EAffect type = EAffect::kPoisoned) {
+	auto a = std::make_shared<Affect<EApply>>();
+	a->affect_type = type;
+	a->caster_id = caster_id;
+	return a;
 }
 
 }  // namespace
@@ -75,6 +83,41 @@ TEST(DotDeathCredit, SelfAuthorCreditsNobody) {
 
 	EXPECT_EQ(nullptr, SelectSelfInflictedKiller(people, victim, /*author_uid*/ 101,
 												 fight::EDamageSource::kUndefined));
+}
+
+// issue #3610: несколько узлов одного аффекта -- тик достается наложенному ПОСЛЕДНИМ (список
+// пополняется через push_front). Если у него есть автор, он и получает урон в зачет.
+TEST(DotAuthorSelect, TickingNodeAuthorWins) {
+	auto ticking = make_poison(202);
+	std::list<Affect<EApply>::shared_ptr> affects{ticking, make_poison(303)};
+
+	EXPECT_EQ(202, SelectAffectAuthorUid(affects, ticking));
+}
+
+// Тот самый баг: поверх яда отравителя лег безавторский узел того же типа (крит-яд с пушки,
+// отравленная еда, dg-триггер, врожденный флаг моба) -- тик достался ему, и опыт терялся.
+// Теперь автор берется у соседнего узла того же типа.
+TEST(DotAuthorSelect, AuthorlessNodeFallsBackToSibling) {
+	auto ticking = make_poison(0);
+	std::list<Affect<EApply>::shared_ptr> affects{ticking, make_poison(202)};
+
+	EXPECT_EQ(202, SelectAffectAuthorUid(affects, ticking));
+}
+
+// Узел другого типа автора не одалживает: горение не должно засчитываться отравителю.
+TEST(DotAuthorSelect, OtherAffectTypeIsNotBorrowed) {
+	auto ticking = make_poison(0, EAffect::kPoisoned);
+	std::list<Affect<EApply>::shared_ptr> affects{ticking, make_poison(202, EAffect::kBurning)};
+
+	EXPECT_EQ(0, SelectAffectAuthorUid(affects, ticking));
+}
+
+// Автора нет нигде (съел отраву сам) -- засчитывать некому, и это нормально.
+TEST(DotAuthorSelect, NoAuthorAnywhere) {
+	auto ticking = make_poison(0);
+	std::list<Affect<EApply>::shared_ptr> affects{ticking, make_poison(0)};
+
+	EXPECT_EQ(0, SelectAffectAuthorUid(affects, ticking));
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
Closes #3610

> Арнбьерн богам : опять от яда моб умирает и опыта не дает

## Как это устроено

Урон тика повреждающего аффекта жертва наносит **сама себе**, поэтому убийцу ищут не по указателю, а по `author_uid` — это `caster_id`, записанный в аффекте (`SelectSelfInflictedKiller`, `damage.cpp:383`). Дальше `ProcessDeath` начисляет опыт как за обычное убийство, включая группу.

Тонкость в том, что узлов одного аффекта на персонаже может быть несколько, с разными авторами или вовсе без автора, а **тик достаётся наложенному последним** — `ch->affected` пополняется через `push_front`, а тикает первый узел своего типа (`affect_data.cpp:423-425`, `:472-476`).

## Две дыры

**1. Крит при отравлении с пушек** (`poison.cpp`, `ProcessCritWeaponPoison`) вешал свои узлы `kPoisoned` вообще без автора — хотя отравитель `ch` у него прямо в аргументах. Эти узлы ложились поверх основного яда, тик доставался им, `author_uid` оказывался нулевым, и **весь** урон яда переставал кому-либо засчитываться. Это и есть путь из жалобы: игрок травит с оружия, сам же и сбивает себе кредит.

**2. Тот же эффект давал любой безавторский узел сверху** — отравленная еда (`do_eat.cpp:205-218`), питьё (`poison.cpp`, `TryDrinkPoison`), dg-триггер `%actor% affect ... kPoisoned` (`dg_misc.cpp:313-333`), врождённый флаг моба (`magic.cpp:307`, `caster_id = 0`). Для еды и питья ноль стоит осознанно («сам виноват»), но он не должен обнулять чужой яд, уже висящий на жертве.

## Что сделано

- `ProcessCritWeaponPoison` проставляет `caster_id` — одна строка, чинит конкретный сценарий из жалобы.
- `SelectAffectAuthorUid` — если у тикающего узла автора нет, он берётся у другого узла **того же типа**. Узел чужого типа автора не одалживает (горение не засчитывается отравителю), а полное отсутствие автора по-прежнему значит «засчитывать некому» — сам съел отраву.

Правило вынесено в отдельную функцию рядом с `RunCharAffectTick`, по образцу уже вынесенного `SelectSelfInflictedKiller`, — чтобы проверялось тестами, а не только в бою.

## Чего этот PR НЕ меняет

Если автора нет в комнате в момент смерти (умер сам, ушёл, моб убежал), опыт по-прежнему не начисляется. Это заложено в дизайн и зафиксировано тестом `DotDeathCredit.DeadAuthorCreditsNobody`: `author_uid` намеренно не разыменовывается в живой указатель, иначе получаем обращение к освобождённой памяти. Если жалоба относится и к этому сценарию — это отдельный разговор про то, где хранить кредит.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов. **598 тестов проходят** (было 594 — добавлены четыре).

Новые тесты в `tests/dot.death.credit.cpp`, рядом с существующими на атрибуцию:

| Тест | Что фиксирует |
|---|---|
| `TickingNodeAuthorWins` | у тикающего узла есть автор — он и получает зачёт |
| `AuthorlessNodeFallsBackToSibling` | тот самый баг: безавторский узел сверху, автор берётся у соседнего |
| `OtherAffectTypeIsNotBorrowed` | узел другого типа автора не одалживает |
| `NoAuthorAnywhere` | автора нет нигде — засчитывать некому |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
