### PR TITLE
fix(olc): выравнивать колонки меню по символам, через fmt (#3797)

### DIFF
--- a/src/engine/olc/medit.cpp
+++ b/src/engine/olc/medit.cpp
@@ -705,8 +705,7 @@ void medit_disp_positions(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (i = 0; *position_types[i] != '\n'; i++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s\r\n", grn, i, nrm, position_types[i]);
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {}\r\n", grn, i, nrm, position_types[i]), d->character.get());
 	}
 	SendMsgToChar("Выберите положение : ", d->character.get());
 }
@@ -747,9 +746,9 @@ void medit_disp_resistances(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (i = 0; *resistance_types[i] != '\n'; i++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s : %s%d%s\r\n",
-				grn, i + 1, nrm, resistance_types[i], cyn, GET_RESIST(OLC_MOB(d), i), nrm);
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {} : {}{}{}\r\n",
+									  grn, i + 1, nrm, resistance_types[i], cyn, GET_RESIST(OLC_MOB(d), i), nrm),
+					  d->character.get());
 	}
 	SendMsgToChar("Введите номер и величину сопротивления (-100..100%) (0 - конец) : ", d->character.get());
 }
@@ -762,9 +761,9 @@ void medit_disp_saves(DescriptorData *d) {
 #endif
 	for (auto i: apply_negative) {
 		if (i.savetype != ESaving::kNone) {
-			snprintf(buf, sizeof(buf), "%s%2d%s) %s : %s%d%s\r\n",
-					grn, num++, nrm, i.name.c_str(), cyn, GetSave(OLC_MOB(d), i.savetype), nrm);
-			SendMsgToChar(buf, d->character.get());
+			SendMsgToChar(fmt::format("{}{:2d}{}) {} : {}{}{}\r\n",
+										  grn, num++, nrm, i.name.c_str(), cyn, GetSave(OLC_MOB(d), i.savetype), nrm),
+						  d->character.get());
 		}
 	}
 	SendMsgToChar("Введите номер и величину спас-броска, отрицательное улучшает (0 - конец) : ", d->character.get());
@@ -881,8 +880,7 @@ void medit_disp_sex(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (i = 0; i <= NUM_GENDERS; i++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s\r\n", grn, i, nrm, genders[i]);
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {}\r\n", grn, i, nrm, genders[i]), d->character.get());
 	}
 	SendMsgToChar("Выберите пол : ", d->character.get());
 }
@@ -931,9 +929,9 @@ void medit_disp_features(DescriptorData *d) {
 			snprintf(buf1, sizeof(buf1), "     ");
 		}
 
-		snprintf(buf, kMaxStringLength, "%s%3d%s) %25s%s%s", grn, to_underlying(feat.GetId()), nrm,
-				 feat.GetCName(), buf1, !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:3d}{}) {:>25}{}{}",
+									  grn, to_underlying(feat.GetId()), nrm, feat.GetCName(), buf1, !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 
 	SendMsgToChar("\r\nУкажите номер способности. (0 - конец) : ", d->character.get());
@@ -945,8 +943,7 @@ void medit_disp_race(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (i = 0; i < ENpcRace::kLastNpcRace - ENpcRace::kBasic + 1; i++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s\r\n", grn, i, nrm, npc_race_types[i]);
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {}\r\n", grn, i, nrm, npc_race_types[i]), d->character.get());
 	}
 	SendMsgToChar("Выберите расу моба : ", d->character.get());
 }
@@ -958,8 +955,9 @@ void medit_disp_attack_types(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (i = 0; i < NUM_ATTACK_TYPES; i++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s\r\n", grn, i, nrm, fight::GetAttackTypeDescription(i).c_str());
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {}\r\n",
+									  grn, i, nrm, fight::GetAttackTypeDescription(i).c_str()),
+					  d->character.get());
 	}
 	SendMsgToChar("Выберите тип удара : ", d->character.get());
 }
