### PR TITLE
fix(stat): show the ground timer only for an item lying in a room

### DIFF
--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -962,12 +962,14 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 		case EObjType::kScroll: {
 			// issue.magic-items: заклинания свитка лежат в extra_values, сила -- умение мастера
 			snprintf(buf, sizeof(buf), "%s", utils::OutWordsList(SpellItemSpellsWithPotency(j),
-					ch->player_specials->saved.stringLength, ", ", "Заклинания: ").c_str());
+					ch->player_specials->saved.stringLength, ", ",
+					std::string(kColorGrn) + "Заклинания:" + kColorNrm + " ").c_str());
 			break;
 		}
 		case EObjType::kPotion: {
 			snprintf(buf, sizeof(buf), "%s", utils::OutWordsList(SpellItemSpellsWithPotency(j),
-					ch->player_specials->saved.stringLength, ", ", "Заклинания: ").c_str());
+					ch->player_specials->saved.stringLength, ", ",
+					std::string(kColorGrn) + "Заклинания:" + kColorNrm + " ").c_str());
 			break;
 		}
 		case EObjType::kWand:
@@ -978,8 +980,11 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 				const int potency = static_cast<int>(MagicItemPotency(j, staff_spell) + 0.5f);
 				// issue #3611: у вещи из прототипа сила посчитана по зашитым умолчаниям, а не по
 				// умению мастера -- помечаем так же, как в перечне заклинаний свитков и зелий.
-				snprintf(buf, sizeof(buf), "Заклинание: %s (сила %d%s), %d (из %d) зарядов осталось",
+				snprintf(buf, sizeof(buf), "%sЗаклинание:%s %s%s%s (сила %d%s), %d (из %d) зарядов осталось",
+						kColorGrn, kColorNrm,
+						kColorCyn,
 						MUD::Spell(staff_spell).GetCName(),
+						kColorNrm,
 						potency,
 						IsPotencyFromProto(j) ? ", из прототипа" : "",
 						j->GetPotionValueKey(ObjVal::EValueKey::kCurCharges),

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -808,7 +808,14 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 	else
 		snprintf(buf, sizeof(buf), "Таймер: %d, ", j->get_timer());
 	SendMsgToChar(buf, ch);
-	snprintf(buf, sizeof(buf), "Таймер на земле: %d\r\n", j->get_destroyer());
+	// Таймер на земле тикает только пока вещь лежит в комнате, и выставляется при попадании
+	// туда (PlaceObjToRoom). У вещи в инвентаре в этом поле лежит умолчание конструктора (60),
+	// которое выглядело настоящим таймером, хотя таким никогда не станет.
+	if (j->get_in_room() != kNowhere) {
+		snprintf(buf, sizeof(buf), "Таймер на земле: %d\r\n", j->get_destroyer());
+	} else {
+		snprintf(buf, sizeof(buf), "\r\n");
+	}
 	SendMsgToChar(buf, ch);
 	std::string str;
 

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -976,9 +976,12 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 			{
 				const auto staff_spell = static_cast<ESpell>(j->GetSpellItemSpellNum(1));
 				const int potency = static_cast<int>(MagicItemPotency(j, staff_spell) + 0.5f);
-				snprintf(buf, sizeof(buf), "Заклинание: %s (сила %d), %d (из %d) зарядов осталось",
+				// issue #3611: у вещи из прототипа сила посчитана по зашитым умолчаниям, а не по
+				// умению мастера -- помечаем так же, как в перечне заклинаний свитков и зелий.
+				snprintf(buf, sizeof(buf), "Заклинание: %s (сила %d%s), %d (из %d) зарядов осталось",
 						MUD::Spell(staff_spell).GetCName(),
 						potency,
+						IsPotencyFromProto(j) ? ", из прототипа" : "",
 						j->GetPotionValueKey(ObjVal::EValueKey::kCurCharges),
 						j->GetPotionValueKey(ObjVal::EValueKey::kMaxCharges));
 			}

--- a/src/gameplay/magic/magic_utils.cpp
+++ b/src/gameplay/magic/magic_utils.cpp
@@ -388,9 +388,12 @@ std::vector<std::string> SpellItemSpellsWithPotency(const ObjData *item) {
 			continue;
 		}
 		const int potency = static_cast<int>(MagicItemPotency(item, spell_id) + 0.5f);
+		// имя заклинания выделяем цветом, как в списке заклинаний моба
 		spells.push_back(from_proto
-				? fmt::format("{} (сила {}, из прототипа)", MUD::Spell(spell_id).GetName(), potency)
-				: fmt::format("{} (сила {})", MUD::Spell(spell_id).GetName(), potency));
+				? fmt::format("{}{}{} (сила {}, из прототипа)",
+						kColorCyn, MUD::Spell(spell_id).GetName(), kColorNrm, potency)
+				: fmt::format("{}{}{} (сила {})",
+						kColorCyn, MUD::Spell(spell_id).GetName(), kColorNrm, potency));
 	}
 
 	return spells;

--- a/src/gameplay/mechanics/identify.cpp
+++ b/src/gameplay/mechanics/identify.cpp
@@ -80,14 +80,16 @@ static void ShowObjTypeSpecificValues(const ObjData *obj, CharData *ch) {
 switch (obj->get_type()) {
 	case EObjType::kScroll: {
 		SendMsgToChar(utils::OutWordsList(SpellItemSpellsWithPotency(obj),
-				ch->player_specials->saved.stringLength, ", ", "Содержит заклинание: ") + "\r\n", ch);
+				ch->player_specials->saved.stringLength, ", ",
+				std::string(kColorGrn) + "Содержит заклинание:" + kColorNrm + " ") + "\r\n", ch);
 		break;
 	}
 		// issue.potion-hotfix: a potion reads its spells from the ObjVal keys and shows its maker-derived
 	// POTENCY (Сила), never a per-spell level -- the drinker's own skill/stats are irrelevant.
 	case EObjType::kPotion: {
 		SendMsgToChar(utils::OutWordsList(SpellItemSpellsWithPotency(obj),
-				ch->player_specials->saved.stringLength, ", ", "Содержит заклинание: ") + "\r\n", ch);
+				ch->player_specials->saved.stringLength, ", ",
+				std::string(kColorGrn) + "Содержит заклинание:" + kColorNrm + " ") + "\r\n", ch);
 		break;
 	}
 	case EObjType::kWand:

