### PR TITLE
fix(shop): не обещать купить то, что торговец не купит

### DIFF
--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -971,10 +971,15 @@ void shop_node::do_shop_cmd(CharData *ch, CharData *keeper, ObjData *obj, std::s
 			return;
 		}
 
+		// Условия те же, что в ветке "Продать": иначе торговец называл цену за предмет, который
+		// потом отказывался брать. Дешёвая вещь схлопывается до одной куны ("кожаная фляга" за
+		// две куны при любом profit), а продажа за куну и меньше запрещена -- вот он и обещал
+		// то, чего не сделает.
 		if (obj->has_flag(EObjFlag::kNosell)
 			|| obj->has_flag(EObjFlag::kNamed)
 			|| obj->has_flag(EObjFlag::kRepopDecay)
-			|| obj->has_flag(EObjFlag::kZonedecay)) {
+			|| obj->has_flag(EObjFlag::kZonedecay)
+			|| buy_price <= 1) {
 			tell_to_char(keeper, ch, ShopMsg(ESM::kWontBuy).c_str());
 			return;
 		} else {


### PR DESCRIPTION
Торговец, который продаёт кожаную флягу, на `оценить фляга` называет цену в одну куну, а на `продать фляга` отвечает отказом.

## Почему

Условие отказа стоит **только в ветке «Продать»**:

```cpp
if (cmd == "Продать") {
    if (obj->has_flag(EObjFlag::kNosell)
        || obj->has_flag(EObjFlag::kNamed)
        || obj->has_flag(EObjFlag::kRepopDecay)
        || (buy_price <= 1)          // <-- этого нет в "Оценить"
        || obj->has_flag(EObjFlag::kZonedecay)
        || bloody::is_bloody(obj)) {
```

В ветке «Оценить» проверялись одни флаги, без цены. А цена скупки считается так:

```cpp
buy_price = std::max(1L, (buy_price * profit) / 100);
```

У дешёвой вещи она схлопывается до единицы при **любой** прибыли магазина. Кожаная фляга (предмет 2182, она и лежит в наборах магазинов) стоит 2 куны:

| profit | (2 × profit) / 100 | итог |
|---|---|---|
| 99% | 1 | 1 |
| 50% | 1 | 1 |
| 30% | 0 → `max(1)` | 1 |
| 20% | 0 → `max(1)` | 1 |

Оценка такую цену пропускала и называла игроку, продажа — отвергала.

Задета не только фляга: под это попадает всё, у чего цена скупки выходит в единицу, то есть примерно всё дешевле 3–5 кун в зависимости от `profit` магазина.

## Что сделано

Условия в обеих ветках приведены к одному виду — добавлена проверка `buy_price <= 1` в «Оценить». Теперь торговец на оценку сразу говорит, что не купит.

Сам порог не трогаю: если он поставлен, чтобы магазины не заваливали дешёвкой, пусть остаётся. Меняется только то, что торговец больше не обещает несбыточного.

## Проверено

Сборка чистая, 681 тест зелёный. На живом: `оценить фляга` и `продать фляга` у любого торговца, где она есть в ассортименте — оба должны отвечать отказом. И проверить, что вещь подороже (скупка выше куны) по-прежнему и оценивается, и продаётся.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUwDWDnYdXrJdvjDVd36QH
