### PR TITLE
fix(zedit): read the yes/no answer by character, not by byte

### DIFF
--- a/src/engine/olc/zedit.cpp
+++ b/src/engine/olc/zedit.cpp
@@ -1900,15 +1900,20 @@ void zedit_parse(DescriptorData *d, char *arg) {
 
 		case ZEDIT_RESET_IDLE:
 			// * Parse and add new reset_idle and return to main menu.
-			if (!arg[0] || !strchr("YyNnДдНн", arg[0])) {
-				SendMsgToChar("Повторите ввод (y или n) : ", d->character.get());
-			} else {
-				if (strchr("YyДд", arg[0]))
-					OLC_ZONE(d)->reset_idle = 1;
-				else
-					OLC_ZONE(d)->reset_idle = 0;
-				OLC_ZONE(d)->vnum = 1;
-				zedit_disp_menu(d);
+			{
+				// Ответ сверяем по символу, а не по байту: в UTF-8 "Д", "д", "Н" и "н" начинаются
+				// с одного и того же байта 0xD0, поэтому strchr по строке с кириллицей находил
+				// любой из них в обоих списках -- и "нет" срабатывало как "да".
+				const char32_t answer = native_text::first_char_code_lower(arg);
+				const bool yes = (answer == 'y' || answer == rus::kDe);
+				const bool no = (answer == 'n' || answer == rus::kEn);
+				if (!yes && !no) {
+					SendMsgToChar("Повторите ввод (y или n) : ", d->character.get());
+				} else {
+					OLC_ZONE(d)->reset_idle = yes ? 1 : 0;
+					OLC_ZONE(d)->vnum = 1;
+					zedit_disp_menu(d);
+				}
 			}
 			break;
 


### PR DESCRIPTION
Найдено при сплошном проходе по байт-против-символа после #3795.

## Что не так

Вопрос «сбрасывать ли пустую зону» в zedit разбирался через `strchr` по строке с кириллицей:

```cpp
if (!arg[0] || !strchr("YyNnДдНн", arg[0])) {
    SendMsgToChar("Повторите ввод (y или n) : ", d->character.get());
} else {
    if (strchr("YyДд", arg[0]))
```

`strchr` сравнивает **байты**, а в UTF-8 «Д» (D0 94), «д» (D0 B4), «Н» (D0 9D) и «н» (D0 BD) начинаются с одного и того же байта — `0xD0`. Значит любой русский ответ находился и в первом списке (принят), и во втором (истолкован как «да»). Ответ «н» ставил `reset_idle = 1`, то есть строго наоборот.

Латинские `y` и `n` работали правильно — они однобайтовые.

## Что сделано

Ответ читается символом через `native_text::first_char_code_lower` и сверяется с `'y'`/`'n'` и `rus::kDe`/`rus::kEn`. Регистр функция складывает сама, отдельные заглавные варианты не нужны.

## Проверено

Сборка чистая, 669 тестов зелёные. Юнит-тестом не покрыть: разбор сидит внутри диалога OLC и требует дескриптора.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
