### PR TITLE
fix(act): делать заглавной букву целиком, а не первый байт

### DIFF
--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -33,6 +33,7 @@
 #include "gameplay/fight/arena.h"
 #include "utils/grammar/declensions.h"
 #include "gameplay/mechanics/magic_item.h"
+#include "utils/native_text.h"
 
 #include "comm.h"
 
@@ -2727,9 +2728,17 @@ void perform_act(const char *orig,
 					*buf = *(i++);
 					buf++;
 				}
-				*buf = a_ucc(*i);
-				i++;
-				buf++;
+				// Заглавной делаем букву целиком, а не первый байт: в UTF-8 русская буква
+				// двухбайтовая, и a_ucc(*i) портил ведущий байт -- "Волчица" приезжала как
+				// "?олчица" (issue #3797/#3681).
+				const std::size_t letter_bytes = native_text::char_bytes(i);
+				std::string first(i, letter_bytes);
+				native_text::capitalize_first(first);
+				for (const char symbol : first) {
+					*buf = symbol;
+					++buf;
+				}
+				i += letter_bytes;
 				cap = 0;
 			}
 			while ((*buf = *(i++)))


### PR DESCRIPTION
Мородей убил волчицу и получил:

```
...доведут до смерти кого угодно. ?олчица не была исключением.
```

## Почему

Сообщение в `spell_msg.xml` записано как `\u$N не был$G исключением.` — `\u` означает «следующую подстановку с большой буквы». В `act()` этот признак обрабатывался побайтно:

```cpp
*buf = a_ucc(*i);
i++;
```

`a_ucc` поднимает регистр **одного байта**, а в UTF-8 русская буква занимает два. Портился ведущий байт — клиент получал обломок вместо «В».

## Что сделано

Берём символ целиком по `native_text::char_bytes`, поднимаем регистр через `native_text::capitalize_first` и копируем результат — он может оказаться другой длины, для кириллицы той же. Обработка цветовых кодов `&X` перед буквой не менялась.

## Проверено

Сборка чистая, 673 теста зелёные. Юнит-тестом не покрыть: `act()` требует персонажей и дескриптор; проверять на живом — любое сообщение с `\u$N`, например смерть от «ледяных пальцев».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
