### PR TITLE
fix(liquid): mark a filled drinkcon as renamed

### DIFF
--- a/src/gameplay/mechanics/liquid.cpp
+++ b/src/gameplay/mechanics/liquid.cpp
@@ -593,6 +593,9 @@ void name_to_drinkcon(ObjData *obj, int type) {
 		snprintf(new_name, kMaxInputLength, "%s с %s", obj->get_PName(name_case).c_str(), potion_name);
 		obj->set_PName(name_case, new_name);
 	}
+	// issue #3620: имя сосуда больше не совпадает с прототипом -- без этой пометки olc при правке
+	// прототипа восстановит исходное имя, и сосуд перестанет показывать свое содержимое.
+	obj->set_is_rename(true);
 }
 
 std::string print_spell(const ObjData *obj, int num) {


### PR DESCRIPTION
По следам #3620.

`name_to_drinkcon` (`liquid.cpp:576-594`) дописывает к имени сосуда название жидкости — в алиасы, краткое описание и все падежи, — но `is_rename` не ставит.

Из-за этого при правке прототипа в OLC срабатывает полное обновление (`oedit.cpp:158`), имя восстанавливается из прототипа, и сосуд перестаёт показывать своё содержимое: вместо «бурдюк с синим зельем» снова «бурдюк». Восстановление падежей в `oedit.cpp:164-167` не помогает — оно как раз завязано на `is_rename`.

Обратная функция `name_from_drinkcon` пометку намеренно **не снимает**: она срезает только свою добавку, а имя вещи могло быть изменено и чем-то ещё — снятие открыло бы вещь для затирания.

Из того же аудита остаётся непомеченным клановый титул на вещи (`house.cpp:5520`) — в этот PR не входит.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов, 594 теста проходят.

Тестами не покрыть: функция правит имена живого объекта, а проверяемое — одна пометка рядом с переименованием. В игре проверяется так: налить зелье в сосуд, поправить прототип сосуда в OLC, убедиться, что имя с названием жидкости осталось.

🤖 Generated with [Claude Code](https://claude.com/claude-code)