### PR TITLE
tools: проверять, с какой оптимизацией собраны подпроекты

### DIFF
--- a/tools/check_build_optimization.py
+++ b/tools/check_build_optimization.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Проверить, с какой оптимизацией собраны движок и подпроекты.
+
+Подпроекты (fmt, yaml-cpp, zlib, gtest, luajit) получают свои флаги от meson при ПЕРВОЙ
+конфигурации каталога сборки. Если каталог старше, чем строка с default_options в meson.build,
+то библиотека так и останется собранной без -O -- а это, например, пятикратная разница на
+fmt::format, которым движок печатает почти всё.
+
+    tools/check_build_optimization.py [каталог_сборки]     # по умолчанию build
+
+Чинится без полной пересборки:
+
+    meson configure <каталог> -Dfmt:optimization=2 && ninja -C <каталог>
+"""
+
+import json
+import os
+import sys
+
+# Кого проверяем и какой оптимизации ждём как минимум.
+WANT = {"fmt": 2, "yaml-cpp": 2, "zlib": 2, "gtest": 2, "luajit": 2, "sol2": 2}
+
+LEVELS = {"0": 0, "1": 1, "2": 2, "3": 3, "g": 1, "s": 2, "fast": 3}
+
+
+def flags_of(entry: dict) -> list:
+    command = entry.get("command") or " ".join(entry.get("arguments", []))
+    return [token for token in command.split() if token.startswith("-O")]
+
+
+def level_of(flags: list) -> int:
+    if not flags:
+        return -1
+    return max(LEVELS.get(flag[2:], 0) for flag in flags)
+
+
+def main() -> int:
+    build_dir = sys.argv[1] if len(sys.argv) > 1 else "build"
+    path = os.path.join(build_dir, "compile_commands.json")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            entries = json.load(handle)
+    except OSError as error:
+        print(f"не прочитать {path}: {error}", file=sys.stderr)
+        return 2
+
+    seen = {}
+    engine = None
+    for entry in entries:
+        # Путь бывает и относительным (subprojects/fmt/...), и абсолютным.
+        source = entry.get("file", "").replace("\\", "/")
+        marker = "subprojects/"
+        index = source.find(marker)
+        if index >= 0:
+            name = source[index + len(marker):].split("/", 1)[0]
+            seen.setdefault(name, flags_of(entry))
+        elif engine is None and "libcircle" in source:
+            engine = flags_of(entry)
+
+    print(f"каталог сборки: {build_dir}")
+    print(f"  {'движок':<12} {' '.join(engine) if engine else '(не найден)'}")
+
+    bad = []
+    for name, flags in sorted(seen.items()):
+        want = WANT.get(name)
+        mark = ""
+        if want is not None and level_of(flags) < want:
+            mark = "  <-- без оптимизации!"
+            bad.append(name)
+        print(f"  {name:<12} {' '.join(flags) if flags else '(нет -O)'}{mark}")
+
+    if bad:
+        print()
+        print("Собрано без оптимизации: " + ", ".join(bad))
+        print("Чинится без полной пересборки:")
+        print("    meson configure %s %s && ninja -C %s"
+              % (build_dir, " ".join(f"-D{name}:optimization=2" for name in bad), build_dir))
+        return 1
+
+    print()
+    print("Всё в порядке.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Из разговора про скорость `fmt::format`: замер против нашей собранной `libfmt.a` дал 525 нс на простое форматирование вместо ожидаемых 104. Оказалось, библиотека в моём каталоге сборки собрана **вообще без `-O`**.

## Почему так выходит

В `meson.build:353` для fmt указано `default_options: ['default_library=static', 'optimization=2']`, и на свежем каталоге всё правильно — fmt получает `-O2`. Но `default_options` применяется только при **первой** конфигурации подпроекта. Каталог, созданный раньше этой строки, остаётся с неоптимизированной библиотекой навсегда, и никакого сигнала об этом нет: сборка идёт, тесты проходят, просто всё медленнее.

У меня в `build/` так собраны `gtest` и `yaml-cpp` — а до сегодняшнего дня был и `fmt`.

## Насколько это заметно

`fmt::format` с одним числом и строкой, 300 000 вызовов, `-O3` у вызывающего кода:

| сборка fmt | время |
|---|---|
| `-O2` (как задумано) | 104 нс |
| без `-O` | 525 нс |

Впятеро. Вызовов `fmt::format` в движке больше шестисот, включая логи и сообщения.

## Что делает скрипт

```
tools/check_build_optimization.py [каталог_сборки]
```

Читает `compile_commands.json`, показывает флаги движка и каждого подпроекта, помечает те, что собраны без оптимизации, и печатает готовую команду для починки — без полной пересборки:

```
каталог сборки: build
  движок       -Og
  fmt          -O2
  gtest        (нет -O)  <-- без оптимизации!
  yaml-cpp     (нет -O)  <-- без оптимизации!

Собрано без оптимизации: gtest, yaml-cpp
Чинится без полной пересборки:
    meson configure build -Dgtest:optimization=2 -Dyaml-cpp:optimization=2 && ninja -C build
```

Возвращает 1, если что-то не в порядке, — годится и для проверки в CI.

## Что стоит проверить

Боевой каталог сборки: если он старый, там сейчас именно такая `fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
