### PR TITLE
fix(world): find_char no longer returns characters already out of the world

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -3702,6 +3702,13 @@ int get_filename(const char *orig_name, char *filename, int mode) {
 CharData *find_char(long uid) {
 	auto it = chardata_by_uid.find(uid);
 	if (it != chardata_by_uid.end()) {
+		// Выведенного из мира не отдаем. Убитый персонаж уходит не мгновенно: его выносят из
+		// комнаты (in_room = kNowhere), а из списков вычищают только в конце пульса. До этого
+		// момента все, что успевает выполниться -- триггеры смерти, отложенные команды,
+		// разрешение uid в скриптах -- получало указатель на "живого" мертвеца.
+		if (it->second->in_room == kNowhere) {
+			return nullptr;
+		}
 		return it->second;
 	}
 	return nullptr;


### PR DESCRIPTION
## Что было

Убитый персонаж уходит из мира не мгновенно. `AddToExtractedList` (`world_characters.cpp:102`) снимает с него экипировку, выносит из комнаты и кладёт в список на извлечение, а вычищается он из списков только в конце пульса, в `PurgeExtractedList()`.

При этом `find_char` отдавал его как ни в чём не бывало:

```cpp
CharData *find_char(long uid) {
	auto it = chardata_by_uid.find(uid);
	if (it != chardata_by_uid.end()) {
		return it->second;
	}
	return nullptr;
}
```

Всё, что успевает выполниться в этом промежутке, получало указатель на «живого» мертвеца: триггеры смерти, отложенные команды мобов, разрешение `%uid%` в DG (`dg_scripts.cpp:492`, `:554`, `:598`, `:3717`), поиск кастера аффекта.

## Что стало

```cpp
if (it->second->in_room == kNowhere) {
	return nullptr;
}
```

Признак — `in_room == kNowhere`, как принято в проекте: флаг `purged` устарел и оставлен только для совместимости.

Все двадцать вызовов `find_char` этот случай уже обрабатывают — поиск кастера аффекта (`magic.cpp`, `magic_rooms.cpp`), владельца предмета (`obj_save_ext.cpp`), вывод в `stat`, разрешение UID в скриптах.

## Чего эта правка не закрывает

`%world.curmobs%` тут ни при чём: `AddToExtractedList` строкой выше зовёт `mobs_by_vnum_remove`, так что из индекса по внуму убитый моб выпадает сразу и счётчик его уже не видит.

Сборка чистая, тесты проходят (572).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
