### PR TITLE
build: собирать emmyluacodestyle с оптимизацией

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -253,7 +253,9 @@ if luajit_opt != 'disabled'
         emmy_dep = dependency(
             'emmyluacodestyle',
             fallback: ['emmyluacodestyle', 'emmyluacodestyle_dep'],
-            default_options: ['warning_level=0'],
+            # optimization выставляем явно: верхний уровень собирается с buildtype=plain,
+            # и без этого подпроект получает вообще никакого -O (issue: см. tools/check_build_optimization.py)
+            default_options: ['warning_level=0', 'optimization=2'],
         )
         dependencies += emmy_dep
         project_args += '-DWITH_LUA_FORMATTER'

--- a/tools/check_build_optimization.py
+++ b/tools/check_build_optimization.py
@@ -18,7 +18,8 @@ import os
 import sys
 
 # Кого проверяем и какой оптимизации ждём как минимум.
-WANT = {"fmt": 2, "yaml-cpp": 2, "zlib": 2, "gtest": 2, "luajit": 2, "sol2": 2}
+WANT = {"fmt": 2, "yaml-cpp": 2, "zlib": 2, "gtest": 2, "luajit": 2, "sol2": 2,
+        "emmyluacodestyle": 2}
 
 LEVELS = {"0": 0, "1": 1, "2": 2, "3": 3, "g": 1, "s": 2, "fast": 3}
 


### PR DESCRIPTION
Скрипт из #3803 на боевом каталоге показал:

```
каталог сборки: build
  движок       -Og
  emmyluacodestyle (нет -O)
  fmt          -O2
  yaml-cpp     -O2
```

`fmt` и `yaml-cpp` в порядке, а форматтер Lua собран без оптимизации — и это, в отличие от моего случая, **не следствие старого каталога**. У остальных подпроектов в `meson.build` стоит `optimization=2` в `default_options`, а у `emmyluacodestyle` — только `warning_level=0`. Верхний уровень собирается с `buildtype=plain`, meson сам никаких `-O` не добавляет, так что подпроект не получал оптимизации никогда, в том числе на свежем каталоге.

## Что сделано

* `meson.build` — `optimization=2` в `default_options` для `emmyluacodestyle`, как у `fmt`, `gtest` и остальных;
* `tools/check_build_optimization.py` — знает про этот подпроект и помечает его как непорядок (раньше просто печатал «нет -O» без пометки, потому что его не было в списке ожидаемых).

Подключается форматтер только при `-Dlua_formatter=true`, так что в обычный игровой бинарь он не попадает — но раз собирается, пусть собирается по-человечески.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
