### PR TITLE
build: compile third-party subprojects at -O2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -128,12 +128,12 @@ endif
 zlib_opt = get_option('zlib')
 if zlib_opt != 'disabled'
     if zlib_opt == 'builtin'
-        zlib_sub = subproject('zlib', default_options: ['default_library=static', 'tests=disabled', 'unity=off'])
+        zlib_sub = subproject('zlib', default_options: ['default_library=static', 'tests=disabled', 'unity=off', 'optimization=2'])
         zlib_dep = zlib_sub.get_variable('zlib_dep')
     elif zlib_opt == 'system'
         zlib_dep = dependency('zlib', required: true, allow_fallback: false)
     else
-        zlib_dep = dependency('zlib', required: true, fallback: ['zlib', 'zlib_dep'], default_options: ['default_library=static', 'tests=disabled', 'unity=off'])
+        zlib_dep = dependency('zlib', required: true, fallback: ['zlib', 'zlib_dep'], default_options: ['default_library=static', 'tests=disabled', 'unity=off', 'optimization=2'])
     endif
     project_args += '-DHAVE_ZLIB'
     dependencies += zlib_dep
@@ -142,12 +142,12 @@ endif
 iconv_opt = get_option('iconv')
 if iconv_opt != 'disabled'
     if iconv_opt == 'builtin'
-        iconv_sub = subproject('iconv', default_options: ['default_library=static', 'tests=disabled'])
+        iconv_sub = subproject('iconv', default_options: ['default_library=static', 'tests=disabled', 'optimization=2'])
         iconv_dep = iconv_sub.get_variable('iconv_dep')
     elif iconv_opt == 'system'
         iconv_dep = dependency('iconv', required: true, allow_fallback: false)
     else
-        iconv_dep = dependency('iconv', required: true, fallback: ['iconv', 'iconv_dep'], default_options: ['default_library=static', 'tests=disabled'])
+        iconv_dep = dependency('iconv', required: true, fallback: ['iconv', 'iconv_dep'], default_options: ['default_library=static', 'tests=disabled', 'optimization=2'])
     endif
     project_args += '-DHAVE_ICONV'
     dependencies += iconv_dep
@@ -156,16 +156,16 @@ endif
 telegram_opt = get_option('telegram')
 if telegram_opt != 'disabled'
     if telegram_opt == 'builtin'
-        curl_sub = subproject('curl', default_options: ['default_library=static', 'tests=disabled'])
+        curl_sub = subproject('curl', default_options: ['default_library=static', 'tests=disabled', 'optimization=2'])
         curl_dep = curl_sub.get_variable('curl_dep')
-        ssl_sub = subproject('openssl', default_options: ['default_library=static', 'tests=disabled'])
+        ssl_sub = subproject('openssl', default_options: ['default_library=static', 'tests=disabled', 'optimization=2'])
         ssl_dep = ssl_sub.get_variable('openssl_dep')
     elif telegram_opt == 'system'
         curl_dep = dependency('libcurl', required: true, allow_fallback: false)
         ssl_dep = dependency('openssl', required: true, allow_fallback: false)
     else
-        curl_dep = dependency('libcurl', required: true, fallback: ['curl', 'curl_dep'], default_options: ['default_library=static', 'tests=disabled'])
-        ssl_dep = dependency('openssl', required: true, fallback: ['openssl', 'openssl_dep'], default_options: ['default_library=static', 'tests=disabled'])
+        curl_dep = dependency('libcurl', required: true, fallback: ['curl', 'curl_dep'], default_options: ['default_library=static', 'tests=disabled', 'optimization=2'])
+        ssl_dep = dependency('openssl', required: true, fallback: ['openssl', 'openssl_dep'], default_options: ['default_library=static', 'tests=disabled', 'optimization=2'])
     endif
     project_args += '-DHAVE_TG'
     dependencies += [curl_dep, ssl_dep]
@@ -255,7 +255,7 @@ endif
 sqlite_opt = get_option('sqlite')
 if sqlite_opt != 'disabled'
     if sqlite_opt == 'builtin'
