### PR TITLE
fix(dg): guard against a null enemy in the HitPrcnt shake-off log

### DIFF
--- a/src/engine/scripting/dg_mobcmd.cpp
+++ b/src/engine/scripting/dg_mobcmd.cpp
@@ -50,6 +50,8 @@
 #include "gameplay/core/game_limits.h"
 #include "gameplay/mechanics/damage.h"
 
+#include <fmt/format.h>
+
 struct mob_command_info {
 	const char *command;
 	EPosition minimum_position;
@@ -1579,10 +1581,15 @@ bool mob_script_command_interpreter(CharData *ch, char *argument, Trigger *trig)
 			char st[] = "";
 			do_stand(ch, st, 0, 0);
 		}
-		if (!(ch->GetEnemy()->IsNpc() && !IsCharmice(ch->GetEnemy()))) {
-			sprintf(buf, "mob command_interpreter: моб %s (%d) отжил из лага/стана в HitPercent, проценты жизни %d, сражается с %s", 
-					ch->get_name().c_str(), GET_MOB_VNUM(ch), GET_TRIG_NARG(trig), ch->GetEnemy()->get_name().c_str());
-			mob_log(ch, trig, buf);
+		// issue #3719: под контролем моб мог ни разу не ударить в ответ, и GetEnemy() тут nullptr
+		// (HitPrcnt дергается из hit() по жертве, а не по атакующему) -- разыменовывать его нельзя.
+		const auto *enemy = ch->GetEnemy();
+		if (!enemy || !(enemy->IsNpc() && !IsCharmice(enemy))) {
+			mob_log(ch, trig,
+					fmt::format("mob command_interpreter: моб {} ({}) отжил из лага/стана в HitPercent, "
+								"проценты жизни {}, сражается с {}",
+								ch->get_name(), GET_MOB_VNUM(ch), GET_TRIG_NARG(trig),
+								enemy ? enemy->get_name().c_str() : "никем").c_str());
 		}
 	}
 // damage mtrigger срабатывает всегда


### PR DESCRIPTION
Закрывает #3719.

## Что падало

```
#0  mob_script_command_interpreter (...) at src/engine/entities/char_data.h:549
#1  mob_command_interpreter (...) at src/engine/scripting/dg_mobcmd.cpp:1616
#4  hitprcnt_mtrigger (...) at src/engine/scripting/dg_triggers.cpp:683
#5  hit (...) at src/gameplay/fight/fight_hit.cpp:1140
```

`char_data.h:549` — это `bool IsNpc() const { return is_npc_; }`, то есть разыменование нулевого `this`.

## Причина

В блоке «моб стряхивает контроль в HitPrcnt» (тот, что добавлялся по #3658) строка лога дергала `ch->GetEnemy()` без проверки, причем дважды:

```cpp
if (!(ch->GetEnemy()->IsNpc() && !IsCharmice(ch->GetEnemy()))) {
    sprintf(buf, "... сражается с %s", ..., ch->GetEnemy()->get_name().c_str());
```

`GetEnemy()` возвращает `fight_targets_.enemy`, по умолчанию `nullptr`. HitPrcnt-триггер дергается из `hit()` по **жертве**, а не по атакующему, и весь блок отрабатывает как раз тогда, когда моб под контролем (`kHold` / `kStopFight` / `kMagicStopFight` / `kSleep`) или в лаге. Такой моб мог ни разу не ударить в ответ — цель боя у него не выставлена, `GetEnemy()` пустой.

## Что сделано

Указатель берется один раз и проверяется; при отсутствии противника в лог идет «сражается с никем» вместо падения. Заодно `sprintf` в глобальный `buf` заменен на `fmt::format`.

Проверено: сборка с `-Dbuild_tests=true` чистая, 572 теста проходят.