@@ -972,12 +970,12 @@ void medit_disp_helpers(DescriptorData *d) {
 #endif
 	SendMsgToChar("Установлены мобы-помощники :\r\n", d->character.get());
 	for (auto helper : OLC_MOB(d)->summon_helpers) {
-		snprintf(buf, sizeof(buf), "%s%6d%s %s", grn, helper, nrm, !(++columns % 6) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:6d}{} {}",
+									  grn, helper, nrm, !(++columns % 6) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	if (!columns) {
-		snprintf(buf, sizeof(buf), "%sНЕТ%s", cyn, nrm);
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}НЕТ{}", cyn, nrm), d->character.get());
 	}
 	SendMsgToChar("\r\nУкажите vnum моба-помощника (0 - конец) : ", d->character.get());
 }
@@ -998,9 +996,9 @@ void medit_disp_skills(DescriptorData *d) {
 			snprintf(buf1, sizeof(buf1), "     ");
 		}
 
-		snprintf(buf, kMaxStringLength, "%s%3d%s) %25s%s%s", grn, to_underlying(skill.GetId()), nrm,
-				 skill.GetName(), buf1, !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:3d}{}) {:>25}{}{}",
+									  grn, to_underlying(skill.GetId()), nrm, skill.GetName(), buf1, !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	SendMsgToChar("\r\nУкажите номер и уровень владения умением (0 - конец) : ", d->character.get());
 }
@@ -1019,9 +1017,9 @@ void medit_disp_spells(DescriptorData *d) {
 		} else {
 			snprintf(buf1, sizeof(buf1), "     ");
 		}
-		snprintf(buf, kMaxStringLength, "%s%3d%s) %25s%s%s", grn, to_underlying(spell_id), nrm,
-				 MUD::Spell(spell_id).GetCName(), buf1, !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:3d}{}) {:>25}{}{}",
+									  grn, to_underlying(spell_id), nrm, MUD::Spell(spell_id).GetCName(), buf1, !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	SendMsgToChar("\r\nУкажите номер и количество заклинаний (0 - конец) : ", d->character.get());
 }
@@ -1030,15 +1028,17 @@ void medit_disp_spells(DescriptorData *d) {
 void medit_disp_mob_flags(DescriptorData *d) {
 	disp_planes_values(d, action_bits, 2);
 	OLC_MOB(d)->char_specials.saved.mob_flags.sprintbits(action_bits, buf1, sizeof(buf1), ",", 5);
-	snprintf(buf, kMaxStringLength, "\r\nТекущие флаги : %s%s%s\r\nВыберите флаг (0 - выход) : ", cyn, buf1, nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\nТекущие флаги : {}{}{}\r\nВыберите флаг (0 - выход) : ",
+								  cyn, buf1, nrm),
+				  d->character.get());
 }
 
 void medit_disp_npc_flags(DescriptorData *d) {
 	disp_planes_values(d, function_bits, 2);
 	OLC_MOB(d)->mob_specials.npc_flags.sprintbits(function_bits, buf1, sizeof(buf1), ",", 5);
-	snprintf(buf, kMaxStringLength, "\r\nТекущие флаги : %s%s%s\r\nВыберите флаг (0 - выход) : ", cyn, buf1, nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\nТекущие флаги : {}{}{}\r\nВыберите флаг (0 - выход) : ",
+								  cyn, buf1, nrm),
+				  d->character.get());
 }
 
 // * Display affection flags menu.
