### PR TITLE
fix(ai): log "can't find path" only for route walking, not for tracking

### DIFF
--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -499,8 +499,9 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 
 			// Предполагаемый маршрут считаем и показываем только для живого моба
 			// (не vstat): vstat ставит временный прототип в комнату rnum 1 чужой
-			// зоны, а kStayZone-моб не строит путь между зонами, из-за чего
-			// find_first_step зря писал "can't find path" в errlog (issue #3384).
+			// зоны, а kStayZone-моб не строит путь между зонами. В лог это теперь
+			// не сыплется в любом случае -- find_first_step молчит, пока его не
+			// попросят жаловаться (issue #3384).
 			if (!virt) {
 				// пытаемся просчитать маршрут на несколько клеток вперед
 				std::vector<RoomVnum> predictive_path_vnum_list;

--- a/src/gameplay/ai/graph.cpp
+++ b/src/gameplay/ai/graph.cpp
@@ -32,7 +32,7 @@ extern CharData *mob_proto;
 void bfs_enqueue(RoomRnum room, int dir);
 void bfs_dequeue(void);
 void bfs_clear_queue(void);
-int find_first_step(RoomRnum src, RoomRnum target, CharData *ch);
+int find_first_step(RoomRnum src, RoomRnum target, CharData *ch, bool complain = false);
 
 struct bfs_queue_struct {
 	RoomRnum room;
@@ -78,7 +78,7 @@ int VALID_EDGE(RoomRnum x, int y, int edge_range, bool through_locked_doors, boo
  * Intended usage: in mobile_activity, give a mob a dir to go if they're
  * tracking another mob or a PC.  Or, a 'track' skill for PCs.
  */
-int find_first_step(RoomRnum src, RoomRnum target, CharData *ch) {
+int find_first_step(RoomRnum src, RoomRnum target, CharData *ch, bool complain) {
 	int curr_dir, edge;
 	bool through_locked_doors = false;
 	bool through_closed_doors = false;
@@ -162,8 +162,9 @@ int find_first_step(RoomRnum src, RoomRnum target, CharData *ch) {
 		}
 	}
 	bfs_queue.clear();
-	if (ch->IsNpc()) {
-		sprintf(buf, "[%d] Mob (mob: %s vnum: %d) can't find path.", GET_ROOM_VNUM(ch->in_room), GET_NAME(ch), GET_MOB_VNUM(ch));
+	if (complain && ch->IsNpc()) {
+		sprintf(buf, "[%d] Mob (mob: %s vnum: %d) can't find path to room [%d].",
+				GET_ROOM_VNUM(ch->in_room), GET_NAME(ch), GET_MOB_VNUM(ch), GET_ROOM_VNUM(target));
 		mudlog(buf, NRM, kLvlBuilder, ERRLOG, true);
 	}
 	return (kBfsNoPath);

--- a/src/gameplay/ai/graph.h
+++ b/src/gameplay/ai/graph.h
@@ -3,6 +3,9 @@
 
 class CharData;
 
-int find_first_step(RoomRnum src, RoomRnum target, CharData *ch);
+// complain: жаловаться в лог, если путь не найден. По умолчанию молчим -- ненайденный путь
+// это штатный исход почти для всех вызовов (моб выслеживает обидчика, тот ушел в другую зону
+// или за !трек). Жалуется только ходьба по маршруту: там недостижимая точка -- ошибка билдера.
+int find_first_step(RoomRnum src, RoomRnum target, CharData *ch, bool complain = false);
 
 #endif //BYLINS_GRAPH_H

--- a/src/gameplay/ai/spec_procs.cpp
+++ b/src/gameplay/ai/spec_procs.cpp
@@ -49,7 +49,7 @@ extern CharData *get_player_of_name(const char *name);
 // extern functions
 void DoDrop(CharData *ch, char *argument, int, int);
 void do_say(CharData *ch, char *argument, int cmd, int subcmd);
-int find_first_step(RoomRnum src, RoomRnum target, CharData *ch);
+int find_first_step(RoomRnum src, RoomRnum target, CharData *ch, bool complain = false);
 
 // local functions
 int mayor(CharData *ch, void *me, int cmd, char *argument);
@@ -821,7 +821,9 @@ int npc_walk(CharData *ch) {
 			return (npc_walk(ch));
 	}
 
-	door = find_first_step(ch->in_room, rnum, ch);
+	// Единственное место, где ненайденный путь -- настоящая проблема: у моба задан маршрут,
+	// а дойти до очередной точки нельзя. Жалуемся билдеру.
+	door = find_first_step(ch->in_room, rnum, ch, true);
 
 	return (door);
 }


### PR DESCRIPTION
## Откуда сотни строк

`find_first_step()` писал в errlog на каждый неудачный обход в ширину для любого NPC:

```cpp
if (ch->IsNpc()) {
	sprintf(buf, "[%d] Mob (mob: %s vnum: %d) can't find path.", ...);
	mudlog(buf, NRM, kLvlBuilder, ERRLOG, true);
}
```

Основной источник — мобы с флагом «помнит» и умением «выследить». `mobact.cpp:307` раз в такт перебирает игроков онлайн, находит среди них запомненных обидчиков и зовёт `go_track()`, а тот — `find_first_step()`. Обидчик ушёл в другую зону, за запертую дверь или в комнату с `!трек` — пути нет.

Это штатный исход, а не ошибка: у моба вроде «Биглона» (внум 92226) маршрута нет вовсе, он просто помнит обидчика и пытается его найти. В сислоге таких строк набиралось по паре сотен.

## Правка

У `find_first_step()` появился параметр `complain`, по умолчанию `false`. Жалуется теперь ровно одно место — `npc_walk()`:

```cpp
// Единственное место, где ненайденный путь -- настоящая проблема: у моба задан маршрут,
// а дойти до очередной точки нельзя. Жалуемся билдеру.
door = find_first_step(ch->in_room, rnum, ch, true);
```

Там маршрут задан билдером, и недостижимая точка — настоящая ошибка данных, которую как раз надо видеть.

Заодно в сообщение добавлена целевая комната: без неё непонятно, до какой точки маршрута моб не дошёл.

```
было:  [92201] Mob (mob: Биглон vnum: 92226) can't find path.
стало: [92201] Mob (mob: Биглон vnum: 92226) can't find path to room [92240].
```

Комментарий в `do_stat.cpp` про issue #3384 поправлен: обходной путь там больше не нужен, вызов и так молчит.

Сборка чистая, тесты проходят (604).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
