### PR TITLE
fix: guard std::clamp calls against inverted bounds

### DIFF
--- a/src/engine/entities/char_data.cpp
+++ b/src/engine/entities/char_data.cpp
@@ -1280,7 +1280,7 @@ int ClampBaseStat(const CharData *ch, const EBaseStat stat_id, const int stat_va
 	if (ch->IsNpc() || privilege::IsGod(ch))
 		return std::clamp(stat_value, kLeastBaseStat, kMobBaseStatCap);
 	else
-		return std::clamp(stat_value, kLeastBaseStat, MUD::Class(ch->GetClass()).GetBaseStatCap(stat_id));
+		return std::clamp(stat_value, kLeastBaseStat, std::max(kLeastBaseStat, MUD::Class(ch->GetClass()).GetBaseStatCap(stat_id)));
 }
 
 int GetRealBaseStat(const CharData *ch, EBaseStat stat_id) {

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -2382,7 +2382,7 @@ void oedit_parse(DescriptorData *d, char *arg) {
 				drinkcon_values_menu(d);
 				return;
 			case OEDIT_DRINKCON_CURRENT: number = atoi(arg);
-				OLC_OBJ(d)->set_val(1, std::clamp(number, 0, GET_OBJ_VAL(OLC_OBJ(d), 0)));
+				OLC_OBJ(d)->set_val(1, std::clamp(number, 0, std::max(0, GET_OBJ_VAL(OLC_OBJ(d), 0))));
 				OLC_MODE(d) = OEDIT_DRINKCON_VALUES;
 				drinkcon_values_menu(d);
 				return;

--- a/src/engine/ui/cmd_god/do_set.cpp
+++ b/src/engine/ui/cmd_god/do_set.cpp
@@ -363,7 +363,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			break;
 		case 14: {
 			auto new_value = static_cast<long>(value);
-			new_value = std::clamp(new_value, 0L, experience::GetExpUntilNextLvl(vict, kLvlImmortal) - 1) - vict->get_exp();
+			new_value = std::clamp(new_value, 0L, std::max(0L, experience::GetExpUntilNextLvl(vict, kLvlImmortal) - 1)) - vict->get_exp();
 			experience::gain_exp_regardless(vict, new_value);
 			break;
 		}

--- a/src/gameplay/core/experience.cpp
+++ b/src/gameplay/core/experience.cpp
@@ -197,7 +197,7 @@ void decrease_level(CharData *ch) {
 	}
 
 	check_max_hp(ch);
-	ch->set_max_move(ch->get_max_move() - std::clamp(add_move, 1, ch->get_max_move()));
+	ch->set_max_move(ch->get_max_move() - std::min(add_move, ch->get_max_move()));   // issue #3631: не уходим ниже 0
 
 	GET_WIMP_LEV(ch) = std::clamp(GET_WIMP_LEV(ch), 0, ch->get_real_max_hit()/2);
 	if (!privilege::IsImmortal(ch)) {

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -514,7 +514,7 @@ bool RunWholeCastWards(ActionContext &ctx, bool is_magic) {
 					// otherwise the fixed prob (spell-side <reflection> / flat-prob reflect).
 					chance = (refl.max > 0)
 						? std::clamp(static_cast<int>(ward.second - CalcCastPotency(ctx.potency())),
-									 refl.min, refl.max)
+									 refl.min, std::max(refl.min, refl.max))
 						: refl.prob;
 				} else if (absb.chance != EApply::kNone) {
 					// stat-driven: capped GET_<apply>(victim), same clamp as the elemental-resist path.

--- a/src/gameplay/magic/magic_utils.cpp
+++ b/src/gameplay/magic/magic_utils.cpp
@@ -311,7 +311,8 @@ int CalcNoisyAmount(double floor_val, double scaled, double sigma, int cap, doub
 	const double mean = floor_val + scaled;
 	const double sd = sigma * scaled;
 	const int lo = std::max(0, static_cast<int>(std::floor(floor_val)));
-	const int hi = (cap > 0) ? cap : std::numeric_limits<int>::max();
+	// issue #3631: cap ниже пола дал бы std::clamp lo>hi -- держим hi>=lo
+	const int hi = (cap > 0) ? std::max(lo, cap) : std::numeric_limits<int>::max();
 	// issue.potion-hotfix: a brewed potion replays its FROZEN brew-luck z (a standard normal) instead
 	// of drawing -- amount = mean + z*sd -- so every quaff of the potion is identical, yet each of its
 	// spells still applies its OWN sigma (via sd) to the one z. NaN = no fixed noise, draw as usual.

--- a/src/gameplay/mechanics/guilds.cpp
+++ b/src/gameplay/mechanics/guilds.cpp
@@ -274,6 +274,9 @@ void GuildInfo::DisplayMenu(CharData *trainer, CharData *ch) const {
 }
 
 void GuildInfo::LearnWithTalentNum(CharData *trainer, CharData *ch, std::size_t talent_num) const {
+	if (learning_talents_.empty()) {
+		return;   // issue #3631: нечему учить -- иначе clamp(1, size=0) с lo>hi
+	}
 	talent_num = std::clamp(talent_num, size_t(1), learning_talents_.size());
 
 	for (const auto &talent : learning_talents_) {
@@ -550,7 +553,7 @@ int GuildInfo::GuildSkill::CalcGuildSkillCap(CharData *ch) const {
 }
 
 int GuildInfo::GuildSkill::CalcPracticesQuantity(CharData *ch) const {
-	return std::clamp(CalcGuildSkillCap(ch) - GetTrainedSkill(ch, id_), 1, practices_);
+	return std::clamp(CalcGuildSkillCap(ch) - GetTrainedSkill(ch, id_), 1, std::max(1, practices_));   // issue #3631: hi>=lo
 }
 
 long GuildInfo::GuildSkill::CalcPrice(CharData *buyer) const {

--- a/src/gameplay/skills/repair.cpp
+++ b/src/gameplay/skills/repair.cpp
@@ -58,7 +58,7 @@ void DoRepair(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			act("$n попытал$u починить $o3, но сломал$g $S еще больше.",
 				false, ch, obj, nullptr, kToRoom | kToArenaListen);
 			auto decay = (obj->get_maximum_durability() - obj->get_current_durability()) / 10;
-			decay = std::clamp(decay, 1, obj->get_maximum_durability()/20);
+			decay = std::clamp(decay, 1, std::max(1, obj->get_maximum_durability() / 20));   // issue #3631: hi>=lo
 			if (obj->get_maximum_durability() > decay) {
 				obj->set_maximum_durability(obj->get_maximum_durability() - decay);
 			} else {


### PR DESCRIPTION
Профилактический аудит после краша #3631: там `std::clamp(val, lo, hi)` упал по glibc-ассерту, потому что `lo > hi`. Проверил все вызовы `std::clamp` с рантайм-границами. `std::clamp` требует `lo <= hi`, иначе UB, а под hunt-сборкой (`_FORTIFY_SOURCE`) — abort в точке.

Идиома фикса: где нижняя граница — константа-пол, а верхняя вычисляется и может упасть ниже, оборачиваем верхнюю в `std::max(пол, hi)`. Смысл сохраняется — «кап не ниже пола».

## Достижимы в обычной игре

| Место | Как ломается |
|---|---|
| `repair.cpp:61` | `макс.прочность/20 == 0` при прочности < 20 → `clamp(decay, 1, 0)`. Провал починки дешёвой вещи — обычный игрок |
| `guilds.cpp:277` | пустой `learning_talents_` → `clamp(talent_num, 1, 0)`. Игрок ввёл число у гильдии без талантов. Добавлен ранний выход |

## Битые данные/конфиг

| Место | Как ломается |
|---|---|
| `guilds.cpp:553` | `practices_ == 0` |
| `magic.cpp:516` | `refl.min/max` из данных таланта, `min > max` возможно |
| `char_data.cpp:1283` | base-stat cap класса ниже пола |
| `magic_utils.cpp:319` | латентно: `cap` ниже `floor` у будущего вызова с `cap > 0` (сегодня все вызовы с `cap=0`, безопасно) |

## God/builder

| Место | Как ломается |
|---|---|
| `do_set.cpp:366` | `GetExpUntilNextLvl-1 == -1` у макс. персонажа (`set exp`) |
| `oedit.cpp:2385` | `val[0]` отрицательный при правке сосуда |

## Особый случай

`experience.cpp:200` — `clamp(add_move, 1, max_move)` при `max_move == 0` даёт `lo > hi`. Заменён на `std::min(add_move, max_move)`: при нулевом max_move вычитаем 0, а не 1 (иначе ушли бы в минус). Семантика вернее исходной.

## Что НЕ здесь

Сам краш #3631 (`ApplyHeal`, `magic.cpp:1893`) чинится в отдельном PR #3632. Этот PR — только профилактика остальных мест того же класса.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов, **604 теста проходят**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)