### PR TITLE
fix(depot): keep the depot messages red past the item name

### DIFF
--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -2364,9 +2364,13 @@ bool Clan::PutChest(CharData *ch, ObjData *obj, ObjData *chest) {
 				&& CLAN(d->character)
 				&& CLAN(d->character) == CLAN(ch)
 				&& d->character->IsFlagged(EPrf::kTakeMode)) {
-				SendMsgToChar(d->character.get(), "[Хранилище]: %s'%s сдал%s %s%s.'%s\r\n",
-							  kColorBoldRed, GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), obj->get_PName(grammar::ECase::kAcc).c_str(),
-							  clan_get_custom_label(obj, CLAN(ch)).c_str(), kColorNrm);
+				// Цвет повторяем после имени предмета: у именных вещей оно само цветное и
+				// закрывается сбросом (&n), из-за чего хвост фразы терял цвет.
+				SendMsgToChar(fmt::format("[Хранилище]: &R'{} сдал{} {}{}&R.'&n\r\n",
+										  GET_NAME(ch), grammar::SexEnding(ch->get_sex(), 1),
+										  obj->get_PName(grammar::ECase::kAcc),
+										  clan_get_custom_label(obj, CLAN(ch))),
+							  d->character.get());
 			}
 		}
 
@@ -2409,11 +2413,11 @@ bool Clan::TakeChest(CharData *ch, ObjData *obj, ObjData *chest) {
 				&& CLAN(d->character)
 				&& CLAN(d->character) == CLAN(ch)
 				&& d->character->IsFlagged(EPrf::kTakeMode)) {
-				SendMsgToChar(d->character.get(), "[Хранилище]: %s'%s забрал%s %s%s.'%s\r\n",
-							  kColorBoldRed, GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1),
-							  obj->get_PName(grammar::ECase::kAcc).c_str(),
-							  clan_get_custom_label(obj, CLAN(d->character)).c_str(),
-							  kColorNrm);
+				SendMsgToChar(fmt::format("[Хранилище]: &R'{} забрал{} {}{}&R.'&n\r\n",
+										  GET_NAME(ch), grammar::SexEnding(ch->get_sex(), 1),
+										  obj->get_PName(grammar::ECase::kAcc),
+										  clan_get_custom_label(obj, CLAN(d->character))),
+							  d->character.get());
 			}
 		}
 

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1182,12 +1182,14 @@ void clan_chest_invoice(ObjData *j) {
 			&& d->character->IsFlagged(EPrf::kDecayMode)
 			&& CLAN(d->character)
 			&& CLAN(d->character)->GetRent() == room) {
-			SendMsgToChar(d->character.get(), "[Хранилище]: %s'%s%s рассыпал%s в прах'%s\r\n",
-						  kColorBoldRed,
-						  j->get_short_description().c_str(),
-						  clan_get_custom_label(j, CLAN(d->character)).c_str(),
-						  grammar::ObjSexEnding((j)->get_sex(), 2),
-						  kColorNrm);
+			// Цвет включается заново после имени предмета: у именных вещей имя само цветное и
+			// закрывается сбросом (&n), поэтому без повтора красной оставалась одна открывающая
+			// кавычка, а хвост фразы шел обычным цветом.
+			SendMsgToChar(fmt::format("[Хранилище]: &R'{}{}&R рассыпал{} в прах'&n\r\n",
+									  j->get_short_description(),
+									  clan_get_custom_label(j, CLAN(d->character)),
+									  grammar::ObjSexEnding(j->get_sex(), 2)),
+						  d->character.get());
 		}
 	}
 