@@ -1046,17 +1046,17 @@ void medit_disp_aff_flags(DescriptorData *d) {
 	const auto &order = affects::MenuOrder();
 	int col = 0;
 	for (size_t i = 0; i < order.size(); ++i) {
-		snprintf(buf1, sizeof(buf1), "%s%3zu%s) %-25.25s", grn, i + 1, nrm,
-				affects::AffectMsg(order[i], affects::EAffectMsgType::kShortDesc).c_str());
-		SendMsgToChar(buf1, d->character.get());
+		SendMsgToChar(fmt::format("{}{:3d}{}) {:<25.25}", grn, i + 1, nrm,
+								  affects::AffectMsg(order[i], affects::EAffectMsgType::kShortDesc)),
+					  d->character.get());
 		if (++col % 2 == 0) {
 			SendMsgToChar("\r\n", d->character.get());
 		}
 	}
 	const std::string cur = affects::DescribeActive(OLC_MOB(d)->char_specials.saved.affected_by, ", ");
-	snprintf(buf, kMaxStringLength, "\r\nCurrent flags   : %s%s%s\r\nEnter aff flag number (0 to quit) : ",
-			cyn, cur.c_str(), nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\nCurrent flags   : {}{}{}\r\nEnter aff flag number (0 to quit) : ",
+								  cyn, cur.c_str(), nrm),
+				  d->character.get());
 }
 
 // * Display main menu.
