### PR TITLE
feat(dg): add obj.placetoroom -- put an item into a room by its number

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -1550,6 +1550,24 @@ void do_mload(CharData *ch, char *argument, int cmd, int subcmd, Trigger *trig);
 void do_dgoload(ObjData *obj, char *argument, int cmd, int subcmd, Trigger *trig);
 void do_wload(RoomData *room, char *argument, int cmd, int subcmd, Trigger *trig);
 
+// Изъять предмет оттуда, где он сейчас лежит, кем бы он ни держался. Нужно и для
+// object.put, и для object.placetoroom, поэтому вынесено из обоих.
+// Возвращает false, если предмет уже нигде -- вызывающему в этом случае размещать нечего.
+static bool RemoveObjFromAnywhere(ObjData *obj) {
+	if (obj->get_worn_by()) {
+		UnequipChar(obj->get_worn_by(), obj->get_worn_on(), CharEquipFlags());
+	} else if (obj->get_carried_by()) {
+		RemoveObjFromChar(obj);
+	} else if (obj->get_in_obj()) {
+		RemoveObjFromObj(obj);
+	} else if (obj->get_in_room() > kNowhere) {
+		RemoveObjFromRoom(obj);
+	} else {
+		return false;
+	}
+	return true;
+}
+
 void find_replacement(void *go,
 					  Script *sc,
 					  Trigger *trig,
@@ -3697,6 +3715,37 @@ void find_replacement(void *go,
 				*str = '\0';
 			}
 		}
+		// issue #3732: положить предмет в комнату одним движением, откуда бы он ни лежал --
+		// из комнаты, из рук, из контейнера, из экипировки. То же самое умеет object.put, но он
+		// требует UID приемника, а это лишнее знание для билдера: здесь достаточно номера комнаты,
+		// хотя UID тоже принимается. Предмет переносится сам, со своим таймером, меткой владельца
+		// и зачарованиями -- в отличие от связки oload + opurge, которая создает новый экземпляр
+		// с прототипа. Возвращает 1 при успехе и 0 при неудаче.
+		else if (!str_cmp(field, "placetoroom")) {
+			snprintf(str, str_size, "0");
+			RoomRnum room_to_place = kNowhere;
+			if (*subfield == UID_ROOM) {
+				RoomData *room_by_uid = find_room(atoi(subfield + 1));
+				if (room_by_uid && room_by_uid->vnum != kNowhere) {
+					room_to_place = GetRoomRnum(room_by_uid->vnum);
+				}
+			} else {
+				const auto vnum = atoi(subfield);
+				if (vnum > 0) {
+					room_to_place = GetRoomRnum(vnum);
+				}
+			}
+			if (room_to_place == kNowhere) {
+				trig_log(trig, "object.placetoroom: недопустимая комната");
+				return;
+			}
+			if (!RemoveObjFromAnywhere(obj)) {
+				trig_log(trig, "object.placetoroom: не удалось извлечь предмет");
+				return;
+			}
+			PlaceObjToRoom(obj, room_to_place);
+			snprintf(str, str_size, "1");
+		}
 		else if (!str_cmp(field, "put")) {
 			ObjData *obj_to = nullptr;
 			CharData *char_to = nullptr;
@@ -3729,15 +3778,7 @@ void find_replacement(void *go,
 			}
 			//found something to put our object
 			//let's make it nobody's!
-			if (obj->get_worn_by()) {
-				UnequipChar(obj->get_worn_by(), obj->get_worn_on(), CharEquipFlags());
-			} else if (obj->get_carried_by()) {
-				RemoveObjFromChar(obj);
-			} else if (obj->get_in_obj()) {
-				RemoveObjFromObj(obj);
-			} else if (obj->get_in_room() > kNowhere) {
-				RemoveObjFromRoom(obj);
-			} else {
+			if (!RemoveObjFromAnywhere(obj)) {
 				trig_log(trig, "object.put: не удалось извлечь объект");
 				return;
 			}


### PR DESCRIPTION
Закрывает #3732.

## Новое поле

```
%obj.placetoroom(1201)%
```

Кладёт предмет в комнату, откуда бы он ни лежал — из комнаты, из рук, из контейнера, из экипировки. Аргумент — номер комнаты; UID комнаты тоже понимается, но знать про него билдеру не нужно. Возвращает `1` при успехе и `0` при неудаче.

Смысл в том, что **предмет переносится сам** — со своим таймером, меткой владельца, зачарованиями и значениями. Привычная связка `oload` + `opurge` этого не умеет: она создаёт новый экземпляр с прототипа, а старый уничтожает, теряя всё накопленное.

## Почему отдельное поле, а не object.put

Технически то же самое умеет `object.put`, но он требует UID приёмника — лишнее знание там, где хватает номера комнаты. DG рассчитан на билдеров, а не на программистов.

**Сам `object.put` не тронут.** В первой версии этого PR я расширил его на приём обычного числа — и это было неправильно: `%obj.put(1201)%` ничего не сообщает о том, что за число, а переменная с числовым значением молча превратилась бы в комнату. Требование UID у `put` осознанное, оно там и остаётся.

## Без второй реализации

Общая часть — изъятие предмета оттуда, где он лежит, — вынесена из `object.put` в `RemoveObjFromAnywhere` и используется обоими полями:

```cpp
static bool RemoveObjFromAnywhere(ObjData *obj) {
	if (obj->get_worn_by())                 { UnequipChar(...); }
	else if (obj->get_carried_by())         { RemoveObjFromChar(obj); }
	else if (obj->get_in_obj())             { RemoveObjFromObj(obj); }
	else if (obj->get_in_room() > kNowhere) { RemoveObjFromRoom(obj); }
	else                                    { return false; }
	return true;
}
```

Надетый предмет снимается через `UnequipChar`, который сам зовёт `RemoveEquipmentAffects` — слот освобождается, аффекты вещи уходят с персонажа.

## Проверка

Сборка чистая, 577 тестов проходят.

В игре, по одной строке в триггере:

- предмет из инвентаря → лежит в 1201, таймер и метка владельца на месте;
- предмет из контейнера → то же, вес контейнера уменьшился;
- **надетый предмет** → слот освободился, аффекты вещи с персонажа ушли;
- несуществующая комната → жалоба в лог триггера, поле вернуло `0`.

## Осталось за рамками

Документации по полям DG в репозитории нет, она живёт в базе знаний — описание `placetoroom` надо добавить туда.

Отдельный PR под Lua не нужен: там это уже есть — `obj:moveToRoom(...)` в `lua_entity_bindings.cpp:1744`, с той же механикой изъятия. DG этой правкой догоняет Lua, а не наоборот.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
