### PR TITLE
fix(clans): stop losing container items silently

### DIFF
--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -2490,10 +2490,19 @@ void Clan::ChestLoad() {
 	for (ClanListType::const_iterator clan = Clan::ClanList.begin(); clan != Clan::ClanList.end(); ++clan) {
 		for (auto chest : world[GetRoomRnum((*clan)->chest_room)]->contents) {
 			if (Clan::is_clan_chest(chest)) {
+				int wiped = 0;
 				for (temp = chest->get_contains(); temp; temp = obj_next) {
 					obj_next = temp->get_next_content();
 					RemoveObjFromObj(temp);
 					ExtractObjFromWorld(temp);
+					++wiped;
+				}
+				// issue #3737: зачистка молчала, и потерю содержимого сундука нельзя было связать
+				// с релоадом. Штатно она безобидна -- вещи тут же читаются обратно из файла,
+				// но если файл отстал, в логе останется след, с чего всё началось.
+				if (wiped > 0) {
+					log("<Clan> ChestLoad: сундук дружины %s очищен перед перечитыванием, предметов: %d",
+						(*clan)->abbrev.c_str(), wiped);
 				}
 				ExtractObjFromWorld(chest);
 				break;

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -1397,6 +1397,20 @@ void obj_point_update() {
 									 char_get_custom_label(j->get_in_obj(), cont_owner).c_str());
 							act(buf, false, cont_owner, j, nullptr, kToChar);
 					}
+				} else if (j->get_in_obj()->get_in_room() != kNowhere
+						   && !world[j->get_in_obj()->get_in_room()]->people.empty()
+						   && !Clan::is_clan_chest(j->get_in_obj())
+						   && !Clan::is_ingr_chest(j->get_in_obj())) {
+					// issue #3737: контейнер лежит в комнате и ничей -- сообщения не было вовсе, вещь
+					// пропадала совершенно молча. Сундук дружины сюда не идёт: о нём уже сказал
+					// clan_chest_invoice, второе сообщение было бы дублем. Ингр-хран молчит намеренно --
+					// там тысячи ингредиентов, распад каждого превратился бы в спам.
+					char buf[kMaxStringLength];
+					snprintf(buf, kMaxStringLength, "$o рассыпал$U в прах в %s...",
+							 j->get_in_obj()->get_PName(grammar::ECase::kPre).c_str());
+					CharData *witness = world[j->get_in_obj()->get_in_room()]->first_character();
+					act(buf, false, witness, j, nullptr, kToChar);
+					act(buf, false, witness, j, nullptr, kToRoom);
 				}
 				RemoveObjFromObj(j);
 			}


### PR DESCRIPTION
Хвост #3737 (PR #3738): сама пропажа вещей в клановых сундуках починена, а **молчаливость** осталась. Здесь правится только она -- поведение распада не меняется.

## 1. Контейнер, лежащий в комнате

Если контейнер никем не несётся и не надет, `cont_owner` оставался `nullptr` и сообщения не было ни одного -- вещь пропадала совершенно молча. Теперь рассыпание видит комната, ровно так же, как видно рассыпание вещи, лежащей на полу.

Что сюда **не** идёт:

- **сундук дружины** -- о нём уже сказал `clan_chest_invoice` (сообщение тем, у кого включён режим распада, плюс строка в логе дружины), второе сообщение было бы дублем;
- **ингр-хран** -- молчит намеренно: там тысячи ингредиентов, распад каждого превратился бы в спам. В лог дружины он тоже не пишется, лог остаётся только у волшебного сундука.

## 2. Зачистка сундуков в `ChestLoad`

Она молчала полностью -- связать пропажу с `reload clan` по логам было нечем, разбор #3737 шёл по косвенным следам. Теперь в сислог пишется, у какой дружины и сколько предметов выгребли:

```
<Clan> ChestLoad: сундук дружины ДНЗ очищен перед перечитыванием, предметов: 14
```

Штатно это безобидно -- вещи тут же читаются обратно из файла, -- но если файл отстал, в логе останется след, с чего всё началось. На первичной загрузке не срабатывает: в памяти пусто.

## Проверка

Сборка чистая, 577 тестов проходят. В игре не проверял.

🤖 Generated with [Claude Code](https://claude.com/claude-code)