### PR TITLE
refactor(filter): drop the FixDot now handled inside IsEquivalent

### DIFF
--- a/src/engine/ui/objects_filter.cpp
+++ b/src/engine/ui/objects_filter.cpp
@@ -448,10 +448,10 @@ size_t ParseFilter::affects_cnt() const {
 // Совпало ли имя флага с запросом. isname тут не годится: он срезает у запроса ведущие
 // не-буквы, поэтому "!рассыпется" искалось как "рассыпется" и находило противоположный флаг --
 // какой из пары попадётся, решал порядок в таблице, а не запрос (issue #3774). IsEquivalent
-// сравнивает пословно, ведущий "!" остаётся частью имени. FixDot нужен на имени, потому что
-// в apply_types слова разделены точками ("защита.от.стихии.огня"), а Split режет по пробелу.
+// сравнивает пословно, разбирая точки в именах вроде "защита.от.стихии.огня", и ведущий "!"
+// остаётся частью имени.
 static bool MatchAffectName(const char *str, const char *affect_name) {
-	return utils::IsEquivalent(str, utils::FixDot(affect_name));
+	return utils::IsEquivalent(str, affect_name);
 }
 
 bool ParseFilter::init_affect(char *str, size_t str_len) {


### PR DESCRIPTION
Хвост от #3775 и #3776.

В #3775 `MatchAffectName` разбирала точки в имени флага сама:

```cpp
return utils::IsEquivalent(str, utils::FixDot(affect_name));
```

Это было нужно, потому что тогда `IsEquivalent` применяла `FixDot` только к запросу, и имя вроде `защита.от.стихии.огня` оставалось одним словом. После #3776 она режет по точкам обе стороны — вызов стал лишним.

Поведение не меняется, `FixDot` идемпотентен. Тесты фильтра из #3775 проходят без него, включая `защита.от.огня` на имени `защита.от.стихии.огня`. Полный прогон — 584 теста зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
