### PR TITLE
refactor(who): убрать глобальные буферы из команды "кто" (#3807)

### DIFF
--- a/src/engine/ui/cmd/do_who.cpp
+++ b/src/engine/ui/cmd/do_who.cpp
@@ -198,15 +198,18 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		std::string line;
 		num_can_see++;
 		if (short_list) {
-			const std::string colored_name = fmt::format("{}{}{}", GetPkNameColor(tch), GET_NAME(tch), kColorNrm);
+			// Ширину добираем ВНУТРИ цветовых кодов, а не поверх них: код цвета -- семь невидимых
+			// символов, и "{:<30}" по строке вместе с ними давал колонку не в 30 знаков, а в 16.
+			const std::string colored_name =
+				fmt::format("{}{:<30}{}", GetPkNameColor(tch), GET_NAME(tch), kColorNrm);
 			if (privilege::IsImpl(ch) || ch->IsFlagged(EPrf::kCoderinfo)) {
-				line = fmt::format("{}[{:2} {}] {:<30}{}",
+				line = fmt::format("{}[{:2} {}] {}{}",
 								   privilege::IsGod(tch.get()) ? kColorWht : "",
 								   GetRealLevel(tch), MUD::Class(tch->GetClass()).GetCName(),
 								   colored_name,
 								   privilege::IsGod(tch.get()) ? kColorNrm : "");
 			} else {
-				line = fmt::format("{}{:<30}{}",
+				line = fmt::format("{}{}{}",
 								   privilege::IsImmortal(tch.get()) ? kColorWht : "",
 								   colored_name,
 								   privilege::IsImmortal(tch.get()) ? kColorNrm : "");

--- a/src/engine/ui/cmd/do_who.cpp
+++ b/src/engine/ui/cmd/do_who.cpp
@@ -5,8 +5,8 @@
 #include "engine/ui/cmd/do_who.h"
 #include "utils/russian_keys.h"
 #include "utils/native_text.h"
+#include "utils/utils_string.h"
 #include <string>
-#include <string_view>
 #include <utility>
 #include <fmt/format.h>
 #include "administration/privilege.h"
@@ -28,28 +28,15 @@ const char *IMM_WHO_FORMAT =
 
 const char *MORT_WHO_FORMAT = "Формат: кто [имя] [-?]\r\n";
 
-// Первое слово строки (в нижнем регистре) и остаток -- то же, что делает half_chop, но без
-// фиксированных буферов: half_chop копирует остаток с оглядкой на kMaxStringLength, поэтому
-// буфер меньше этого размера ему передавать нельзя (issue #3807).
-std::pair<std::string, std::string> ChopWord(std::string_view line) {
-	constexpr std::string_view kSpaces = " \t\r\n\v\f";
-
-	const auto word_begin = line.find_first_not_of(kSpaces);
-	if (word_begin == std::string_view::npos) {
-		return {};
-	}
-	const auto word_end = line.find_first_of(kSpaces, word_begin);
-
-	std::string word{line.substr(word_begin,
-								 word_end == std::string_view::npos ? std::string_view::npos : word_end - word_begin)};
+// Первое слово в нижнем регистре и остаток -- utils::ExtractFirstArgument плюс то, что
+// half_chop делал сам: понижение регистра (сравнения ниже рассчитывают на него) и срез
+// ведущих пробелов в остатке.
+std::pair<std::string, std::string> ChopWord(const std::string &line) {
+	std::string rest;
+	std::string word = utils::ExtractFirstArgument(line, rest);
 	native_text::to_lower(word);
-	if (word_end == std::string_view::npos) {
-		return {std::move(word), {}};
-	}
-
-	const auto rest_begin = line.find_first_not_of(kSpaces, word_end);
-	return {std::move(word),
-			rest_begin == std::string_view::npos ? std::string() : std::string(line.substr(rest_begin))};
+	utils::TrimLeft(rest);
+	return {std::move(word), std::move(rest)};
 }
 
 } // namespace

--- a/src/engine/ui/cmd/do_who.cpp
+++ b/src/engine/ui/cmd/do_who.cpp
@@ -40,56 +40,62 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	ECharClass showclass{ECharClass::kUndefined};
 
 	skip_spaces(&argument);
-	strcpy(buf, argument);
+	// Разбор идёт по своим буферам, а не по глобальным buf/arg/buf1: те общие на весь процесс,
+	// и любой вызов посреди разбора затирал бы разобранное (issue #3807).
+	char rest[kMaxInputLength];
+	char token[kMaxInputLength];
+	char tail[kMaxInputLength];
+	strncpy(rest, argument, sizeof(rest) - 1);
+	rest[sizeof(rest) - 1] = '\0';
 
 	// Проверка аргументов команды "кто"
-	while (*buf) {
-		half_chop(buf, arg, buf1);
-		if (!str_cmp(arg, "боги") && strlen(arg) == 4) {
+	while (*rest) {
+		half_chop(rest, token, tail);
+		if (!str_cmp(token, "боги") && strlen(token) == 4) {
 			low = kLvlImmortal;
 			high = kLvlImplementator;
-			strcpy(buf, buf1);
-		} else if (a_isdigit(*arg)) {
+			strcpy(rest, tail);
+		} else if (a_isdigit(*token)) {
 			if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo))
-				sscanf(arg, "%d-%d", &low, &high);
-			strcpy(buf, buf1);
-		} else if (*arg == '-') {
-			const char32_t mode = native_text::first_char_code(arg + 1);    // just in case; we destroy arg in the switch
+				sscanf(token, "%d-%d", &low, &high);
+			strcpy(rest, tail);
+		} else if (*token == '-') {
+			const char32_t mode = native_text::first_char_code(token + 1);    // just in case; we destroy token in the switch
 			switch (mode) {
 				case 'b':
 				case rus::kI:
 					if (privilege::IsImmortal(ch) || GET_GOD_FLAG(ch, EGf::kDemigod) || ch->IsFlagged(EPrf::kCoderinfo))
 						showname = true;
-					strcpy(buf, buf1);
+					strcpy(rest, tail);
 					break;
 				case 'z':
 					if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo))
 						localwho = true;
-					strcpy(buf, buf1);
+					strcpy(rest, tail);
 					break;
 				case 's':
 					if (privilege::IsImmortal(ch) || ch->IsFlagged(EPrf::kCoderinfo))
 						short_list = true;
-					strcpy(buf, buf1);
+					strcpy(rest, tail);
 					break;
-				case 'l': half_chop(buf1, arg, buf);
+				case 'l': half_chop(tail, token, rest);
 					if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo))
-						sscanf(arg, "%d-%d", &low, &high);
+						sscanf(token, "%d-%d", &low, &high);
 					break;
-				case 'n': half_chop(buf1, name_search, buf);
+				case 'n': half_chop(tail, name_search, rest);
 					break;
 				case 'r':
 					if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo))
 						who_room = true;
-					strcpy(buf, buf1);
+					strcpy(rest, tail);
 					break;
-				case 'c': half_chop(buf1, arg, buf);
+				case 'c': half_chop(tail, token, rest);
 					if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo)) {
-/*						const size_t len = strlen(arg);
+/*						const size_t len = strlen(token);
 						for (size_t i = 0; i < len; i++) {
-							showclass |= FindCharClassMask(arg[i]);
+							showclass |= FindCharClassMask(token[i]);
 						}*/
-						showclass = FindAvailableCharClassId(arg);
+						showclass = FindAvailableCharClassId(token);
 					}
 					break;
 				case 'h':
