### PR TITLE
fix(dg): let a sleeping player use commands near a "*" command trigger

### DIFF
--- a/src/engine/scripting/dg_triggers.cpp
+++ b/src/engine/scripting/dg_triggers.cpp
@@ -488,11 +488,13 @@ int command_mtrigger(CharData *actor, char *cmd, const char *argument) {
 				}
 
 				if (compare_cmd(GET_TRIG_NARG(t), t->arglist.c_str(), cmd)) {
-					if (!actor->IsNpc()
-						&& (actor->GetPosition() == EPosition::kSleep))   // command триггер не будет срабатывать если игрок спит
-					{
-						SendMsgToChar("Сделать это в ваших снах?\r\n", actor);
-						return 1;
+					// Спящий игрок command-триггеры не запускает. Раньше здесь команда ещё и
+					// съедалась с ответом "Сделать это в ваших снах?", и рядом с триггером на "*"
+					// (он совпадает с любой командой) спящий не мог выполнить вообще ничего -- в том
+					// числе "проснуться", то есть выбирался только реконнектом. Теперь триггер просто
+					// пропускаем, а команду разбирает интерпретатор со своей проверкой позиции.
+					if (!actor->IsNpc() && actor->GetPosition() == EPosition::kSleep) {
+						continue;
 					}
 
 					ADD_UID_CHAR_VAR(buf, t, actor, "actor", 0);
@@ -1014,11 +1016,10 @@ int cmd_otrig(ObjData *obj, CharData *actor, char *cmd, const char *argument, in
 			if (IS_SET(GET_TRIG_NARG(t), type)
 				&& (t->arglist[0] == '*'
 				|| 0 == strn_cmp(t->arglist.c_str(), cmd, t->arglist.size()))) {
-				if (!actor->IsNpc()
-					&& (actor->GetPosition() == EPosition::kSleep))   // command триггер не будет срабатывать если игрок спит
-				{
-					SendMsgToChar("Сделать это в ваших снах?\r\n", actor);
-					return 1;
+				// Спящий игрок command-триггеры не запускает, но и команду у него не отбираем:
+				// см. комментарий в command_mtrigger.
+				if (!actor->IsNpc() && actor->GetPosition() == EPosition::kSleep) {
+					continue;
 				}
 				ADD_UID_CHAR_VAR(buf, t, actor, "actor", 0);
 				skip_spaces(&argument);
@@ -1397,11 +1398,10 @@ int command_wtrigger(CharData *actor, char *cmd, const char *argument) {
 		}
 
 		if (compare_cmd(GET_TRIG_NARG(t), t->arglist.c_str(), cmd)) {
-			if (!actor->IsNpc()
-				&& (actor->GetPosition() == EPosition::kSleep))   // command триггер не будет срабатывать если игрок спит
-			{
-				SendMsgToChar("Сделать это в ваших снах?\r\n", actor);
-				return 1;
+			// Спящий игрок command-триггеры не запускает, но и команду у него не отбираем:
+			// см. комментарий в command_mtrigger.
+			if (!actor->IsNpc() && actor->GetPosition() == EPosition::kSleep) {
+				continue;
 			}
 // в идеале бы в триггере бой проверять а не хардкодом, ленивые скотины....
 			if (actor->GetPosition() == EPosition::kFight && t->arglist[0] != '*') {


### PR DESCRIPTION
Багрепорт от Мородея: лёг спать, а на `прос` / `проснуться` получал «Сделать это в ваших снах?». Помог только реконнект.

## Что происходит

Командные триггеры проверяются в `interpreter.cpp` **до** поиска самой команды. Если триггер совпал, а игрок спит, движок отвечал и забирал команду себе:

```cpp
if (!actor->IsNpc() && (actor->GetPosition() == EPosition::kSleep)) {
    SendMsgToChar("Сделать это в ваших снах?\r\n", actor);
    return 1;                       // команда считается обработанной
}
```

Достаточно, чтобы арглист триггера совпал с набранной командой. В мире такие есть, и совпадают они как раз с `проснуться` — это командные триггеры комнат снов:

| триггер | арглист | комнаты |
|---|---|---|
| 69318 | `проснуться` | зона 693: 69352, 69360, 69384, 69390–69396 («Синий сон», «Черный сон», «Сон во сне» …) |
| 73794 | `проснуться очнуться пробудиться выйти` | зона 737: 73756–73758 («Порог вещего сна», «Путь огня», «Путь воды») |
| 85208 | `… проснуться проснуть просну прос про` | зона 852: 85211 («Черный лес») |
| 87005 | `проснуться` | зона 870: 87016 («Пустырь») |

Уснув в такой комнате, игрок попадал в тупик: команду `проснуться` забирал триггер, а сам триггер не запускался, потому что игрок спит. Всё остальное работало, но проснуться было нельзя — оставался только реконнект (при входе позиция восстанавливается). С самой командой при этом всё в порядке: у неё минимальная позиция `kSleep`, интерпретатор её пропускает — просто до интерпретатора дело не доходило.

Триггер на `*` (`compare_cmd` возвращает истину для любой команды) запирал бы вообще всё, но таких в мире сейчас нет — проверил все `triggers.yaml`.

Стамина к делу отношения не имеет, она только объясняет, почему он лёг спать.

## Что сделано

Спящий игрок по-прежнему не запускает command-триггеры, но команду у него больше не отбирают: проверка позиции пропускает триггер (`continue`), и команду разбирает интерпретатор со своей проверкой минимальной позиции. `проснуться` работает, а всё, что спящему не положено, интерпретатор отсечёт сам — своим же сообщением.

Правка в трёх местах `dg_triggers.cpp`: `command_mtrigger`, `command_otrigger`, `command_wtrigger`.

## О чём стоит знать

1. Если у триггера осмысленный арглист (скажем, `залезть`), спящий игрок теперь получит «Чаво?» вместо «Сделать это в ваших снах?» — команды-то такой в таблице нет. Менее информативно, зато не запирает. Если хочется сохранить сообщение, можно отвечать только когда арглист не `*`, — скажи, переделаю.
2. Рядом лежит тот же дефект для боя: в `command_wtrigger` проверка `kFight` так же отвечает «Вы не можете это сделать в бою» и забирает команду, то есть триггер на `*` в комнате глушит любые команды в бою. Не трогал — это отдельное решение, там сообщение может быть намеренным.

## Проверено

Сборка чистая, 585 тестов зелёные, малый мир поднимается. Юнит-тестом не покрыть: нужен мир с триггером, спящий игрок и интерпретатор.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
