### PR TITLE
fix(pour): transfer only what the source holds, not the target's free space

### DIFF
--- a/src/engine/ui/cmd/do_pour.cpp
+++ b/src/engine/ui/cmd/do_pour.cpp
@@ -212,12 +212,27 @@ void do_pour(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	// копируем тип жидкости //
 	to_obj->set_val(2, GET_OBJ_VAL(from_obj, 2));
 
-	int n1 = GET_OBJ_VAL(from_obj, 1);
-	int n2 = GET_OBJ_VAL(to_obj, 1);
-	int t1 = std::max(0, from_obj->GetPotionValueKey(ObjVal::EValueKey::kLiquidTimer));
-	int t2 = std::max(0, to_obj->GetPotionValueKey(ObjVal::EValueKey::kLiquidTimer));
+	// issue #3727: сколько переливаем -- не больше свободного места в приемнике и не больше того,
+	// что реально есть в источнике. Раньше приемник заливали "под горлышко", а недолив правили тем,
+	// что val[1] источника уходил в минус. После переезда ликвид-ядра в ObjVal так делать нельзя:
+	// ObjVal::set удаляет запись при отрицательном значении, get_val на пропавшем ключе молча
+	// откатывается на сырой val[] (после миграции он нулевой), и коррекция получала 0 вместо
+	// недостачи -- приемник оставался полным, а жидкость бралась из воздуха: 144 глотка самогона
+	// превращались в 500. Бездонный фонтан (val[1] == 999) по-прежнему наливает сколько влезет.
+	const bool endless_source = (from_obj->get_type() == EObjType::kFountain
+			&& GET_OBJ_VAL(from_obj, 1) == 999);
+	const int free_space = GET_OBJ_VAL(to_obj, 0) - GET_OBJ_VAL(to_obj, 1);
+	amount = endless_source ? free_space : std::min(free_space, GET_OBJ_VAL(from_obj, 1));
+
+	const int n1 = amount;                      // сколько долили
+	const int n2 = GET_OBJ_VAL(to_obj, 1);      // сколько уже было
+	const int t1 = std::max(0, from_obj->GetPotionValueKey(ObjVal::EValueKey::kLiquidTimer));
+	const int t2 = std::max(0, to_obj->GetPotionValueKey(ObjVal::EValueKey::kLiquidTimer));
 	// issue.potion-hotfix: blend the two containers' CONTENTS freshness (kLiquidTimer) by fill amount.
-	to_obj->SetPotionValueKey(ObjVal::EValueKey::kLiquidTimer, (n1 * t1 + n2 * t2) / (n1 + n2));
+	// issue #3727: вес первого слагаемого -- перелитый объем, а не все содержимое источника.
+	if (n1 + n2 > 0) {
+		to_obj->SetPotionValueKey(ObjVal::EValueKey::kLiquidTimer, (n1 * t1 + n2 * t2) / (n1 + n2));
+	}
 //	sprintf(buf, "Игрок %s переливает жижку. Первая емкость: %s (%d) Вторая емкость %s (%d). SCMD %d",
 //		GET_NAME(ch), from_obj->get_PName(ECase::kGen).c_str(), GET_OBJ_VNUM(from_obj), to_obj->get_PName(ECase::kGen).c_str(),  GET_OBJ_VNUM(to_obj), subcmd);
 //	mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
@@ -225,30 +240,26 @@ void do_pour(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 //	mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
 
 	// New alias //
-	if (GET_OBJ_VAL(to_obj, 1) == 0)
+	if (GET_OBJ_VAL(to_obj, 1) == 0) {
 		name_to_drinkcon(to_obj, GET_OBJ_VAL(from_obj, 2));
-	// Then how much to pour //
-	amount = (GET_OBJ_VAL(to_obj, 0) - GET_OBJ_VAL(to_obj, 1));
+	}
 	// issue.potion-hotfix: mixing a potion into a non-empty container blends the maker skill/stat by
 	// quantity -- the n2 units already there plus the `amount` poured in. Spells match (checked above).
 	if (n2 > 0 && is_potion(from_obj)) {
 		drinkcon::mix_potion_values(to_obj, from_obj, n2, amount);
 	}
-	if (from_obj->get_type() != EObjType::kFountain
-		|| GET_OBJ_VAL(from_obj, 1) != 999) {
+	if (!endless_source) {
 		from_obj->sub_val(1, amount);
 	}
-	to_obj->set_val(1, GET_OBJ_VAL(to_obj, 0));
+	to_obj->add_val(1, amount);
 	// issue.potion-hotfix: a freshly filled liquid container's contents spoil over time -- track it.
 	world_objects.decay_manager().register_perishable(to_obj);
 
 	// Then the poison boogie //
 
 
-	if (GET_OBJ_VAL(from_obj, 1) <= 0)    // There was too little //
+	if (!endless_source && GET_OBJ_VAL(from_obj, 1) <= 0)    // Источник опустел //
 	{
-		to_obj->add_val(1, GET_OBJ_VAL(from_obj, 1));
-		amount += GET_OBJ_VAL(from_obj, 1);
 		from_obj->set_val(1, 0);
 		from_obj->set_val(2, 0);
 		from_obj->set_val(3, 0);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -36,6 +36,7 @@ test_sources = files(
     'char.leaders.cpp',
     'char.morph.copy.cpp',
     'obj.copy.cpp',
+    'obj.liquid_core.cpp',
     'spell_item_convert.cpp',
     'act.makefood.cpp',
     'utils.editor.cpp',

--- a/tests/obj.liquid_core.cpp
+++ b/tests/obj.liquid_core.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include "engine/entities/obj_data.h"
+
+namespace {
+
+constexpr ObjVnum kJarVnum = 100700;
+
+// issue.magic-items-hotfix: у сосуда и фонтана val[0..2] переехали в ключи ObjVal
+// (kLiquidCapacity / kLiquidCurrent / kLiquidType), а сами val[] перестали быть
+// источником правды.
+ObjData::shared_ptr MakeDrinkContainer(int capacity, int current) {
+	auto prototype = std::make_shared<CObjectPrototype>(kJarVnum);
+	auto jar = std::make_shared<ObjData>(*prototype);
+	jar->set_type(EObjType::kLiquidContainer);
+	jar->set_val(0, capacity);
+	jar->set_val(1, current);
+	return jar;
+}
+
+TEST(ObjLiquidCore, ValuesRoundTripThroughObjVal) {
+	const auto jar = MakeDrinkContainer(500, 144);
+
+	EXPECT_EQ(500, GET_OBJ_VAL(jar, 0));
+	EXPECT_EQ(144, GET_OBJ_VAL(jar, 1));
+}
+
+// issue #3727: ObjVal::set удаляет запись при отрицательном значении, а get_val на
+// пропавшем ключе молча откатывается на сырой val[]. Значит уход объема в минус НЕ
+// сохраняется, и прочитать оттуда недостачу нельзя -- на этом и погорел перелив,
+// который заливал приемник под горлышко и правил недолив отрицательным остатком.
+// Любой код, считающий объем жидкости, обязан клампить сам.
+TEST(ObjLiquidCore, SubtractingBelowZeroDoesNotStoreTheDeficit) {
+	const auto jar = MakeDrinkContainer(500, 144);
+
+	jar->sub_val(1, 500);
+
+	EXPECT_GE(GET_OBJ_VAL(jar, 1), 0);
+	EXPECT_NE(GET_OBJ_VAL(jar, 1), -356);
+}
+
+// Перелив теперь считает объем через min() и в минус не уходит -- проверяем ту самую
+// арифметику: из ведра на 144 глотка в пустую бочку на 500 переливается ровно 144.
+TEST(ObjLiquidCore, PourTransfersNoMoreThanTheSourceHolds) {
+	const auto bucket = MakeDrinkContainer(144, 144);
+	const auto barrel = MakeDrinkContainer(500, 0);
+
+	const int free_space = GET_OBJ_VAL(barrel, 0) - GET_OBJ_VAL(barrel, 1);
+	const int amount = std::min(free_space, GET_OBJ_VAL(bucket, 1));
+	bucket->sub_val(1, amount);
+	barrel->add_val(1, amount);
+
+	EXPECT_EQ(144, amount);
+	EXPECT_EQ(144, GET_OBJ_VAL(barrel, 1));
+	EXPECT_EQ(0, GET_OBJ_VAL(bucket, 1));
+}
+
+}  // namespace
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
Закрывает #3727.

## Что было

Ведерко самогона на 144 глотка переливается в пустую бочку на 500 — бочка становится заполненной самогоном на 100%. 356 глотков возникают из воздуха.

## Причина

Старый алгоритм перелива (ещё из CircleMUD) заливал приёмник под горлышко, намеренно уводил `val[1]` источника в минус и правил недолив обратным сложением:

```cpp
amount = to.val0 - to.val1;                 // 500 — всё свободное место
from->sub_val(1, amount);                   // 144 - 500 = -356, недостача
to->set_val(1, to.val0);                    // залили под горлышко
if (GET_OBJ_VAL(from, 1) <= 0) {
    to->add_val(1, GET_OBJ_VAL(from, 1));   // ждём -356, откатываем перелив
```

После issue.magic-items-hotfix `val[0..2]` сосудов и фонтанов перенаправлены в ключи `ObjVal`, а у `ObjVal::set` контракт: отрицательное значение **удаляет запись** (`obj_data.h:93`). Минус не сохраняется, `ObjVal::get` на пропавшем ключе отдаёт `-1`, и `ObjData::get_val` (`obj_data.h:249`) молча откатывается на сырой `val[]`, который после миграции нулевой.

Коррекция получала `0` вместо `-356` — и приёмник оставался залитым под горлышко.

## Что стало

Объём считается сразу через `min(свободное место, содержимое источника)` и переносится ровно он, без прохода через отрицательное значение.

Заодно кламп чинит смешивание: `mix_potion_values` и блендинг свежести `kLiquidTimer` получали вес по свободному месту приёмника, а не по реально перелитому объёму — то есть при недоливе свежесть и качество считались с завышенным весом источника.

Бездонный фонтан (`val[1] == 999`) выделен в `endless_source` и ведёт себя как раньше.

`do_drink`, `do_drunkoff` и `liquid.cpp` тем же не страдают — там объём клампится по содержимому до вычитания.

## Проверка

`tests/obj.liquid_core.cpp` — фиксирует контракт ликвид-ядра (минус не сохраняется, `get_val` откатывается на сырой `val[]`) и арифметику перелива.

Сборка чистая, 577 тестов проходят.

Проверка в игре:

```
oload obj <внум ведра>       # ёмкость поменьше, налить доверху
oload obj <внум бочки>       # ёмкость побольше
лить бочка земля             # опустошить приёмник
лить ведро.самогон бочка
стат бочка                   # val[1] должен быть 144, а не 500
стат ведро                   # val[1] должен быть 0
```

## Осталось за рамками

`ObjData::get_val` при пропавшем ключе молча откатывается на сырой `m_vals[]` — это маскирует ровно такие ошибки: любой арифметический проход через ноль по ликвид-ядру читает не ноль, а протухшее значение. Фоллбэк нужен для миграции старых миров, так что трогать его в этом PR не стал.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
