### PR TITLE
fix(ui): досчитать оставшиеся колонки по символам, через fmt (#3797)

### DIFF
--- a/src/administration/ban.cpp
+++ b/src/administration/ban.cpp
@@ -16,6 +16,13 @@
 
 #include <fmt/format.h>
 
+// Ширину колонок считает fmt: printf меряет её в байтах, и русское имя бога в графе
+// "Banned By" ломало столбец, а обрезка по .16 могла разрубить букву пополам (issue #3797).
+namespace {
+constexpr auto kBanRow = "{:<25.25}  {:<8.8}  {:<10.10}  {:<16.16} {:<8.8}\r\n";
+constexpr auto kProxyRow = "{:<25.25}  {:<16.16}\r\n";
+}  // namespace
+
 const std::string &BanList::ban_filename() { return MUD::StateManager().Path(state::EStateFile::kBannedSites); }
 const std::string &BanList::proxy_ban_filename() { return MUD::StateManager().Path(state::EStateFile::kBannedProxies); }
 const char *BanList::ban_types[] = {
@@ -312,26 +319,20 @@ void BanList::ShowBannedIp(int sort_mode, CharData *ch) {
 	}
 
 	SortIp(sort_mode);
-	char format[kMaxInputLength], to_unban[kMaxInputLength], buff[kMaxInputLength], *listbuf = nullptr, *timestr;
-	strcpy(format, "%-25.25s  %-8.8s  %-10.10s  %-16.16s %-8.8s\r\n");
-	sprintf(buf, format, "Banned Site Name", "Ban Type", "Banned On", "Banned By", "To Unban");
-
-	listbuf = str_add(listbuf, buf);
-	sprintf(buf, format,
-			"---------------------------------",
-			"---------------------------------",
-			"---------------------------------",
-			"---------------------------------", "---------------------------------");
-	listbuf = str_add(listbuf, buf);
+	char to_unban[kMaxInputLength], buff[kMaxInputLength], *listbuf = nullptr, *timestr;
+	listbuf = str_add(listbuf, fmt::format(fmt::runtime(kBanRow),
+										   "Banned Site Name", "Ban Type", "Banned On", "Banned By", "To Unban").c_str());
+	listbuf = str_add(listbuf, fmt::format(fmt::runtime(kBanRow),
+										   "-------------------------", "--------", "----------",
+										   "----------------", "--------").c_str());
 
 	for (auto &i : ban_list_) {
 		timestr = asctime(localtime(&(i->BanDate)));
 		*(timestr + 10) = 0;
 		strcpy(to_unban, timestr);
 		sprintf(buff, "%ldh", static_cast<long int>(i->UnbanDate - time(nullptr)) / 3600);
-		sprintf(buf, format, i->BannedIp.c_str(), ban_types[i->BanType],
-				to_unban, i->BannerName.c_str(), buff);
-		listbuf = str_add(listbuf, buf);
+		listbuf = str_add(listbuf, fmt::format(fmt::runtime(kBanRow), i->BannedIp, ban_types[i->BanType],
+											   to_unban, i->BannerName, buff).c_str());
 		strcpy(buf, i->BanReason.c_str());
 		strcat(buf, "\r\n");
 		listbuf = str_add(listbuf, buf);
@@ -348,17 +349,12 @@ void BanList::ShowBannedIpByMask(int sort_mode, CharData *ch, const char *mask) 
 	}
 
 	SortIp(sort_mode);
-	char format[kMaxInputLength], to_unban[kMaxInputLength], buff[kMaxInputLength], *listbuf = nullptr, *timestr;
-	strcpy(format, "%-25.25s  %-8.8s  %-10.10s  %-16.16s %-8.8s\r\n");
-	sprintf(buf, format, "Banned Site Name", "Ban Type", "Banned On", "Banned By", "To Unban");
-
-	listbuf = str_add(listbuf, buf);
-	sprintf(buf, format,
-			"---------------------------------",
-			"---------------------------------",
-			"---------------------------------",
-			"---------------------------------", "---------------------------------");
-	listbuf = str_add(listbuf, buf);
+	char to_unban[kMaxInputLength], buff[kMaxInputLength], *listbuf = nullptr, *timestr;
+	listbuf = str_add(listbuf, fmt::format(fmt::runtime(kBanRow),
+										   "Banned Site Name", "Ban Type", "Banned On", "Banned By", "To Unban").c_str());
+	listbuf = str_add(listbuf, fmt::format(fmt::runtime(kBanRow),
+										   "-------------------------", "--------", "----------",
+										   "----------------", "--------").c_str());
 
 	for (auto &i : ban_list_) {
 		if (strncmp(i->BannedIp.c_str(), mask, strlen(mask)) == 0) {
@@ -366,9 +362,8 @@ void BanList::ShowBannedIpByMask(int sort_mode, CharData *ch, const char *mask) 
 			*(timestr + 10) = 0;
 			strcpy(to_unban, timestr);
 			sprintf(buff, "%ldh", static_cast<long int>(i->UnbanDate - time(nullptr)) / 3600);
-			sprintf(buf, format, i->BannedIp.c_str(), ban_types[i->BanType],
-					to_unban, i->BannerName.c_str(), buff);
-			listbuf = str_add(listbuf, buf);
+			listbuf = str_add(listbuf, fmt::format(fmt::runtime(kBanRow), i->BannedIp, ban_types[i->BanType],
+												   to_unban, i->BannerName, buff).c_str());
 			strcpy(buf, i->BanReason.c_str());
 			strcat(buf, "\r\n");
 			listbuf = str_add(listbuf, buf);
@@ -390,14 +385,12 @@ void BanList::ShowBannedProxy(int sort_mode, CharData *ch) {
 		return;
 	}
 	SortProxy(sort_mode);
-	char format[kMaxInputLength], *listbuf = nullptr;
-	strcpy(format, "%-25.25s  %-16.16s\r\n");
-	sprintf(buf, format, "Banned Site Name", "Banned By");
-	SendMsgToChar(buf, ch);
-	sprintf(buf, format, "---------------------------------", "---------------------------------");
-	listbuf = str_add(listbuf, buf);
+	char *listbuf = nullptr;
+	SendMsgToChar(fmt::format(fmt::runtime(kProxyRow), "Banned Site Name", "Banned By"), ch);
+	listbuf = str_add(listbuf, fmt::format(fmt::runtime(kProxyRow),
+										   "-------------------------", "----------------").c_str());
 	for (auto &i : proxy_ban_list_) {
-		sprintf(buf, format, i->BannedIp.c_str(), i->BannerName.c_str());
+		snprintf(buf, kMaxStringLength, "%s", fmt::format(fmt::runtime(kProxyRow), i->BannedIp, i->BannerName).c_str());
 		listbuf = str_add(listbuf, buf);
 	}
 	page_string(ch->desc, listbuf, 1);

--- a/src/engine/olc/medit.cpp
+++ b/src/engine/olc/medit.cpp
@@ -1323,7 +1323,8 @@ void medit_parse(DescriptorData *d, char *arg) {
 
 			//-------------------------------------------------------------------
 		case MEDIT_MAIN_MENU: i = 0;
-			olc_log("%s command %c", GET_NAME(d->character), *arg);
+			olc_log("%s command %s", GET_NAME(d->character),
+					std::string(arg, native_text::char_bytes(arg)).c_str());
 			switch (native_text::first_char_code(arg)) {
 				case 'q':
 				case 'Q':

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -1743,7 +1743,8 @@ void oedit_parse(DescriptorData *d, char *arg) {
 				default: oedit_disp_menu(d);
 					break;
 			}
-			olc_log("%s command %c", GET_NAME(d->character), *arg);
+			olc_log("%s command %s", GET_NAME(d->character),
+					std::string(arg, native_text::char_bytes(arg)).c_str());
 			return;
 			// * end of OEDIT_MAIN_MENU
 

--- a/src/engine/olc/redit.cpp
+++ b/src/engine/olc/redit.cpp
@@ -669,7 +669,8 @@ void redit_parse(DescriptorData *d, char *arg) {
 					redit_disp_menu(d);
 					break;
 			}
-			olc_log("%s command %c", GET_NAME(d->character), *arg);
+			olc_log("%s command %s", GET_NAME(d->character),
+					std::string(arg, native_text::char_bytes(arg)).c_str());
 			return;
 
 		case OLC_SCRIPT_EDIT:

--- a/src/engine/scripting/dg_event.cpp
+++ b/src/engine/scripting/dg_event.cpp
@@ -98,7 +98,7 @@ void print_event_list(CharData *ch)
 		if (!wed || !wed->trigger) {
 			continue;
 		}
-		sprintf(buf, "[%-3d] Trigger: %s, VNum: [%5d]\r\n", trig_counter, GET_TRIG_NAME(wed->trigger), GET_TRIG_VNUM(wed->trigger));
+		sprintf(buf, "[%-3d] Trigger: %s, VNum: [%7d]\r\n", trig_counter, GET_TRIG_NAME(wed->trigger), GET_TRIG_VNUM(wed->trigger));
 //		if (wed->trigger->wait_line != nullptr) {
 		if (wed->trigger->wait_event.time_remaining > 0 && wed->trigger->wait_line != nullptr) {
 			sprintf(buf+strlen(buf), "    Wait: %d, Current line: %s (num line: %d)\r\n", GET_TRIG_WAIT(wed->trigger).time_remaining, 

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -953,10 +953,13 @@ void script_stat(CharData *ch, Script *sc) {
 		snprintf(namebuf, sizeof(namebuf), "%s:%ld", tv.name.c_str(), tv.context);
 		if (tv.value[0] == UID_CHAR || tv.value[0] == UID_ROOM || tv.value[0] == UID_OBJ || tv.value[0] == UID_CHAR_ALL) {
 			find_uid_name(tv.value.c_str(), name, sizeof(name));
-			snprintf(buf, sizeof(buf), "    %15s:  %s\r\n", tv.context ? namebuf : tv.name.c_str(), name);
+			// Ширину колонки имени считает fmt: printf меряет её в байтах, и русское имя
+			// переменной ломало столбец (issue #3797).
+			SendMsgToChar(fmt::format("    {:>15}:  {}\r\n",
+									  tv.context ? namebuf : tv.name.c_str(), name), ch);
 		} else
-			snprintf(buf, sizeof(buf), "    %15s:  %s\r\n", tv.context ? namebuf : tv.name.c_str(), tv.value.c_str());
-		SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("    {:>15}:  {}\r\n",
+									  tv.context ? namebuf : tv.name.c_str(), tv.value), ch);
 	}
 
 	for (auto t : sc->script_trig_list) {
@@ -1007,11 +1010,10 @@ void script_stat(CharData *ch, Script *sc) {
 				if (!var_name.empty()) {
 					if (tv.value[0] == UID_CHAR || tv.value[0] == UID_ROOM || tv.value[0] == UID_OBJ || tv.value[0] == UID_CHAR_ALL) {
 						find_uid_name(tv.value.c_str(), name, sizeof(name));
-						snprintf(buf, sizeof(buf), "    %15s:  %s\r\n", var_name.c_str(), name);
+						SendMsgToChar(fmt::format("    {:>15}:  {}\r\n", var_name, name), ch);
 					} else {
-						snprintf(buf, sizeof(buf), "    %15s:  %s\r\n", var_name.c_str(), tv.value.c_str());
+						SendMsgToChar(fmt::format("    {:>15}:  {}\r\n", var_name, tv.value), ch);
 					}
-					SendMsgToChar(buf, ch);
 				}
 			}
 		}

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -832,7 +832,7 @@ void do_stat_trigger(CharData *ch, Trigger *trig, bool need_num) {
 		return;
 	}
 
-	snprintf(sb, sizeof(sb), "Name: '%s%s%s',  VNum: [%s%5d%s], RNum: [%5d]\r\n",
+	snprintf(sb, sizeof(sb), "Name: '%s%s%s',  VNum: [%s%7d%s], RNum: [%7d]\r\n",
 			kColorYel, trig->get_name().c_str(), kColorNrm,
 			kColorGrn, trig_index[(trig)->get_rnum()]->vnum,
 			kColorNrm, trig->get_rnum());
@@ -963,7 +963,7 @@ void script_stat(CharData *ch, Script *sc) {
 	}
 
 	for (auto t : sc->script_trig_list) {
-		snprintf(buf, sizeof(buf), "\r\n  Trigger: %s%s%s, VNum: [%s%5d%s], RNum: [%5d], Context: [%ld]\r\n",
+		snprintf(buf, sizeof(buf), "\r\n  Trigger: %s%s%s, VNum: [%s%7d%s], RNum: [%7d], Context: [%ld]\r\n",
 				kColorYel, GET_TRIG_NAME(t), kColorNrm,
 				kColorGrn, GET_TRIG_VNUM(t), kColorNrm, GET_TRIG_RNUM(t), t->context);
 		SendMsgToChar(buf, ch);

--- a/src/engine/ui/cmd/do_exits.cpp
+++ b/src/engine/ui/cmd/do_exits.cpp
@@ -40,7 +40,7 @@ void DoExits(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 					const RoomRnum rnum_exit_room = EXIT(ch, door)->to_room();
 					if (ch->IsFlagged(EPrf::kMapper) && !ch->IsFlagged(EPlrFlag::kScriptWriter)
 						&& !ROOM_FLAGGED(rnum_exit_room, ERoomFlag::kMoMapper)) {
-						sprintf(buf2 + strlen(buf2), "[%5d] %s", GET_ROOM_VNUM(rnum_exit_room), world[rnum_exit_room]->name);
+						sprintf(buf2 + strlen(buf2), "[%7d] %s", GET_ROOM_VNUM(rnum_exit_room), world[rnum_exit_room]->name);
 					} else {
 						strcat(buf2, world[rnum_exit_room]->name);
 					}

--- a/src/engine/ui/cmd/do_pray_gods.cpp
+++ b/src/engine/ui/cmd/do_pray_gods.cpp
@@ -78,7 +78,7 @@ void do_pray_gods(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				 GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), argument);
 		ch->remember_add(buf1, Remember::PRAY);
 
-		snprintf(buf, kMaxStringLength, "&R[%5d] %s воззвал%s к богам с сообщением : '%s'&n\r\n",
+		snprintf(buf, kMaxStringLength, "&R[%7d] %s воззвал%s к богам с сообщением : '%s'&n\r\n",
 				 world[ch->in_room]->vnum, GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), argument);
 	}
 

--- a/src/engine/ui/cmd_god/do_liblist.cpp
+++ b/src/engine/ui/cmd_god/do_liblist.cpp
@@ -96,7 +96,7 @@ void do_liblist(CharData *ch, char *argument, int cmd, int subcmd) {
 			out += buf_;
 			for (nr = kFirstRoom; nr <= top_of_world && (world[nr]->vnum <= last); nr++) {
 				if (world[nr]->vnum >= first) {
-					snprintf(buf_, sizeof(buf_), "%5d. [%5d] (%3d) %s",
+					snprintf(buf_, sizeof(buf_), "%5d. [%7d] (%3d) %s",
 							 ++found, world[nr]->vnum, nr, world[nr]->name);
 					out += buf_;
 					if (!world[nr]->proto_script->empty()) {

--- a/src/engine/ui/cmd_god/do_show.cpp
+++ b/src/engine/ui/cmd_god/do_show.cpp
@@ -286,7 +286,7 @@ std::string print_zone_enters(ZoneRnum zone) {
 					&& world[world[n]->dir_option[dir]->to_room()]->vnum > 0) {
 					// Ширину колонки направления считает fmt: printf меряет её в байтах, и русское
 					// "северо-восток" занимало вдвое больше, чем показывал %6s (issue #3797).
-					out += fmt::format("  Номер комнаты:{:5d} Направление:{:>6} Вход в комнату:{:5d}\r\n",
+					out += fmt::format("  Номер комнаты:{:7d} Направление:{:>6} Вход в комнату:{:7d}\r\n",
 									   world[n]->vnum, dirs_rus[dir],
 									   world[world[n]->dir_option[dir]->to_room()]->vnum);
 					found = true;
@@ -314,7 +314,7 @@ std::string print_zone_exits(ZoneRnum zone) {
 				if (world[n]->dir_option[dir]
 					&& world[world[n]->dir_option[dir]->to_room()]->zone_rn != zone
 					&& world[world[n]->dir_option[dir]->to_room()]->vnum > 0) {
-					out += fmt::format("  Номер комнаты:{:5d} Направление:{:>6} Выход в комнату:{:5d}\r\n",
+					out += fmt::format("  Номер комнаты:{:7d} Направление:{:>6} Выход в комнату:{:7d}\r\n",
 									   world[n]->vnum, dirs_rus[dir],
 									   world[world[n]->dir_option[dir]->to_room()]->vnum);
 					found = true;
@@ -339,7 +339,7 @@ void print_zone_to_buf(char **bufptr, ZoneRnum zone) {
 	snprintf(tmpstr, BUFFER_SIZE,
 			 "%3d %s\r\n"
 			 "Уровнь зоны %2d, Средний уровень мобов: %2d; Type: %-20.20s; Age: %3d; Reset: %3d (%1d)(%1d)\r\n"
-			 "First: %5d, Top: %5d %s %s; ResetIdle: %s; Занято: %s; Активность: %.2f; Группа: %2d; \r\n"
+			 "First: %7d, Top: %7d %s %s; ResetIdle: %s; Занято: %s; Активность: %.2f; Группа: %2d; \r\n"
 			 "Автор: %s, количество репопов зоны (с перезагрузки): %d, всего посещений: %d, вход в зону: %d\r\n",
 			 zone_table[zone].vnum,
 			 zone_table[zone].name.c_str(),
@@ -692,7 +692,7 @@ void do_show(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				for (j = 0; j < EDirection::kMaxDirNum; j++) {
 					if (world[i]->dir_option[j]
 						&& world[i]->dir_option[j]->to_room() == 0) {
-						sprintf(buf + strlen(buf), "%2d: [%5d] %s\r\n", ++k,
+						sprintf(buf + strlen(buf), "%2d: [%7d] %s\r\n", ++k,
 								GET_ROOM_VNUM(i), world[i]->name);
 					}
 				}
@@ -704,13 +704,13 @@ void do_show(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		case 6: strcpy(buf, "Смертельных выходов\r\n" "-------------------\r\n");
 			for (i = kFirstRoom, j = 0; i <= top_of_world; i++)
 				if (ROOM_FLAGGED(i, ERoomFlag::kDeathTrap))
-					sprintf(buf + strlen(buf), "%2d: [%5d] %s\r\n", ++j, GET_ROOM_VNUM(i), world[i]->name);
+					sprintf(buf + strlen(buf), "%2d: [%7d] %s\r\n", ++j, GET_ROOM_VNUM(i), world[i]->name);
 			page_string(ch->desc, buf, true);
 			break;
 		case 7: strcpy(buf, "Комнаты для богов\r\n" "-----------------\r\n");
 			for (i = kFirstRoom, j = 0; i <= top_of_world; i++)
 				if (ROOM_FLAGGED(i, ERoomFlag::kGodsRoom))
-					sprintf(buf + strlen(buf), "%2d: [%5d] %s\r\n", ++j, GET_ROOM_VNUM(i), world[i]->name);
+					sprintf(buf + strlen(buf), "%2d: [%7d] %s\r\n", ++j, GET_ROOM_VNUM(i), world[i]->name);
 			page_string(ch->desc, buf, true);
 			break;
 		case 8: *buf = '\0';

--- a/src/engine/ui/cmd_god/do_show.cpp
+++ b/src/engine/ui/cmd_god/do_show.cpp
@@ -338,14 +338,16 @@ void print_zone_to_buf(char **bufptr, ZoneRnum zone) {
 	char tmpstr[BUFFER_SIZE];
 	snprintf(tmpstr, BUFFER_SIZE,
 			 "%3d %s\r\n"
-			 "Уровнь зоны %2d, Средний уровень мобов: %2d; Type: %-20.20s; Age: %3d; Reset: %3d (%1d)(%1d)\r\n"
+			 "Уровнь зоны %2d, Средний уровень мобов: %2d; Type: %s; Age: %3d; Reset: %3d (%1d)(%1d)\r\n"
 			 "First: %7d, Top: %7d %s %s; ResetIdle: %s; Занято: %s; Активность: %.2f; Группа: %2d; \r\n"
 			 "Автор: %s, количество репопов зоны (с перезагрузки): %d, всего посещений: %d, вход в зону: %d\r\n",
 			 zone_table[zone].vnum,
 			 zone_table[zone].name.c_str(),
 			 zone_table[zone].level,
 			 zone_table[zone].mob_level,
-			 MUD::ZoneTypes()[zone_table[zone].type].GetName().c_str(),
+			 // Тип зоны по-русски: ширину поля печатаем сами, через fmt, -- printf мерил бы её
+			 // в байтах (issue #3797).
+			 fmt::format("{:<20.20}", MUD::ZoneTypes()[zone_table[zone].type].GetName()).c_str(),
 			 zone_table[zone].age, zone_table[zone].lifespan,
 			 zone_table[zone].reset_mode,
 			 (zone_table[zone].reset_mode == 3) ? (CanBeReset(zone) ? 1 : 0) : (IsZoneEmpty(zone) ? 1 : 0),

--- a/src/engine/ui/cmd_god/do_show.cpp
+++ b/src/engine/ui/cmd_god/do_show.cpp
@@ -284,11 +284,11 @@ std::string print_zone_enters(ZoneRnum zone) {
 				if (world[n]->dir_option[dir]
 					&& world[world[n]->dir_option[dir]->to_room()]->zone_rn == zone
 					&& world[world[n]->dir_option[dir]->to_room()]->vnum > 0) {
-					snprintf(tmp, sizeof(tmp),
-							 "  Номер комнаты:%5d Направление:%6s Вход в комнату:%5d\r\n",
-							 world[n]->vnum, dirs_rus[dir],
-							 world[world[n]->dir_option[dir]->to_room()]->vnum);
-					out += tmp;
+					// Ширину колонки направления считает fmt: printf меряет её в байтах, и русское
+					// "северо-восток" занимало вдвое больше, чем показывал %6s (issue #3797).
+					out += fmt::format("  Номер комнаты:{:5d} Направление:{:>6} Вход в комнату:{:5d}\r\n",
+									   world[n]->vnum, dirs_rus[dir],
+									   world[world[n]->dir_option[dir]->to_room()]->vnum);
 					found = true;
 				}
 			}
@@ -314,11 +314,9 @@ std::string print_zone_exits(ZoneRnum zone) {
 				if (world[n]->dir_option[dir]
 					&& world[world[n]->dir_option[dir]->to_room()]->zone_rn != zone
 					&& world[world[n]->dir_option[dir]->to_room()]->vnum > 0) {
-					snprintf(tmp, sizeof(tmp),
-							 "  Номер комнаты:%5d Направление:%6s Выход в комнату:%5d\r\n",
-							 world[n]->vnum, dirs_rus[dir],
-							 world[world[n]->dir_option[dir]->to_room()]->vnum);
-					out += tmp;
+					out += fmt::format("  Номер комнаты:{:5d} Направление:{:>6} Выход в комнату:{:5d}\r\n",
+									   world[n]->vnum, dirs_rus[dir],
+									   world[world[n]->dir_option[dir]->to_room()]->vnum);
 					found = true;
 				}
 			}

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -137,7 +137,7 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 	SendMsgToChar(ch, " ЛАГ: [%d]\r\n", k->get_wait());
 	if (k->IsNpc()) {
 		snprintf(buf, sizeof(buf),
-				"Синонимы: &S%s&s, VNum: [%5d], RNum: [%5d]\r\n",
+				"Синонимы: &S%s&s, VNum: [%7d], RNum: [%7d]\r\n",
 				k->GetCharAliases().c_str(),
 				GET_MOB_VNUM(k),
 				k->get_rnum());
@@ -736,7 +736,7 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 		snprintf(buf2, sizeof(buf2), "None");
 	}
 
-	SendMsgToChar(ch, "VNum: [%s%5d%s], RNum: [%5d], UniqueID: [%ld], Id: [%ld]\r\n",
+	SendMsgToChar(ch, "VNum: [%s%7d%s], RNum: [%7d], UniqueID: [%ld], Id: [%ld]\r\n",
 				  kColorGrn, vnum, kColorNrm, j->get_rnum(), j->get_unique_id(), j->get_id());
 
 	SendMsgToChar(ch, "Расчет критерия: %f, мортов: (%f) \r\n", j->show_koef_obj(), j->show_mort_req());
@@ -1206,7 +1206,7 @@ void do_stat_room(CharData *ch, const int rnum = 0) {
 
 	sprinttype(rm->sector_type, sector_types, smallBuf);
 	snprintf(buf, sizeof(buf),
-			"Зона: [%3d], VNum: [%s%5d%s], RNum: [%5d], Тип  сектора: %s\r\n",
+			"Зона: [%3d], VNum: [%s%7d%s], RNum: [%7d], Тип  сектора: %s\r\n",
 			zone_table[rm->zone_rn].vnum, kColorGrn, rm->vnum, kColorNrm, rnum, smallBuf);
 	SendMsgToChar(buf, ch);
 
@@ -1278,7 +1278,7 @@ void do_stat_room(CharData *ch, const int rnum = 0) {
 			if (rm->dir_option[i]->to_room() == kNowhere)
 				snprintf(smallBuf, sizeof(smallBuf), " %sNONE%s", kColorCyn, kColorNrm);
 			else
-				snprintf(smallBuf, sizeof(smallBuf), "%s%5d%s", kColorCyn,
+				snprintf(smallBuf, sizeof(smallBuf), "%s%7d%s", kColorCyn,
 						GET_ROOM_VNUM(rm->dir_option[i]->to_room()), kColorNrm);
 			sprintbit(rm->dir_option[i]->exit_info.get_plane(0), exit_bits, tmpBuf, sizeof(tmpBuf));
 			snprintf(buf, sizeof(buf),

--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -670,16 +670,17 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 			for (auto tv : k->script->global_vars) {
 				if (tv.value[0] == UID_CHAR) {
 					find_uid_name(tv.value.c_str(), name, sizeof(name));
-					snprintf(buf, sizeof(buf), "    %10s:  [CharUID]: %s\r\n", tv.name.c_str(), name);
+					// Ширину колонки имени считает fmt: printf меряет её в байтах (issue #3797).
+					SendMsgToChar(fmt::format("    {:>10}:  [CharUID]: {}\r\n", tv.name, name), ch);
 				} else if (tv.value[0] == UID_OBJ) {
 					find_uid_name(tv.value.c_str(), name, sizeof(name));
-					snprintf(buf, sizeof(buf), "    %10s:  [ObjUID]: %s\r\n", tv.name.c_str(), name);
+					SendMsgToChar(fmt::format("    {:>10}:  [ObjUID]: {}\r\n", tv.name, name), ch);
 				} else if (tv.value[0] == UID_ROOM) {
 					find_uid_name(tv.value.c_str(), name, sizeof(name));
-					snprintf(buf, sizeof(buf), "    %10s:  [RoomUID]: %s\r\n", tv.name.c_str(), name);
-				} else
-					snprintf(buf, sizeof(buf), "    %10s:  %s\r\n", tv.name.c_str(), tv.value.c_str());
-				SendMsgToChar(buf, ch);
+					SendMsgToChar(fmt::format("    {:>10}:  [RoomUID]: {}\r\n", tv.name, name), ch);
+				} else {
+					SendMsgToChar(fmt::format("    {:>10}:  {}\r\n", tv.name, tv.value), ch);
+				}
 			}
 		}
 

--- a/src/engine/ui/cmd_god/do_tabulate.cpp
+++ b/src/engine/ui/cmd_god/do_tabulate.cpp
@@ -132,7 +132,7 @@ int TabulateObjsByAliases(char *searchname, CharData *ch) {
 	for (const auto &nr : obj_proto) {
 		if (isname(searchname, nr->get_aliases())) {
 			++found;
-			sprintf(buf, "%3d. [%5d] %s\r\n",
+			sprintf(buf, "%3d. [%7d] %s\r\n",
 					found, nr->get_vnum(),
 					nr->get_short_description().c_str());
 			SendMsgToChar(buf, ch);

--- a/src/engine/ui/cmd_god/do_tabulate.cpp
+++ b/src/engine/ui/cmd_god/do_tabulate.cpp
@@ -162,11 +162,8 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 	if (f) {
 		for (const auto &i : obj_proto) {
 			if (i->has_flag(plane, 1 << plane_offset)) {
-				snprintf(buf, kMaxStringLength, "%3d. [%7d] %60s : %s\r\n",
-						 ++found, i->get_vnum(),
-						 utils::RemoveColors(i->get_short_description()).c_str(),
-						 extra_bits[counter]);
-				out += buf;
+				out += fmt::format("{:3d}. [{:7d}] {:>60} : {}\r\n",
+								   ++found, i->get_vnum(), utils::RemoveColors(i->get_short_description()).c_str(), extra_bits[counter]);
 			}
 		}
 	}
@@ -182,11 +179,8 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 		for (const auto &i : obj_proto) {
 			for (plane = 0; plane < kMaxObjAffect; plane++) {
 				if (i->get_affected(plane).location == static_cast<EApply>(counter)) {
-					snprintf(buf, kMaxStringLength, "%3d. [%7d] %60s : %s, значение: %d\r\n",
-							 ++found, i->get_vnum(),
-							 utils::RemoveColors(i->get_short_description()).c_str(),
-							 apply_types[counter], i->get_affected(plane).modifier);
-					out += buf;
+					out += fmt::format("{:3d}. [{:7d}] {:>60} : {}, значение: {}\r\n",
+									   ++found, i->get_vnum(), utils::RemoveColors(i->get_short_description()).c_str(), apply_types[counter], i->get_affected(plane).modifier);
 					continue;
 				}
 			}
@@ -209,11 +203,8 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 	if (f) {
 		for (const auto &i : obj_proto) {
 			if (i->get_affect_flags().get_flag(plane, 1 << plane_offset)) {
-				snprintf(buf, kMaxStringLength, "%3d. [%7d] %60s : %s\r\n",
-						 ++found, i->get_vnum(),
-						 utils::RemoveColors(i->get_short_description()).c_str(),
-						 equipment_affects[counter]);
-				out += buf;
+				out += fmt::format("{:3d}. [{:7d}] {:>60} : {}\r\n",
+								   ++found, i->get_vnum(), utils::RemoveColors(i->get_short_description()).c_str(), equipment_affects[counter]);
 			}
 		}
 	}
@@ -234,11 +225,8 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 	if (f) {
 		for (const auto &i : obj_proto) {
 			if (i->get_affect_flags().get_flag(plane, 1 << plane_offset)) {
-				snprintf(buf, kMaxStringLength, "%3d. [%7d] %60s : запрещен для: %s\r\n",
-						 ++found, i->get_vnum(),
-						 utils::RemoveColors(i->get_short_description()).c_str(),
-						 anti_bits[counter]);
-				out += buf;
+				out += fmt::format("{:3d}. [{:7d}] {:>60} : запрещен для: {}\r\n",
+								   ++found, i->get_vnum(), utils::RemoveColors(i->get_short_description()).c_str(), anti_bits[counter]);
 			}
 		}
 	}
@@ -259,11 +247,8 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 	if (f) {
 		for (const auto &i : obj_proto) {
 			if (i->get_affect_flags().get_flag(plane, 1 << plane_offset)) {
-				snprintf(buf, kMaxStringLength, "%3d. [%7d] %60s : неудобен для: %s\r\n",
-						 ++found, i->get_vnum(),
-						 utils::RemoveColors(i->get_short_description()).c_str(),
-						 no_bits[counter]);
-				out += buf;
+				out += fmt::format("{:3d}. [{:7d}] {:>60} : неудобен для: {}\r\n",
+								   ++found, i->get_vnum(), utils::RemoveColors(i->get_short_description()).c_str(), no_bits[counter]);
 			}
 		}
 	}
@@ -281,11 +266,8 @@ int TabulateObjsByFlagName(char *searchname, CharData *ch) {
 			if (i->has_skills()) {
 				auto it = i->get_skills().find(skill_id);
 				if (it != i->get_skills().end()) {
-					snprintf(buf, kMaxStringLength, "%3d. [%7d] %60s : %s, значение: %d\r\n",
-							 ++found, i->get_vnum(),
-							 utils::RemoveColors(i->get_short_description()).c_str(),
-							 MUD::Skill(skill_id).GetName(), it->second);
-					out += buf;
+					out += fmt::format("{:3d}. [{:7d}] {:>60} : {}, значение: {}\r\n",
+									   ++found, i->get_vnum(), utils::RemoveColors(i->get_short_description()).c_str(), MUD::Skill(skill_id).GetName(), it->second);
 				}
 			}
 		}

--- a/src/engine/ui/cmd_god/do_users.cpp
+++ b/src/engine/ui/cmd_god/do_users.cpp
@@ -296,11 +296,11 @@ void do_users(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					&& sight::CanSee(ch, ci)
 					&& ci->in_room != kNowhere) {
 					if (d->original && d->character) {
-						sprintf(line2, " [%5d] %s (in %s)",
+						sprintf(line2, " [%7d] %s (in %s)",
 								GET_ROOM_VNUM(d->character->in_room),
 								world[d->character->in_room]->name, GET_NAME(d->character));
 					} else {
-						sprintf(line2, " [%5d] %s",
+						sprintf(line2, " [%7d] %s",
 								GET_ROOM_VNUM(ci->in_room), world[ci->in_room]->name);
 					}
 				}

--- a/src/engine/ui/modify.cpp
+++ b/src/engine/ui/modify.cpp
@@ -1011,7 +1011,9 @@ void do_skillset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			if (MUD::Spell(spell_id).IsInvalid()) {    // This is valid.
 				continue;
 			}
-			sprintf(help + strlen(help), "%30s", MUD::Spell(spell_id).GetCName());
+			// Ширину поля считает fmt: printf меряет её в байтах, и русское название заклинания
+			// занимало вдвое больше, чем показывал %30s -- колонки разъезжались (issue #3797).
+			strcat(help, fmt::format("{:>30}", MUD::Spell(spell_id).GetCName()).c_str());
 			if (qend++ % 4 == 3) {
 				strcat(help, "\r\n");
 				SendMsgToChar(help, ch);

--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -1947,7 +1947,8 @@ void Clan::hcontrol_exphistory(CharData *ch, std::string &text) {
 	}
 	for (std::multimap<long long, std::string>::const_reverse_iterator i = tmp_list.rbegin(), iend = tmp_list.rend();
 		 i != iend; ++i) {
-		SendMsgToChar(ch, "%5s - %s\r\n", i->second.c_str(), ExpFormat(i->first).c_str());
+		// Аббревиатура клана русская, ширину поля считает fmt (issue #3797).
+		SendMsgToChar(fmt::format("{:>5} - {}\r\n", i->second, ExpFormat(i->first)), ch);
 	}
 }
 

--- a/src/gameplay/crafting/im.cpp
+++ b/src/gameplay/crafting/im.cpp
@@ -1018,7 +1018,9 @@ void do_rset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		SendMsgToChar("Формат: rset <игрок> '<рецепт>' <значение>\r\n", ch);
 		strcpy(help, "Зарегистрированные рецепты:\r\n");
 		for (qend = 0, i = 0; i <= top_imrecipes; i++) {
-			sprintf(help + strlen(help), "%30s", imrecipes[i].name);
+			// Ширину поля считает fmt: printf меряет её в байтах, и русское название рецепта
+			// занимало вдвое больше, чем показывал %30s -- колонки разъезжались (issue #3797).
+			strcat(help, fmt::format("{:>30}", imrecipes[i].name).c_str());
 			if (qend++ % 2 == 1) {
 				strcat(help, "\r\n");
 				SendMsgToChar(help, ch);

--- a/src/gameplay/fight/pk.cpp
+++ b/src/gameplay/fight/pk.cpp
@@ -595,8 +595,10 @@ void pk_list_sprintf(CharData *ch, char *buff) {
 	strcat(buff, "              Имя    Kill Rvng Clan Batl Thif\r\n");
 	for (const auto &[uid, pk] : ch->pk_map) {
 		auto temp = GetPlayerNameByUnique(uid);
-		sprintf(buff + strlen(buff), "%20s %4ld %4ld", temp.empty() ? "<УДАЛЕН>" : temp.c_str(),
-				pk.kill_num, pk.revenge_num);
+		// Ширину имени считает fmt: printf меряет её в байтах, и русское имя ломало столбец
+		// (issue #3797).
+		strcat(buff, fmt::format("{:>20} {:4d} {:4d}",
+								 temp.empty() ? "<УДАЛЕН>" : temp, pk.kill_num, pk.revenge_num).c_str());
 
 		if (pk.clan_exp > time(nullptr)) {
 			sprintf(buff + strlen(buff), " %4ld", static_cast<long>(pk.clan_exp - time(nullptr)));

--- a/src/gameplay/mechanics/named_stuff.cpp
+++ b/src/gameplay/mechanics/named_stuff.cpp
@@ -176,7 +176,10 @@ bool parse_nedit_menu(CharData *ch, char *arg) {
 	if ((*buf1 < '1' || *buf1 > '8') && (native_text::first_char_code_lower(buf1) != rus::kVe
 			&& native_text::first_char_code_lower(buf1) != rus::kHa
 			&& native_text::first_char_code_lower(buf1) != rus::kU)) {
-		SendMsgToChar(ch, "Неверный параметр %c!\r\n", *buf1);
+		// Печатаем символ целиком, а не первый байт: под UTF-8 русская буква в char не влезает,
+		// и игрок получал в ответ обломок вместо своей буквы (issue #3797).
+		SendMsgToChar(fmt::format("Неверный параметр {}!\r\n",
+								  std::string_view(buf1, native_text::char_bytes(buf1))), ch);
 		return false;
 	}
 	if (!*buf2 && native_text::first_char_code_lower(buf1) != rus::kVe

--- a/src/gameplay/statistics/mob_stat.cpp
+++ b/src/gameplay/statistics/mob_stat.cpp
@@ -119,8 +119,11 @@ void LogClassesExpStat() {
 
 	log("Saving class exp stats.");
 	for (const auto & i : (*tmp_array)) {
-		log("class_exp: %13s   %15lld   %3llu%%",
-			MUD::Class(i.first).GetPluralCName(), i.second, top_exp != 0 ? i.second * 100 / top_exp : 0);
+		// Ширину колонки считает fmt: log печатает printf-ом, а тот меряет её в байтах, и
+		// русское название профессии ломало столбец в логе (issue #3797).
+		log("%s", fmt::format("class_exp: {:>13}   {:>15}   {:>3}%",
+							  MUD::Class(i.first).GetPluralCName(), i.second,
+							  top_exp != 0 ? i.second * 100 / top_exp : 0).c_str());
 	}
 }
 


### PR DESCRIPTION
Продолжение #3797 после меню OLC (#3798). Те же грабли: ширину поля задавал printf, а он меряет её в байтах — русский текст либо разъезжал столбец, либо резался посреди буквы.

## Что разобрано

**Игрокам:**
* `im.cpp` — список рецептов (`%30s`);
* `modify.cpp` — список заклинаний (`%30s`).

**Списки банов** (`ban.cpp`): имя бога в графе «Banned By» (`%-16.16s`) и адрес (`%-25.25s`). Формат таблицы вынесен в константы `kBanRow` и `kProxyRow`, промежуточный `char format[]` и `sprintf` в общий `buf` больше не нужны — строки собираются `fmt::format` и сразу уходят в `str_add`.

**Команды богов:**
* `do_tabulate` — `%60s` под краткое имя предмета, шесть мест;
* `do_stat` и `dg_scripts` — имена переменных триггеров;
* `do_show` — названия направлений в списке входов и выходов зоны (`%6s`, а «северо-восток» это 13 символов).

**Лог:** `mob_stat.cpp` — `%13s` под название профессии во множественном числе, столбцы в логе тоже разъезжались.

## Что оставлено намеренно

* `do_toggle.cpp` — 41 формат `%-3s`, но все под `ON`/`OFF`: ASCII, работает верно;
* `do_levels.cpp` — ширины под числа с разделителями разрядов;
* `title.cpp` — `%.*s`, где байтовая длина как раз и нужна: печатается ровно один символ, и длина берётся у него же.

После этой правки в `src` не осталось ни одного формата с шириной, под который подставляется русский текст, — проверил проходом по всем `.cpp`.

## Проверено

Сборка чистая, 673 теста зелёные, малый мир поднимается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH

---

## Заодно: внум в колонке — семь знаков

`kMaxProtoNumber = 9999999`, то есть внум семизначный, а поля под него стояли шириной пять. В `sight.cpp` это поправлено в #3786, но остальные места остались: `show`, `stat`, `vnum`, `liblist`, `users`, `exits`, «воззвать», `dg_event` и список триггеров в `dg_scripts` — **19 мест**.

Внумы от 100000 давно в ходу: 39 зон, больше тысячи предметов, самый большой в мире — 1002347. В пятизначном поле такая строка съезжает вправо и ломает колонку ровно так же, как русское имя.

Командный лог (`<имя> {комната} [команда]`, `interpreter.cpp`) не тронут намеренно: колонок там нет, а формат читают сторонние разборщики.

---

## И ещё: `%c` — печать одного байта вместо символа

Под UTF-8 русская буква в `char` не влезает физически, так что `%c` печатает только первый байт — до игрока доезжает обломок.

Мест с `%c` в движке 82, но почти все безобидны: служебные метки UID в триггерах (`%c%ld` с `UID_CHAR`), буквы флагов, коды команд зоны, разбор `sscanf`, шестнадцатеричный дамп в логе. Реальных четыре, и все печатают пользовательский ввод:

* `named_stuff.cpp` — «Неверный параметр %c!» в ответ игроку;
* `medit`, `redit`, `oedit` — `olc_log("%s command %c")` пишет в лог букву, которую набрал билдер.

Везде теперь печатается символ целиком: длина берётся у `native_text::char_bytes`, сообщение игроку собирает `fmt::format`.
