### PR TITLE
fix(io): give the prompt room for a group fight

### DIFF
--- a/src/engine/structs/structs.h
+++ b/src/engine/structs/structs.h
@@ -105,7 +105,11 @@ const int kZonesReset = 1;    // number of zones to reset at one time //
 
 // Variables for the output buffering system //
 constexpr uint16_t kMaxSockBuf = 48 * 1024;	// Size of kernel's sock buf   //
-const uint16_t kMaxPromptLength = 256;		// Max length of prompt        //
+// Сколько байт отводится промпту. В бою он содержит состояние всей группы и цели -- по
+// "[имя:состояние]" на каждого, плюс цветовые последовательности по 7 байт. Группа из трёх
+// упирается в прежние 256 байт: строка обрезалась посреди слова, а под UTF-8 ещё и посреди
+// буквы, и игрок видел хвост из вопросительных знаков (issue #3761).
+const uint16_t kMaxPromptLength = 1024;		// Max length of prompt        //
 const uint8_t kGarbageSpace = 32;				// Space for **OVERFLOW** etc  //
 const uint16_t kSmallBufsize = 1024;			// Static output buffer size   //
 // Max amount of output that can be buffered //


### PR DESCRIPTION
Закрывает #3761. Промпт приклеивается к выводу с обрезкой по
kMaxPromptLength (iosystem.cpp:784), а он равнялся 256 байтам. В бою в
промпт входит состояние всей группы и цели -- по "[имя:состояние]" на
каждого, плюс цветовые последовательности по 7 байт на штуку. Группа из
трёх в этот потолок уже не влезает, и строка обрывается посреди слова.

Под UTF-8 обрыв приходится ещё и на середину буквы: перекодировщик
выводит половинку как "?", отсюда вопросительный знак в конце строки,
про который спрашивал репортёр.

Считал на его же примере: тот промпт в KOI8-R занимает 186 байт и
проходит, в UTF-8 -- ровно 256, то есть впритык, и любой четвёртый
участник боя ломает строку.

Поднял лимит до 1024 байт. Он вычитается из kLargeBufSize, то есть
буфер вывода уменьшается на 768 байт из 47 килобайт -- незаметно.

Сборка чистая, 577 тестов проходят.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)