@@ -103,8 +109,8 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			}    // end of switch
 		} else    // endif
 		{
-			strcpy(name_search, arg);
-			strcpy(buf, buf1);
+			strcpy(name_search, token);
+			strcpy(rest, tail);
 
 		}
 	}            // end while (parser)
@@ -113,14 +119,9 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 
 	// Строки содержащие имена
-	sprintf(buf, "%sБОГИ%s\r\n", kColorBoldCyn, kColorNrm);
-	std::string imms(buf);
-
-	sprintf(buf, "%sПривилегированные%s\r\n", kColorCyn, kColorNrm);
-	std::string demigods(buf);
-
-	sprintf(buf, "%sИгроки%s\r\n", kColorCyn, kColorNrm);
-	std::string morts(buf);
+	std::string imms = fmt::format("{}БОГИ{}\r\n", kColorBoldCyn, kColorNrm);
+	std::string demigods = fmt::format("{}Привилегированные{}\r\n", kColorCyn, kColorNrm);
+	std::string morts = fmt::format("{}Игроки{}\r\n", kColorCyn, kColorNrm);
 
 	int all = 0;
 
@@ -162,109 +163,107 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			continue;
 		}
 
-		*buf = '\0';
+		// Строка игрока собирается в свою std::string: глобальный buf на это не годится --
+		// он общий на весь процесс и переполняется молча (issue #3807).
+		std::string line;
 		num_can_see++;
 		if (short_list) {
-			char tmp[kMaxInputLength];
-			snprintf(tmp, sizeof(tmp), "%s%s%s", GetPkNameColor(tch), GET_NAME(tch), kColorNrm);
-			// Ширина колонки - в символах, а не в байтах (issue #3681): fmt "{:<30}" считает
-			// байты, из-за чего колонка с русским именем под UTF-8 выходит вдвое уже.
+			const std::string colored_name = fmt::format("{}{}{}", GetPkNameColor(tch), GET_NAME(tch), kColorNrm);
 			if (privilege::IsImpl(ch) || ch->IsFlagged(EPrf::kCoderinfo)) {
-				strcpy(buf, fmt::format("{}[{:2} {}] {:<30}{}",
-						privilege::IsGod(tch.get()) ? kColorWht : "",
-						GetRealLevel(tch), MUD::Class(tch->GetClass()).GetCName(),
-						tmp,
-						privilege::IsGod(tch.get()) ? kColorNrm : "").c_str());
+				line = fmt::format("{}[{:2} {}] {:<30}{}",
+								   privilege::IsGod(tch.get()) ? kColorWht : "",
+								   GetRealLevel(tch), MUD::Class(tch->GetClass()).GetCName(),
+								   colored_name,
+								   privilege::IsGod(tch.get()) ? kColorNrm : "");
 			} else {
-				strcpy(buf, fmt::format("{}{:<30}{}",
-						privilege::IsImmortal(tch.get()) ? kColorWht : "",
-						tmp,
-						privilege::IsImmortal(tch.get()) ? kColorNrm : "").c_str());
+				line = fmt::format("{}{:<30}{}",
+								   privilege::IsImmortal(tch.get()) ? kColorWht : "",
+								   colored_name,
+								   privilege::IsImmortal(tch.get()) ? kColorNrm : "");
 			}
 		} else {
 			if (privilege::IsImpl(ch)
 				|| ch->IsFlagged(EPrf::kCoderinfo)) {
-				sprintf(buf, "%s[%2d %2d %s(%5d)] %s%s%s%s",
-						privilege::IsImmortal(tch.get()) ? kColorWht : "",
-						GetRealLevel(tch),
-						remort::GetRealRemort(tch),
-						MUD::Class(tch->GetClass()).GetAbbr().c_str(),
-						tch->get_pfilepos(),
-						GetPkNameColor(tch),
-						privilege::IsImmortal(tch.get()) ? kColorWht : "", tch->race_or_title().c_str(), kColorNrm);
+				line = fmt::format("{}[{:2d} {:2d} {}({:5d})] {}{}{}{}",
+								   privilege::IsImmortal(tch.get()) ? kColorWht : "",
+								   GetRealLevel(tch),
+								   remort::GetRealRemort(tch),
+								   MUD::Class(tch->GetClass()).GetAbbr(),
+								   tch->get_pfilepos(),
+								   GetPkNameColor(tch),
+								   privilege::IsImmortal(tch.get()) ? kColorWht : "", tch->race_or_title(), kColorNrm);
 			} else {
-				sprintf(buf, "%s %s%s%s",
-						GetPkNameColor(tch),
-						privilege::IsImmortal(tch.get()) ? kColorWht : "", tch->race_or_title().c_str(), kColorNrm);
+				line = fmt::format("{} {}{}{}",
+								   GetPkNameColor(tch),
+								   privilege::IsImmortal(tch.get()) ? kColorWht : "", tch->race_or_title(), kColorNrm);
 			}
 
 			if (GET_INVIS_LEV(tch))
-				sprintf(buf + strlen(buf), " (i%d)", GET_INVIS_LEV(tch));
+				line += fmt::format(" (i{})", GET_INVIS_LEV(tch));
 			else if (AFF_FLAGGED(tch, EAffect::kInvisible))
-				sprintf(buf + strlen(buf), " (невидим%s)", grammar::SexEnding((tch)->get_sex(), 6));
+				line += fmt::format(" (невидим{})", grammar::SexEnding((tch)->get_sex(), 6));
 			if (AFF_FLAGGED(tch, EAffect::kHide))
-				strcat(buf, " (прячется)");
+				line += " (прячется)";
 			if (AFF_FLAGGED(tch, EAffect::kDisguise))
-				strcat(buf, " (маскируется)");
+				line += " (маскируется)";
 
 			if (tch->IsFlagged(EPlrFlag::kMailing))
-				strcat(buf, " (отправляет письмо)");
+				line += " (отправляет письмо)";
 			else if (tch->IsFlagged(EPlrFlag::kWriting))
-				strcat(buf, " (пишет)");
+				line += " (пишет)";
 
 			if (tch->IsFlagged(EPrf::kNoHoller))
-				sprintf(buf + strlen(buf), " (глух%s)", grammar::SexEnding((tch)->get_sex(), 1));
+				line += fmt::format(" (глух{})", grammar::SexEnding((tch)->get_sex(), 1));
 			if (tch->IsFlagged(EPrf::kNoTell))
-				sprintf(buf + strlen(buf), " (занят%s)", grammar::SexEnding((tch)->get_sex(), 6));
+				line += fmt::format(" (занят{})", grammar::SexEnding((tch)->get_sex(), 6));
 			if (tch->IsFlagged(EPlrFlag::kMuted))
-				sprintf(buf + strlen(buf), " (молчит)");
+				line += " (молчит)";
 			if (tch->IsFlagged(EPlrFlag::kDumbed))
-				sprintf(buf + strlen(buf), " (нем%s)", grammar::SexEnding((tch)->get_sex(), 6));
+				line += fmt::format(" (нем{})", grammar::SexEnding((tch)->get_sex(), 6));
 			if (tch->IsFlagged(EPlrFlag::kKiller) == EPlrFlag::kKiller)
-				sprintf(buf + strlen(buf), "&R (ДУШЕГУБ)&n");
+				line += "&R (ДУШЕГУБ)&n";
 			if ((privilege::IsImmortal(ch) || GET_GOD_FLAG(ch, EGf::kDemigod)) && !(tch)->player_specials->saved.NameGod
 				&& GetRealLevel(tch) <= kNameLevel) {
-				sprintf(buf + strlen(buf), " &W!НЕ ОДОБРЕНО!&n");
+				line += " &W!НЕ ОДОБРЕНО!&n";
 				if (showname) {
-					sprintf(buf + strlen(buf),
-							"\r\nПадежи: %s/%s/%s/%s/%s/%s Email: &S%s&s Пол: %s",
-							GET_PAD(tch, 0), GET_PAD(tch, 1), GET_PAD(tch, 2),
-							GET_PAD(tch, 3), GET_PAD(tch, 4), GET_PAD(tch, 5),
-							GET_GOD_FLAG(ch, EGf::kDemigod) ? "скрыто" : GET_EMAIL(tch),
-							genders[static_cast<int>(tch->get_sex())]);
+					line += fmt::format("\r\nПадежи: {}/{}/{}/{}/{}/{} Email: &S{}&s Пол: {}",
+										GET_PAD(tch, 0), GET_PAD(tch, 1), GET_PAD(tch, 2),
+										GET_PAD(tch, 3), GET_PAD(tch, 4), GET_PAD(tch, 5),
+										GET_GOD_FLAG(ch, EGf::kDemigod) ? "скрыто" : GET_EMAIL(tch),
+										genders[static_cast<int>(tch->get_sex())]);
 				}
 			}
 			if ((GetRealLevel(ch) == kLvlImplementator) && (NORENTABLE(tch)))
-				sprintf(buf + strlen(buf), " &R(В КРОВИ)&n");
+				line += " &R(В КРОВИ)&n";
 			else if ((privilege::IsImmortal(ch) || ch->IsFlagged(EPrf::kCoderinfo)) && NAME_BAD(tch)) {
-				sprintf(buf + strlen(buf), " &Wзапрет %s!&n", GetNameById((tch)->player_specials->saved.NameIDGod).c_str());
+				line += fmt::format(" &Wзапрет {}!&n", GetNameById((tch)->player_specials->saved.NameIDGod));
 			}
 			if (privilege::IsGod(ch) && (GET_GOD_FLAG(tch, EGf::kAllowTesterMode)))
-				sprintf(buf + strlen(buf), " &G(ТЕСТЕР!)&n");
+				line += " &G(ТЕСТЕР!)&n";
 			if (privilege::IsGod(ch) && (GET_GOD_FLAG(tch, EGf::kSkillTester)))
-				sprintf(buf + strlen(buf), " &G(СКИЛЛТЕСТЕР!)&n");
+				line += " &G(СКИЛЛТЕСТЕР!)&n";
 			if (privilege::IsGod(ch) && (tch->IsFlagged(EPlrFlag::kAutobot)))
-				sprintf(buf + strlen(buf), " &G(БОТ!)&n");
+				line += " &G(БОТ!)&n";
 			if (privilege::IsImmortal(tch.get()))
-				strcat(buf, kColorNrm);
+				line += kColorNrm;
 		}        // endif shortlist
 
 		if (privilege::IsImmortal(tch.get())) {
 			imms_num++;
-			imms += buf;
+			imms += line;
 			if (!short_list || !(imms_num % 4)) {
 				imms += "\r\n";
 			}
 		} else if (GET_GOD_FLAG(tch, EGf::kDemigod)
 			&& (privilege::IsImmortal(ch) || ch->IsFlagged(EPrf::kCoderinfo) || GET_GOD_FLAG(tch, EGf::kDemigod))) {
 			demigods_num++;
-			demigods += buf;
+			demigods += line;
 			if (!short_list || !(demigods_num % 4)) {
 				demigods += "\r\n";
 			}
 		} else {
 			morts_num++;
-			morts += buf;
+			morts += line;
 			if (!short_list || !(morts_num % 4))
 				morts += "\r\n";
 		}
