### PR TITLE
fix(bless): allow blessing only weapons and armor

### DIFF
--- a/src/gameplay/handlers/alter_bless.cpp
+++ b/src/gameplay/handlers/alter_bless.cpp
@@ -15,6 +15,11 @@ namespace handlers {
 EStageResult AlterBless(ActionContext &ctx) {
 	CharData *ch = ctx.caster();
 	ObjData *obj = ctx.ovict;
+	// Благословение прибавляет прочность и кубы, поэтому имеет смысл только для оружия и брони.
+	// Раньше благословить можно было что угодно, вплоть до хлеба.
+	if (obj->get_type() != EObjType::kWeapon && !ObjSystem::is_armor_type(obj)) {
+		return EStageResult::kFail;
+	}
 	if (!obj->has_flag(EObjFlag::kBless) && (obj->get_weight() <= 5 * GetRealLevel(ch))) {
 		obj->set_extra_flag(EObjFlag::kBless);
 		if (obj->has_flag(EObjFlag::kNodrop)) {


### PR DESCRIPTION
Благословение прибавляет максимальную прочность (+25%) и кубы оружия, то есть осмысленно только там, где прочность и кубы работают. Проверки типа в `AlterBless` не было вовсе — цель заклинания `kTarObjInv|kTarObjEquip`, фильтра ни в обработчике, ни в `talent_actions`, — поэтому благословить можно было что угодно, вплоть до хлеба.

Теперь только оружие и броня.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов, 594 теста проходят.

## Смежное, в этот PR не входит

- `alter_curse` симметрично не ограничен по типу — проклясть можно любую вещь.
- `kBless` с предмета не снимается нигде в коде: `unset_extraflag(EObjFlag::kBless)` не встречается ни разу, `del_timed_spell` зовётся только для `kLight` (`alter_darkness.cpp:17`), а таймер благословения `-1` (бессрочный), так что `remove_tmp_extra` не сработает. То есть благословение сейчас необратимо.

🤖 Generated with [Claude Code](https://claude.com/claude-code)