-        sqlite_sub = subproject('sqlite3')
+        sqlite_sub = subproject('sqlite3', default_options: ['optimization=2'])
         sqlite_dep = sqlite_sub.get_variable('sqlite3_dep')
     elif sqlite_opt == 'system'
         sqlite_dep = dependency('sqlite3', required: true, allow_fallback: false)
@@ -335,12 +335,12 @@ endif
 
 fmt_opt = get_option('fmt')
 if fmt_opt == 'builtin'
-    fmt_sub = subproject('fmt', default_options: ['default_library=static'])
+    fmt_sub = subproject('fmt', default_options: ['default_library=static', 'optimization=2'])
     fmt_dep = fmt_sub.get_variable('fmt_dep')
 elif fmt_opt == 'system'
     fmt_dep = dependency('fmt', required: true, allow_fallback: false)
 else
-    fmt_dep = dependency('fmt', required: true, fallback: ['fmt', 'fmt_dep'], default_options: ['default_library=static'])
+    fmt_dep = dependency('fmt', required: true, fallback: ['fmt', 'fmt_dep'], default_options: ['default_library=static', 'optimization=2'])
 endif
 
 subdir('src/third_party_libs/libfort')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,11 +1,11 @@
 message('Seting up tests...')
 if gtest_opt == 'builtin'
-    gtest_sub = subproject('gtest', default_options: ['default_library=static'])
+    gtest_sub = subproject('gtest', default_options: ['default_library=static', 'optimization=2'])
     gtest_dep = gtest_sub.get_variable('gtest_dep')
 elif gtest_opt == 'system'
     gtest_dep = dependency('gtest', required: true, allow_fallback: false)
 else
-    gtest_dep = dependency('gtest', required: true, fallback: ['gtest', 'gtest_dep'], default_options: ['default_library=static'])
+    gtest_dep = dependency('gtest', required: true, fallback: ['gtest', 'gtest_dep'], default_options: ['default_library=static', 'optimization=2'])
 endif
 
 test_sources = files(


### PR DESCRIPTION
Продолжение истории с yaml-cpp. Субпроекты сторонних библиотек наследовали оптимизацию главного проекта — а в release это `-Og`, — из-за чего yaml-cpp парсил мир вчетверо медленнее нужного (24 с против 6). У yaml-cpp это уже вылечено `optimization=2`; здесь то же самое для остальных компилируемых зависимостей.

Идея: **наш код остаётся отлаживаемым на `-Og`, а сторонние библиотеки оптимизированы `-O2`.** Их всё равно не отлаживают построчно, а на скорость они влияют.

## Что затронуто

| Библиотека | Зачем |
|---|---|
| `fmt` | форматирование, повсеместно |
| `zlib` | MCCP-сжатие — горячий сетевой путь, на каждый пакет каждому игроку |
| `iconv` | перекодировки |
| `sqlite` | парсинг мира в sqlite-формате (та же природа, что yaml) |
| `curl` / `openssl` | telegram |
| `gtest` | быстрее компиляция тестов |

**Не тронуты:** `sol2` (header-only — компилировать нечего), `luajit` (собирает себя своим билд-скриптом с внутренним `-O2`).

## Важно про применение

Правка `default_options` субпроекта берётся только при **чистом** `meson setup` (не при `ninja` поверх), и нужен meson, который доводит эту опцию до субпроекта. Старые версии (напр. 1.3.2 из apt Ubuntu) её не доводят — субпроект остаётся на `-Og`. Это и было причиной «builtin 22 секунды хоть тресни» на проде до обновления meson. После этого PR на каждой машине нужен свежий meson + пересборка с нуля.

## Проверка

Чистый `meson setup` + сборка: фактические флаги в `build.ninja` подтверждают `-O2` у библиотек (yaml-cpp, fmt, gtest — в дефолтной конфигурации; zlib — при `-Dzlib=builtin`, 15 строк `-O2`). `circle`, `mud-sim`, `tests` линкуются, **604 теста проходят**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)