@@ -296,19 +295,15 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 	out += "\r\nВсего:";
 	if (imms_num) {
-		sprintf(buf, " бессмертных %d", imms_num);
-		out += buf;
+		out += fmt::format(" бессмертных {}", imms_num);
 	}
 	if (demigods_num) {
-		sprintf(buf, " привилегированных %d", demigods_num);
-		out += buf;
+		out += fmt::format(" привилегированных {}", demigods_num);
 	}
 	if (all && morts_num) {
-		sprintf(buf, " смертных %d (видимых %d)", all, morts_num);
-		out += buf;
+		out += fmt::format(" смертных {} (видимых {})", all, morts_num);
 	} else if (morts_num) {
-		sprintf(buf, " смертных %d", morts_num);
-		out += buf;
+		out += fmt::format(" смертных {}", morts_num);
 	}
 
 	out += ".\r\n";

--- a/src/engine/ui/cmd/do_who.cpp
+++ b/src/engine/ui/cmd/do_who.cpp
@@ -5,6 +5,9 @@
 #include "engine/ui/cmd/do_who.h"
 #include "utils/russian_keys.h"
 #include "utils/native_text.h"
+#include <string>
+#include <string_view>
+#include <utility>
 #include <fmt/format.h>
 #include "administration/privilege.h"
 #include "utils/grammar/gender.h"
