### PR TITLE
fix(liquid): вычищать хвостовой пробел и у пустой ёмкости

### DIFF
--- a/src/gameplay/mechanics/liquid.cpp
+++ b/src/gameplay/mechanics/liquid.cpp
@@ -574,26 +574,26 @@ static std::string CutLiquidName(const std::string &name, size_t pos, size_t sep
 	return utils::TrimRightCopy(name.substr(0, pos - separator_len));
 }
 
-void name_from_drinkcon(ObjData *obj) {
-	size_t pos = find_liquid_name(obj->get_aliases().c_str());
-	if (pos == std::string::npos || pos < 1) {
-		return;
+// Снять с одного поля название жидкости. Если снимать нечего -- всё равно срезать хвостовые
+// пробелы: у пустой ёмкости название жидкости уже снято, а пробел от старой обрезки в имени
+// остался, и "бросить" показывал "древний череп  ." с дырой перед точкой.
+static std::string StripLiquidName(const std::string &name, size_t separator_len) {
+	const size_t pos = find_liquid_name(name.c_str());
+	if (pos == std::string::npos || pos < separator_len) {
+		return utils::TrimRightCopy(name);
 	}
-	obj->set_aliases(CutLiquidName(obj->get_aliases(), pos, 1));
+	return CutLiquidName(name, pos, separator_len);
+}
 
-	pos = find_liquid_name(obj->get_short_description().c_str());
-	if (pos == std::string::npos || pos < kLiquidSeparator.length()) {
-		return;
-	}
-	obj->set_short_description(CutLiquidName(obj->get_short_description(), pos, kLiquidSeparator.length()));
+void name_from_drinkcon(ObjData *obj) {
+	// Каждое поле обрабатываем независимо: раньше первое же поле без названия жидкости
+	// прерывало разбор остальных, и падежи расходились между собой.
+	obj->set_aliases(StripLiquidName(obj->get_aliases(), 1));
+	obj->set_short_description(StripLiquidName(obj->get_short_description(), kLiquidSeparator.length()));
 
 	for (int c = grammar::ECase::kFirstCase; c <= grammar::ECase::kLastCase; c++) {
 		auto name_case = static_cast<grammar::ECase>(c);
-		pos = find_liquid_name(obj->get_PName(name_case).c_str());
-		if (pos == std::string::npos || pos < kLiquidSeparator.length()) {
-			return;
-		}
-		obj->set_PName(name_case, CutLiquidName(obj->get_PName(name_case), pos, kLiquidSeparator.length()));
+		obj->set_PName(name_case, StripLiquidName(obj->get_PName(name_case), kLiquidSeparator.length()));
 	}
 }
 

--- a/tests/liquid.name_roundtrip.cpp
+++ b/tests/liquid.name_roundtrip.cpp
@@ -85,4 +85,17 @@ TEST(LiquidNameRoundTrip, StoredExtraSpaceHealsOnReload) {
 	EXPECT_EQ(jar->get_aliases().find("  "), std::string::npos) << "в синонимах двойных пробелов тоже быть не должно";
 }
 
+TEST(LiquidNameRoundTrip, EmptyJarLosesTheStrayTrailingSpace) {
+	// Пустую ёмкость снятие названия жидкости раньше не трогало вовсе: снимать нечего, разбор
+	// выходил на первом же поле. Пробел, оставшийся в имени от старой обрезки, так и жил в файле
+	// вещей, и "бросить" показывал "древний череп  ." -- с дырой перед точкой.
+	auto jar = MakeJar("древний череп ");
+
+	name_from_drinkcon(jar.get());
+
+	EXPECT_EQ(jar->get_short_description(), "древний череп");
+	EXPECT_EQ(jar->get_PName(grammar::ECase::kAcc), "древний череп") << "падежи тоже";
+	EXPECT_EQ(jar->get_aliases(), "древний череп") << "и синонимы";
+}
+
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
```
бро все чере
Вы бросили древний череп  .
Вы бросили древний череп  .
```

Дыра перед точкой — хвостовой пробел в имени предмета. Тянется он из времён, когда обрезка снимала три байта разделителя `" с "` вместо четырёх (в UTF-8 буква «с» двухбайтовая), и такие имена успели уехать в файлы вещей.

## Почему самолечение не сработало

В прошлой правке `name_from_drinkcon` научился срезать хвостовые пробелы — но только там, где нашёл название жидкости:

```cpp
size_t pos = find_liquid_name(obj->get_aliases().c_str());
if (pos == std::string::npos || pos < 1) {
    return;                       // <- у пустой ёмкости выходим сразу
}
```

У **пустой** ёмкости названия жидкости нет ни в одном поле — снимать нечего, разбор выходит на первой же строке, и пробел остаётся навсегда. Именно такие черепа игрок и бросал: в инвентаре они значились как `древний череп [2]`, без жидкости.

Тем же `return` обрывался и разбор падежей: поле без названия жидкости прекращало обработку остальных, так что падежи могли разойтись между собой.

## Что сделано

Каждое поле обрабатывается отдельно, и хвостовые пробелы срезаются в любом случае:

```cpp
static std::string StripLiquidName(const std::string &name, size_t separator_len) {
    const size_t pos = find_liquid_name(name.c_str());
    if (pos == std::string::npos || pos < separator_len) {
        return utils::TrimRightCopy(name);
    }
    return CutLiquidName(name, pos, separator_len);
}
```

Чинится при первой же загрузке вещи: `obj_save` зовёт `name_from_drinkcon` для каждой ёмкости.

## Тест

`LiquidNameRoundTrip.EmptyJarLosesTheStrayTrailingSpace` — пустая ёмкость с пробелом в имени: проверяются краткое имя, падеж и синонимы. Без правки падает. Полный прогон — 673 теста зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
