### PR TITLE
diag(obj-lifecycle): add holder (inv/worn/cont) to [objlife] logs

### DIFF
--- a/src/engine/core/obj_handler.cpp
+++ b/src/engine/core/obj_handler.cpp
@@ -205,7 +205,7 @@ void RemoveObjFromRoom(ObjData *object) {
 	}
 
 	{
-		log("[objlife] RemoveObjFromRoom %s #%d room %d", object->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(object), get_room_where_obj(object));
+		log("[objlife] RemoveObjFromRoom %s #%d room %d at %s", object->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(object), get_room_where_obj(object), ObjLocDesc(object).c_str());
 		auto &list = world[object->get_in_room()]->contents;
 		list.remove(object);
 	}
@@ -248,7 +248,7 @@ void RemoveObjFromObj(ObjData *obj) {
 		mudlog("SYSERR: trying to illegally extract obj from obj.");
 		return;
 	}
-	log("[objlife] RemoveObjFromObj %s #%d room %d", obj->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(obj), get_room_where_obj(obj));
+	log("[objlife] RemoveObjFromObj %s #%d room %d at %s", obj->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(obj), get_room_where_obj(obj), ObjLocDesc(obj).c_str());
 	auto obj_from = obj->get_in_obj();
 	auto head = obj_from->get_contains();
 	obj->remove_me_from_contains_list(head);
@@ -276,6 +276,15 @@ void object_list_new_owner(ObjData *list, CharData *ch) {
 		object_list_new_owner(list->get_next_content(), ch);
 		list->set_carried_by(ch);
 	}
+}
+
+// issue #3646: краткое описание текущего носителя предмета для [objlife]-логов.
+std::string ObjLocDesc(ObjData *obj) {
+	if (auto *h = obj->get_carried_by()) { return std::string("inv:") + GET_NAME(h) + " #" + std::to_string(GET_MOB_VNUM(h)); }
+	if (auto *h = obj->get_worn_by()) { return std::string("worn:") + GET_NAME(h) + " #" + std::to_string(GET_MOB_VNUM(h)); }
+	if (auto *c = obj->get_in_obj()) { return std::string("cont:") + c->get_PName(grammar::ECase::kNom).c_str() + " #" + std::to_string(GET_OBJ_VNUM(c)); }
+	if (obj->get_in_room() != kNowhere) { return "room"; }
+	return "nowhere";
 }
 
 RoomVnum get_room_where_obj(ObjData *obj, bool deep) {
@@ -356,7 +365,7 @@ void ExtractObjFromWorld(ObjData *obj, bool showlog) {
 	utils::CExecutionTimer timer;
 
 	strcpy(name, obj->get_PName(grammar::ECase::kNom).c_str());
-	log("[objlife] ExtractObjFromWorld %s #%d room %d", obj->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(obj), get_room_where_obj(obj));
+	log("[objlife] ExtractObjFromWorld %s #%d room %d at %s", obj->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(obj), get_room_where_obj(obj), ObjLocDesc(obj).c_str());
 	if (showlog) {
 		log("[Extract obj] Start for: %s vnum == %d room = %d timer == %d",
 				name, GET_OBJ_VNUM(obj), roomload, obj->get_timer());

--- a/src/engine/core/obj_handler.h
+++ b/src/engine/core/obj_handler.h
@@ -21,6 +21,7 @@ void PlaceObjIntoObj(ObjData *obj, ObjData *obj_to);
 void RemoveObjFromObj(ObjData *obj);
 void object_list_new_owner(ObjData *list, CharData *ch);
 RoomVnum get_room_where_obj(ObjData *obj, bool deep = false);
+std::string ObjLocDesc(ObjData *obj);
 void ExtractObjFromWorld(ObjData *obj, bool showlog = false);
 // issue #3563: пишет в syslog о пропаже вещи у игрока; звать до отвязки от владельца.
 void LogPlayerObjLoss(ObjData *obj, const char *reason);

--- a/src/engine/db/world_objects.cpp
+++ b/src/engine/db/world_objects.cpp
@@ -392,7 +392,7 @@ void WorldObjects::GetObjListByVnum(const ObjVnum vnum, std::list<ObjData *> &re
 }
 
 void WorldObjects::AddToExtractedList(ObjData *obj) {
-	if (obj) { log("[objlife] AddToExtractedList %s #%d room %d", obj->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(obj), get_room_where_obj(obj)); }
+	if (obj) { log("[objlife] AddToExtractedList %s #%d room %d at %s", obj->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(obj), get_room_where_obj(obj), ObjLocDesc(obj).c_str()); }
 	lua_scripting::LuaScriptEngine::CancelWaitsForObject(obj);
 	const ObjData::shared_ptr object_ptr = get_by_raw_ptr(obj);
 

--- a/src/gameplay/mechanics/inventory.cpp
+++ b/src/gameplay/mechanics/inventory.cpp
@@ -252,7 +252,7 @@ void RemoveObjFromChar(ObjData *object) {
 		log("SYSERR: NULL object or owner passed to obj_from_char");
 		return;
 	}
-	log("[objlife] RemoveObjFromChar %s #%d room %d", object->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(object), get_room_where_obj(object));
+	log("[objlife] RemoveObjFromChar %s #%d room %d at %s", object->get_PName(grammar::ECase::kNom).c_str(), GET_OBJ_VNUM(object), get_room_where_obj(object), ObjLocDesc(object).c_str());
 	object->remove_me_from_contains_list(object->get_carried_by()->carrying);
 
 	// set flag for crash-save system, but not on mobs!


### PR DESCRIPTION
По следам путаницы: два RemoveObjFromChar на один предмет выглядели одинаково (сперва снятие у игрока при передаче, затем у моба-получателя при рассыпании в ExtractObjFromWorld). Добавлен носитель.

Хелпер ObjLocDesc(obj) -> "inv:<имя> #vnum" / "worn:<имя> #vnum" / "cont:<имя> #vnum" / "room" / "nowhere". Дописан во все [objlife]-логи объектов как поле "at %s". Теперь видно, у кого именно снимается предмет.