### PR TITLE
fix(register): keep registered chars out of the proxy room

### DIFF
--- a/src/administration/punishments.cpp
+++ b/src/administration/punishments.cpp
@@ -254,7 +254,7 @@ bool SetRegister(CharData *ch, CharData *vict, char *reason) {
 	}
 	ClearPundata(pundata);
 	if (vict->IsFlagged(EPlrFlag::kRegistred)) {
-		SendMsgToChar("Вашей жертва уже зарегистрирована.\r\n", ch);
+		SendMsgToChar("Ваша жертва уже зарегистрирована.\r\n", ch);
 		return false;
 	};
 	sprintf(buf, "%s registered by %s.", GET_NAME(vict), GET_NAME(ch));

--- a/src/engine/ui/login.cpp
+++ b/src/engine/ui/login.cpp
@@ -511,7 +511,10 @@ void do_entergame(DescriptorData *d) {
 		load_room = r_named_start_room;
 	else if (d->character->IsFlagged(EPlrFlag::kFrozen))
 		load_room = r_frozen_start_room;
-	else if (!check_dupes_host(d))
+	// Зарегистрированного в комнату незарегистрированных не сажаем: проверка по IP отказывает
+	// и ему (лимит коннектов с адреса считается для всех), но метка регистрации важнее -- иначе
+	// он окажется в комнате, из которой сам уже не выберется.
+	else if (!check_dupes_host(d) && !RegisterSystem::IsRegistered(d->character.get()))
 		load_room = r_unreg_start_room;
 	else {
 		if ((load_room = GET_LOADROOM(d->character)) == kNowhere) {

--- a/src/gameplay/core/game_limits.cpp
+++ b/src/gameplay/core/game_limits.cpp
@@ -406,6 +406,32 @@ int interpolate(int min_value, int pulse) {
 	}
 	return (sign * (int_p + carry));
 }
+// Вернуть игрока из комнаты для незарегистрированных туда, откуда он в нее попал. Общее для двух
+// случаев: игроку разрешили вход (появилась прокси-запись) и игрока зарегистрировали.
+void ReleaseFromUnregRoom(const CharData::shared_ptr &i) {
+	SendMsgToChar("Неведомая вытолкнула вас из комнаты для незарегистрированных игроков.\r\n", i.get());
+	act(RegisterSystem::IsRegistered(i.get())
+			? "$n появил$u в центре комнаты, показывая всем штампик регистрации.\r\n"
+			: "$n появил$u в центре комнаты, правда без штампика регистрации...\r\n",
+		false, i.get(), nullptr, nullptr, kToRoom);
+
+	int restore = i->get_was_in_room();
+	if (restore == kNowhere
+		|| restore == r_unreg_start_room) {
+		restore = GET_LOADROOM(i);
+		if (restore == kNowhere) {
+			restore = calc_loadroom(i.get());
+		}
+		restore = GetRoomRnum(restore);
+	}
+
+	char_from_room(i);
+	char_to_room(i, restore);
+	sight::look_at_room(i.get(), restore);
+
+	i->set_was_in_room(kNowhere);
+}
+
 void beat_punish(const CharData::shared_ptr &i) {
 	int restore;
 	// Проверяем на выпуск чара из кутузки
@@ -617,25 +643,17 @@ void beat_punish(const CharData::shared_ptr &i) {
 				i->set_was_in_room(kNowhere);
 			};
 		} else if (restore == r_unreg_start_room && check_dupes_host(i->desc, true) && !privilege::IsImmortal(i.get())) {
-			SendMsgToChar("Неведомая вытолкнула вас из комнаты для незарегистрированных игроков.\r\n", i.get());
-			act("$n появил$u в центре комнаты, правда без штампика регистрации...\r\n",
-				false, i.get(), nullptr, nullptr, kToRoom);
-			restore = i->get_was_in_room();
-			if (restore == kNowhere
-				|| restore == r_unreg_start_room) {
-				restore = GET_LOADROOM(i);
-				if (restore == kNowhere) {
-					restore = calc_loadroom(i.get());
-				}
-				restore = GetRoomRnum(restore);
-			}
-
-			char_from_room(i);
-			char_to_room(i, restore);
-			sight::look_at_room(i.get(), restore);
-
-			i->set_was_in_room(kNowhere);
+			ReleaseFromUnregRoom(i);
 		}
+	} else if (i->in_room == r_unreg_start_room
+			   && i->desc
+			   && i->desc->state == EConState::kPlaying
+			   && !privilege::IsImmortal(i.get())) {
+		// Зарегистрированному в комнате незарегистрированных делать нечего. Раньше вытаскивание
+		// жило только в ветке для незарегистрированных, поэтому тот, кого зарегистрировали уже
+		// сидящим там, оставался в ней навсегда: ни регистрация, ни прокси-запись не помогали,
+		// вынести его мог только бог руками.
+		ReleaseFromUnregRoom(i);
 	}
 }
 


### PR DESCRIPTION
Разбор случая с Елизаветой: персонаж с флагом REGED сидел в комнате 103 и не мог из неё выйти, а `register` отказывал -- «жертва уже зарегистрирована».

## 1. Из 103 вытаскивало только незарегистрированных

Ветка выноса в `beat_punish` (`game_limits.cpp`) лежала внутри

```cpp
} else if (!RegisterSystem::IsRegistered(i.get()) && i->desc && i->desc->state == EConState::kPlaying) {
```

То есть работала **только для незарегистрированных**. Кого зарегистрировали уже сидящим в 103 -- оставался там навсегда: ни регистрация, ни добавленная прокси-запись не помогали, до проверки дело просто не доходило. Вынести мог только бог руками.

Добавлена ветка для тех, кто в 103 и не подпал под предыдущие; сам вынос вынесен в `ReleaseFromUnregRoom` и переиспользован обеими ветками. Комнате говорится разное: «показывая всем штампик регистрации» вместо прежнего «правда без штампика регистрации».

## 2. При входе в 103 сажало и зарегистрированных

`login.cpp:514` сажал в 103 всех, кому отказал `check_dupes_host`. А он отказывает и зарегистрированному: лимит коннектов с адреса считается для всех -- это осознанно, так написано в шапке `dupe_check.cpp` («есть proxy запись - проверяем лимит **даже для зарегистрированных**»). В итоге зарегистрированный въезжал в комнату, из которой сам уже не выберется.

Теперь метка регистрации важнее: сообщение о лимите он получит, но в 103 не попадёт.

## 3. Опечатка

`Вашей жертва уже зарегистрирована.` -> `Ваша жертва уже зарегистрирована.`

## Проверка

Сборка чистая, 577 тестов проходят. В игре не проверял.

## Рядом, но не трогал

- `SetRegister` (`punishments.cpp:250`) берёт `Get(vict, EType::kHell)` и делает по нему `ClearPundata` -- то есть регистрация затирает данные наказания **темницей** (срок, причину, бога), а запись `kUnreg` не чистит. И `ClearPundata` вызывается до проверки «уже зарегистрирована», так что данные стираются даже при отказе. Похоже на копипасту, но это отдельная правка.
- `game_limits.cpp:488`: по истечении срока разрегистрации игроку пишут «Ваша регистрация восстановлена», после чего вызывается `UnsetFlag(kRegistred)` вместо `SetFlag` -- флаг не возвращается, а запись наказания уже стёрта.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
