### PR TITLE
build(hunt): raise fortify level from 2 to 3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,9 +14,15 @@ dependencies = []
 
 build_profile = get_option('build_profile')
 
-# hunt: собираем ровно как release, но с -D_FORTIFY_SOURCE=2 -- дешёвый (околонулевой
-# оверхед) ловец переполнений фиксированных буферов в sprintf/strcpy/memcpy и т.п.,
-# падает в момент записи за границу с бэктрейсом. Дальше ведём себя как release.
+# hunt: собираем ровно как release, но с -D_FORTIFY_SOURCE=3 -- ловец переполнений в
+# sprintf/strcpy/memcpy и т.п., падает в момент записи за границу с бэктрейсом. Дальше
+# ведём себя как release.
+#
+# Уровень 3 (нужен gcc 12+) отличается от 2 тем, что берёт размер цели не только когда он
+# известен на этапе компиляции, но и через __builtin_dynamic_object_size -- то есть видит
+# буферы, выделенные в рантайме, а не только char buf[N]. Замеры: на чистой строковой
+# молотилке 2 даёт +21%, 3 даёт +30% к времени; на загрузке мира разница между ними тонет
+# в шуме между прогонами.
 fortify_source = false
 if build_profile == 'hunt'
     build_profile = 'release'
@@ -54,7 +60,7 @@ if cpp.get_argument_syntax() == 'gcc'
     project_args += ['-Wno-format-truncation']
     if fortify_source
         # -U на случай, если тулчейн уже определил _FORTIFY_SOURCE (иначе redefine-варнинг)
-        project_args += ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=2']
+        project_args += ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
     endif
     if host_system != 'windows' and build_profile != 'fasttest'
         add_project_link_arguments('-rdynamic', language: 'cpp')


### PR DESCRIPTION
Профиль `hunt` заводился, чтобы ловить порчу памяти в момент записи, а не через полчаса в чужом `malloc`. Уровень 2 для этого недостаточен.

## В чём разница

`_FORTIFY_SOURCE=2` берёт размер цели только когда он известен на этапе компиляции — то есть видит `char buf[N]`, но не видит буфер из `malloc`. Уровень 3 (gcc 12+) добавляет `__builtin_dynamic_object_size` и ловит и такие.

На живом примере — переполнение динамического буфера:

```
fortify=2:  malloc(): corrupted top size       ← порча всплыла позже, в чужом malloc
fortify=3:  *** buffer overflow detected ***   ← поймано в момент записи
```

Первое — ровно то сообщение, с которого начинался #3568, и место записи мы тогда искали неделю. Ради этого профиль и существует.

## Замеры

Загрузка мира (small world), медиана трёх прогонов на выровненных данных:

| | медиана | к release |
|---|---|---|
| release без fortify | 1.778 c | — |
| fortify=2 | 2.150 c | +20.9% |
| fortify=3 | 1.888 c | +6.2% |

Разница между уровнями здесь в пределах шума между прогонами (у `=2` всего два валидных прогона), так что читать её как «тройка быстрее двойки» не стоит — правильный вывод в том, что переход с 2 на 3 не делает сборку заметно дороже.

Худший случай — синтетика из одних только `strcpy`/`strcat`/`snprintf`/`memcpy` в цикле: `=2` даёт +21%, `=3` даёт +30%. Реальный код так не выглядит.

## Проверка

`meson setup build_hunt --wipe -Dbuild_profile=hunt` + полная пересборка: без единого предупреждения, флаг подтверждён в `compile_commands.json` (`_FORTIFY_SOURCE=3`).

Профиль `hunt` остаётся отдельным, в `release` fortify не переезжает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)