### PR TITLE
fix(fight): an empty spell slot is not an error

### DIFF
--- a/src/gameplay/fight/fight.cpp
+++ b/src/gameplay/fight/fight.cpp
@@ -1111,11 +1111,15 @@ void mob_casting(CharData *ch) {
 			case EObjType::kWand:
 			case EObjType::kStaff: {
 				// issue.magic-items: заклинание и заряды лежат в extra_values, val[] у этих типов нулевые
-				const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(1));
+				const int spell_num = item->GetSpellItemSpellNum(1);
+				if (spell_num <= 0) {
+					break;   // заклинание не задано -- посох просто не боевой, это не поломка
+				}
+				const auto spell_id = static_cast<ESpell>(spell_num);
 				if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
 					mudlog(fmt::format("SYSERR: неверное заклинание в посохе {} #{}, позиция 1, значение {}",
 							item->get_PName(grammar::ECase::kNom), GET_OBJ_VNUM(item),
-							item->GetSpellItemSpellNum(1)), BRF, kLvlImmortal, SYSLOG, true);
+							spell_num), BRF, kLvlImmortal, SYSLOG, true);
 					break;
 				}
 
@@ -1127,11 +1131,15 @@ void mob_casting(CharData *ch) {
 			}
 			case EObjType::kPotion: {
 				for (int i = 1; i <= 3; i++) {
-					const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(i));
+					const int spell_num = item->GetSpellItemSpellNum(i);
+					if (spell_num <= 0) {
+						continue;   // пустой слот -- это норма, заклинание может быть и одно
+					}
+					const auto spell_id = static_cast<ESpell>(spell_num);
 					if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
 						mudlog(fmt::format("SYSERR: неверное заклинание в напитке {} #{}, позиция {}, значение {}",
 								item->get_PName(grammar::ECase::kNom), GET_OBJ_VNUM(item), i,
-								item->GetSpellItemSpellNum(i)), BRF, kLvlImmortal, SYSLOG, true);
+								spell_num), BRF, kLvlImmortal, SYSLOG, true);
 						continue;
 					}
 					if (MUD::Spell(spell_id).IsFlagged(kNpcAffectNpc | kNpcUnaffectNpc | kNpcUnaffectNpcCaster)) {
@@ -1142,11 +1150,15 @@ void mob_casting(CharData *ch) {
 			}
 			case EObjType::kScroll: {
 				for (int i = 1; i <= 3; i++) {
-					const auto spell_id = static_cast<ESpell>(item->GetSpellItemSpellNum(i));
+					const int spell_num = item->GetSpellItemSpellNum(i);
+					if (spell_num <= 0) {
+						continue;   // пустой слот -- это норма, заклинание может быть и одно
+					}
+					const auto spell_id = static_cast<ESpell>(spell_num);
 					if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
 						mudlog(fmt::format("SYSERR: неверное заклинание в свитке {} #{}, позиция {}, значение {}",
 								item->get_PName(grammar::ECase::kNom), GET_OBJ_VNUM(item), i,
-								item->GetSpellItemSpellNum(i)), BRF, kLvlImmortal, SYSLOG, true);
+								spell_num), BRF, kLvlImmortal, SYSLOG, true);
 						continue;
 					}
 


### PR DESCRIPTION
Регрессия от #3615, моя. Боги получили поток шума в игру:

```
SYSERR: неверное заклинание в напитке красный пузырек #141, позиция 2, значение -1
SYSERR: неверное заклинание в напитке красный пузырек #141, позиция 3, значение -1
SYSERR: неверное заклинание в свитке свиток возврата #1341, позиция 2, значение -1
SYSERR: неверное заклинание в свитке свиток возврата #1341, позиция 3, значение -1
...
```

## Что происходит

Моб в бою перебирает свои магические предметы, выбирая боевое заклинание, и у каждого зелья и свитка проверяет **все три** слота. У обычного предмета заполнен только первый, во втором и третьем лежит `-1` — «слота нет». Код считал это ошибкой.

Ругань шла на каждый предмет каждый раунд боя — отсюда одинаковые строки по четыре раза подряд.

Раньше сообщение уходило в `log()`, то есть в syslog, который никто не читает, и его никто не замечал. В #3615 я перевёл его на `mudlog` — с намерением, чтобы боги узнавали о поломке раньше игроков. Получилось наоборот: вместо редкого сигнала пошёл шум, в котором настоящая поломка утонет.

## Что изменилось

Пустой слот (`<= 0`) пропускается молча — это штатное состояние, заклинание у предмета может быть и одно. Ругань остаётся только на слот с заданным, но недопустимым номером — то есть на действительно битые данные.

Поправлено во всех трёх ветках: посохи и жезлы, зелья, свитки.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов, 602 теста проходят.

Тестами это не покрыть: код требует моба в бою с предметами в инвентаре. Проверяется в игре — бой с мобом, который носит зелья или свитки, не должен давать в лог ни строчки про позиции 2 и 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)