### PR TITLE
fix(clans): persist chest/ingr-chest removal when an item decays inside

### DIFF
--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -1375,6 +1375,37 @@ int Clan::delete_obj(int vnum) {
 	return num;
 }
 
+// Предмет рассыпался по таймеру внутри кланового хранилища. Savers сундука и ингр-храна --
+// dirty-трекеры (сохраняют только помеченные кланы), а распад сам по себе dirty не метил:
+// файл не переписывался, и предмет возвращался из него после ребута. Метим владельца dirty и
+// уменьшаем счётчик вещей (при take он уменьшается, при распаде забывали). Вызывается из
+// obj_point_update, пока предмет ещё лежит в сундуке (до ExtractObjFromWorld).
+void Clan::OnChestObjDecay(ObjData *j) {
+	ObjData *container = j ? j->get_in_obj() : nullptr;
+	if (!container) {
+		return;
+	}
+	const int room_vnum = GET_ROOM_VNUM(container->get_in_room());
+	for (auto &clan : Clan::ClanList) {
+		if (Clan::is_clan_chest(container) && clan->GetRent() == room_vnum) {
+			if (clan->chest_objcount > 0) {
+				clan->chest_objcount--;
+			}
+			GlobalObjects::chest_saver().mark_dirty(clan.get());
+			return;
+		}
+		if (Clan::is_ingr_chest(container)
+			&& clan->get_ingr_chest_room_rnum() >= 0
+			&& GET_ROOM_VNUM(clan->get_ingr_chest_room_rnum()) == room_vnum) {
+			if (clan->ingr_chest_objcount_ > 0) {
+				clan->ingr_chest_objcount_--;
+			}
+			GlobalObjects::ingr_chest_saver().mark_dirty(clan.get());
+			return;
+		}
+	}
+}
+
 // * hcontrol outcast имя - отписывание любого персонажа от дружины, кроме воеводы.
 void Clan::hcon_outcast(CharData *ch, std::string &buffer) {
 	std::string name;

--- a/src/gameplay/clans/house.h
+++ b/src/gameplay/clans/house.h
@@ -202,6 +202,10 @@ class Clan {
   static bool is_ingr_chest(ObjData *obj);
   static void clan_invoice(CharData *ch, bool enter);
   static int delete_obj(int vnum);
+  // Предмет распался внутри кланового сундука или ингр-храна: помечаем владеющий клан dirty
+  // (иначе savers -- dirty-трекеры -- не перезапишут файл, и предмет воскреснет после ребута) и
+  // уменьшаем счётчик вещей хранилища (при take он уменьшается, при распаде -- нет).
+  static void OnChestObjDecay(ObjData *j);
   static void save_pk_log();
   static bool put_ingr_chest(CharData *ch, ObjData *obj, ObjData *chest);
   static bool take_ingr_chest(CharData *ch, ObjData *obj, ObjData *chest);

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1268,6 +1268,9 @@ void obj_point_update() {
 		if (j->get_in_obj() && Clan::is_clan_chest(j->get_in_obj())) {
 			clan_chest_invoice(j);
 		}
+		// Распад в клановом сундуке/ингр-хране: пометить клан dirty и поправить счётчик, иначе
+		// dirty-savers не перезапишут файл и предмет воскреснет после ребута.
+		Clan::OnChestObjDecay(j);
 		if (IS_CORPSE(j)) {
 				ObjData *jj, *next_thing2;
 				for (jj = j->get_contains(); jj; jj = next_thing2) {


### PR DESCRIPTION
Бог сделал `delete 756`, но сердце-ингредиент в клановом ингр-хране пережило ребут и вернулось живым.

## Причина

`delete` штатно ставит предметам `timer=0` (`foreach_with_vnum`), и они должны рассыпаться по таймеру. Сердце в ингр-хране — живой зарегистрированный объект, `timer=0` до него доходит, оно рассыпается.

Но savers кланового сундука и ингр-храна — **dirty-трекеры** (сохраняют только помеченные кланы, #3612). Точка распада `obj_point_update` (`game_limits.cpp`):

```cpp
if (j->get_in_obj() && Clan::is_clan_chest(j->get_in_obj())) {
    clan_chest_invoice(j);   // только сообщение игрокам + запись в лог, dirty НЕ метит
}
```

— для обычного сундука метит только сообщение, а для ингр-храна (`is_ingr_chest`) ветки нет вовсе. Клан не помечается dirty → файл хранилища не переписывается → на следующем `ChestLoad` (ребут) предмет воскресает из файла с сохранённым таймером.

Плюс счётчик вещей хранилища при распаде не уменьшался, хотя при `take` — уменьшается (`chest_objcount--`, `ingr_chest_objcount_--`).

## Фикс

`Clan::OnChestObjDecay(j)` в точке распада, для **обоих** типов хранилищ:
- находит владеющий клан по комнате контейнера;
- метит его dirty у нужного савера (`chest_saver` / `ingr_chest_saver`) → файл перепишется без распавшегося предмета;
- уменьшает счётчик вещей хранилища.

Вызывается пока предмет ещё лежит в сундуке (до `ExtractObjFromWorld`); к моменту прогона савера предмет уже извлечён, поэтому перезапись его не включает.

Сама команда `delete` корректна — `timer=0` достаточно. Чинилась точка распада, не удаление.

## Проверка

Сборка `release` + `build_tests=true`, без варнингов, **604 теста проходят**.

Тестами путь не покрыт (требует живого клана с хранилищем и распада по пульсу). Проверяется в игре: `delete` ингредиента, лежащего в клановом ингр-хране, затем ребут — предмет не должен возвращаться.

🤖 Generated with [Claude Code](https://claude.com/claude-code)