### PR TITLE
fix(utils): split both sides by dots in IsEqual

### DIFF
--- a/src/engine/ui/cmd_god/do_tabulate.cpp
+++ b/src/engine/ui/cmd_god/do_tabulate.cpp
@@ -152,7 +152,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			plane_offset = 0;
 			continue;
 		}
-		if (utils::IsEqual(searchname, utils::FixDot(extra_bits[counter]))) {
+		if (utils::IsEqual(searchname, extra_bits[counter])) {
 			f = true;
 			break;
 		}
@@ -172,7 +172,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 // --------------------- apply_types
 	f = false;
 	for (counter = 0; *apply_types[counter] != '\n'; counter++) {
-		if (utils::IsEqual(searchname, utils::FixDot(apply_types[counter]))) {
+		if (utils::IsEqual(searchname, apply_types[counter])) {
 			f = true;
 			break;
 		}
@@ -199,7 +199,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			plane_offset = 0;
 			continue;
 		}
-		if (utils::IsEqual(searchname, utils::FixDot(equipment_affects[counter]))) {
+		if (utils::IsEqual(searchname, equipment_affects[counter])) {
 			f = true;
 			break;
 		}
@@ -224,7 +224,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			plane_offset = 0;
 			continue;
 		}
-		if (utils::IsEqual(searchname, utils::FixDot(anti_bits[counter]))) {
+		if (utils::IsEqual(searchname, anti_bits[counter])) {
 			f = true;
 			break;
 		}
@@ -249,7 +249,7 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			plane_offset = 0;
 			continue;
 		}
-		if (utils::IsEqual(searchname, utils::FixDot(no_bits[counter]))) {
+		if (utils::IsEqual(searchname, no_bits[counter])) {
 			f = true;
 			break;
 		}

--- a/src/utils/utils_string.cpp
+++ b/src/utils/utils_string.cpp
@@ -130,7 +130,11 @@ bool IsAbbr(const char *arg1, const char *arg2) {
 }
 
 bool IsEqual(const std::string &abbr, const std::string &words) {
-	std::vector<std::string> words_list = utils::Split(words);
+	// FixDot с обеих сторон: точка и подчёркивание -- такие же разделители слов, как пробел.
+	// Раньше их разбирали только в запросе, и вызывающим приходилось помнить про FixDot на
+	// стороне имени (пять мест в do_tabulate.cpp), иначе имя вроде "макс.жизнь" оставалось
+	// одним словом и не совпадало даже само с собой.
+	std::vector<std::string> words_list = utils::Split(utils::FixDot(words));
 	std::vector<std::string> abbr_list = utils::Split(utils::FixDot(abbr));
 	auto it = words_list.begin();
 

--- a/tests/utils.string.cpp
+++ b/tests/utils.string.cpp
@@ -535,6 +535,16 @@ TEST(Utils_String, IsEqual_PrefixAbbrev_ReturnsTrue)
 	EXPECT_TRUE(utils::IsEqual("hel", "hello"));
 }
 
+TEST(Utils_String, IsEqual_DotsSplitBothSides)
+{
+	// Точка в имени -- разделитель слов, как и в запросе.
+	EXPECT_TRUE(utils::IsEqual("макс.жизнь", "макс.жизнь"));
+	EXPECT_TRUE(utils::IsEqual("макс", "макс.жизнь"));
+	EXPECT_TRUE(utils::IsEqual("hel_wor", "hello_world"));
+	// Порядок слов по-прежнему обязателен, пропускать слова имени нельзя.
+	EXPECT_FALSE(utils::IsEqual("жизнь", "макс.жизнь"));
+}
+
 // ===== IsEquivalent =====
 
 TEST(Utils_String, IsEquivalent_AbbreviatedMatch_ReturnsTrue)


### PR DESCRIPTION
Третья правка из той же серии (#3774 → #3775 → #3776), к `IsEqual`.

## Асимметрия

```cpp
std::vector<std::string> words_list = utils::Split(words);                  // имя -- по пробелу
std::vector<std::string> abbr_list = utils::Split(utils::FixDot(abbr));     // запрос -- ещё и по точке
```

Имя с точками оставалось одним словом, поэтому `IsEqual("макс.жизнь", "макс.жизнь")` возвращала ложь. Вызывающим приходилось помнить про `FixDot` на стороне имени — в `do_tabulate.cpp` так сделано в пяти местах подряд:

```cpp
if (utils::IsEqual(searchname, utils::FixDot(extra_bits[counter]))) {
```

## Что сделано

`FixDot` применяется к обеим сторонам, а из пяти вызовов убран — он там теперь лишний. Поведение вызовов не меняется: `FixDot` идемпотентен, и раньше эти места работали правильно именно потому, что делали его сами.

Порядок слов и запрет пропуска слов имени у `IsEqual` не менялись — этим она и отличается от `IsEquivalent`.

## Проверено

`tests/utils.string.cpp` — новый тест: точки режут обе стороны (`макс.жизнь` совпадает сама с собой, `макс` — префикс первого слова, `hel_wor` находит `hello_world`), и тут же зафиксировано, что пропуск слов по-прежнему запрещён (`жизнь` не совпадает с `макс.жизнь`). Без правки тест падает. Полный прогон — 578 тестов зелёные.

Независим от #3776: та правка про `IsEquivalent`, эта про `IsEqual`. Общий файл только `tests/utils.string.cpp`, и правки в нём в разных местах.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