@@ -1070,7 +1070,7 @@ void medit_disp_menu(DescriptorData *d) {
 		"[H[J"
 #endif
 			"-- МОБ:  [%s%d%s]\r\n"
-			"%s1%s) Пол: %s%-7.7s%s\r\n"
+			"%s1%s) Пол: %s%s%s\r\n"
 			"%s2%s) Синонимы: %s&S%s&s\r\n"
 			"%s3&n) Именительный (это кто)         : %s&e\r\n"
 			"%s4&n) Родительный (нет кого)         : %s&e\r\n"
@@ -1087,7 +1087,9 @@ void medit_disp_menu(DescriptorData *d) {
 			"%sK%s) Класс защиты: [%s%4d%s],%sL%s) Опыт        : [%s%9ld%s],\r\n"
 			"%sM%s) Куны        : [%s%4ld%s],%sN%s) NumGoldDice : [%s%4d%s],%sO%s) SizeGoldDice: [%s%4d%s]\r\n",
 			cyn, OLC_NUM(d), nrm,
-			grn, nrm, yel, genders[(int) mob->get_sex()], nrm,
+			// Поле пола ровняем по символам: printf меряет ширину в байтах, и русское "женский"
+			// занимало вдвое больше, чем показывал %-7.7s (issue #3797).
+			grn, nrm, yel, fmt::format("{:<7.7}", genders[(int) mob->get_sex()]).c_str(), nrm,
 			grn, nrm, yel, GET_ALIAS(mob),
 			grn, GET_PAD(mob, 0),
 			grn, GET_PAD(mob, 1),

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -43,6 +43,7 @@
 #include "engine/db/global_objects.h"
 #include "gameplay/mechanics/dungeons.h"
 #include <sys/stat.h>
+#include <fmt/format.h>
 
 #include <array>
 #include <vector>
@@ -478,8 +479,7 @@ void oedit_disp_prompt_apply_menu(DescriptorData *d) {
 			SendMsgToChar(buf, d->character.get());
 			SendMsgToChar("\r\n", d->character.get());
 		} else {
-			snprintf(buf, sizeof(buf), "%s%d%s) Ничего.\r\n", grn, counter + 1, nrm);
-			SendMsgToChar(buf, d->character.get());
+			SendMsgToChar(fmt::format("{}{}{}) Ничего.\r\n", grn, counter + 1, nrm), d->character.get());
 		}
 	}
 	SendMsgToChar("\r\nВыберите изменяемый аффект (0 - выход) : ", d->character.get());
@@ -493,12 +493,11 @@ void oedit_liquid_type(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (counter = 0; counter < NUM_LIQ_TYPES; counter++) {
-		snprintf(buf, sizeof(buf), " %s%2d%s) %s%-20.20s %s", grn, counter, nrm, yel,
-				drinks[counter], !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format(" {}{:2d}{}) {}{:<20.20} {}",
+									  grn, counter, nrm, yel, drinks[counter], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
-	snprintf(buf, sizeof(buf), "\r\n%sВыберите тип жидкости : ", nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\n{}Выберите тип жидкости : ", nrm), d->character.get());
 	OLC_MODE(d) = OEDIT_VALUE_3;
 }
 
@@ -508,9 +507,9 @@ void show_apply_olc(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (counter = 0; counter < EApply::kNumberApplies; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-40.40s %s", grn, counter, nrm,
-				apply_types[counter], !(++columns % 3) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<40.40} {}",
+									  grn, counter, nrm, apply_types[counter], !(++columns % 3) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	SendMsgToChar("\r\nЧто добавляем (0 - выход) : ", d->character.get());
 }
@@ -528,9 +527,9 @@ void oedit_disp_weapon_menu(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (counter = 0; counter < NUM_ATTACK_TYPES; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s %s", grn, counter, nrm,
-				fight::GetAttackTypeDescription(counter).c_str(), !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}",
+									  grn, counter, nrm, fight::GetAttackTypeDescription(counter).c_str(), !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	SendMsgToChar("\r\nВыберите тип удара (0 - выход): ", d->character.get());
 }
@@ -545,12 +544,11 @@ void oedit_disp_spells_menu(DescriptorData *d) {
 		if (MUD::Spell(spell_id).IsInvalid()) {
 			continue;
 		}
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s%-30.30s %s", grn, to_underlying(spell_id), nrm, yel,
-				MUD::Spell(spell_id).GetCName(), !(++columns % 4) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {}{:<30.30} {}",
+									  grn, to_underlying(spell_id), nrm, yel, MUD::Spell(spell_id).GetCName(), !(++columns % 4) ? "\r\n" : ""),
+					  d->character.get());
 	}
-	snprintf(buf, sizeof(buf), "\r\n%sВыберите магию (0 - выход) : ", nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\n{}Выберите магию (0 - выход) : ", nrm), d->character.get());
 }
 
 void oedit_disp_skills2_menu(DescriptorData *d) {
@@ -563,12 +561,11 @@ void oedit_disp_skills2_menu(DescriptorData *d) {
 			continue;
 		}
 
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s%-20.20s %s", grn, to_underlying(skill_id), nrm, yel,
-				MUD::Skill(skill_id).GetName(), !(++columns % 3) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {}{:<20.20} {}",
+									  grn, to_underlying(skill_id), nrm, yel, MUD::Skill(skill_id).GetName(), !(++columns % 3) ? "\r\n" : ""),
+					  d->character.get());
 	}
-	snprintf(buf, sizeof(buf), "\r\n%sВыберите умение (0 - выход) : ", nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\n{}Выберите умение (0 - выход) : ", nrm), d->character.get());
 }
 
 void oedit_disp_receipts_menu(DescriptorData *d) {
@@ -577,12 +574,11 @@ void oedit_disp_receipts_menu(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (int counter = 0; counter <= top_imrecipes; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s%-20.20s %s", grn, counter, nrm, yel,
-				imrecipes[counter].name, !(++columns % 3) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {}{:<20.20} {}",
+									  grn, counter, nrm, yel, imrecipes[counter].name, !(++columns % 3) ? "\r\n" : ""),
+					  d->character.get());
 	}
-	snprintf(buf, sizeof(buf), "\r\n%sВыберите рецепт : ", nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\n{}Выберите рецепт : ", nrm), d->character.get());
 }
 
 void oedit_disp_feats_menu(DescriptorData *d) {
@@ -595,12 +591,11 @@ void oedit_disp_feats_menu(DescriptorData *d) {
 			continue;
 		}
 
-		snprintf(buf, sizeof(buf), "%s%2d%s) %s%-20.20s %s", grn, to_underlying(feat.GetId()), nrm, yel,
-				feat.GetCName(), !(++columns % 3) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {}{:<20.20} {}",
+									  grn, to_underlying(feat.GetId()), nrm, yel, feat.GetCName(), !(++columns % 3) ? "\r\n" : ""),
+					  d->character.get());
 	}
