### PR TITLE
feat(io): log who lost output on a buffer overflow

### DIFF
--- a/src/engine/core/iosystem.cpp
+++ b/src/engine/core/iosystem.cpp
@@ -146,6 +146,15 @@ void write_to_output(const char *txt, DescriptorData *t) {
 	if (size + t->bufptr > kLargeBufSize - 1) {
 		t->bufptr = ~0ull;
 		buf_overflows++;
+		// Дальше и до конца такта весь вывод этому дескриптору молча выбрасывается (проверка
+		// bufptr == ~0ull в начале функции), а игрок об этом не узнает. Пишем в сислог, кому и
+		// на какой команде не хватило буфера -- иначе такие случаи видны только счётчиком в
+		// "показать статистика", без единой подробности.
+		log("SYSERR: output overflow: %s [%s], команда '%s', в буфере %zu б, отброшено %zu б",
+			t->character ? GET_NAME(t->character) : "<без персонажа>",
+			*t->host ? t->host : "?",
+			t->last_input,
+			t->bufspace, size);
 		return;
 	}
 	buf_switches++;


### PR DESCRIPTION
Когда вывод не влезает даже в большой буфер (около 47 КБ), дескриптор
переводится в состояние переполнения, и весь дальнейший вывод до конца
такта молча выбрасывается -- проверка bufptr == ~0ull в начале
write_to_output. Игрок при этом не получает ни текста, ни сообщения об
ошибке, а в статистике растёт только счётчик "переполненных буферов" без
единой подробности.

Теперь в сислог пишется, кому и на чём не хватило: имя персонажа, хост,
последняя введённая команда, сколько оставалось в буфере и сколько байт
отброшено.

Типичные виновники -- вывод простыней: базар без фильтра, справка
целиком, показ большого сундука. С этой строкой станет видно, какие
именно команды упираются в потолок, и стоит ли им резать вывод
страницами.

Сборка чистая, 577 тестов проходят.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)