### PR TITLE
fix(shops): stop the reload recursion introduced in #3701

### DIFF
--- a/src/engine/ui/cmd_god/do_reload.cpp
+++ b/src/engine/ui/cmd_god/do_reload.cpp
@@ -197,7 +197,10 @@ void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	} else if (!str_cmp(arg, "offtop")) {
 		offtop_system::Init();
 	} else if (!str_cmp(arg, "shop")) {
-		ShopExt::load(true);
+		// Каталог наборов, а следом магазины: ShopItemSetsLoader::Reload сам зовет
+		// ShopExt::load(true). Звать load(true) отсюда мало -- внумы и цены живут в
+		// наборах, и правка в них иначе не доедет (issue #3700).
+		MUD::CfgManager().ReloadCfg("shop_item_sets");
 	} else if (!str_cmp(arg, "named")) {
 		NamedStuff::load();
 	} else if (!str_cmp(arg, "celebrates")) {

--- a/src/gameplay/economics/shop_ext.cpp
+++ b/src/gameplay/economics/shop_ext.cpp
@@ -403,14 +403,15 @@ parser_wrapper::DataNode ShopsLoader::CreateElementNode(parser_wrapper::DataNode
 // Thin entry points: route through cfg_manager so boot, `reload shop` and the item-set
 // editor share one path (cfg_manager supplies the DataNode).
 //
-// issue #3700: каталог наборов читаем здесь же и всегда перед магазинами. Внумы и цены
-// товаров живут в shop_item_sets.xml, а shops.xml только ссылается на набор по id и
-// разворачивает его из g_item_sets. Раньше каталог грузился отдельной строкой на буте, а
-// "reload shop" перечитывал только shops.xml -- и подставлял внумы из каталога, оставшегося
-// в памяти с загрузки. Правка внума в наборе не доезжала до перезапуска.
+// Перезагрузка каталога наборов сюда НЕ входит, и это принципиально:
+// ShopItemSetsLoader::Reload сам зовет load(true), чтобы правка каталога сразу доехала до
+// магазинов. Если добавить сюда ReloadCfg("shop_item_sets"), получится бесконечная
+// рекурсия -- мад висит и умирает (issue #3700, откат правки из #3701). Точка входа,
+// которой нужны обе части, -- ReloadCfg("shop_item_sets"): каталог, а следом магазины.
+//
+// На буте рекурсии нет: там LoadCfg, а не Reload, поэтому обе части читаются здесь.
 void load(bool reload) {
 	if (reload) {
-		MUD::CfgManager().ReloadCfg("shop_item_sets");
 		MUD::CfgManager().ReloadCfg("shops");
 	} else {
 		MUD::CfgManager().LoadCfg("shop_item_sets");


### PR DESCRIPTION
Срочно: `reload shop` вешает мад намертво — минута тишины и смерть процесса. Регресс моей же правки #3701.

## Причина

`ShopItemSetsLoader::Reload` уже пересобирает магазины сам:

```cpp
void ShopItemSetsLoader::Reload(parser_wrapper::DataNode data) {
	Load(data);
	vedun::RegisterEditorEnums();
	load(true);   // rebuild shops so catalog edits take effect immediately
}
```

А в #3701 я добавил в `load(true)` вызов `ReloadCfg("shop_item_sets")`. Получился цикл:

```
load(true) -> ReloadCfg("shop_item_sets") -> ShopItemSetsLoader::Reload -> load(true) -> ...
```

Каждый виток заново разбирает XML и пересобирает список магазинов, отсюда минута и смерть — по стеку или по памяти.

Дыра из #3700 при этом была закрыта с другой стороны: каталог перечитывался через `ReloadCfg("shop_item_sets")` из редактора, и он же дёргал пересборку магазинов. Не хватало ровно одного — чтобы в этот вход попадала команда `reload shop`. Вместо этого я продублировал вызов внутри `load()`.

## Правка

- `load(true)` снова перезагружает только магазины, с комментарием, почему каталог сюда добавлять нельзя;
- ветка `shop` в `do_reload.cpp` зовёт `ReloadCfg("shop_item_sets")` — он читает каталог и следом магазины;
- загрузка на буте (`load(false)`) не менялась: там `LoadCfg`, а не `Reload`, рекурсии нет, обе части читаются на месте.

Граф вызовов после правки ацикличен:

```
reload shop -> ReloadCfg(shop_item_sets) -> ShopItemSetsLoader::Reload -> load(true)
            -> ReloadCfg(shops) -> ShopsLoader::Reload -> Load
```

Задача из #3700 при этом остаётся решённой: правка внума в наборе доезжает по `reload shop`, потому что команда теперь идёт через каталог.

Сборка чистая, тесты проходят (604).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
