### PR TITLE
fix(magic): guard overheal clamp against hp already above the cap

### DIFF
--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -1884,6 +1884,12 @@ void ApplyHeal(CharData *victim, int hit, int extra_percent) {
 		return;
 	}
 	const int cap = max_hp + max_hp * extra_percent / 100;
+	// HP уже выше оверхил-капа (накопилось прошлыми кастами или упал max_hp) -- лечить нечем и
+	// нельзя урезать. Без этой проверки std::clamp получал lo(get_hit) > hi(cap) и падал по
+	// glibc-ассерту (issue #3631).
+	if (victim->get_hit() >= cap) {
+		return;
+	}
 	victim->set_hit(std::clamp(victim->get_hit() + hit, victim->get_hit(), cap));
 }
 


### PR DESCRIPTION
Closes #3631

## Креш

```
std::clamp<int>(val=4919, lo=4615, hi=4482)   ← lo (4615) > hi (4482)
→ __glibcxx_assert_fail → abort (SIGABRT)
```

Стек: `otrigger dgcast увеличить жизнь` → `CallMagic(kExtraHits)` → `CastToPoints` → **`ApplyHeal`** (`magic.cpp:1887`).

## Причина

`ApplyHeal` для оверхил-заклинаний (лечат выше максимума) делает:

```cpp
const int cap = max_hp + max_hp * extra_percent / 100;   // 133% макс. HP при extra_percent=33
victim->set_hit(std::clamp(victim->get_hit() + hit, victim->get_hit(), cap));
//                                        lo = get_hit()          hi = cap
```

`std::clamp(val, lo, hi)` требует `lo <= hi`, иначе UB / glibc-ассерт. Если текущее HP цели **уже выше** оверхил-капа — накопилось прошлыми кастами «увеличить жизнь» или упал `max_hp` (спал бафф, смена морфа и т.п.) — то `lo = get_hit() (4615) > hi = cap (4482)`, и clamp роняет процесс.

Верхний guard `if (get_hit() >= kMaxHits) return;` защищает только от **глобального** потолка HP, а не от локального оверхил-капа.

## Фикс

```cpp
if (victim->get_hit() >= cap) {
    return;   // HP уже выше капа -- лечить нечем и урезать нельзя
}
```

После этого `lo = get_hit() < cap = hi`, инвариант clamp соблюдён. Семантика верная: оверхил не должен **снижать** HP, если оно уже выше капа.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов, **604 теста проходят**.

Тестами путь не покрыт (требует каста через триггер на цель с HP выше капа), но условие краха арифметическое и снимается guard-ом однозначно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)