--- a/src/gameplay/mechanics/liquid.cpp
+++ b/src/gameplay/mechanics/liquid.cpp
@@ -612,7 +612,8 @@ std::string print_spell(const ObjData *obj, int num) {
 	char buf_[kMaxInputLength];
 	// issue #3611: у вещи из прототипа сила посчитана по зашитым умолчаниям, а не по умению
 	// мастера -- помечаем так же, как у свитков, зелий, посохов и жезлов.
-	snprintf(buf_, sizeof(buf_), "Содержит заклинание: %s%s (сила %d%s)%s\r\n",
+	snprintf(buf_, sizeof(buf_), "%sСодержит заклинание:%s %s%s (сила %d%s)%s\r\n",
+			 kColorGrn, kColorNrm,
 			 kColorCyn,
 			 MUD::Spell(spell_id).GetCName(),
 			 potency,

--- a/src/gameplay/mechanics/liquid.cpp
+++ b/src/gameplay/mechanics/liquid.cpp
@@ -610,10 +610,13 @@ std::string print_spell(const ObjData *obj, int num) {
 	// (сила) as a potion, not the retired per-spell level.
 	const int potency = static_cast<int>(MagicItemPotency(obj, spell_id) + 0.5f);
 	char buf_[kMaxInputLength];
-	snprintf(buf_, sizeof(buf_), "Содержит заклинание: %s%s (сила %d)%s\r\n",
+	// issue #3611: у вещи из прототипа сила посчитана по зашитым умолчаниям, а не по умению
+	// мастера -- помечаем так же, как у свитков, зелий, посохов и жезлов.
+	snprintf(buf_, sizeof(buf_), "Содержит заклинание: %s%s (сила %d%s)%s\r\n",
 			 kColorCyn,
 			 MUD::Spell(spell_id).GetCName(),
 			 potency,
+			 IsPotencyFromProto(obj) ? ", из прототипа" : "",
 			 kColorNrm);
 
 	return buf_;


### PR DESCRIPTION
Ты видел в `stat`:

```
Вес: 1, Цена: 1, Рента(eq): 1, Рента(inv): 1, Таймер: 30, Таймер на земле: 60
```

и 60 там взяться неоткуда.

## Причина

`destroyer` осмыслен только пока вещь лежит в комнате: тикает он в `obj_decay_manager.cpp:202-207` по содержимому комнат, а выставляется при попадании на землю (`obj_handler.cpp:117-125`):

| Что | Таймер |
|---|---|
| обычная вещь | 10 |
| деньги | 60 |
| комната-ловушка | 5 |
| вещь с триггерами | 10 |

У вещи в инвентаре в поле лежит умолчание конструктора — `ObjData::DEFAULT_DESTROYER == 60` (`obj_data.h:179,199`). Оно совпало со значением для денег, поэтому выглядело настоящим таймером, хотя обычная вещь на земле всегда получает 10.

## Что меняется

Строка показывается только для вещи, реально лежащей в комнате. Для вещи в инвентаре, надетой или в контейнере — не показывается вовсе, вместо неё перевод строки (иначе предыдущая строка осталась бы без переноса).

## Проверка

Сборка `release` + `build_tests=true`, без варнингов, 602 теста проходят.

## Смежное, в этот PR не входит

`DEFAULT_DESTROYER = 60` как умолчание выглядит неудачно: оно совпадает с `kMoneyDestroyTimer` и потому читается как осмысленное значение. Ноль был бы честнее, но `obj_decay_manager.cpp:204` трактует достижение нуля как «удалить вещь», так что менять умолчание нужно с оглядкой на распад — отдельной задачей.

🤖 Generated with [Claude Code](https://claude.com/claude-code)