@@ -25,11 +28,34 @@ const char *IMM_WHO_FORMAT =
 
 const char *MORT_WHO_FORMAT = "Формат: кто [имя] [-?]\r\n";
 
+// Первое слово строки (в нижнем регистре) и остаток -- то же, что делает half_chop, но без
+// фиксированных буферов: half_chop копирует остаток с оглядкой на kMaxStringLength, поэтому
+// буфер меньше этого размера ему передавать нельзя (issue #3807).
+std::pair<std::string, std::string> ChopWord(std::string_view line) {
+	constexpr std::string_view kSpaces = " \t\r\n\v\f";
+
+	const auto word_begin = line.find_first_not_of(kSpaces);
+	if (word_begin == std::string_view::npos) {
+		return {};
+	}
+	const auto word_end = line.find_first_of(kSpaces, word_begin);
+
+	std::string word{line.substr(word_begin,
+								 word_end == std::string_view::npos ? std::string_view::npos : word_end - word_begin)};
+	native_text::to_lower(word);
+	if (word_end == std::string_view::npos) {
+		return {std::move(word), {}};
+	}
+
+	const auto rest_begin = line.find_first_not_of(kSpaces, word_end);
+	return {std::move(word),
+			rest_begin == std::string_view::npos ? std::string() : std::string(line.substr(rest_begin))};
+}
+
 } // namespace
 
 void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-	char name_search[kMaxInputLength];
