### PR TITLE
fix(ui): show timed cast duration next to a permanent affect

### DIFF
--- a/src/engine/ui/cmd/do_affects.cpp
+++ b/src/engine/ui/cmd/do_affects.cpp
@@ -12,6 +12,8 @@
 #include "gameplay/mechanics/groups.h"
 #include "gameplay/affects/affect_data.h"
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -31,17 +33,16 @@ int AffectDisplayMod(const Affect<EApply>::shared_ptr &aff) {
 	return aff->duration;
 }
 
-void FormatAffectDuration(int mod, char *out, size_t out_sz) {
+std::string FormatAffectDuration(int mod) {
 	// A permanent affect (mod < 0) reads as unlimited, not "less than an hour".
 	if (mod < 0) {
-		snprintf(out, out_sz, "(постоянно)");
-	} else if ((mod + 1) / kSecsPerMudHour) {
-		snprintf(out, out_sz, "(%d %s)",
-				 (mod + 1) / kSecsPerMudHour + 1,
-				 grammar::GetDeclensionInNumber((mod + 1) / kSecsPerMudHour + 1, grammar::EWhat::kHour));
-	} else {
-		snprintf(out, out_sz, "(менее часа)");
+		return "(постоянно)";
 	}
+	const int hours = (mod + 1) / kSecsPerMudHour;
+	if (hours > 0) {
+		return fmt::format("({} {})", hours + 1, grammar::GetDeclensionInNumber(hours + 1, grammar::EWhat::kHour));
+	}
+	return "(менее часа)";
 }
 
 // issue.affects-squash: one displayed row, aggregating every affect that renders under the same name.
@@ -117,14 +118,21 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 		for (const auto &r : rows) {
 			// A permanent source wins the label; otherwise show the longest remaining time.
-			FormatAffectDuration(r.permanent ? -1 : r.best_mod, buf2, sizeof(buf2));
-			snprintf(buf, kMaxStringLength, "%s%s%-21s %-12s%s",
-					 (!r.name.empty() && r.name[0] == '!') ? "Состояние  : " : "Заклинание : ",
-					 kColorBoldCyn, r.name.c_str(), buf2, kColorNrm);
+			std::string line = fmt::format("{}{}{:<21} {:<12}{}",
+										   (!r.name.empty() && r.name[0] == '!') ? "Состояние  : " : "Заклинание : ",
+										   kColorBoldCyn, r.name,
+										   FormatAffectDuration(r.permanent ? -1 : r.best_mod), kColorNrm);
 			if (r.count > 1) {
-				snprintf(buf + strlen(buf), kMaxStringLength - strlen(buf), " [x%d]", r.count);
+				line += fmt::format(" [x{}]", r.count);
 			}
-			SendMsgToChar(strcat(buf, "\r\n"), ch);
+			// issue #3739: a permanent source used to swallow the timed cast collapsed into the same
+			// row, so "(постоянно) [x2]" told the player neither whether the spell was cast at all,
+			// nor how long it had left. Show the timed remainder next to the permanent label.
+			if (r.permanent && r.has_timed) {
+				line += fmt::format(" временный {}", FormatAffectDuration(r.best_mod));
+			}
+			line += "\r\n";
+			SendMsgToChar(line.c_str(), ch);
 		}
 		return;
 	}
@@ -139,10 +147,10 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		// fall back to the casting spell's name for affects not yet migrated off Affect::type.
 		snprintf(sp_name, sizeof(sp_name), "%s",
 				affects::AffectMsg(aff->affect_type, affects::EAffectMsgType::kShortDesc).c_str());
-		FormatAffectDuration(AffectDisplayMod(aff), buf2, sizeof(buf2));
+		const std::string duration = FormatAffectDuration(AffectDisplayMod(aff));
 		snprintf(buf, kMaxStringLength, "%s%s%-21s %-12s%s ",
 				 *sp_name == '!' ? "Состояние  : " : "Заклинание : ",
-				 kColorBoldCyn, sp_name, buf2, kColorNrm);
+				 kColorBoldCyn, sp_name, duration.c_str(), kColorNrm);
 		*buf2 = '\0';
 		if (immortal) {
 			if (aff->modifier) {


### PR DESCRIPTION
Закрывает #3739.

## Проблема

Если один и тот же аффект есть и постоянный (шмотка, врожденный), и накастованный, свернутая строка аффектов показывала только:

```
Заклинание : магическое зеркало    (постоянно)  [x2]
```

Игрок не видел ни того, что заклинание вообще накастовано, ни сколько ему осталось.

## Причина

В свернутом виде (`do_affects`, ветка `squash`) постоянный источник выигрывал подпись целиком: `best_mod` по временным источникам считался, но никуда не выводился.

## Что сделано

Если в строке есть и постоянный источник, и временный, после `[xN]` дописывается остаток временного:

```
Заклинание : магическое зеркало    (постоянно)  [x2] временный (3 часа)
```

Заодно `FormatAffectDuration` переведена на возврат `std::string` и `fmt::format` вместо записи в глобальный `buf2`, и рендер строки свернутого вида -- тоже на `fmt::format`.

Полный вид (боги, `аффекты все`) не менялся: там каждый слот и так на своей строке.

## Проверка

Сборка чистая, 577 тестов проходят. В игре вживую не проверял.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
