### PR TITLE
fix(stat): mark item potency taken from the prototype

### DIFF
--- a/src/gameplay/magic/magic_utils.cpp
+++ b/src/gameplay/magic/magic_utils.cpp
@@ -372,7 +372,15 @@ int MagicItemStat(const ObjData *item) {
 
 // issue.magic-items: перечень заклинаний предмета с их силой -- один формат для stat и опознания.
 // Заклинания лежат в extra_values (сырые val[] у свитков, зелий, посохов и жезлов нулевые).
+// issue #3611: см. описание в magic_utils.h.
+bool IsPotencyFromProto(const CObjectPrototype *item) {
+	return item->GetPotionValueKey(ObjVal::EValueKey::kMakerSkill) < 0
+			&& item->GetPotionValueKey(ObjVal::EValueKey::kPotionPotency) <= 0;
+}
+
 std::vector<std::string> SpellItemSpellsWithPotency(const ObjData *item) {
+	const bool from_proto = IsPotencyFromProto(item);
+
 	std::vector<std::string> spells;
 	for (int pos = 1; pos <= 3; ++pos) {
 		const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(pos));
@@ -380,7 +388,9 @@ std::vector<std::string> SpellItemSpellsWithPotency(const ObjData *item) {
 			continue;
 		}
 		const int potency = static_cast<int>(MagicItemPotency(item, spell_id) + 0.5f);
-		spells.push_back(fmt::format("{} (сила {})", MUD::Spell(spell_id).GetName(), potency));
+		spells.push_back(from_proto
+				? fmt::format("{} (сила {}, из прототипа)", MUD::Spell(spell_id).GetName(), potency)
+				: fmt::format("{} (сила {})", MUD::Spell(spell_id).GetName(), potency));
 	}
 
 	return spells;

--- a/src/gameplay/magic/magic_utils.h
+++ b/src/gameplay/magic/magic_utils.h
@@ -3,6 +3,8 @@
 
 #include <limits>
 #include <string>
+
+class CObjectPrototype;
 #include <vector>
 
 #include "gameplay/abilities/feats.h"
@@ -101,6 +103,12 @@ int CalcNoisyAmount(double floor_val, double scaled, double sigma, int cap,
 // the item acts on its own.
 [[nodiscard]] int MagicItemSkill(const ObjData *item);
 [[nodiscard]] int MagicItemStat(const ObjData *item);
+
+// issue #3611: сила вещи, которую сделал игрок, посчитана по его умению (kMakerSkill/kMakerStat) и
+// записана в самой вещи. У вещи из прототипа этих ключей нет, MagicItemPotency берет зашитые
+// умолчания, и число выходит одинаковым у всех вещей с этим заклинанием -- свойством конкретной
+// вещи оно не является. Такую силу помечаем в выводе, чтобы ее не принимали за настоящую.
+[[nodiscard]] bool IsPotencyFromProto(const CObjectPrototype *item);
 
 // issue.magic-items: заклинания свитка/зелья/посоха с их силой, по одному на элемент,
 // вида "исцеление (сила 42)" -- на выход в utils::OutWordsList. Пустой список, если

--- a/tests/spell_item_convert.cpp
+++ b/tests/spell_item_convert.cpp
@@ -7,6 +7,7 @@
 #include "engine/entities/obj_data.h"
 #include "engine/db/db.h"
 #include "utils/utils_parse.h"
+#include "gameplay/magic/magic_utils.h"
 
 #include <memory>
 
@@ -101,8 +102,6 @@ TEST(SpellItemConvert, UnifiedKeyReadAliases) {
 	EXPECT_EQ(str(K::kPotionPotency), "POTION_POTENCY");
 }
 
-// vim: ts=4 sw=4 tw=0 noet syntax=cpp :
-
 
 // issue.magic-items-hotfix: a drink-container/fountain liquid core lives in the kLiquid* keys; the val
 // mutators (get/set/dec/inc/add/sub_val) redirect indices 0..2 to them, so val[] is not the store.
@@ -175,3 +174,33 @@ TEST(SpellItemAccessor, ScrollSpellsByPosition) {
 	EXPECT_LT(p->GetSpellItemSpellNum(0), 0) << "out-of-range position is not a slot";
 	EXPECT_LT(p->GetSpellItemSpellNum(4), 0);
 }
+
+// issue #3611: сила у вещи из прототипа посчитана по зашитым умолчаниям, а не по умению мастера --
+// одна и та же у всех вещей с этим заклинанием. Такую в выводе помечаем "из прототипа".
+TEST(PotencyFromProto, PrototypeItemHasNoMakerKeys) {
+	auto p = make_proto(EObjType::kStaff, 30, 1, 1, 28);
+	EXPECT_TRUE(IsPotencyFromProto(p.get()));
+}
+
+// Вещь, сделанную игроком, не помечаем: ее сила записана в ней самой.
+TEST(PotencyFromProto, CraftedItemCarriesMakerSkill) {
+	auto p = make_proto(EObjType::kPotion, 0, 0, 0, 0);
+	p->SetPotionValueKey(ObjVal::EValueKey::kMakerSkill, 120);
+	EXPECT_FALSE(IsPotencyFromProto(p.get()));
+}
+
+// Нулевое умение мастера -- это "выдохлось до нуля", а не отсутствие ключа: тоже не помечаем.
+TEST(PotencyFromProto, ZeroMakerSkillIsStillStored) {
+	auto p = make_proto(EObjType::kPotion, 0, 0, 0, 0);
+	p->SetPotionValueKey(ObjVal::EValueKey::kMakerSkill, 0);
+	EXPECT_FALSE(IsPotencyFromProto(p.get()));
+}
+
+// Старое зелье без умения мастера, но с заранее посчитанной силой -- она своя, не из умолчаний.
+TEST(PotencyFromProto, LegacyStoredPotencyIsNotProto) {
+	auto p = make_proto(EObjType::kPotion, 0, 0, 0, 0);
+	p->SetPotionValueKey(ObjVal::EValueKey::kPotionPotency, 55);
+	EXPECT_FALSE(IsPotencyFromProto(p.get()));
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
По следам вопроса в #3611:

> vstat obj 60700
> Заклинание: исцеление (сила 1), 1 (из 1) зарядов осталось
> откуда сила заклинания? ведь оно теперь не существует? и почему там 1?

## Откуда бралась цифра

Сила не хранится в предмете и к `val[0]` отношения не имеет. `MagicItemPotency` смотрит ключи мастера (`kMakerSkill`/`kMakerStat`), у вещи из прототипа их нет — берутся зашитые умолчания и прогоняются через `<potency_roll>` самого заклинания:

```
kAuthoredPotionSkill = 80, kAuthoredPotionKeyStat = 25, kNoviceSkillThreshold = 75

skill_coeff = (min(80,75)·1 + max(0,80−75)·7)/100 = 1.1     ← low=1, hi=7 из potency_roll исцеления
stat_coeff  = max(0, 25−25)·18/100 = 0                       ← стат ровно равен порогу 25
                                             итого 1.1 → 1
```

То есть число одинаково у **всех** вещей с этим заклинанием и свойством конкретной вещи не является, хотя в выводе выглядело именно так.

## Что меняется

Сила, посчитанная по умолчаниям, помечается:

```
было:  Заклинание: исцеление (сила 1), 1 (из 1) зарядов осталось
стало: Заклинание: исцеление (сила 1, из прототипа), 1 (из 1) зарядов осталось
```

У вещи, которую сделал игрок, сила своя — пометки нет. Работает одинаково в `stat`/`vstat` и в опознании, для свитков, зелий, жезлов и посохов (общий хелпер `SpellItemSpellsWithPotency`).

**Про признак.** Взял отсутствие ключей мастера, а не флаг `kTransformed`: именно от этих ключей зависит, посчитана сила по мастеру или по умолчаниям — то есть условие ровно то же, по которому ветвится сам `MagicItemPotency`.

По флагу пометка расходилась бы с реальностью в обе стороны:

- варка зелий и магических предметов (`im.cpp:1442,1470,1486`) записывает `kMakerSkill`, но `kTransformed` **не ставит** — сваренное игроком зелье получило бы ложную пометку «из прототипа», хотя сила у него своя;
- `jewelry.cpp:442` и `item_creation.cpp:1674` ставят `kTransformed` **без** `kMakerSkill` — там пометку, наоборот, сняло бы с вещи, сила которой всё равно из умолчаний.

Отдельно учтено старое зелье без умения мастера, но с заранее посчитанной `kPotionPotency` — его сила своя, пометки нет.

## Что этот PR НЕ чинит

`MagicItemPotency` используется не только в выводе, но и в `EmployMagicItem` при реальном применении. То есть авторские свитки, жезлы и посохи сейчас **срабатывают** с силой ~1 — не только показывают её. Если так не задумано, это вопрос баланса всех авторских магических предметов (умолчания 80/25 против новичкового порога 75), и его стоит решать отдельно — здесь я поведение не трогал.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов. **598 тестов проходят** (четыре новых).

| Тест | Что фиксирует |
|---|---|
| `PrototypeItemHasNoMakerKeys` | вещь из прототипа — помечаем |
| `CraftedItemCarriesMakerSkill` | вещь игрока — не помечаем |
| `ZeroMakerSkillIsStillStored` | нулевое умение мастера это «выдохлось», а не «ключа нет» |
| `LegacyStoredPotencyIsNotProto` | старое зелье с посчитанной силой — не помечаем |

Саму строку вывода тестами не покрыть — она требует загруженного реестра заклинаний, поэтому вынес и проверил предикат.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
