### PR TITLE
diag(obj-lifecycle): trace spans on obj/char extract & remove paths

### DIFF
--- a/src/engine/core/char_handler.cpp
+++ b/src/engine/core/char_handler.cpp
@@ -4,6 +4,8 @@
 */
 
 #include "engine/core/char_handler.h"
+#include "utils/tracing/trace_manager.h"
+
 #include "engine/core/obj_handler.h"
 #include "administration/privilege.h"
 
@@ -199,6 +201,8 @@ void DropInventory(CharData *ch, bool zone_reset) {
 }
 
 void ExtractCharFromWorld(CharData *ch, int clear_objs, bool zone_reset) {
+	auto _sp = tracing::TraceManager::Instance().StartSpan("ExtractCharFromWorld");
+	if (ch) { _sp->SetAttribute("mob_vnum", static_cast<int64_t>(ch->IsNpc() ? mob_index[ch->get_rnum()].vnum : -1)); }
 	timechange_unregister_mob(ch);
 	if (ch->purged()) {
 		log("SYSERROR: double extract_char (%s:%d)", __FILE__, __LINE__);

--- a/src/engine/core/obj_handler.cpp
+++ b/src/engine/core/obj_handler.cpp
@@ -4,6 +4,8 @@
 */
 
 #include "engine/core/obj_handler.h"
+#include "utils/tracing/trace_manager.h"
+
 #include "engine/core/char_movement.h"
 #include "engine/core/char_handler.h"
 #include "engine/core/char_movement.h"
@@ -197,6 +199,8 @@ bool CheckObjDecay(ObjData *object,  bool need_extract) {
 }
 
 void RemoveObjFromRoom(ObjData *object) {
+	auto _sp = tracing::TraceManager::Instance().StartSpan("RemoveObjFromRoom");
+	if (object) { _sp->SetAttribute("obj_vnum", static_cast<int64_t>(object->get_vnum())); }
 	if (!object || object->get_in_room() == kNowhere) {
 		debug::backtrace(runtime_config.logs(ERRLOG).handle());
 		log("SYSERR: NULL object (%p) or obj not in a room (%d) passed to RemoveObjFromRoom",
@@ -241,6 +245,8 @@ void PlaceObjIntoObj(ObjData *obj, ObjData *obj_to) {
 }
 
 void RemoveObjFromObj(ObjData *obj) {
+	auto _sp = tracing::TraceManager::Instance().StartSpan("RemoveObjFromObj");
+	if (obj) { _sp->SetAttribute("obj_vnum", static_cast<int64_t>(obj->get_vnum())); }
 	if (obj->get_in_obj() == nullptr) {
 		debug::backtrace(runtime_config.logs(SYSLOG).handle());
 		log("SYSERR: (%s): trying to illegally extract obj from obj.", __FILE__);
@@ -347,6 +353,8 @@ void LogPlayerObjLoss(ObjData *obj, const char *reason) {
 }
 
 void ExtractObjFromWorld(ObjData *obj, bool showlog) {
+	auto _sp = tracing::TraceManager::Instance().StartSpan("ExtractObjFromWorld");
+	if (obj) { _sp->SetAttribute("obj_vnum", static_cast<int64_t>(obj->get_vnum())); }
 	timechange_unregister_obj(obj);
 	char name[kMaxStringLength];
 	ObjData *temp;

--- a/src/engine/db/world_characters.cpp
+++ b/src/engine/db/world_characters.cpp
@@ -1,4 +1,5 @@
 #include "world_characters.h"
+#include "utils/tracing/trace_manager.h"
 #include "engine/core/char_handler.h"
 #include "engine/entities/char_data.h"
 #include "engine/scripting/lua/lua_script_engine.h"
@@ -96,6 +97,8 @@ void Characters::foreach_on_filtered_copy(const foreach_f function, const predic
 }
 
 void Characters::AddToExtractedList(CharData *ch) {
+	auto _sp = tracing::TraceManager::Instance().StartSpan("char.AddToExtractedList");
+	if (ch) { _sp->SetAttribute("mob_vnum", static_cast<int64_t>(ch->IsNpc() ? mob_index[ch->get_rnum()].vnum : -1)); }
 	lua_scripting::LuaScriptEngine::CancelWaitsForOwner(ch);
 	if (ch->IsNpc()) {
 		mobs_by_vnum_remove(ch, mob_index[(ch)->get_rnum()].vnum);

--- a/src/engine/db/world_objects.cpp
+++ b/src/engine/db/world_objects.cpp
@@ -1,4 +1,5 @@
 #include "world_objects.h"
+#include "utils/tracing/trace_manager.h"
 #include "engine/core/obj_handler.h"
 #include "engine/entities/char_data.h"
 #include "obj_prototypes.h"
@@ -392,6 +393,8 @@ void WorldObjects::GetObjListByVnum(const ObjVnum vnum, std::list<ObjData *> &re
 }
 
 void WorldObjects::AddToExtractedList(ObjData *obj) {
+	auto _sp = tracing::TraceManager::Instance().StartSpan("obj.AddToExtractedList");
+	if (obj) { _sp->SetAttribute("obj_vnum", static_cast<int64_t>(obj->get_vnum())); }
 	lua_scripting::LuaScriptEngine::CancelWaitsForObject(obj);
 	const ObjData::shared_ptr object_ptr = get_by_raw_ptr(obj);
 

--- a/src/gameplay/mechanics/inventory.cpp
+++ b/src/gameplay/mechanics/inventory.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "gameplay/mechanics/inventory.h"
+#include "utils/tracing/trace_manager.h"
 
 #include "engine/entities/char_data.h"
 #include "engine/entities/obj_data.h"
@@ -248,6 +249,8 @@ void PlaceObjToInventory(ObjData *object, CharData *ch) {
 }
 
 void RemoveObjFromChar(ObjData *object) {
+	auto _sp = tracing::TraceManager::Instance().StartSpan("RemoveObjFromChar");
+	if (object) { _sp->SetAttribute("obj_vnum", static_cast<int64_t>(object->get_vnum())); }
 	if (!object || !object->get_carried_by()) {
 		log("SYSERR: NULL object or owner passed to obj_from_char");
 		return;


### PR DESCRIPTION
Спаны трейсинга (Tempo) на жизненный цикл ухода объекта/персонажа, для диагностики утечек/потерь предметов (напр. #3646):

- obj.AddToExtractedList   (attr obj_vnum)
- char.AddToExtractedList  (attr mob_vnum)
- ExtractObjFromWorld      (attr obj_vnum)
- ExtractCharFromWorld     (attr mob_vnum)
- RemoveObjFromChar        (attr obj_vnum)
- RemoveObjFromRoom        (attr obj_vnum)
- RemoveObjFromObj         (attr obj_vnum)

Видно по Tempo точный пульс и порядок каждого шага снятия/удаления предмета и по какому vnum.

Замечание: Remove*/Extract* -- горячие пути (на каждое перемещение предмета), спан на вызов даёт оверхед; для прода имеет смысл сэмплировать.