### PR TITLE
fix(objects): mark items permanently altered by spells as transformed

### DIFF
--- a/src/engine/entities/obj_data.cpp
+++ b/src/engine/entities/obj_data.cpp
@@ -499,7 +499,9 @@ void ObjData::unset_enchant() {
 		set_extra_flag(EObjFlag::kHasOneSlot);
 	}
 	unset_extraflag(EObjFlag::kMagic);
-	unset_extraflag(EObjFlag::kTransformed);
+	// issue #3618: kTransformed здесь НЕ снимаем. Снятие зачарования возвращает к прототипу только
+	// его часть, а на вещи могли остаться другие изменения -- благословение, отрава, подгонка по
+	// мерке. Сняв флаг, мы разрешали olc перезаписать вещь прототипом целиком и потерять их.
 }
 
 bool ObjData::clone_olc_object_from_prototype(const ObjVnum vnum) {

--- a/src/gameplay/crafting/im.cpp
+++ b/src/gameplay/crafting/im.cpp
@@ -1435,6 +1435,9 @@ void do_cook(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		imlog(CMP, "Создание результата");
 		const auto result = world_objects.create_from_prototype_by_rnum(tgt);
 		if (result) {
+			// issue #3618: сваренная вещь несет умение мастера и прочие свои значения -- помечаем
+			// сразу, до разбора по типам, иначе правка прототипа в olc перезапишет ее целиком.
+			result->set_extra_flag(EObjFlag::kTransformed);
 			switch (result->get_type()) {
 				case EObjType::kScroll:
 					// issue.magic-items: a crafted scroll stores the crafter's competence (recipe skill + Int),

--- a/src/gameplay/handlers/alter_bless.cpp
+++ b/src/gameplay/handlers/alter_bless.cpp
@@ -26,6 +26,9 @@ EStageResult AlterBless(ActionContext &ctx) {
 		obj->add_maximum(std::max(obj->get_maximum_durability() >> 2, 1));
 		obj->set_current_durability(obj->get_maximum_durability());
 		obj->add_timed_spell(ESpell::kBless, -1);
+		// issue #3618: вещь навсегда разошлась с прототипом (флаг, кубы, максимальная прочность) --
+		// помечаем, иначе правка прототипа в olc затрет наложенное.
+		obj->set_extra_flag(EObjFlag::kTransformed);
 		return AlterMsg(ctx, ESpellMsg::kAlterObjToChar);
 	}
 	return EStageResult::kFail;

--- a/src/gameplay/handlers/alter_curse.cpp
+++ b/src/gameplay/handlers/alter_curse.cpp
@@ -27,6 +27,8 @@ EStageResult AlterCurse(ActionContext &ctx) {
 				obj->dec_val(1);
 			}
 		}
+		// issue #3618: испорченные характеристики обратно не поднимаются -- вещь больше не прототип.
+		obj->set_extra_flag(EObjFlag::kTransformed);
 		return AlterMsg(ctx, ESpellMsg::kAlterObjToChar);
 	}
 	return EStageResult::kFail;

--- a/src/gameplay/handlers/alter_fly.cpp
+++ b/src/gameplay/handlers/alter_fly.cpp
@@ -15,6 +15,8 @@ EStageResult AlterFly(ActionContext &ctx) {
 	ObjData *obj = ctx.ovict;
 	obj->add_timed_spell(ESpell::kFly, -1);
 	obj->set_extra_flag(EObjFlag::kFlying);
+	// issue #3618: таймер -1 -- это бессрочно, флаг лежит в самой вещи и переживает перезагрузку.
+	obj->set_extra_flag(EObjFlag::kTransformed);
 	return AlterMsg(ctx, ESpellMsg::kAlterObjToChar);
 }
 

--- a/src/gameplay/handlers/alter_invisible.cpp
+++ b/src/gameplay/handlers/alter_invisible.cpp
@@ -15,6 +15,7 @@ EStageResult AlterInvisible(ActionContext &ctx) {
 	ObjData *obj = ctx.ovict;
 	if (!obj->has_flag(EObjFlag::kNoinvis) && !obj->has_flag(EObjFlag::kInvisible)) {
 		obj->set_extra_flag(EObjFlag::kInvisible);
+		obj->set_extra_flag(EObjFlag::kTransformed);   // issue #3618: невидимость с вещи сама не спадает
 		return AlterMsg(ctx, ESpellMsg::kAlterObjToChar);
 	}
 	return EStageResult::kFail;

--- a/src/gameplay/handlers/alter_light.cpp
+++ b/src/gameplay/handlers/alter_light.cpp
@@ -15,6 +15,8 @@ EStageResult AlterLight(ActionContext &ctx) {
 	ObjData *obj = ctx.ovict;
 	obj->add_timed_spell(ESpell::kLight, -1);
 	obj->set_extra_flag(EObjFlag::kGlow);
+	// issue #3618: таймер -1 -- это бессрочно, флаг лежит в самой вещи и переживает перезагрузку.
+	obj->set_extra_flag(EObjFlag::kTransformed);
 	return AlterMsg(ctx, ESpellMsg::kAlterObjToChar);
 }
 

--- a/src/gameplay/handlers/alter_poison.cpp
+++ b/src/gameplay/handlers/alter_poison.cpp
@@ -16,6 +16,7 @@ EStageResult AlterPoison(ActionContext &ctx) {
 	if (!GET_OBJ_VAL(obj, 3) && (obj->get_type() == EObjType::kLiquidContainer
 			|| obj->get_type() == EObjType::kFountain || obj->get_type() == EObjType::kFood)) {
 		obj->set_val(3, 1);
+		obj->set_extra_flag(EObjFlag::kTransformed);   // issue #3618: отрава остается в вещи навсегда
 		return AlterMsg(ctx, ESpellMsg::kAlterObjToChar);
 	}
 	return EStageResult::kFail;

--- a/src/gameplay/handlers/alter_remove_curse.cpp
+++ b/src/gameplay/handlers/alter_remove_curse.cpp
@@ -18,6 +18,9 @@ EStageResult AlterRemoveCurse(ActionContext &ctx) {
 		if (obj->get_type() == EObjType::kWeapon) {
 			obj->inc_val(2);
 		}
+		// issue #3618: kNodrop снимается и с вещи, которая была проклята в самом прототипе, --
+		// после этого она от прототипа отличается.
+		obj->set_extra_flag(EObjFlag::kTransformed);
 		return AlterMsg(ctx, ESpellMsg::kAlterObjToChar);
 	}
 	return EStageResult::kFail;

--- a/src/gameplay/mechanics/obj_enchant.cpp
+++ b/src/gameplay/mechanics/obj_enchant.cpp
@@ -138,6 +138,9 @@ void enchant::apply_to_obj(ObjData *obj) const {
 
 	correct_values(obj);
 	obj->add_enchant(*this);
+	// issue #3618: вещь обросла аффектами, флагами и весом поверх прототипа -- помечаем, иначе
+	// правка прототипа в olc перезапишет ее целиком и зачарование потеряется.
+	obj->set_extra_flag(EObjFlag::kTransformed);
 }
 
 void Enchants::add(const enchant &ench) {

--- a/src/gameplay/skills/repair.cpp
+++ b/src/gameplay/skills/repair.cpp
@@ -64,6 +64,9 @@ void DoRepair(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			} else {
 				obj->set_maximum_durability(1);
 			}
+			// issue #3618: максимальная прочность назад не поднимается -- вещь навсегда хуже
+			// прототипа, помечаем, чтобы правка прототипа в olc не вернула ее в исходный вид.
+			obj->set_extra_flag(EObjFlag::kTransformed);
 		} else {
 			act("Вы окончательно доломали $o3.",
 				false, ch, obj, nullptr, kToChar);


### PR DESCRIPTION
Группы A, B и живые пункты D из #3618.

`kTransformed` защищает вещь от перезаписи прототипом в OLC (`oedit.cpp:147` — у помеченной вещи `fullUpdate = false`). Заклинания, меняющие вещь навсегда, флаг не ставили, поэтому правка прототипа билдером затирала наложенное игроком.

## Помечаем

| Заклинание | Что остаётся в вещи навсегда |
|---|---|
| `alter_bless` | `kBless`, снятие `kNodrop`, `inc_val(2)` оружию, **+25% к максимальной прочности** |
| `alter_curse` | `kNodrop`, `dec_val(0/1/2)` — характеристики обратно не поднимаются |
| `alter_remove_curse` | снимает `kNodrop` в том числе с вещи, которая была проклята в самом прототипе |
| `alter_poison` | `set_val(3,1)` — отрава |
| `alter_fly`, `alter_light`, `alter_invisible` | `kFlying`/`kGlow`/`kInvisible` + `add_timed_spell(..., -1)` |

Про последнюю строку: таймер `-1` означает «бессрочно» (`magic_objects.cpp:22`), флаги лежат в extra_flags вещи и переживают перезагрузку. Выглядят временными, но таковыми не являются.

## Не помечаем

- `spell_create_water` — содержимое сосуда, расходуется.
- `alter_repair` — `set_current_durability(max)`, только **текущая** прочность. Она и так гуляет от любого удара; пометка означала бы, что каждая вещь становится «изменённой» после первой же починки.
- `alter_acid` → `DamageObj` — та же текущая прочность, обратимо ремонтом.

Разделительная линия: **максимальная** прочность — свойство вещи из прототипа, помечаем; **текущая** — расходная величина, не помечаем.

## Отдельно: `unset_enchant` больше не снимает флаг

`ObjData::unset_enchant` (`obj_data.cpp:502`) снимал `kTransformed` вместе с `kMagic`. Но снятие зачарования возвращает к прототипу только свою часть, а на вещи могли остаться другие изменения — благословение, отрава, подгонка по мерке. Сняв флаг, мы разрешали OLC перезаписать вещь прототипом целиком и потерять их.

Вызов у метода ровно один (`alter_restoration.cpp:21`), так что правка локальная по последствиям.

## B. Зачарования и сеты

`enchant::apply_to_obj` (`obj_enchant.cpp:116`) навешивает на вещь аффекты, флаги, вес и кубы оружия поверх прототипа — ровно тот случай, ради которого флаг задуман. Одна строка закрывает всю систему зачарований и сетов.

## D. Крафт и умения

Из группы D после разбора живыми оказались два места:

- **варка** (`im.cpp:1437`) — сваренная вещь несёт умение мастера (`MAKER_SKILL`/`MAKER_STAT`), заряды и таймер, всё своё. Флаг ставится сразу после создания результата, до разбора по типам, поэтому покрывает свитки, зелья, жезлы и посохи одним местом. Именно на этом всплыл разбор в #3611.
- **провал починки** (`repair.cpp:66`) — макс. прочность падает навсегда (до 5% за попытку, вплоть до 1), вещь становится хуже прототипа.

Остальное из D отпало: износ инструмента чинится; `set_owner` и `set_material` решено пропустить (owner вдобавок и так восстанавливается OLC, `oedit.cpp:173`); заточка уже покрыта флагом на `sharpening.cpp:99`; в `item_creation` обе рабочие ветки — «перековать» (`:473`) и «сшить одежду» (`:1674`) — покрыты, остальные механики не работают; `craft.cpp` не доделан.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов, **594 теста проходят**.

Тестами эти правки не покрыть: `alter_*` работают через `ActionContext` с живым заклинателем и миром, а проверяемая логика — одна установка флага рядом с самим изменением. Поведение проверяется в игре: наложить благословение на вещь, поправить её прототип в OLC и убедиться, что наложенное не слетело.

Группу C (скрипты) и группу E (механики и экономика) этот PR не трогает — по обеим решено оставить как есть.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
