### PR TITLE
fix(db): stop ReadFileToBuffer from writing before its buffer

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -3462,22 +3462,26 @@ int ReadFileToBuffer(const char *name, char *destination_buf) {
 		sprintf(destination_buf + strlen(destination_buf), "Error: file '%s' is empty.\r\n", name);
 		return (0);
 	}
-	do {
-		const char *dummy = fgets(tmp, READ_SIZE, fl);
-		UNUSED_ARG(dummy);
-
-		tmp[strlen(tmp) - 1] = '\0';    // take off the trailing \n
+	// Цикл идёт по результату fgets. Прежний do/while обрабатывал tmp и после неудачного чтения:
+	// на пустом файле strlen() шёл по неинициализированной памяти, а при нулевой длине
+	// tmp[strlen(tmp) - 1] писал байт ПЕРЕД началом буфера.
+	while (fgets(tmp, READ_SIZE, fl)) {
+		const size_t len = strlen(tmp);
+		// перевод строки снимаем, только если он есть: у строки длиннее READ_SIZE и у последней
+		// строки файла без \n прежний код съедал значащий символ
+		if (len > 0 && tmp[len - 1] == '\n') {
+			tmp[len - 1] = '\0';
+		}
 		strcat(tmp, "\r\n");
 
-		if (!feof(fl)) {
-			if (strlen(destination_buf) + strlen(tmp) + 1 > kMaxExtendLength) {
-				log("SYSERR: %s: string too big (%d max)", name, kMaxStringLength);
-				*destination_buf = '\0';
-				return (-1);
-			}
-			strcat(destination_buf, tmp);
+		if (strlen(destination_buf) + strlen(tmp) + 1 > kMaxExtendLength) {
+			log("SYSERR: %s: string too big (%d max)", name, kMaxStringLength);
+			*destination_buf = '\0';
+			fclose(fl);
+			return (-1);
 		}
-	} while (!feof(fl));
+		strcat(destination_buf, tmp);
+	}
 
 	fclose(fl);
 


### PR DESCRIPTION
`ReadFileToBuffer` читал файл циклом `do/while` и обрабатывал `tmp` даже тогда, когда `fgets` ничего не прочитал — результат чтения демонстративно выбрасывался:

```cpp
const char *dummy = fgets(tmp, READ_SIZE, fl);
UNUSED_ARG(dummy);

tmp[strlen(tmp) - 1] = '\0';    // take off the trailing \n
```

Что из этого следует:

1. **Запись перед началом буфера.** На пустом файле `tmp` остаётся неинициализированным: `strlen()` идёт по чужой памяти, а если там оказался ноль в первом байте, `tmp[strlen(tmp) - 1]` — это `tmp[-1]`.
2. **Съеденный символ.** Перевод строки снимался безусловно, поэтому у строки длиннее `READ_SIZE` (её `fgets` обрезает без `\n`) и у последней строки файла без завершающего перевода терялся значащий символ.
3. **Потерянная последняя строка.** Проверка `if (!feof(fl))` отбрасывала содержимое того чтения, на котором выставился EOF. Для файла без финального `\n` это ровно последняя строка.
4. **Утечка дескриптора.** Выход по переполнению `kMaxExtendLength` возвращал -1, не закрыв файл.

## Правка

Цикл идёт по результату `fgets`, `\n` снимается только если он действительно есть, все прочитанные строки попадают в буфер, `fclose` вызывается на обоих выходах.

## Что изменится в игре

Файлы без завершающего перевода строки (справка, тексты) перестанут терять последнюю строку. Всё остальное поведение прежнее.

## Проверка

Сборка чистая, 577 тестов проходят. В игре не проверял.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