-	name_search[0] = '\0';
+	std::string name_search;
 
 	// Флаги для опций
 	int low = 0, high = kLvlImplementator;
@@ -40,64 +66,69 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	ECharClass showclass{ECharClass::kUndefined};
 
 	skip_spaces(&argument);
-	// Разбор идёт по своим буферам, а не по глобальным buf/arg/buf1: те общие на весь процесс,
+	// Разбор идёт по своим строкам, а не по глобальным buf/arg/buf1: те общие на весь процесс,
 	// и любой вызов посреди разбора затирал бы разобранное (issue #3807).
-	char rest[kMaxInputLength];
-	char token[kMaxInputLength];
-	char tail[kMaxInputLength];
-	strncpy(rest, argument, sizeof(rest) - 1);
-	rest[sizeof(rest) - 1] = '\0';
+	std::string rest = argument ? argument : "";
 
 	// Проверка аргументов команды "кто"
-	while (*rest) {
-		half_chop(rest, token, tail);
-		if (!str_cmp(token, "боги") && strlen(token) == 4) {
+	while (!rest.empty()) {
+		auto [token, tail] = ChopWord(rest);
+		if (token.empty()) {
+			break;
+		}
+		if (token == "боги") {
 			low = kLvlImmortal;
 			high = kLvlImplementator;
-			strcpy(rest, tail);
-		} else if (a_isdigit(*token)) {
+			rest = tail;
+		} else if (a_isdigit(token.front())) {
 			if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo))
-				sscanf(token, "%d-%d", &low, &high);
-			strcpy(rest, tail);
-		} else if (*token == '-') {
-			const char32_t mode = native_text::first_char_code(token + 1);    // just in case; we destroy token in the switch
+				sscanf(token.c_str(), "%d-%d", &low, &high);
+			rest = tail;
+		} else if (token.front() == '-') {
+			const char32_t mode = native_text::first_char_code(token.c_str() + 1);
 			switch (mode) {
 				case 'b':
 				case rus::kI:
 					if (privilege::IsImmortal(ch) || GET_GOD_FLAG(ch, EGf::kDemigod) || ch->IsFlagged(EPrf::kCoderinfo))
 						showname = true;
-					strcpy(rest, tail);
+					rest = tail;
 					break;
 				case 'z':
 					if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo))
 						localwho = true;
-					strcpy(rest, tail);
+					rest = tail;
 					break;
 				case 's':
 					if (privilege::IsImmortal(ch) || ch->IsFlagged(EPrf::kCoderinfo))
 						short_list = true;
-					strcpy(rest, tail);
+					rest = tail;
 					break;
-				case 'l': half_chop(tail, token, rest);
+				case 'l': {
+					auto [value, next] = ChopWord(tail);
+					rest = next;
 					if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo))
