### PR TITLE
chore(olc): не выпускать макрос ZCMD за пределы своего файла

### DIFF
--- a/src/engine/olc/medit.cpp
+++ b/src/engine/olc/medit.cpp
@@ -518,6 +518,10 @@ void medit_save_internally(DescriptorData *d) {
 	data_source->SaveMobs(OLC_ZNUM(d), OLC_NUM(d));
 }
 
+// Макрос живёт только внутри medit_save_internally: в unity-сборке файлы склеиваются,
+// и оставленное определение переопределялось в redit.cpp.
+#undef ZCMD
+
 //-------------------------------------------------------------------
 
 /*

--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -249,8 +249,6 @@ void olc_update_objects(int robj_num, ObjData *olc_obj) {
 
 //------------------------------------------------------------------------
 
-#define ZCMD zone_table[zone].cmd[cmd_no]
-
 void oedit_save_internally(DescriptorData *d) {
 	int robj_num;
 


### PR DESCRIPTION
Сборка ругалась при каждом прогоне:

```
src/engine/olc/redit.cpp:100: warning: "ZCMD" redefined
src/engine/olc/oedit.cpp:252: note: this is the location of the previous definition
```

В unity-сборке файлы склеиваются в одну единицу трансляции, поэтому определение из `oedit.cpp` доживало до `redit.cpp` и переопределялось там.

## Что сделано

* **oedit** — макрос убран совсем: он был объявлен и **ни разу не использован**, единственное упоминание в файле — само определение;
* **medit** — макрос используется в `medit_save_internally`, поэтому после функции добавлен `#undef`, как уже сделано в `zedit` и `redit`.

## Проверено

Сборка чистая — предупреждений не осталось ни одного, 673 теста зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
