### PR TITLE
feat(dg): HitPrcnt -- react while alive (incl. ошеломить) + no duplic…

### DIFF
--- a/src/engine/scripting/dg_mobcmd.cpp
+++ b/src/engine/scripting/dg_mobcmd.cpp
@@ -1547,9 +1547,9 @@ bool mob_script_command_interpreter(CharData *ch, char *argument, Trigger *trig)
 	}
 	// issue #3658: HitPrcnt должен визуально среагировать, а не залипнуть на стан-гейте.
 	// Моб под контролем (и не при смерти) -> стряхиваем контроль с сообщением и поднимаем,
-	// тогда стан-блок ниже уже не паузит. При смерти (HP <= 0) не трогаем.
+	// тогда стан-блок ниже уже не паузит. Выведен из строя (pos < kStun: круг пустоты, при смерти) -- не трогаем.
 	if (trig && IS_SET(GET_TRIG_TYPE(trig), MTRIG_HITPRCNT)
-			&& ch->get_hit() > 0   // issue #3658: живой (в т.ч. ошеломлён=kIncap+лаг), но не при смерти (HP<=0)
+			&& ch->GetPosition() >= EPosition::kStun   // issue #3658: не выведен из строя (kIncap и ниже -- круг пустоты, при смерти)
 			&& (AFF_FLAGGED(ch, EAffect::kHold)
 				|| AFF_FLAGGED(ch, EAffect::kStopFight)
 				|| AFF_FLAGGED(ch, EAffect::kMagicStopFight)

--- a/src/engine/scripting/dg_mobcmd.cpp
+++ b/src/engine/scripting/dg_mobcmd.cpp
@@ -1547,9 +1547,9 @@ bool mob_script_command_interpreter(CharData *ch, char *argument, Trigger *trig)
 	}
 	// issue #3658: HitPrcnt должен визуально среагировать, а не залипнуть на стан-гейте.
 	// Моб под контролем (и не при смерти) -> стряхиваем контроль с сообщением и поднимаем,
-	// тогда стан-блок ниже уже не паузит. При смерти (pos < kStun) не трогаем.
+	// тогда стан-блок ниже уже не паузит. При смерти (HP <= 0) не трогаем.
 	if (trig && IS_SET(GET_TRIG_TYPE(trig), MTRIG_HITPRCNT)
-			&& ch->GetPosition() >= EPosition::kStun
+			&& ch->get_hit() > 0   // issue #3658: живой (в т.ч. ошеломлён=kIncap+лаг), но не при смерти (HP<=0)
 			&& (AFF_FLAGGED(ch, EAffect::kHold)
 				|| AFF_FLAGGED(ch, EAffect::kStopFight)
 				|| AFF_FLAGGED(ch, EAffect::kMagicStopFight)

--- a/src/engine/scripting/dg_triggers.cpp
+++ b/src/engine/scripting/dg_triggers.cpp
@@ -675,8 +675,12 @@ void hitprcnt_mtrigger(CharData *ch) {
 	for (auto t : SCRIPT(ch)->script_trig_list) {
 		if (TRIGGER_CHECK(t, MTRIG_HITPRCNT) && ch->get_max_hit() &&
 			(((ch->get_hit() * 100) / ch->get_max_hit()) <= GET_TRIG_NARG(t))) {
-			ADD_UID_CHAR_VAR(buf, t, ch->GetEnemy(), "actor", 0);
-			script_driver(ch, t, MOB_TRIGGER, TRIG_NEW);
+			// issue #3658: событие HitPrcnt прилетает на каждый удар (в группе -- от каждого игрока).
+			// Если триггер уже запущен (в т.ч. висит на wait), не плодим копию.
+			if (!GET_TRIG_DEPTH(t)) {
+				ADD_UID_CHAR_VAR(buf, t, ch->GetEnemy(), "actor", 0);
+				script_driver(ch, t, MOB_TRIGGER, TRIG_NEW);
+			}
 			break;
 		}
 	}

--- a/src/gameplay/skills/stun.cpp
+++ b/src/gameplay/skills/stun.cpp
@@ -92,7 +92,7 @@ void go_stun(CharData *ch, CharData *vict) {
 			act("$n мощным ударом ошеломил$g $N3!", true, ch,
 				nullptr, vict, kToNotVict | kToArenaListen);
 		}
-		vict->SetPosition(EPosition::kIncap);
+		vict->SetPosition(EPosition::kStun);   // issue #3658: kStun (не kIncap) -- ошеломление можно стряхнуть (HitPrcnt), это не "вывод из строя"
 		SetWaitState(vict, (2 + remort::GetRealRemort(ch) / 5) * kBattleRound * GetSkill(ch, ESkill::kStun) / MUD::Skill(ESkill::kStun).cap);
 		ch->setSkillCooldown(ESkill::kStun, 3 * kBattleRound);
 		hit(ch, vict, ESkill::kUndefined, AFF_FLAGGED(vict, EAffect::kStopRight) ? fight::kOffHand : fight::kMainHand);


### PR DESCRIPTION
…ate run in group (#3658)

Дополнения по замечаниям из #3658:

1. Ошеломить (stun.cpp) вешает kIncap (< kStun) + лаг, но HP > 0 -- это контроль, а не смерть. Прежний порог `pos >= kStun` оставлял ошеломлённого моба в дауне. HitPrcnt срабатывает при HP > 0, а pos < kStun в этот момент бывает лишь от контроля (не от HP). Признак "при смерти" -- HP <= 0, а не позиция. Порог shake-off: `ch->GetPosition() >= kStun` -> `ch->get_hit() > 0`. Теперь ошеломлённый (HP>0) стряхивается (лаг снят, встаёт), умирающий (HP<=0) не реагирует.

2. Событие HitPrcnt прилетает на каждый удар; в группе -- от каждого игрока. Если в триггере есть wait, он висит, а следующий хит запускал КОПИЮ (script_driver TRIG_NEW без защиты). Гард `if (!GET_TRIG_DEPTH(t))` в hitprcnt_mtrigger -- не запускаем копию уже работающего/ждущего триггера.