### PR TITLE
fix(dg): honour trigger add_flag again when the mob is held

### DIFF
--- a/src/engine/scripting/dg_mobcmd.cpp
+++ b/src/engine/scripting/dg_mobcmd.cpp
@@ -1594,10 +1594,17 @@ bool mob_script_command_interpreter(CharData *ch, char *argument, Trigger *trig)
 	}
 // damage mtrigger срабатывает всегда
 	if (!(CheckScript(ch, MTRIG_DAMAGE) || CheckScript(ch, MTRIG_DEATH))) {
+		// issue #3740: add_flag ("выполнять команды моба в неподвижном состоянии") -- аварийный
+		// выход для триггеров, которым обязательно надо доработать до конца, даже если моба
+		// захолдили. Без него скрипт откладывается по кругу: hang_trig_wait перевешивает его
+		// каждую секунду, и пока группа держит моба, до конца триггера дело не доходит. Так
+		// освобожденные души в 756 зоне перестали доходить до mpurge и жили сотни тиков вместо
+		// двух. trig может быть nullptr, поэтому проверка через &&.
 		if (!use_in_stoped && !mob_cmd_info[cmd].use_in_stoped
 				&& (AFF_FLAGGED(ch, EAffect::kHold)
 				|| AFF_FLAGGED(ch, EAffect::kStopFight)
-				|| AFF_FLAGGED(ch, EAffect::kMagicStopFight))) {
+				|| AFF_FLAGGED(ch, EAffect::kMagicStopFight))
+				&& !(trig && trig->add_flag)) {
 			// issue #3523: моб в стане -> команду не теряем: вешаем триггеру wait
 			// 0.025 RL sec, после стана script_driver повторит её (TRIG_FROM_LINE).
 			hang_trig_wait(ch, trig, MOB_TRIGGER, kPassesPerSec, true);


### PR DESCRIPTION
Закрывает #3740.

## Что сломалось

Освобождённые души в 756 зоне вместо двух тиков живут сотни. Пока группа держит душу холдом, её триггер не доходит до `mpurge %self%`.

Регрессию внёс мой же коммит fab2ab7d6 от 30 июля. Вместе с условием по боевому лагу (#3655) из проверки ушло и `&& !trig->add_flag` — я его тогда не учёл:

```diff
 		if (!use_in_stoped && !mob_cmd_info[cmd].use_in_stoped
 				&& (AFF_FLAGGED(ch, EAffect::kHold)
 				|| AFF_FLAGGED(ch, EAffect::kStopFight)
-				|| AFF_FLAGGED(ch, EAffect::kMagicStopFight)
-				|| ch->get_wait() > 0)
-				&& !trig->add_flag) {
+				|| AFF_FLAGGED(ch, EAffect::kMagicStopFight))) {
 			hang_trig_wait(ch, trig, MOB_TRIGGER, kPassesPerSec, true);
 			return false;
 		}
```

`add_flag` — аварийный выход для триггеров, которым надо доработать до конца независимо от состояния моба. В trigedit он так и подписан: «выполнять команды моба в неподвижном состоянии». Без него холд откладывает триггер безусловно, `hang_trig_wait` перевешивает его каждую секунду, и скрипт не заканчивается, пока моба держат.

## Данные зоны ни при чём

У всех девяти триггеров душ `add_flag` выставлен в 1 и был выставлен всегда:

```
#75633 залоадилась душа колда        #75638 залоадилась душа волшебника
#75634 залоадилась душа волхва       #75639 залоадилась душа дружинника
#75635 залоадилась душа витязя       #75640 залоадилась душа лазутчика
#75636 залоадилась душа богатыря     #75641 залоадилась душа стрелка
#75637 залоадилась душа кудесника
```

Сломалось именно чтение флага: в коде он оставался только в OLC и в выводе `дгстат`, в исполнении не участвовал нигде.

## Правка

Возвращаем условие. Проверка через `trig && trig->add_flag` — `trig` в этой функции может быть `nullptr`, рядом он уже проверяется так же (`dg_mobcmd.cpp:1552`).

Условие по `ch->get_wait()` **не возвращаю**: его снимали намеренно, боевой лаг триггеры стопорить не должен.

## Проверка

Сборка чистая, 577 тестов проходят.

В игре: убить моба в 756 зоне, захолдить поднявшуюся душу и подержать. До правки душа жила, пока её держат; теперь должна доработать триггер и запуржиться, как раньше.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