--- a/src/gameplay/mechanics/depot.cpp
+++ b/src/gameplay/mechanics/depot.cpp
@@ -242,13 +242,12 @@ std::string generate_purged_text(long uid, int obj_vnum, unsigned int obj_uid) {
 
 		if (static_cast<unsigned int>(obj->get_unique_id()) == obj_uid
 			&& obj->get_vnum() == obj_vnum) {
-			std::ostringstream text;
-			text << "[Персональное хранилище]: " << kColorBoldRed << "'"
-				 << obj->get_short_description() << char_get_custom_label(obj.get(), ch)
-				 << " рассыпал" << grammar::ObjSexEnding((obj.get())->get_sex(), 2)
-				 << " в прах'" << kColorNrm << "\r\n";
+			// Цвет повторяется после имени -- см. комментарий в SendMsgToChar ниже.
+			auto text = fmt::format("[Персональное хранилище]: &R'{}{}&R рассыпал{} в прах'&n\r\n",
+									obj->get_short_description(), char_get_custom_label(obj.get(), ch),
+									grammar::ObjSexEnding(obj->get_sex(), 2));
 			ExtractObjFromWorld(obj.get());
-			return text.str();
+			return text;
 		}
 		ExtractObjFromWorld(obj.get());
 	}
@@ -634,10 +633,13 @@ void CharNode::update_online_item() {
 				// если чар в лд или еще чего - лучше записать и выдать это ему при след
 				// входе в игру, чтобы уж точно увидел
 				if (ch->desc && ch->desc->state == EConState::kPlaying) {
-					SendMsgToChar(ch, "[Персональное хранилище]: %s'%s%s рассыпал%s в прах'%s\r\n",
-								  kColorBoldRed, (*obj_it)->get_short_description().c_str(),
-								  char_get_custom_label(obj_it->get(), ch).c_str(),
-								  grammar::ObjSexEnding(((*obj_it))->get_sex(), 2), kColorNrm);
+					// Цвет повторяем после имени: именные вещи закрывают свой цвет сбросом (&n),
+					// и без этого красной оставалась только открывающая кавычка.
+					SendMsgToChar(fmt::format("[Персональное хранилище]: &R'{}{}&R рассыпал{} в прах'&n\r\n",
+											  (*obj_it)->get_short_description(),
+											  char_get_custom_label(obj_it->get(), ch),
+											  grammar::ObjSexEnding((*obj_it)->get_sex(), 2)),
+								  ch);
 				} else {
 					add_purged_message(ch->get_uid(), GET_OBJ_VNUM(obj_it->get()), (*obj_it)->get_unique_id());
 				}


### PR DESCRIPTION
## Симптом

```
[Хранилище]: 'сапоги абсолютного повиновения рассыпались в прах'
```

Красной оставалась ровно одна открывающая кавычка, остальная фраза шла обычным цветом.

## Причина

Цвет включался один раз в начале строки, а имя предмета гасило его изнутри. У именных вещей имя само цветное, и каждый кусок закрывается сбросом:

```yaml
nominative: '&Wсапоги&n &Gабсолютного повиновения&n'
```

После `&n` красного больше нет, и хвост «рассыпались в прах'» печатается обычным цветом. Одинокий красный апостроф — не задумка, а единственное, что успело покраситься до имени.

## Правка

Цвет включается заново после имени. Заодно сообщения переведены на `fmt::format` и на коды через `&` вместо констант `kColor*` — у `SendMsgToChar` есть перегрузка под `std::string`, printf-стиль тут не нужен:

```cpp
SendMsgToChar(fmt::format("[Хранилище]: &R'{}{}&R рассыпал{} в прах'&n\r\n",
						  j->get_short_description(),
						  clan_get_custom_label(j, CLAN(d->character)),
						  grammar::ObjSexEnding(j->get_sex(), 2)),
			  d->character.get());
```

Пять мест:

| Файл | Что |
|---|---|
| `gameplay/core/game_limits.cpp` | клановое хранилище: предмет рассыпался |
| `gameplay/mechanics/depot.cpp` | личное хранилище: рассыпался, онлайн |
| `gameplay/mechanics/depot.cpp` | личное хранилище: отложенное сообщение к следующему входу |
| `gameplay/clans/house.cpp` | «сдал» в клановом хранилище |
| `gameplay/clans/house.cpp` | «забрал» в клановом хранилище |

В последних двух имя предмета стоит в середине фразы, поэтому цвет теряли точка с кавычкой в конце — тот же дефект, только с другого края.

Сборка чистая, тесты проходят (604).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
