### PR TITLE
UTF-8: мир пишется в нативной кодировке + скрипт конверсии (#3787)

### DIFF
--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -62,6 +62,24 @@ extern CharData *mob_proto;
 namespace world_loader
 {
 
+namespace {
+
+// Мир на диске -- UTF-8, то есть та же кодировка, в которой движок держит текст (issue #3787).
+// Поэтому пишем как есть: native_text::write_file здесь не годится, он переводит текст
+// в кодировку диска и вернул бы зону в KOI8-R. Загрузка принимает обе кодировки
+// (from_disk_text), так что мир, переведённый не целиком, читается и таким.
+bool WriteWorldFile(const std::string &path, const std::string &text) {
+	std::ofstream out(path, std::ios::binary);
+	if (!out) {
+		return false;
+	}
+	out.write(text.data(), static_cast<std::streamsize>(text.size()));
+	return out.good();
+}
+
+}  // namespace
+
+
 namespace
 {
 
@@ -2743,14 +2761,10 @@ bool YamlWorldDataSource::WriteYamlAtomic(const std::string &filepath, const YAM
 		YAML::Emitter emitter;
 		emitter << node;
 
-		// Файл мира на диске -- KOI8-R, а движок держит текст в нативной кодировке. Собираем
-		// в память и перекодируем один раз при записи через native_text::write_file: иначе
-		// первое же сохранение (OLC или очередь "Reboot saving" из ConvertObjValues) молча
-		// переписывает зону в UTF-8, а загрузка прогоняет её через from_koi8 второй раз --
-		// и мир превращается в кракозябры (issue #3681).
+		// Мир пишется как есть, в нативной кодировке -- см. WriteWorldFile выше (issue #3787).
 		std::ostringstream out;
 		out << emitter.c_str();
-		if (!native_text::write_file(temp_filepath, out.str()))
+		if (!WriteWorldFile(temp_filepath, out.str()))
 		{
 			log("SYSERR: Failed to open temp file for writing: %s", temp_filepath.c_str());
 			return false;
@@ -2794,7 +2808,7 @@ bool YamlWorldDataSource::WriteIndexYaml(const std::string &filepath,
 				out << "- " << v << "\n";
 			}
 		}
-		if (!native_text::write_file(temp_filepath, out.str()))
+		if (!WriteWorldFile(temp_filepath, out.str()))
 		{
 			log("SYSERR: Failed to open temp file for index: %s", temp_filepath.c_str());
 			return false;
@@ -3191,7 +3205,7 @@ void YamlWorldDataSource::SaveZone(int zone_rnum)
 		yaml.DecreaseIndent();
 	}
 
-	if (!native_text::write_file(temp_file, out.str()))
+	if (!WriteWorldFile(temp_file, out.str()))
 	{
 		log("SYSERR: Failed to open temp file for writing: %s", temp_file.c_str());
 		return;
@@ -3382,7 +3396,7 @@ bool YamlWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int not
 			EmitTriggerBody(yaml, trig);
 			yaml.DecreaseIndent();
 		}
-		if (!native_text::write_file(temp_file, out.str()))
+		if (!WriteWorldFile(temp_file, out.str()))
 		{
 			log("SYSERR: Failed to open %s for writing", temp_file.c_str());
 			return false;
@@ -3420,7 +3434,7 @@ bool YamlWorldDataSource::SaveTriggers(int zone_rnum, int specific_vnum, int not
 		yaml.EmptyLine();
 		EmitTriggerBody(yaml, trig);
 
-		if (!native_text::write_file(temp_file, out.str()))
+		if (!WriteWorldFile(temp_file, out.str()))
 		{
 			log("SYSERR: Failed to open %s for writing", temp_file.c_str());
 			continue;
@@ -3688,7 +3702,7 @@ void YamlWorldDataSource::SaveRooms(int zone_rnum, int specific_vnum)
 			EmitRoomBody(yaml, out, room);
 			yaml.DecreaseIndent();
 		}
-		if (!native_text::write_file(temp_file, out.str()))
+		if (!WriteWorldFile(temp_file, out.str()))
 		{
 			log("SYSERR: Failed to open %s for writing", temp_file.c_str());
 			return;
@@ -3724,7 +3738,7 @@ void YamlWorldDataSource::SaveRooms(int zone_rnum, int specific_vnum)
 		yaml.EmptyLine();
 		EmitRoomBody(yaml, out, room);
 
-		if (!native_text::write_file(temp_file, out.str()))
+		if (!WriteWorldFile(temp_file, out.str()))
 		{
 			log("SYSERR: Failed to open %s for writing", temp_file.c_str());
 			continue;
@@ -4335,7 +4349,7 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 			EmitMobBody(yaml, out, *mob);
 			yaml.DecreaseIndent();
 		}
-		if (!native_text::write_file(temp_file, out.str()))
+		if (!WriteWorldFile(temp_file, out.str()))
 		{
 			log("SYSERR: Failed to open %s for writing", temp_file.c_str());
 			return;
@@ -4373,7 +4387,7 @@ void YamlWorldDataSource::SaveMobs(int zone_rnum, int specific_vnum)
 		yaml.EmptyLine();
 		EmitMobBody(yaml, out, *mob);
 
-		if (!native_text::write_file(temp_file, out.str()))
+		if (!WriteWorldFile(temp_file, out.str()))
 		{
 			log("SYSERR: Failed to open %s for writing", temp_file.c_str());
 			continue;
@@ -4810,7 +4824,7 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 			EmitObjectBody(yaml, out, obj);
 			yaml.DecreaseIndent();
 		}
-		if (!native_text::write_file(temp_file, out.str()))
+		if (!WriteWorldFile(temp_file, out.str()))
 		{
 			log("SYSERR: Failed to open %s for writing", temp_file.c_str());
 			return;
@@ -4848,7 +4862,7 @@ void YamlWorldDataSource::SaveObjects(int zone_rnum, int specific_vnum)
 		yaml.EmptyLine();
 		EmitObjectBody(yaml, out, obj);
 
-		if (!native_text::write_file(temp_file, out.str()))
+		if (!WriteWorldFile(temp_file, out.str()))
 		{
 			log("SYSERR: Failed to open %s for writing", temp_file.c_str());
 			continue;

--- a/tools/convert_world_to_utf8.py
+++ b/tools/convert_world_to_utf8.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Перевести файлы мира из KOI8-R в UTF-8 (issue #3787).
+
+Идемпотентен: файл, который уже валидный UTF-8, считается переведённым и не трогается.
+Это та же логика, по которой различает кодировку сам движок (native_text::from_disk_text),
+поэтому повторный прогон безопасен, а прерванный — можно просто повторить.
+
+По умолчанию только показывает, что будет сделано. Для записи нужен --apply.
+
+    ./tools/convert_world_to_utf8.py <каталог>            # посмотреть
+    ./tools/convert_world_to_utf8.py <каталог> --apply    # перевести
+
+Двоичные файлы и файлы, не разбирающиеся ни как UTF-8, ни как KOI8-R, пропускаются
+и перечисляются в конце: их надо посмотреть руками, а не переводить вслепую.
+"""
+
+import argparse
+import os
+import sys
+
+# Расширения, которые в мире содержат текст. Всё остальное (в том числе .bin) не трогаем.
+TEXT_SUFFIXES = {".yaml", ".yml", ".lst", ".xml", ".txt", ".hlp", ".template"}
+
+
+def classify(data: bytes) -> str:
+    """utf8 -- уже переведён; koi8 -- надо перевести; binary -- не текст; unknown -- не понял."""
+    if b"\0" in data:
+        return "binary"
+    try:
+        data.decode("utf-8")
+        return "utf8"
+    except UnicodeDecodeError:
+        pass
+    try:
+        data.decode("koi8-r")
+        return "koi8"
+    except UnicodeDecodeError:
+        return "unknown"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Перевод файлов мира из KOI8-R в UTF-8")
+    parser.add_argument("root", help="каталог мира")
+    parser.add_argument("--apply", action="store_true", help="записать изменения (иначе только показать)")
+    parser.add_argument("--quiet", action="store_true", help="не перечислять каждый файл")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.root):
+        print(f"нет такого каталога: {args.root}", file=sys.stderr)
+        return 2
+
+    counts = {"utf8": 0, "koi8": 0, "binary": 0, "unknown": 0, "skipped": 0}
+    unknown_files = []
+    converted = 0
+
+    for dirpath, _, names in os.walk(args.root):
+        for name in sorted(names):
+            path = os.path.join(dirpath, name)
+            if os.path.splitext(name)[1].lower() not in TEXT_SUFFIXES:
+                counts["skipped"] += 1
+                continue
+            try:
+                with open(path, "rb") as handle:
+                    data = handle.read()
+            except OSError as error:
+                print(f"  не прочитать {path}: {error}", file=sys.stderr)
+                continue
+
+            kind = classify(data)
+            counts[kind] += 1
+            if kind == "unknown":
+                unknown_files.append(os.path.relpath(path, args.root))
+            if kind != "koi8":
+                continue
+
+            if not args.quiet:
+                print(f"  {os.path.relpath(path, args.root)}")
+            if args.apply:
+                text = data.decode("koi8-r").encode("utf-8")
+                # запись через временный файл рядом: прерывание не оставит половину файла
+                temp = path + ".utf8.tmp"
+                with open(temp, "wb") as handle:
+                    handle.write(text)
+                os.replace(temp, path)
+            converted += 1
+
+    print()
+    print(f"уже в UTF-8:      {counts['utf8']}")
+    print(f"{'переведено:' if args.apply else 'будет переведено:':<17} {converted}")
+    print(f"не текст:         {counts['binary']}")
+    print(f"пропущено (не тот суффикс): {counts['skipped']}")
+
+    if unknown_files:
+        print()
+        print(f"НЕ РАЗОБРАЛ {len(unknown_files)} файлов -- посмотрите руками, они не тронуты:")
+        for name in unknown_files[:20]:
+            print(f"    {name}")
+        if len(unknown_files) > 20:
+            print(f"    ... и ещё {len(unknown_files) - 20}")
+        return 1
+
+    if not args.apply and converted:
+        print()
+        print("Это был просмотр. Чтобы записать, повторите с --apply")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Готовит движок к переводу мира на UTF-8 (#3787). Сам мир этим PR не трогается.

## Запись мира

Читать мир движок умеет в обеих кодировках: `from_disk_text` считает валидный UTF-8 уже
переведённым, а всё прочее — KOI8-R. А пишет через `native_text::write_file`, то есть переводит
в кодировку диска. После перевода мира это означало бы, что зона, отредактированная в OLC, тихо
возвращается в KOI8-R — мир не ломается, загрузка принимает обе, но и не сходится к одной.

Одиннадцать точек записи мира переведены на локальный `WriteWorldFile`, который пишет как есть.
Остальные вызовы `native_text::write_file` не тронуты: они про конфиги и данные игроков, те
переводятся отдельно (#3788).

## Скрипт конверсии

`tools/convert_world_to_utf8.py` — для файлов мира вне git. Идемпотентен: уже переведённый файл
не трогает, поэтому повторный и прерванный прогон безопасны. По умолчанию только показывает,
для записи нужен `--apply`. Файлы, не разбирающиеся ни как UTF-8, ни как KOI8-R, не трогает
и перечисляет отдельно.

## Проверено

На дампе `world.20260817`: скрипт перевёл 2877 файлов (188 уже были в UTF-8, ни одного
неразобранного), движок на переведённом мире грузится и отображает кириллицу верно.
Сборка чистая, 666 тестов проходят.

**Чего не проверял:** круг «сохранить зону из OLC и посмотреть кодировку файла» — для него нужен
бессмертный, а под рукой был персонаж 28 уровня. Правка на этом пути механическая (замена
вызова), но вживую он не прогонялся.

## Порядок: влить можно сразу, выкатывать — нет

Влить в master безопасно. А вот **выкатывать на боевой раньше перевода мира нельзя**: движок
будет писать зоны в UTF-8, тогда как в репозитории мира ещё действует
`working-tree-encoding=KOI8-R`. Git возьмёт UTF-8-байты, сочтёт их кои-восьмыми и перекодирует
ещё раз — в репозиторий уедет каша, а не «зона в другой кодировке»:

```
файл в дереве: name: d0 bc d0 b5 d1 87        ← «меч» в UTF-8
блоб в git:    name: d0 bf e2 95 aa d0 bf …   ← двойная перекодировка
```

Симметрично и обратное: старый движок на уже переведённом мире положит зону кои-восьмым блобом
среди UTF-8. Поэтому переход делается с остановленным сервером, а порядок шагов расписан
в инструкции.

Инструкция по самой миграции: https://static.kvirund.dev/utf8-world-3787.html

