### PR TITLE
fix(affects): terminate the "you stop hiding" line with a newline

### DIFF
--- a/src/gameplay/mechanics/hide.cpp
+++ b/src/gameplay/mechanics/hide.cpp
@@ -126,7 +126,10 @@ void MakeVisible(CharData *ch, const EAffect affect) {
 	AFF_FLAGS(ch).unset(affect);
 	ch->check_aggressive = true;
 	if (!to_char.empty()) {
-		SendMsgToChar(to_char.c_str(), ch);
+		// issue #3721: act(), а не SendMsgToChar() -- строка приходит из affect_msg.xml без
+		// перевода в конце, и SendMsgToChar пишет ее в буфер как есть, склеивая со следующей.
+		// kToSleep -- чтобы спящий увидел строку так же, как видел ее при SendMsgToChar.
+		act(to_char.c_str(), false, ch, nullptr, nullptr, kToChar | kToSleep);
 	}
 	if (!to_room.empty()) {
 		act(to_room.c_str(), false, ch, nullptr, nullptr, kToRoom);


### PR DESCRIPTION
Закрывает #3721.

## Почему нет перевода строки

Сообщение живет в `lib/cfg/messages/ru/affect_msg.xml`, в пучке `kHide`, и переводом строки не заканчивается:

```xml
<msg_sheaf id="kHide">
    <message type="kAffDispelledToChar" val="Вы прекратили прятаться."/>
    <message type="kAffDispelledToRoom" val="$n прекратил$g прятаться."/>
```

В `MakeVisible` (`src/gameplay/mechanics/hide.cpp`) через `act()` уходила только **комнатная** строка, а личная — через `SendMsgToChar`:

```cpp
if (!to_char.empty()) {
    SendMsgToChar(to_char.c_str(), ch);      // пишет буфер как есть
}
if (!to_room.empty()) {
    act(to_room.c_str(), false, ch, nullptr, nullptr, kToRoom);
}
```

`SendMsgToChar` (`comm.cpp:2370`) отдает строку в `write_to_output` без изменений, тогда как `act()` дописывает `\r\n` сам в `perform_act` (`comm.cpp:2752-2754`). Отсюда и асимметрия: в комнате все выглядело нормально, а себе строка слипалась со следующей.

## Что сделано

Личная строка тоже идет через `act()`. Флаг `kToSleep` добавлен, чтобы сохранить прежнее поведение: `SendMsgToChar` писал независимо от позиции, а `act()` без этого флага спящего пропустил бы (`SENDOK`).

Тот же прием уже используется для истечения аффектов в `magic.cpp:156`.

Проверено: сборка с `-Dbuild_tests=true` чистая, 573 теста проходят.