### PR TITLE
fix(admin-api): exit_info как BitsetFlags

### DIFF
--- a/src/engine/network/admin_api/parsers.cpp
+++ b/src/engine/network/admin_api/parsers.cpp
@@ -753,7 +753,8 @@ void ParseRoomUpdate(RoomData* room, const nlohmann::json& data)
 			}
 			if (exit_json.contains("exit_info"))
 			{
-				exit->exit_info = exit_json["exit_info"].get<int>();
+				// Single-plane numeric form, mirrors the serializer and the world loaders.
+				exit->exit_info.set_plane(0, exit_json["exit_info"].get<Bitvector>());
 			}
 			if (exit_json.contains("key"))
 			{

--- a/src/engine/network/admin_api/serializers.cpp
+++ b/src/engine/network/admin_api/serializers.cpp
@@ -353,7 +353,9 @@ json SerializeRoom(RoomData& room, int vnum)
 			{
 				exit_obj["keyword"] = Koi8rToUtf8(room.dir_option[dir]->keyword);
 			}
-			exit_obj["exit_info"] = room.dir_option[dir]->exit_info;
+			// exit_info used to be a byte: a single 30-bit plane serialized as a plain number.
+			// BitsetFlags keeps that flag identity, so the JSON stays a number (get_plane(0)).
+			exit_obj["exit_info"] = room.dir_option[dir]->exit_info.get_plane(0);
 			exit_obj["key_vnum"] = room.dir_option[dir]->key;
 			exits.push_back(exit_obj);
 		}


### PR DESCRIPTION
Две сборки в #3711 (`Base + Admin API + OTEL`, `YAML + Admin API + OTEL`) не компилируются: миграция флагов сделала `exit_info` типом `BitsetFlags<EExitFlag>`, а Admin API продолжает работать с ним как с числом.

```
serializers.cpp:356: error: no match for 'operator=' (nlohmann::json = BitsetFlags<EExitFlag>)
parsers.cpp:756:    error: no match for 'operator=' (BitsetFlags<EExitFlag> = int)
```

Красные только эти два джоба, потому что `admin_api` по умолчанию выключен и файлы в остальные сборки не попадают.

`exit_info` был байтом — один 30-битный план, сериализуемый обычным числом, — и миграция это соглашение сохранила (`entities_constants.h`: «packed mapping keeps flag identity, count=30 (one plane)»). Остальной код уже ходит через `get_plane(0)`/`set_plane(0, ...)`: `boot_data_files.cpp:519`, `sqlite_world_data_source.cpp:1364,3142`, `world_checksum.cpp:184`. Здесь то же самое.

JSON-контракт не меняется: `exit_info` как был числом, так и остался, веб-панель править не нужно.

Проверено локально: `meson setup build_adminapi -Dbuild_profile=release -Dadmin_api=true` + `ninja` — сборка проходит.