### PR TITLE
fix(build): silence unused-parameter warning in PlayerI::save_char

### DIFF
--- a/src/engine/entities/player_i.h
+++ b/src/engine/entities/player_i.h
@@ -92,7 +92,7 @@ class PlayerI {
 	virtual void dps_end_round(int/* type*/, CharData * /*ch*/ = nullptr) {};
 	virtual void dps_add_exp(int/* exp*/, bool/* battle*/ = false) {};
 
-	virtual void save_char(bool update_save_time = true) {};
+	virtual void save_char(bool/* update_save_time*/ = true) {};
 	virtual int load_char_ascii(const char * /*name*/, const int /* load_flags */) { return -1; };
 
 	virtual bool get_disposable_flag(int/* num*/) { return false; };


### PR DESCRIPTION
Пустая заглушка `PlayerI::save_char` держала имя параметра:

```cpp
virtual void save_char(bool update_save_time = true) {};
```

`-Wunused-parameter` стрелял в каждой единице трансляции, куда попадает `char_data.h` — то есть почти в каждой, и в логе сборки это была самая частая строка.

Имя убрано в комментарий, как у всех соседних заглушек в том же файле (`dps_add_exp`, `mobmax_add`, `dps_end_round` и прочие):

```cpp
virtual void save_char(bool/* update_save_time*/ = true) {};
```

Значение по умолчанию сохранено, сигнатура не менялась — переопределения в наследниках не затронуты.

Сборка чистая, предупреждение исчезло, 574 теста проходят.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
