### PR TITLE
fix(observability): keep the heartbeat span name constant

### DIFF
--- a/src/engine/core/heartbeat.cpp
+++ b/src/engine/core/heartbeat.cpp
@@ -576,10 +576,11 @@ void Heartbeat::operator()(const int missed_pulses) {
 	const auto current_heartbeat_number = global_pulse_number();
 	const auto current_pulse_number = pulse_number();
 
-	// Create trace span for this pulse
-	char span_name[64];
-	snprintf(span_name, sizeof(span_name), "Heartbeat #%lu pulse #%d", current_heartbeat_number, current_pulse_number);
-	auto pulse_span = tracing::TraceManager::Instance().StartSpan(span_name);
+	// Create trace span for this pulse.
+	// The name must stay constant: it becomes the span_name label in the metrics
+	// generator, so embedding the counters here produced one metric series per
+	// pulse. Both numbers are recorded as span attributes below instead.
+	auto pulse_span = tracing::TraceManager::Instance().StartSpan("Heartbeat");
 
 	utils::CExecutionTimer timer;
 	pulse(missed_pulses, label);


### PR DESCRIPTION
## Проблема

`Heartbeat::operator()` собирал имя спана через `snprintf`, подставляя туда счётчики:

```cpp
snprintf(span_name, sizeof(span_name), "Heartbeat #%lu pulse #%d", ...);
auto pulse_span = tracing::TraceManager::Instance().StartSpan(span_name);
```

Имя спана в Tempo превращается в лейбл `span_name` метрик-генератора, поэтому **каждый пульс порождал новый набор серий** в Prometheus.

## Масштаб на бою

Замеры на живом сервере (`bylins-new-4000`, ревизия fcb84d9c2):

| Показатель | Значение |
|---|---|
| Уникальных `span_name` всего | 8 590 710 |
| Из них `Heartbeat #N pulse #N` | **8 590 514 (99.998%)** |
| Активных серий в Prometheus | 2.13 млн, из них 2.07 млн — span-metrics |
| Размер TSDB | **300 GB** |
| CPU Prometheus | 600%+ (6+ ядер из 16) |
| RSS Prometheus | 8.2 GB |

Показательно, что это единственная течь: у остальных 196 форм имён спанов ровно по одному значению каждая — то есть инструментирование в целом написано правильно.

## Правка

Имя спана делается константным — `"Heartbeat"`. Оба счётчика **и так уже** писались атрибутами несколькими строками ниже:

```cpp
pulse_span->SetAttribute("heartbeat_number", ...);
pulse_span->SetAttribute("pulse_number", ...);
```

Так что в имени они были чистым дублированием, и при переходе на константу не теряется ничего: в трейсах номера остаются на месте, а в метриках `span_name` схлопывается в одно значение. Это же и канон OTel — имя спана должно быть низкокардинальным именем операции, а идентификаторы идут в атрибуты.

Локальная переменная `span_name` больше нигде не используется и удалена вместе с `snprintf`.

## Что дальше (вне этого PR)

Правка останавливает рост, но не подчищает уже накопленное. На сервере отдельно нужно:

- удалить старые блоки TSDB либо дождаться retention 30d — освободит около 250-280 GB;
- решить судьбу 34 GB трейсов в Tempo: сами спаны хартбита продолжат писаться с прежней частотой (правка меняет имя, а не объём), так что тут поможет либо сэмплирование хартбита, либо более короткий retention.

## Проверка

Правка сводится к передаче строкового литерала в `StartSpan(const std::string&)` и удалению двух ставших ненужными локальных объявлений; ссылок на `span_name` в файле не осталось. Локально полная сборка не запускалась — рабочие `build*/` в репозитории устарели и не содержат `engine/core` в `compile_commands.json`, так что компиляцию подтверждает CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)