### PR TITLE
fix(dg): say what really went wrong with a dgcast target (#3779)

### DIFF
--- a/src/engine/scripting/dg_misc.cpp
+++ b/src/engine/scripting/dg_misc.cpp
@@ -214,20 +214,37 @@ void do_dg_cast(void *go, Trigger *trig, int type, std::string cmd) {
 	ObjData *tobj = nullptr;
 	RoomData *troom = nullptr;
 
+	// Причину неудачи ниже пишем один раз: раньше к разобранной причине ("victim not found",
+	// "в разных клетках комнат") добавлялась ещё и общая строка "target not found", и в логе
+	// на одну неудачу приходилось два сообщения.
+	bool reason_logged = false;
+
 	if (!target_name.empty() && target_name[0] == UID_CHAR) {
 		tch = get_char(target_name.c_str());
 		if (tch == nullptr) {
 			snprintf(buf2, kMaxStringLength, "dg_cast: victim (%s) not found, аргумент: %s", target_name.c_str() + 1, argument.c_str());
 			trig_log(trig, buf2);
+			reason_logged = true;
 		} else if (kNowhere == caster->in_room) {
 			sprintf(buf2, "dg_cast: caster (%s) in kNowhere", caster->get_name().c_str());
 			trig_log(trig, buf2);
+			reason_logged = true;
+		} else if (kNowhere == tch->in_room) {
+			// Цель успела умереть между "set target" и "dgcast": из комнаты её убирают сразу,
+			// а из character_list -- только на следующем пульсе, поэтому get_char её ещё находит.
+			// Без этой ветки такая цель попадала в "в разных клетках комнат" и уводила разбор
+			// не в ту сторону (issue #3779).
+			sprintf(buf2, "dg_cast: цель (%s) уже мертва, аргумент: %s",
+					tch->get_name().c_str(), argument.c_str());
+			trig_log(trig, buf2);
+			reason_logged = true;
 		} else if (tch->in_room != caster->in_room) {
 			sprintf(buf2,
 					"dg_cast: caster (%s) and victim (%s) в разных клетках комнат",
 					caster->get_name().c_str(),
 					tch->get_name().c_str());
 			trig_log(trig, buf2);
+			reason_logged = true;
 		} else {
 			target = 1;
 			troom = world[caster->in_room];
@@ -237,8 +254,14 @@ void do_dg_cast(void *go, Trigger *trig, int type, std::string cmd) {
 	}
 	if (target) {
 		CallMagic(caster, tch, tobj, troom, spell_id, GetRealLevel(caster));
-	} else if (spell_id != ESpell::kResurrection && spell_id != ESpell::kAnimateDead) {
-		sprintf(buf2, "dg_cast: target not found, аргумент: %s", argument.c_str());
+	} else if (!reason_logged && spell_id != ESpell::kResurrection && spell_id != ESpell::kAnimateDead) {
+		if (target_name.empty()) {
+			// Цели не передали вовсе -- обычно %random.pc% в комнате, где живых игроков не осталось.
+			// Прежнее "target not found" читалось как "цель была, но движок её не нашёл".
+			sprintf(buf2, "dg_cast: цель не указана, аргумент: %s", argument.c_str());
+		} else {
+			sprintf(buf2, "dg_cast: target not found, аргумент: %s", argument.c_str());
+		}
 		trig_log(trig, buf2);
 	}
 	if (dummy_mob)


### PR DESCRIPTION
Закрывает #3779.

Разбор лога из тикета: в триггере 97941 (`Люцифер BATTLE1!!`) три каста подряд, и перед каждым `set target %random.pc%` без проверки. Первый каст убил Вултора — он зашёл в комнату с запада в 11:37:00.935 и умер в 11:37:01.095, будучи единственным игроком. На строках 9 и 11 `%random.pc%` возвращать было уже некого, `%target%` разворачивался в пустоту, и `dg_cast` писал `target not found`.

Гипотеза из тикета («умер, перенесён в kNowhere, но из комнаты не удалён») не подтвердилась: `AddToExtractedList()` первым делом зовёт `RemoveCharFromRoom()`, а тот в одном месте и стирает чара из `people`, и ставит `in_room = kNowhere`. Так что виноват был не движок, а формулировка: `target not found` читается как «цель была, но не нашли».

## Что сделано

Поведение не меняется, только лог.

1. **Пустая цель называется пустой.** `dg_cast: цель не указана, аргумент: …` вместо `target not found`. Это обычный исход для `%random.*%` в комнате без подходящих кандидатов.

2. **Умершая цель называется умершей.** Между `set target` и `dgcast` цель может умереть: из комнаты её убирают сразу, а из `character_list` — только на следующем пульсе, поэтому `get_char()` её ещё находит. Такая цель попадала в ветку «в разных клетках комнат», хотя комнаты у неё уже нет. Теперь: `dg_cast: цель (…) уже мертва`. Признак смерти — `in_room == kNowhere`, а не устаревший `purged()`.

3. **Причина не дублируется.** Ветки `victim not found`, `caster in kNowhere` и «в разных клетках комнат» не завершали разбор, поэтому следом всегда печаталось ещё и общее `target not found` — два сообщения на одну неудачу. Теперь общая строка пишется только если конкретной причины не было.

Шум в SCRIPT LOG от самого триггера это не убирает — там нужна проверка `if %target%` перед кастами, но это к автору триггеров.

## Проверено

Сборка чистая, 585 тестов зелёные, малый мир поднимается. Юнит-тестами `do_dg_cast` не покрыт — нужен мир, каст и живой триггер; правка чисто логовая.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
