### PR TITLE
fix(dg): stop reading an uninitialized buffer when parsing %var.field(subfield)%

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -4082,6 +4082,11 @@ void var_subst(void *go, Script *sc, Trigger *trig, int type, const char *line, 
 
 			field = p;
 			subfield_p = subfield;    //new
+			// Буфер обязательно гасим: ниже его длина участвует в расчете места под
+			// вложенную подстановку, а до первой записи здесь лежит мусор со стека.
+			// Из-за этого у %world.curobjs(66809)% отрезало последний символ -- движок
+			// ругался на несуществующий внум 6680.
+			*subfield = '\0';
 			if (*p == '.') {
 				*(p++) = '\0';
 				local_p = local;
@@ -4100,7 +4105,12 @@ void var_subst(void *go, Script *sc, Trigger *trig, int type, const char *line, 
 						paren_count--;
 						if (!paren_count) {
 							*local_p = '\0';
-							var_subst(go, sc, trig, type, local, subfield_p, sizeof(subfield) - strlen(subfield));
+							// Остаток буфера считаем по указателю, а не по strlen: подполя пишутся
+							// друг за другом, и длина содержимого тут ни при чем. Со strlen на
+							// неинициализированной памяти разность могла уйти в минус и как size_t
+							// стать огромной -- snprintf писал бы за пределы буфера.
+							var_subst(go, sc, trig, type, local, subfield_p,
+									  sizeof(subfield) - static_cast<size_t>(subfield_p - subfield));
 							local_p = nullptr;
 							subfield_p = subfield + strlen(subfield);
 						}


### PR DESCRIPTION
## Симптом

```
SCRIPT LOG (Trigger: убили колдуна, VNum: 66809) : Указан неверный параметр vnum (6680) в curobjs [строка: 1]
```

В строке 1 триггера стоит `%world.curobjs(66809)%`, объекты 66809–66811 в зоне 668 существуют. У внума отрезало последний символ.

## Причина

`var_subst` (`dg_scripts.cpp:4052`) разбирает `%var.field(subfield)%`. Буфер под подполе объявлен неинициализированным:

```cpp
char *subfield_p, subfield[kMaxTrglineLength];
```

а размер для вложенного разбора считался по его содержимому:

```cpp
var_subst(go, sc, trig, type, local, subfield_p, sizeof(subfield) - strlen(subfield));
```

На первом же подполе `strlen` читает мусор со стека — записать туда ещё ничего не успели. Сколько символов доедет до `snprintf`, зависит от того, что осталось в этой памяти от прошлых вызовов. Отсюда и капризность: триггер не менялся, а ошибка то появляется, то нет.

Хуже того, `strlen` сканирует **за пределами** массива, пока не наткнётся на ноль. Если мусор длиннее буфера, разность уходит в минус и как `size_t` становится огромной — тогда `snprintf` пишет без ограничения, то есть портит стек. Пока просто не выстрелило.

## Правка

```cpp
subfield_p = subfield;
*subfield = '\0';   // ниже его длина участвует в расчете места
...
var_subst(go, sc, trig, type, local, subfield_p,
		  sizeof(subfield) - static_cast<size_t>(subfield_p - subfield));
```

Остаток места теперь считается по указателю, а не по содержимому: подполя пишутся друг за другом, и длина текста тут ни при чём. Гашение буфера оставлено отдельно — оно нужно, чтобы `strlen` в других местах не читал мусор, и чтобы пустое подполе выглядело пустым.

Сборка чистая, тесты проходят (604).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
