### PR TITLE
fix(utils): split both sides by dots and consume matched words in IsEquivalent

### DIFF
--- a/src/utils/utils_string.cpp
+++ b/src/utils/utils_string.cpp
@@ -144,18 +144,26 @@ bool IsEqual(const std::string &abbr, const std::string &words) {
 
 
 bool IsEquivalent(const std::string &abbr, const std::string &words) {
-	std::vector<std::string> words_list = utils::Split(words);
+	// FixDot с обеих сторон: точка и подчёркивание -- такие же разделители слов, как пробел.
+	// Раньше их разбирали только в запросе, поэтому имя вроде "макс.жизнь" оставалось одним
+	// словом, и даже точное "макс.жизнь" с ним не совпадало.
+	std::vector<std::string> words_list = utils::Split(utils::FixDot(words));
 	std::vector<std::string> abbr_list = utils::Split(utils::FixDot(abbr));
 	auto it = words_list.begin();
 
-	for (auto abr : abbr_list) {
-		for (; it != words_list.end(); it++) {
+	for (const auto &abr : abbr_list) {
+		for (; it != words_list.end(); ++it) {
 			if (utils::IsAbbr(abr.c_str(), (*it).c_str())) {
 				break;
 			}
 		}
-		if (it == words_list.end())
+		if (it == words_list.end()) {
 			return false;
+		}
+		// Совпавшее слово имени занято: следующее слово запроса ищем дальше по имени.
+		// Без этого шага одно слово имени закрывало сколько угодно слов запроса, и
+		// "утренняя.утренняя" считалось совпадением с "утренняя звезда".
+		++it;
 	}
 	return true;
 }

--- a/tests/utils.string.cpp
+++ b/tests/utils.string.cpp
@@ -552,4 +552,26 @@ TEST(Utils_String, IsEquivalent_SkipsWords_ReturnsTrue)
 	EXPECT_TRUE(utils::IsEquivalent("wor", "hello world"));
 }
 
+TEST(Utils_String, IsEquivalent_EachAbbrTakesItsOwnWord)
+{
+	// Слово имени, которое уже совпало, второй раз не засчитывается.
+	EXPECT_FALSE(utils::IsEquivalent("hel hel", "hello world"));
+	EXPECT_TRUE(utils::IsEquivalent("hel hel", "hello hello"));
+}
+
+TEST(Utils_String, IsEquivalent_DotsSplitBothSides)
+{
+	// Точка в имени -- разделитель слов, как и в запросе.
+	EXPECT_TRUE(utils::IsEquivalent("макс.жизнь", "макс.жизнь"));
+	EXPECT_TRUE(utils::IsEquivalent("жизнь", "макс.жизнь"));
+	EXPECT_TRUE(utils::IsEquivalent("hel_wor", "hello_world"));
+}
+
+TEST(Utils_String, IsEquivalent_OrderMatters)
+{
+	// Слова запроса ищутся по порядку, пропуская лишние слова имени.
+	EXPECT_TRUE(utils::IsEquivalent("hel wor", "hello big world"));
+	EXPECT_FALSE(utils::IsEquivalent("wor hel", "hello big world"));
+}
+
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
Замечено при разборе #3774, отдельно от самой правки фильтра (#3775). Две правки в одной функции.

## Точки разбираются только в запросе

```cpp
std::vector<std::string> words_list = utils::Split(words);                  // имя -- по пробелу
std::vector<std::string> abbr_list = utils::Split(utils::FixDot(abbr));     // запрос -- ещё и по точке
```

Имя с точками оставалось одним словом, поэтому `макс.жизнь` не совпадало даже само с собой, а `жизнь` не находило `макс.жизнь`. Точка и подчёркивание — такие же разделители слов, как пробел, так что теперь `FixDot` применяется к обеим сторонам.

Побочный плюс: пропадает нужда звать `FixDot` на стороне имени у вызывающих. Сейчас так приходится делать в пяти местах `do_tabulate.cpp` — правда, для `IsEqual`, у которого ровно та же асимметрия; её можно снять следом.

## Совпавшее слово имени не занималось

```cpp
for (; it != words_list.end(); it++) {
    if (utils::IsAbbr(abr.c_str(), (*it).c_str())) {
        break;
    }
}
```

`break` тут на месте — он выходит из поиска, как только слово запроса нашлось. Но следующее слово запроса начинало поиск **с того же самого слова имени**, поэтому одно слово имени могло закрыть сколько угодно слов запроса: `hel hel` считалось совпадением с `hello world`. Теперь совпавшее слово занято (`++it`).

Порядок и пропуск лишних слов имени не менялись.

## Кого это касается

На `IsEquivalent` опираются поиск заклинаний, умений и талантов (`magic_utils.cpp`), валют (`currencies.cpp`), гильдий (`guilds.cpp`), `msg_container` и — после #3775 — имена флагов в фильтре предметов. Точек в именах там нет (проверил `spells.xml` — 249 имён, ни одного с точкой; `search` у валют вида «медная гривна»), слова запроса разные, так что видимое поведение не меняется: `сереб.грив` по-прежнему находит «серебряная гривна».

## Проверено

`tests/utils.string.cpp` — три новых теста: точки режут обе стороны, занятое слово второй раз не засчитывается, порядок слов по-прежнему обязателен. Без правок падают ровно те тесты, что описывают баги. Полный прогон — 580 тестов зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