-						sscanf(token, "%d-%d", &low, &high);
+						sscanf(value.c_str(), "%d-%d", &low, &high);
 					break;
-				case 'n': half_chop(tail, name_search, rest);
+				}
+				case 'n': {
+					auto [value, next] = ChopWord(tail);
+					name_search = value;
+					rest = next;
 					break;
+				}
 				case 'r':
 					if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo))
 						who_room = true;
-					strcpy(rest, tail);
+					rest = tail;
 					break;
-				case 'c': half_chop(tail, token, rest);
+				case 'c': {
+					auto [value, next] = ChopWord(tail);
+					rest = next;
 					if (privilege::IsGod(ch) || ch->IsFlagged(EPrf::kCoderinfo)) {
-/*						const size_t len = strlen(token);
-						for (size_t i = 0; i < len; i++) {
-							showclass |= FindCharClassMask(token[i]);
-						}*/
-						showclass = FindAvailableCharClassId(token);
+						showclass = FindAvailableCharClassId(value.c_str());
 					}
 					break;
+				}
 				case 'h':
 				case '?':
 				default:
@@ -109,13 +140,12 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			}    // end of switch
 		} else    // endif
 		{
-			strcpy(name_search, token);
-			strcpy(rest, tail);
-
+			name_search = token;
+			rest = tail;
 		}
 	}            // end while (parser)
 
