### PR TITLE
fix(filter): keep the leading "!" as part of the affect name (#3774)

### DIFF
--- a/src/engine/ui/objects_filter.cpp
+++ b/src/engine/ui/objects_filter.cpp
@@ -15,6 +15,7 @@
 #include "gameplay/mechanics/stable_objs.h"
 #include "engine/db/player_index.h"
 #include "gameplay/classes/pc_classes.h"
+#include "utils/utils_string.h"
 
 #include <set>
 
@@ -444,6 +445,15 @@ size_t ParseFilter::affects_cnt() const {
 	return affect_weap.size() + affect_apply.size() + affect_extra.size();
 }
 
+// Совпало ли имя флага с запросом. isname тут не годится: он срезает у запроса ведущие
+// не-буквы, поэтому "!рассыпется" искалось как "рассыпется" и находило противоположный флаг --
+// какой из пары попадётся, решал порядок в таблице, а не запрос (issue #3774). IsEquivalent
+// сравнивает пословно, ведущий "!" остаётся частью имени. FixDot нужен на имени, потому что
+// в apply_types слова разделены точками ("защита.от.стихии.огня"), а Split режет по пробелу.
+static bool MatchAffectName(const char *str, const char *affect_name) {
+	return utils::IsEquivalent(str, utils::FixDot(affect_name));
+}
+
 bool ParseFilter::init_affect(char *str, size_t str_len) {
 	// Аимя!
 	bool strong = false;
@@ -470,7 +480,7 @@ bool ParseFilter::init_affect(char *str, size_t str_len) {
 		if (strong && !strcmp(str, apply_types[num])) {
 			affect_apply.push_back(num);
 			return true;
-		} else if (!strong && isname(str, apply_types[num])) {
+		} else if (!strong && MatchAffectName(str, apply_types[num])) {
 			affect_apply.push_back(num);
 			return true;
 		}
@@ -482,7 +492,7 @@ bool ParseFilter::init_affect(char *str, size_t str_len) {
 			if (strong && !strcmp(str, equipment_affects[num])) {
 				affect_weap.push_back(num);
 				return true;
-			} else if (!strong && isname(str, equipment_affects[num])) {
+			} else if (!strong && MatchAffectName(str, equipment_affects[num])) {
 				affect_weap.push_back(num);
 				return true;
 			}
@@ -496,7 +506,7 @@ bool ParseFilter::init_affect(char *str, size_t str_len) {
 			if (strong && !strcmp(str, extra_bits[num])) {
 				affect_extra.push_back(num);
 				return true;
-			} else if (!strong && isname(str, extra_bits[num])) {
+			} else if (!strong && MatchAffectName(str, extra_bits[num])) {
 				affect_extra.push_back(num);
 				return true;
 			}

--- a/tests/filter.affect_name.cpp
+++ b/tests/filter.affect_name.cpp
@@ -1,0 +1,55 @@
+// Имя аффекта в фильтре предметов ищется вместе с ведущим "!" (issue #3774).
+//
+// В extra_bits лежат два разных флага -- "рассыпется" и "!рассыпется" (не рассыпается).
+// Нестрогий поиск шёл через isname, а тот срезает у запроса ведущие не-буквы, поэтому
+// "!рассыпется" искалось как "рассыпется" и находило противоположный флаг: какой из пары
+// попадётся, решал порядок в таблице, а не запрос. Пара "невидим" / "!невидим" путалась
+// в другую сторону -- там первым в таблице лежит вариант с восклицательным знаком.
+
+#include "engine/ui/objects_filter.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+namespace {
+
+// Разобрать имя аффекта так же, как это делает фильтр "vnum f Аимя", и вернуть
+// то, что фильтр считает разобранным (print печатает найденные флаги по именам).
+std::string ParseAffect(const char *query) {
+	ParseFilter filter(ParseFilter::CLAN);
+	char buffer[kMaxInputLength];
+	strncpy(buffer, query, sizeof(buffer) - 1);
+	buffer[sizeof(buffer) - 1] = '\0';
+	if (!filter.init_affect(buffer, strlen(buffer))) {
+		return "";
+	}
+	return filter.print();
+}
+
+}  // namespace
+
+TEST(ObjectsFilter_AffectName, LeadingBangBelongsToTheName) {
+	EXPECT_EQ(ParseAffect("рассыпется"), "Арассыпется");
+	EXPECT_EQ(ParseAffect("!рассыпется"), "А!рассыпется");
+}
+
+TEST(ObjectsFilter_AffectName, PairWithBangIsNotConfusedInEitherDirection) {
+	// Тут в таблице первым лежит "!невидим", то есть путаница шла в обратную сторону.
+	EXPECT_EQ(ParseAffect("невидим"), "Аневидим");
+	EXPECT_EQ(ParseAffect("!невидим"), "А!невидим");
+}
+
+TEST(ObjectsFilter_AffectName, WordSkippingAndAbbreviationsStillWork) {
+	// Слова запроса ищутся по порядку с пропуском, каждое -- по префиксу.
+	EXPECT_EQ(ParseAffect("защита.от.огня"), "Азащита.от.стихии.огня");
+	EXPECT_EQ(ParseAffect("вплавить"), "Аможно вплавить 1 камень");
+	EXPECT_EQ(ParseAffect("стойк"), "Астойкость");
+}
+
+TEST(ObjectsFilter_AffectName, UnknownNameIsNotParsed) {
+	EXPECT_EQ(ParseAffect("такого.флага.нет"), "");
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -57,6 +57,7 @@ test_sources = files(
     'world_data_source_manager.cpp',
     'bitset_flags.cpp',
     'extra_description.cpp',
+    'filter.affect_name.cpp',
     'trigger_indenter.cpp',
     'trigger_script_parser.cpp',
     'trigger_obj_load_index.cpp',


### PR DESCRIPTION
Закрывает #3774.

`vnum f Тконтейнер А!рассыпется` находил не тот флаг.

В `extra_bits` лежат два разных флага — `рассыпется` (индекс 10) и `!рассыпется` (индекс 13, «не рассыпается»). Нестрогий поиск имени шёл через `isname()`, а он в самом начале срезает у запроса ведущие не-буквы (`utils_string.cpp:924`):

```cpp
for (curstr = str; !a_isalnum(*curstr); curstr++) { ... }
```

`!рассыпется` превращалось в `рассыпется`, перебор шёл по таблице сверху вниз, и первым попадался обычный «рассыпется». Фильтр молча брал противоположный флаг и показывал предметы, которые как раз рассыпаются.

Пара `невидим` / `!невидим` путалась в другую сторону: там первым в таблице лежит вариант с восклицательным знаком, поэтому `Аневидим` находил `!невидим`. То есть какой флаг попадётся, решал порядок в массиве, а не запрос.

## Что сделано

Сравнение имени вынесено в `MatchAffectName()` поверх `utils::IsEquivalent`: слова сопоставляются по порядку с пропуском и по префиксу — ровно то, что делал `isname`, включая разбор точек в именах вроде `защита.от.стихии.огня`, — но ведущий `!` остаётся частью имени.

Строгий поиск (`!` в конце запроса, `strcmp`) не менялся.

**Порядок мёржа.** Разбор точек живёт внутри `IsEquivalent` и приезжает из #3776, поэтому база у этого PR — ветка той правки, а не master. После её мёржа GitHub сам перенацелит базу на master.

## Изменение поведения

Имя флага теперь ищется ровно так, как отображается, включая ведущую звезду: `А*отравлен` вместо `Аотравлен`. Флаги со `*` видны только иммам, игроки с ними не сталкиваются.

## Проверено

`tests/filter.affect_name.cpp` — обе путавшиеся пары плюс проверка, что пропуск слов и сокращения (`защита.от.огня`, `вплавить`, `стойк`) работают по-прежнему. Без правки два теста из четырёх падают, два «что не сломалось» проходят в обоих случаях. Полный прогон — 581 тест зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
