### PR TITLE
fix(status): walk the argument by characters, not by bytes

### DIFF
--- a/src/engine/ui/cmd/do_display.cpp
+++ b/src/engine/ui/cmd/do_display.cpp
@@ -38,8 +38,12 @@ void do_display(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	} else {
 		set_display_bits(ch, false);
 
+		// Аргумент перебираем посимвольно, а не побайтно: под UTF-8 русская буква занимает два
+		// байта, и шаг в один байт приводил ко второму, хвостовому байту буквы. Он не совпадал
+		// ни с одной меткой и уводил в default, то есть свой набор букв поставить было нельзя
+		// вовсе -- работали только "статус все" и "статус нет".
 		const size_t len = strlen(argument);
-		for (size_t i = 0; i < len; i++) {
+		for (size_t i = 0; i < len; i += native_text::char_bytes(argument + i)) {
 			switch (native_text::first_char_code_lower(argument + i)) {
 				case 'h':
 				case rus::kZhe: ch->SetFlag(EPrf::kDispHp);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -65,6 +65,7 @@ test_sources = files(
     'world_data_source_manager.cpp',
     'bitset_flags.cpp',
     'extra_description.cpp',
+    'status.command.cpp',
     'filter.affect_name.cpp',
     'trigger_indenter.cpp',
     'trigger_script_parser.cpp',

--- a/tests/status.command.cpp
+++ b/tests/status.command.cpp
@@ -1,0 +1,69 @@
+// Команда "статус" со своим набором букв (issue: статус все/нет работали, свой набор -- нет).
+//
+// Аргумент разбирался побайтно, а под UTF-8 русская буква занимает два байта: после каждой
+// буквы шаг в один байт приводил к её хвостовому байту, тот не совпадал ни с одной меткой и
+// уводил разбор в default -- команда печатала справку и не ставила ничего. Латиница из одного
+// байта при этом работала, поэтому баг выглядел как "русские буквы не принимаются".
+
+#include "engine/ui/cmd/do_display.h"
+
+#include "simulator/character_builder.h"
+#include "engine/entities/char_data.h"
+#include "gameplay/core/constants.h"
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+namespace {
+
+CharData::shared_ptr MakePlayer(simulator::CharacterBuilder &builder) {
+	builder.make_basic_player(static_cast<short>(ECharClass::kSorcerer), 30);
+	return builder.get();
+}
+
+void RunStatus(const CharData::shared_ptr &ch, const char *argument) {
+	char buffer[64];
+	strncpy(buffer, argument, sizeof(buffer) - 1);
+	buffer[sizeof(buffer) - 1] = '\0';
+	do_display(ch.get(), buffer, 0, 0);
+}
+
+}  // namespace
+
+TEST(StatusCommand, CyrillicLettersSetTheirOwnFlags) {
+	simulator::CharacterBuilder builder;
+	auto ch = MakePlayer(builder);
+
+	RunStatus(ch, "жзв");
+
+	EXPECT_TRUE(ch->IsFlagged(EPrf::kDispHp)) << "Ж -- жизнь";
+	EXPECT_TRUE(ch->IsFlagged(EPrf::kDispMana)) << "З -- запас сил";
+	EXPECT_TRUE(ch->IsFlagged(EPrf::kDispExits)) << "В -- выходы";
+	EXPECT_FALSE(ch->IsFlagged(EPrf::kDispMoney)) << "Д не набирали";
+}
+
+TEST(StatusCommand, LatinLettersStillWork) {
+	simulator::CharacterBuilder builder;
+	auto ch = MakePlayer(builder);
+
+	RunStatus(ch, "hw");
+
+	EXPECT_TRUE(ch->IsFlagged(EPrf::kDispHp));
+	EXPECT_TRUE(ch->IsFlagged(EPrf::kDispMana));
+	EXPECT_FALSE(ch->IsFlagged(EPrf::kDispExits));
+}
+
+TEST(StatusCommand, UnknownLetterStopsParsing) {
+	simulator::CharacterBuilder builder;
+	auto ch = MakePlayer(builder);
+
+	RunStatus(ch, "жяв");
+
+	// Поведение как было: неизвестная буква печатает справку и обрывает разбор, но то, что
+	// успело примениться до неё, остаётся.
+	EXPECT_TRUE(ch->IsFlagged(EPrf::kDispHp)) << "Ж до неизвестной буквы";
+	EXPECT_FALSE(ch->IsFlagged(EPrf::kDispExits)) << "В после неё уже не разбирается";
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
`статус все` и `статус нет` работают, а свой набор букв поставить нельзя — команда печатает справку и ничего не меняет.

## Почему

Первые два варианта разбираются через `str_cmp` до цикла, поэтому они и работали. Свой набор разбирался побайтно:

```cpp
const size_t len = strlen(argument);
for (size_t i = 0; i < len; i++) {
    switch (native_text::first_char_code_lower(argument + i)) {
```

Под UTF-8 русская буква занимает два байта. После каждой буквы шаг в один байт приводил к её хвостовому байту — он не совпадает ни с одной меткой и уводит разбор в `default`, то есть в справку и `return`. На модели видно наглядно:

```
посимвольно      -> ['ж', 'з', 'в']
побайтно (как было) -> ['ж', '?мусор?', 'з', '?мусор?', 'в', '?мусор?']
```

Латиница из одного байта при этом работала: `статус hw` ставил флаги как надо. Отсюда и вид бага — «русские буквы не принимаются».

## Что сделано

Шаг по символу, `native_text::char_bytes`. Для однобайтовых букв это тот же шаг на единицу, так что латиница ведёт себя как раньше. Функция всегда возвращает не меньше единицы, зациклиться цикл не может.

## Тест

`tests/status.command.cpp`: кириллический набор (`жзв` → жизнь, запас сил, выходы), латиница (`hw`) и поведение при неизвестной букве — разбор обрывается, а применённое до неё остаётся; это как было, тест просто фиксирует.

Без правки падает ровно тест с кириллицей, два других проходят в обоих случаях. Полный прогон — 672 теста зелёные.

## До выката

Обходной путь для игроков — латинские буквы: `статус жзв` = `статус hwe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
