### PR TITLE
diag(#3646): trace spans on obj/char AddToExtractedList

### DIFF
--- a/src/engine/db/world_characters.cpp
+++ b/src/engine/db/world_characters.cpp
@@ -1,4 +1,5 @@
 #include "world_characters.h"
+#include "utils/tracing/trace_manager.h"
 #include "engine/core/char_handler.h"
 #include "engine/entities/char_data.h"
 #include "engine/scripting/lua/lua_script_engine.h"
@@ -96,6 +97,9 @@ void Characters::foreach_on_filtered_copy(const foreach_f function, const predic
 }
 
 void Characters::AddToExtractedList(CharData *ch) {
+	// diag #3646: trace which pulse a char is queued for extraction (wraps DropEquipment/DropInventory)
+	auto _diag_span = tracing::TraceManager::Instance().StartSpan("char.AddToExtractedList");
+	if (ch) { _diag_span->SetAttribute("mob_vnum", static_cast<int64_t>(ch->IsNpc() ? mob_index[ch->get_rnum()].vnum : -1)); }
 	lua_scripting::LuaScriptEngine::CancelWaitsForOwner(ch);
 	if (ch->IsNpc()) {
 		mobs_by_vnum_remove(ch, mob_index[(ch)->get_rnum()].vnum);

--- a/src/engine/db/world_objects.cpp
+++ b/src/engine/db/world_objects.cpp
@@ -1,4 +1,5 @@
 #include "world_objects.h"
+#include "utils/tracing/trace_manager.h"
 #include "engine/core/obj_handler.h"
 #include "engine/entities/char_data.h"
 #include "obj_prototypes.h"
@@ -392,6 +393,9 @@ void WorldObjects::GetObjListByVnum(const ObjVnum vnum, std::list<ObjData *> &re
 }
 
 void WorldObjects::AddToExtractedList(ObjData *obj) {
+	// diag #3646: trace which pulse an object is queued for extraction
+	auto _diag_span = tracing::TraceManager::Instance().StartSpan("obj.AddToExtractedList");
+	if (obj) { _diag_span->SetAttribute("obj_vnum", static_cast<int64_t>(obj->get_vnum())); }
 	lua_scripting::LuaScriptEngine::CancelWaitsForObject(obj);
 	const ObjData::shared_ptr object_ptr = get_by_raw_ptr(obj);
 


### PR DESCRIPTION
Временная диагностика для #3646. Добавляет спаны:
- obj.AddToExtractedList  (attr obj_vnum)  -- когда объект ставится в очередь
- char.AddToExtractedList (attr mob_vnum)  -- когда моб ставится в очередь (внутри -- DropEquipment/DropInventory)

Цель: по Tempo увидеть точный pulse_number постановки куртки 7604 и грузного цыгана 7610 в очередь, чтобы подтвердить/опровергнуть, что mjunk и mpurge идут в одном пульсе (и потому PurgeExtractedList между ними не успевает).

НЕ для master -- откатить после диагностики.