-	if (PerformWhoSpamcontrol(ch, strlen(name_search) ? kWhoListname : kWhoListall))
+	if (PerformWhoSpamcontrol(ch, name_search.empty() ? kWhoListall : kWhoListname))
 		return;
 
 	// Строки содержащие имена
@@ -138,7 +168,7 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			++all;
 		}
 
-		if (*name_search && !(isname(name_search, GET_NAME(tch)))) {
+		if (!name_search.empty() && !isname(name_search, GET_NAME(tch))) {
 			continue;
 		}
 


### PR DESCRIPTION
Первый файл слоя 1 из #3807 — заодно проба приёма на небольшом объёме.

## Что было

Команда «кто» собирала вывод в глобальных `buf`, `buf1` и `arg` (`utils.h:638`) — 54 обращения на 360 строк файла. Буферы общие на весь процесс, поэтому любой вызов посреди сборки строки затирает накопленное, а переполнение ловится только сторожевым байтом `plant_magic`, уже после факта.

Отдельно забавное место: строка игрока и так собиралась через `fmt::format`, но результат потом переписывался в глобальный буфер:

```cpp
strcpy(buf, fmt::format("{}[{:2} {}] {:<30}{}", ...).c_str());
```

## Что стало

* разбор аргументов ведёт локальный помощник `ChopWord` — первое слово в нижнем регистре и остаток, обе части `std::string`;
* строка игрока, заголовки разделов и итоговые счётчики собираются `fmt::format` в `std::string`;
* лишняя пересылка через `strcpy` ушла — `fmt::format` пишет сразу в свою строку.

`sprintf` и `strcat` в файле не осталось ни одного. Обращений к глобальным буферам — тоже.

Вывод не менялся: те же форматы, та же ширина `{:<30}`, те же цветовые коды.

## Проверено

Сборка чистая, 673 теста зелёные, малый мир поднимается. Проверять на живом — команда `кто` во всех видах: `кто`, `кто -s`, `кто -n имя`, `кто -c профессия`, `кто боги`, `кто 20-30`.

## Дальше

По плану #3807 следующие кандидаты, от простого к сложному: `do_set.cpp` / `do_set_all.cpp` (61/62 обращения), `corpse.cpp` (52), `named_stuff.cpp` (85), `punishments.cpp` (98), `identify.cpp` (149), `do_score.cpp` (137), `do_show.cpp` (97), `do_stat.cpp` (350), `dg_scripts.cpp` (479).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH

---

## Правка после ревью (второй коммит)

Первая версия заменила глобальные буферы **локальными `char[]`** — и это было неверно дважды.

**Неверно по существу.** `half_chop` копирует остаток через `strl_cpy(arg2, temp, kMaxStringLength)`, то есть рассчитывает на буфер в 32768 байт, а я передавал буферы по `kMaxInputLength` = 2048. Сегодня это не стреляет только потому, что и строка команды, и строка триггера ограничены теми же 2048 байтами (`kMaxTrglineLength == kMaxInputLength`). Любое изменение лимита — и запись уходит за границу стекового массива.

**Не то по замыслу.** Слой 1 из #3807 — про переход на `std::string`, а не про перенос тех же `char[]` из глобальной области в локальную. И это прямо расходилось с правилом, которое только что легло в `CONTRIBUTING.md` (#3808).

Теперь фиксированных буферов в файле не осталось вовсе.

## Заодно починилось «кто боги»

```cpp
if (!str_cmp(arg, "боги") && strlen(arg) == 4)
```

В KOI8-R «боги» занимало ровно 4 байта, в UTF-8 — 8. После перехода вторая половина условия перестала выполняться, и слово уходило в поиск по имени: `кто боги` искал игрока с именем «боги» вместо списка бессмертных.

Проверка длины тут и не нужна — `str_cmp` сравнивает строки целиком, а не по префиксу, так что условие сократилось до `token == "боги"` (слово уже приведено к нижнему регистру).

Отдельно проверить в игре стоит именно `кто боги`.

---

## Третий коммит: ширина колонки в коротком списке

В `кто -s` имя сначала оборачивали в цвет, а потом дополняли до тридцати знаков:

```cpp
tmp = цвет + имя + сброс;
fmt::format("{:<30}", tmp)
```

Цветовой код — семь невидимых символов (`\x1B[1;31m`), сброс — ещё семь, и `fmt` считает их наравне с буквами. В колонке оставалось **16 видимых знаков вместо тридцати**:

```
было : видимых знаков в колонке = 16
стало: видимых знаков в колонке = 30
```

Теперь ширина добирается внутри цветов — `fmt::format("{}{:<30}{}", цвет, имя, сброс)`.

Заодно снят устаревший комментарий, утверждавший, что `fmt` меряет ширину в байтах. Это было верно, пока русский текст лежал в KOI8-R: такая строка не является валидным UTF-8, и `fmt` считал байты. После флипа он считает символы — проверено замером.

---

## Четвёртый коммит: опереться на готовое

Свой разбор строки оказался лишним — строковый аналог `half_chop` в проекте уже есть: `utils::ExtractFirstArgument` (`utils_string.h:150`, прямо подписан «аналог one_argument для string»).

Локальный `ChopWord` остался тонкой обёрткой над ним и добавляет ровно то, чего тот не делает, а `half_chop` делал: понижает регистр слова (сравнения в разборе на это рассчитывают) и срезает ведущие пробелы в остатке.