-	snprintf(buf, sizeof(buf), "\r\n%sВыберите способность (0 - выход) : ", nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\n{}Выберите способность (0 - выход) : ", nrm), d->character.get());
 }
 
 void oedit_disp_skills_mod_menu(DescriptorData *d) {
@@ -620,9 +615,9 @@ void oedit_disp_skills_mod_menu(DescriptorData *d) {
 		} else {
 			strncpy(buf1, "     ", sizeof(buf1) - strlen(buf1) - 1);
 		}
-		snprintf(buf, kMaxStringLength, "%s%3d%s) %25s%s%s", grn, to_underlying(skill_id), nrm,
-				 MUD::Skill(skill_id).GetName(), buf1, !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:3d}{}) {:>25}{}{}",
+									  grn, to_underlying(skill_id), nrm, MUD::Skill(skill_id).GetName(), buf1, !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	SendMsgToChar("\r\nУкажите номер и уровень владения умением (0 - конец) : ", d->character.get());
 }
@@ -889,11 +884,9 @@ void oedit_disp_val4_menu(DescriptorData *d) {
 
 		case EObjType::kMagicComponent:
 			// названия классов -- из единого источника GetIngredientClassName
-			snprintf(buf, sizeof(buf), "Класс ингредиента (0-%s, 1-%s, 2-%s): ",
-					GetIngredientClassName(EIngredientClass::kRosl),
-					GetIngredientClassName(EIngredientClass::kJiv),
-					GetIngredientClassName(EIngredientClass::kTverd));
-			SendMsgToChar(buf, d->character.get());
+			SendMsgToChar(fmt::format("Класс ингредиента (0-{}, 1-{}, 2-{}): ",
+										  GetIngredientClassName(EIngredientClass::kRosl), GetIngredientClassName(EIngredientClass::kJiv), GetIngredientClassName(EIngredientClass::kTverd)),
+						  d->character.get());
 			break;
 
 		case EObjType::kCraftMaterial: SendMsgToChar("Введите условный уровень: ", d->character.get());
@@ -913,9 +906,9 @@ void oedit_disp_type_menu(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (counter = 0; counter < NUM_ITEM_TYPES; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s %s", grn, counter, nrm,
-				item_types[counter], !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}",
+									  grn, counter, nrm, item_types[counter], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	SendMsgToChar("\r\nВыберите тип предмета : ", d->character.get());
 }
@@ -976,9 +969,9 @@ void oedit_disp_wear_menu(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (counter = 0; counter < NUM_ITEM_WEARS; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s %s", grn, counter + 1, nrm,
-				wear_bits[counter], !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}",
+									  grn, counter + 1, nrm, wear_bits[counter], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	sprintbit(OLC_OBJ(d)->get_wear_flags(), wear_bits, buf1, sizeof(buf1));
 	snprintf(buf,
@@ -996,9 +989,9 @@ void oedit_disp_mater_menu(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (counter = 0; counter < 32 && *material_name[counter] != '\n'; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s %s", grn, counter + 1, nrm,
-				material_name[counter], !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}",
+									  grn, counter + 1, nrm, material_name[counter], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	snprintf(buf, sizeof(buf), "\r\nСделан из : %s%s%s\r\n"
 				 "Выберите материал (0 - выход) : ", cyn, material_name[OLC_OBJ(d)->get_material()], nrm);
@@ -1011,9 +1004,9 @@ void oedit_disp_ingradient_menu(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (counter = 0; counter < 32 && *ingradient_bits[counter] != '\n'; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s %s", grn, counter + 1, nrm,
-				ingradient_bits[counter], !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}",
+									  grn, counter + 1, nrm, ingradient_bits[counter], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	sprintbit(OLC_OBJ(d)->get_spec_param(), ingradient_bits, buf1, sizeof(buf1));
 	snprintf(buf, kMaxStringLength, "\r\nТип ингредиента : %s%s%s\r\n" "Дополните тип (0 - выход) : ", cyn, buf1, nrm);
@@ -1023,9 +1016,9 @@ void oedit_disp_ingradient_menu(DescriptorData *d) {
 void oedit_disp_magic_container_menu(DescriptorData *d) {
 	int counter, columns = 0;
 	for (counter = 0; counter < 32 && *magic_container_bits[counter] != '\n'; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s %s", grn, counter + 1, nrm,
-				magic_container_bits[counter], !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}",
+									  grn, counter + 1, nrm, magic_container_bits[counter], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	sprintbit(OLC_OBJ(d)->get_spec_param(), magic_container_bits, buf1, sizeof(buf1));
 	snprintf(buf, kMaxStringLength, "\r\nТип контейнера : %s%s%s\r\n" "Дополните тип (0 - выход) : ", cyn, buf1, nrm);
@@ -1208,13 +1201,9 @@ void oedit_disp_skills_menu(DescriptorData *d) {
 #endif
 	int columns = 0;
 	for (size_t counter = 0; counter < wskill_bits.size(); counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s %s",
-				grn,
-				static_cast<int>(counter + 1),
-				nrm,
-				wskill_bits[counter],
-				!(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}",
+									  grn, static_cast<int>(counter + 1), nrm, wskill_bits[counter], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	snprintf(buf, sizeof(buf),
 			"%sТренируемое умение : %s%d%s\r\n"

--- a/src/engine/olc/olc.cpp
+++ b/src/engine/olc/olc.cpp
@@ -9,6 +9,7 @@
 ***************************************************************************/
 
 #include "olc.h"
+#include <fmt/format.h>
 
 #include "engine/db/obj_prototypes.h"
 #include "engine/entities/obj_data.h"
@@ -444,8 +445,9 @@ void disp_planes_values(DescriptorData *d, const char *names[], short num_column
 			c++;
 		if (d->character->GetLevel() < kLvlImplementator && *names[counter] == '*')
 			continue;
-		sprintf(buf, "&g%c%d&n) %-30.30s %s", c, plane, names[counter], !(++column % num_column) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("&g{}{}&n) {:<30.30} {}",
+								  c, plane, names[counter], !(++column % num_column) ? "\r\n" : ""),
+					  d->character.get());
 	}
 }
 

--- a/src/engine/olc/redit.cpp
+++ b/src/engine/olc/redit.cpp
@@ -34,6 +34,7 @@
 #include "engine/core/sysdep.h"
 #include "engine/core/conf.h"
 #include "gameplay/mechanics/dungeons.h"
+#include <fmt/format.h>
 
 #include <sys/stat.h>
 
@@ -486,9 +487,9 @@ void redit_disp_sector_menu(DescriptorData *d) {
 	SendMsgToChar("[H[J", d->character);
 #endif
 	for (counter = 0; counter < NUM_ROOM_SECTORS; counter++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s %s", grn, counter, nrm,
-				sector_types[counter], !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}",
+									  grn, counter, nrm, sector_types[counter], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	SendMsgToChar("\r\nТип поверхности в комнате : ", d->character.get());
 	OLC_MODE(d) = REDIT_SECTOR;

--- a/src/engine/olc/zedit.cpp
+++ b/src/engine/olc/zedit.cpp
@@ -25,6 +25,7 @@
 #include "engine/core/sysdep.h"
 #include "engine/core/conf.h"
 #include <sys/stat.h>
+#include <fmt/format.h>
 
 #include <vector>
 
@@ -933,15 +934,15 @@ void zedit_disp_menu(DescriptorData *d) {
 				 grn, nrm, ired, type1_zones, nrm, grn, nrm, grn, type2_zones, nrm);
 		SendMsgToChar(buf, d->character.get());
 	}
-	snprintf(buf, kMaxStringLength, "%sT%s) Режим            : %s%s%s\r\n",
-			 grn, nrm, yel, OLC_ZONE(d)->under_construction ? "ТЕСТИРУЕТСЯ" : "подключена", nrm);
-	SendMsgToChar(buf, d->character.get());
-	snprintf(buf, kMaxStringLength, "%sG%s) Оптимальное число игроков  : %s%d%s\r\n",
-			 grn, nrm, yel, OLC_ZONE(d)->group, nrm);
-	SendMsgToChar(buf, d->character.get());
-	snprintf(buf, kMaxStringLength, "%sV%s) Стартовая комната зоны     : %s%d%s\r\n",
-			 grn, nrm, yel, OLC_ZONE(d)->entrance, nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("{}T{}) Режим            : {}{}{}\r\n",
+								  grn, nrm, yel, OLC_ZONE(d)->under_construction ? "ТЕСТИРУЕТСЯ" : "подключена", nrm),
+				  d->character.get());
+	SendMsgToChar(fmt::format("{}G{}) Оптимальное число игроков  : {}{}{}\r\n",
+								  grn, nrm, yel, OLC_ZONE(d)->group, nrm),
+				  d->character.get());
+	SendMsgToChar(fmt::format("{}V{}) Стартовая комната зоны     : {}{}{}\r\n",
+								  grn, nrm, yel, OLC_ZONE(d)->entrance, nrm),
+				  d->character.get());
 	
 	// Print the commands into display buffer.
 	zedit_disp_commands(d);
@@ -988,9 +989,9 @@ void zedit_disp_type_menu(DescriptorData *d) {
 	// of vnums is the configuration author's responsibility (the legacy ztypes.lst
 	// loader implicitly assumed 0..N-1 contiguous slots, the registry doesn't).
 	for (const auto &zone_type : MUD::ZoneTypes()) {
-		sprintf(buf, "%s%2d%s) %-20.20s %s", grn, zone_type.GetId(), nrm,
-				zone_type.GetName().c_str(), !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20} {}", grn, zone_type.GetId(), nrm,
+								  zone_type.GetName(), !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 	SendMsgToChar("\r\nВыберите тип зоны : ", d->character.get());
 }

--- a/src/engine/scripting/dg_olc.cpp
+++ b/src/engine/scripting/dg_olc.cpp
@@ -16,6 +16,7 @@
 
 #include "utils/native_text.h"
 #include "dg_olc.h"
+#include <fmt/format.h>
 
 #include <memory>
 #include <string>
@@ -401,13 +402,15 @@ void trigedit_disp_types(DescriptorData *d) {
 #endif
 
 	for (i = 0; i < NUM_TRIG_TYPE_FLAGS; i++) {
-		snprintf(buf, sizeof(buf), "%s%2d%s) %-20.20s  %s", grn, i + 1, nrm, types[i], !(++columns % 2) ? "\r\n" : "");
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}{:2d}{}) {:<20.20}  {}",
+									  grn, i + 1, nrm, types[i], !(++columns % 2) ? "\r\n" : ""),
+					  d->character.get());
 	}
 
 	sprintbit(GET_TRIG_TYPE(OLC_TRIG(d)), types, buf1, sizeof(buf1), 2);
-	snprintf(buf, kMaxStringLength, "\r\nCurrent types : %s%s%s\r\nEnter type (0 to quit) : ", cyn, buf1, nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\nCurrent types : {}{}{}\r\nEnter type (0 to quit) : ",
+								  cyn, buf1, nrm),
+				  d->character.get());
 }
 
 void trigedit_parse(DescriptorData *d, char *arg) {
@@ -990,9 +993,9 @@ void dg_script_menu(DescriptorData *d) {
 #undef FMT
 
 	for (const auto trigger_vnum : OLC_SCRIPT(d)) {
-		snprintf(buf, sizeof(buf), "     %2d) [%s%d%s] %s%s%s", ++i, cyn,
-				trigger_vnum, nrm, cyn, trig_index[GetTriggerRnum(trigger_vnum)]->proto->get_name().c_str(), nrm);
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("     {:2d}) [{}{}{}] {}{}{}",
+									  ++i, cyn, trigger_vnum, nrm, cyn, trig_index[GetTriggerRnum(trigger_vnum)]->proto->get_name().c_str(), nrm),
+					  d->character.get());
 		if (trig_index[GetTriggerRnum(trigger_vnum)]->proto->get_attach_type() != OLC_ITEM_TYPE(d)) {
 			snprintf(buf, sizeof(buf), "   %s** Mis-matched Trigger Type **%s\r\n", grn, nrm);
 		} else {

--- a/src/gameplay/mechanics/obj_sets_olc.cpp
+++ b/src/gameplay/mechanics/obj_sets_olc.cpp
@@ -5,6 +5,7 @@
 #include "utils/russian_keys.h"
 #include "utils/native_text.h"
 #include "utils/grammar/declensions.h"
+#include <fmt/format.h>
 
 #include <string>
 #include <vector>
@@ -1191,16 +1192,14 @@ void sedit::show_activ_skill(CharData *ch) {
 
 	int col = 0;
 	std::string out;
-	char buf_[128];
 
 	for (auto i = ESkill::kFirst; i <= ESkill::kLast; ++i) {
 		if (MUD::Skills().IsInvalid(i)) {
 			continue;
 		}
-		snprintf(buf_, sizeof(buf_), "%s%3d%s) %25s     %s",
-				 kColorGrn, to_underlying(i), kColorNrm,
-				 MUD::Skill(i).GetName(), !(++col % 2) ? "\r\n" : "");
-		out += buf_;
+		out += fmt::format("{}{:3d}{}) {:>25}     {}",
+						   kColorGrn, to_underlying(i), kColorNrm,
+						   MUD::Skill(i).GetName(), !(++col % 2) ? "\r\n" : "");
 	}
 	SendMsgToChar(out, ch);
 	SendMsgToChar(


### PR DESCRIPTION
Первый заход по #3797 — меню OLC, они в issue первым приоритетом.

## Было

Ширина поля задавалась printf-ом (`%-20.20s`, `%-30.30s`, `%25s`), а printf меряет её в **байтах**. Меню магии в `oedit` уходило клиенту так:

```
 1) легкое исцелени�  2) серьезное исцел�  3) критическое исц�  4) исцеление
 5) групповое исцел�  6) великое исцелен�  7) клич мощи               8) увеличить жизнь
```

Длинные названия резались посреди буквы (последний байт битый), короткие добивались до 30 байт, то есть до пятнадцати символов вместо тридцати — и колонка плясала.

## Стало

`fmt::format` для UTF-8 считает и ширину, и точность **по символам**, так что `"{:<20.20}"` делает ровно то, что `"%-20.20s"` делал под KOI8-R. Проверил на нашей сборке fmt:

```
{:<20}  "легкое исцеление"  -> 16 символов + 4 пробела
{:.10}  "легкое исцеление"  -> "легкое исц", буква не рвётся
```

Заодно вывод этих меню переехал со `snprintf` в глобальный `buf` на `fmt::format` с локальной строкой — общего буфера в этих местах больше нет.

## Объём

42 места в семи файлах: `oedit` (21), `medit` (15), `zedit` (4), `dg_olc` (3), `redit`, `olc`, `obj_sets_olc`. Большая часть правки механическая: `"%s%2d%s) %-20.20s %s"` → `"{}{:2d}{}) {:<20.20} {}"`.

Отдельно в `medit` поле пола (`%-7.7s`) осталось внутри большого многострочного `snprintf` — там аргумент теперь готовится через `fmt::format("{:<7.7}", ...)` и передаётся уже готовой строкой.

## Проверено

Сборка чистая (заодно убрал ставший ненужным буфер в `obj_sets_olc`, из-за него был warning), 669 тестов зелёные.

## Дальше по issue

Остаются игроцкие места (`im.cpp`, `modify.cpp`, `do_levels.cpp`, `title.cpp`), списки банов и команды богов (`do_tabulate`, `do_stat`, `do_show`, `dg_scripts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
