### PR TITLE
feat(utf8): state записывается в нативной кодировке (#3787)

### DIFF
--- a/src/administration/proxy.cpp
+++ b/src/administration/proxy.cpp
@@ -15,6 +15,7 @@
 #include "engine/core/comm.h"
 #include "engine/entities/char_data.h"
 #include "utils/utils.h"
+#include "utils/native_text.h"
 
 #include <sstream>
 #include "utils/logger.h"
@@ -243,7 +244,11 @@ void RegisterSystem::load() {
 	while (file >> email) {
 		ReadEndString(file);
 		std::getline(file, comment);
-		email_list[email] = comment;
+		// Границы чтения тут не было вовсе: комментарий держит имя того, кто регистрировал,
+		// и причину -- то есть русский текст, который уходил в память дисковыми байтами и
+		// показывался богам в "stat" мусором. Запись всегда шла нативной, так что файл ещё и
+		// расходился сам с собой по мере добавления записей (issue #3787).
+		email_list[email] = native_text::from_disk_line(comment.c_str());
 	}
 	file.close();
 }
@@ -260,6 +265,7 @@ void RegisterSystem::save() {
 		return;
 	}
 	for (auto &it : email_list) {
+		// Зеркало к чтению: state/ хранится в нативной кодировке, пишем как есть.
 		file << it.first << "\n" << it.second << "\n";
 	}
 	file.close();

--- a/src/engine/boot/state_manager.cpp
+++ b/src/engine/boot/state_manager.cpp
@@ -7,6 +7,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <system_error>
 #include <utility>
 
@@ -62,26 +63,43 @@ std::vector<std::string> StateManager::LoadLines(EStateFile file) const {
 		if (!line.empty() && line.back() == '\r') {
 			line.pop_back();   // tolerate CRLF files
 		}
-		// Граница чтения: списки лежат на диске в кодировке мира (сейчас KOI8-R), в память
-		// идут нативными. Здесь же имена персонажей, титулы и баны, и без пары к to_disk
-		// на записи они уезжали в транслит при первой же перезаписи файла (issue #3681).
+		// Граница чтения: строка принимается в любой из двух кодировок -- валидный UTF-8
+		// считается уже нативным, всё остальное разбирается как KOI8-R. Так файл, переведённый
+		// не целиком, читается правильно, и старые списки живут рядом с новыми (issue #3787).
 		lines.push_back(native_text::from_disk_line(line.c_str()));
 	}
 	return lines;
 }
 
+std::string StateManager::LoadText(EStateFile file) const {
+	std::ifstream in(Path(file), std::ios::binary);
+	if (!in.is_open()) {
+		return {};   // absent file == empty (normal on first boot)
+	}
+	const std::string raw((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+	// Граница чтения, та же что в LoadLines, но на весь файл сразу (issue #3787).
+	return native_text::from_disk_text(raw);
+}
+
 bool StateManager::SaveLines(EStateFile file, const std::vector<std::string> &lines) const {
+	std::string body;
+	for (const auto &l : lines) {
+		body += l;   // граница записи, зеркало к LoadLines: пишем нативное как есть
+		body += '\n';
+	}
+	return SaveText(file, body);
+}
+
+bool StateManager::SaveText(EStateFile file, const std::string &text) const {
 	const std::string &path = Path(file);
 	const std::string tmp = path + ".tmp";
 	{
-		std::ofstream out(tmp, std::ios::trunc);
+		std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
 		if (!out.is_open()) {
 			log("SYSERR: StateManager: cannot open '%s' for writing", tmp.c_str());
 			return false;
 		}
-		for (const auto &l : lines) {
-			out << native_text::to_disk(l) << '\n';   // граница записи, зеркало к LoadLines
-		}
+		out.write(text.data(), static_cast<std::streamsize>(text.size()));
 		out.flush();
 		if (!out.good()) {
 			log("SYSERR: StateManager: write error on '%s'", tmp.c_str());
@@ -109,7 +127,7 @@ bool StateManager::AppendLine(EStateFile file, const std::string &line) const {
 		log("SYSERR: StateManager: cannot open '%s' for append", path.c_str());
 		return false;
 	}
-	out << native_text::to_disk(line) << '\n';   // граница записи, зеркало к LoadLines
+	out << line << '\n';   // граница записи, зеркало к LoadLines: пишем нативное как есть
 	return out.good();
 }
 

--- a/src/engine/boot/state_manager.h
+++ b/src/engine/boot/state_manager.h
@@ -60,6 +60,11 @@ class StateManager {
 	[[nodiscard]] std::vector<std::string> LoadLines(EStateFile file) const;
 	// Atomically replace the whole file (write a .tmp then rename).
 	bool SaveLines(EStateFile file, const std::vector<std::string> &lines) const;
+	// То же для файлов, которые читаются и пишутся целиком (XML-кэши статистики). Пара к
+	// LoadLines/SaveLines для тех, кому строки не подходят: границу кодировки держит здесь же,
+	// а не каждый вызывающий у себя.
+	[[nodiscard]] std::string LoadText(EStateFile file) const;
+	bool SaveText(EStateFile file, const std::string &text) const;
 	// Append one line (creating the file if absent).
 	bool AppendLine(EStateFile file, const std::string &line) const;
 	// Load, drop every line for which drop(line) is true, then SaveLines the rest atomically.

--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -1059,17 +1059,17 @@ void ZoneTrafficSave() {
 		zone_node.append_attribute("traffic") = i.traffic;
 	}
 
-	// Граница записи: XML уходит на диск в кодировке мира, а не в нативной
-	// (issue #3681).
+	// Граница записи: state/ хранится в нативной кодировке, поэтому пишем как есть
+	// (issue #3787). SaveText кладёт файл атомарно, зеркально LoadText.
 	std::ostringstream xml;
 	doc.save(xml, "\t", pugi::format_default, pugi::encoding_utf8);
-	native_text::write_file(MUD::StateManager().Path(state::EStateFile::kZoneTraffic), xml.str());
+	MUD::StateManager().SaveText(state::EStateFile::kZoneTraffic, xml.str());
 }
 void zone_traffic_load() {
 	pugi::xml_document doc;
-	// Файл лежит на диске в KOI8-R; читаем через границу кодировки, а разбираем уже
-	// буфер в нативной кодировке движка (issue #3681). Под KOI8-R это тождество.
-	const std::string xml_db = native_text::read_data_file(MUD::StateManager().Path(state::EStateFile::kZoneTraffic));
+	// Граница чтения: LoadText принимает файл в любой из двух кодировок и отдаёт нативный
+	// буфер, разбираем уже его (issue #3787).
+	const std::string xml_db = MUD::StateManager().LoadText(state::EStateFile::kZoneTraffic);
 	pugi::xml_parse_result result = doc.load_buffer(xml_db.data(), xml_db.size());
 	if (!result) {
 		snprintf(buf, kMaxStringLength, "...%s", result.description());

--- a/src/gameplay/mechanics/sets_drop.cpp
+++ b/src/gameplay/mechanics/sets_drop.cpp
@@ -889,7 +889,10 @@ void init_xhelp_full() {
 
 bool load_unique_mobs() {
 	pugi::xml_document doc;
-	pugi::xml_parse_result result = doc.load_file(MUD::StateManager().Path(state::EStateFile::kUniqueMobs).c_str());
+	// Граница чтения: файл берём через StateManager, а не pugi::load_file -- тот читает байты
+	// мимо границы кодировки и под UTF-8 отдал бы дисковые байты как нативные (issue #3787).
+	const std::string xml_mobs = MUD::StateManager().LoadText(state::EStateFile::kUniqueMobs);
+	pugi::xml_parse_result result = doc.load_buffer(xml_mobs.data(), xml_mobs.size());
 	int vnum = 0;
 	int level = 0;
 	if (!result) {
@@ -965,11 +968,11 @@ void save_unique_mobs() {
 		mob_node.append_attribute("vnum") = it->first;
 		mob_node.append_attribute("level") = it->second;
 	}
-	// Граница записи: XML уходит на диск в кодировке мира, а не в нативной
-	// (issue #3681).
+	// Граница записи: state/ хранится в нативной кодировке, поэтому пишем как есть
+	// (issue #3787). SaveText кладёт файл атомарно, зеркально LoadText.
 	std::ostringstream xml;
 	doc.save(xml, "\t", pugi::format_default, pugi::encoding_utf8);
-	native_text::write_file(MUD::StateManager().Path(state::EStateFile::kUniqueMobs), xml.str());
+	MUD::StateManager().SaveText(state::EStateFile::kUniqueMobs, xml.str());
 }
 
 void save_drop_table() {

--- a/src/gameplay/mechanics/title.cpp
+++ b/src/gameplay/mechanics/title.cpp
@@ -425,10 +425,9 @@ void TitleSystem::save_title_list() {
 	for (TitleListType::const_iterator it = title_list.begin(); it != title_list.end(); ++it)
 		out << it->first << " " << it->second->unique << "\n" << it->second->pre_title << "\n" << it->second->title
 			<< "\n";
-	// Граница записи: на диск уходит кодировка мира (сейчас KOI8-R), зеркально
-	// чтению -- иначе первое же сохранение переводит файл в UTF-8, и откат на
-	// прежнюю сборку становится невозможен (issue #3681).
-	const std::string on_disk = native_text::to_disk(out.str());
+	// Граница записи: state/ хранится в нативной кодировке, поэтому титулы уходят на диск
+	// как есть. Чтение (from_disk_line) принимает и старый KOI8-R (issue #3787).
+	const std::string on_disk = out.str();
 	file.write(on_disk.data(), static_cast<std::streamsize>(on_disk.size()));
 	file.close();
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -48,6 +48,7 @@ test_sources = files(
     'accounts.storage.cpp',
     'translit_koi8.cpp',
     'parser_wrapper.encoding.cpp',
+    'state_manager.encoding.cpp',
     'utf8.cpp',
     'native_text.cpp',
     'text_semantics.cpp',

--- a/tests/state_manager.encoding.cpp
+++ b/tests/state_manager.encoding.cpp
@@ -1,0 +1,133 @@
+// Граница кодировки у файлов состояния (state/) -- issue #3787.
+//
+// state/ хранится в нативной кодировке движка: записи уходят на диск как есть, а чтение
+// принимает и старый KOI8-R, и уже переведённый UTF-8, разбирая каждую строку отдельно
+// (native_text::from_disk_line). Тесты держат оба конца этой границы:
+//   * запись не переводит текст -- иначе первое же сохранение вернуло бы файл в KOI8-R,
+//     ровно так и жил cfg до #3794;
+//   * цикл load/save байт в байт воспроизводит файл -- защита от повторного перевода,
+//     который однажды раздул obj_sets.xml до 6.7 ГБ (см. parser_wrapper.encoding.cpp);
+//   * файл, оставшийся в KOI8-R, читается правильно, и переведённый наполовину -- тоже.
+//
+// Сам тест -- чистый ASCII: кириллица записана байтовыми escape-последовательностями UTF-8
+// и приводится к нативной кодировке через native_text.
+
+#include "engine/boot/state_manager.h"
+#include "utils/native_text.h"
+#include "utils/translit_koi8.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+// "Стрибог" и "Мышь" в UTF-8: имена персонажей -- ровно то, что лежит в этих списках.
+const char *const kStateNameUtf8 = "\xD0\xA1\xD1\x82\xD1\x80\xD0\xB8\xD0\xB1\xD0\xBE\xD0\xB3";
+const char *const kStateOtherUtf8 = "\xD0\x9C\xD1\x8B\xD1\x88\xD1\x8C";
+
+std::string NativeFromUtf8(const char *utf8) {
+	return native_text::from_koi8(codepages::Utf8ToKoi8(utf8));
+}
+
+std::string ReadStateFileBytes(const std::filesystem::path &path) {
+	std::ifstream in(path, std::ios::binary);
+	std::ostringstream buffer;
+	buffer << in.rdbuf();
+	return buffer.str();
+}
+
+// StateManager отдаёт пути относительно каталога мира, так что тест работает в своём
+// временном каталоге и возвращает прежний, что бы ни случилось с проверками.
+class StateTestDir {
+ public:
+	StateTestDir() : previous_(std::filesystem::current_path()),
+					 root_(std::filesystem::temp_directory_path() / "bylins_state_test") {
+		std::filesystem::remove_all(root_);
+		std::filesystem::create_directories(root_ / "state");
+		std::filesystem::current_path(root_);
+	}
+	~StateTestDir() {
+		std::filesystem::current_path(previous_);
+		std::error_code ec;
+		std::filesystem::remove_all(root_, ec);
+	}
+
+ private:
+	std::filesystem::path previous_;
+	std::filesystem::path root_;
+};
+
+}  // namespace
+
+TEST(StateManagerEncoding, SaveLinesWritesNativeBytes) {
+	StateTestDir dir;
+	const state::StateManager manager;
+	const std::string name = NativeFromUtf8(kStateNameUtf8);
+
+	ASSERT_TRUE(manager.SaveLines(state::EStateFile::kApprovedNames, {name}));
+
+	// На диске должно лежать ровно то, что было в памяти: границы записи здесь больше нет.
+	EXPECT_EQ(ReadStateFileBytes(manager.Path(state::EStateFile::kApprovedNames)), name + "\n");
+}
+
+TEST(StateManagerEncoding, SaveLoadSaveIsByteIdentical) {
+	StateTestDir dir;
+	const state::StateManager manager;
+	const std::vector<std::string> lines{NativeFromUtf8(kStateNameUtf8), NativeFromUtf8(kStateOtherUtf8)};
+
+	ASSERT_TRUE(manager.SaveLines(state::EStateFile::kApprovedNames, lines));
+	const std::string first = ReadStateFileBytes(manager.Path(state::EStateFile::kApprovedNames));
+
+	const auto loaded = manager.LoadLines(state::EStateFile::kApprovedNames);
+	EXPECT_EQ(loaded, lines) << "строки должны вернуться ровно такими, какими ушли";
+
+	ASSERT_TRUE(manager.SaveLines(state::EStateFile::kApprovedNames, loaded));
+	EXPECT_EQ(ReadStateFileBytes(manager.Path(state::EStateFile::kApprovedNames)), first)
+			<< "цикл load/save обязан воспроизводить файл байт в байт";
+}
+
+TEST(StateManagerEncoding, ReadsAListLeftInKoi8) {
+	StateTestDir dir;
+	const state::StateManager manager;
+	{
+		std::ofstream out(manager.Path(state::EStateFile::kApprovedNames), std::ios::binary);
+		out << codepages::Utf8ToKoi8(kStateNameUtf8) << "\n";
+	}
+
+	const auto loaded = manager.LoadLines(state::EStateFile::kApprovedNames);
+	ASSERT_EQ(loaded.size(), 1u);
+	EXPECT_EQ(loaded[0], NativeFromUtf8(kStateNameUtf8));
+}
+
+TEST(StateManagerEncoding, ReadsAHalfConvertedList) {
+	// Так выглядит список, который движок уже дописывал нативным, пока файл лежал в KOI8-R:
+	// решение о кодировке принимается для каждой строки отдельно, поэтому читается и такой.
+	StateTestDir dir;
+	const state::StateManager manager;
+	{
+		std::ofstream out(manager.Path(state::EStateFile::kApprovedNames), std::ios::binary);
+		out << codepages::Utf8ToKoi8(kStateNameUtf8) << "\n" << NativeFromUtf8(kStateOtherUtf8) << "\n";
+	}
+
+	const auto loaded = manager.LoadLines(state::EStateFile::kApprovedNames);
+	ASSERT_EQ(loaded.size(), 2u);
+	EXPECT_EQ(loaded[0], NativeFromUtf8(kStateNameUtf8));
+	EXPECT_EQ(loaded[1], NativeFromUtf8(kStateOtherUtf8));
+}
+
+TEST(StateManagerEncoding, SaveTextAndLoadTextMirrorEachOther) {
+	StateTestDir dir;
+	const state::StateManager manager;
+	const std::string body = "<mobs>" + NativeFromUtf8(kStateNameUtf8) + "</mobs>\n";
+
+	ASSERT_TRUE(manager.SaveText(state::EStateFile::kUniqueMobs, body));
+	EXPECT_EQ(ReadStateFileBytes(manager.Path(state::EStateFile::kUniqueMobs)), body);
+	EXPECT_EQ(manager.LoadText(state::EStateFile::kUniqueMobs), body);
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tools/convert_state_to_utf8.py
+++ b/tools/convert_state_to_utf8.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Перевести файлы состояния сервера (lib/state) из KOI8-R в UTF-8 (issue #3787).
+
+Пара к tools/convert_cfg_to_utf8.py, но разбор построчный, а не пофайловый, и вот почему.
+Списки в state/ движок читает через native_text::from_disk_line, то есть решает о кодировке
+для КАЖДОЙ строки отдельно: валидная UTF-8 строка считается уже переведённой, всё остальное
+разбирается как KOI8-R. Скрипт повторяет ровно это правило, поэтому:
+
+  * файл, переведённый наполовину, доводится до конца, а не портится повторным переводом
+    (так может выглядеть список, в который движок дописывал строки уже нативными);
+  * результат совпадает с тем, что прочитает движок -- расхождения между конвертером и
+    загрузчиком быть не может по построению.
+
+Двоичные файлы (statistics/mob_stat.bin и всё, где есть нулевой байт) не трогаются.
+
+ВАЖНО: сервер должен быть остановлен. Эти файлы пишутся в рантайме, и сохранение поверх
+свежепереведённого файла старым бинарём вернёт его в KOI8-R.
+
+    ./tools/convert_state_to_utf8.py lib/state            # посмотреть
+    ./tools/convert_state_to_utf8.py lib/state --apply    # перевести
+"""
+
+import argparse
+import os
+import re
+import sys
+
+# Объявление кодировки правим только в шапке XML (unique_mobs.xml, statistics/*.xml).
+DECLARATION = re.compile(rb'^(<\?xml[^>]*encoding\s*=\s*")([^"]+)(")', re.IGNORECASE)
+
+
+def convert_line(line: bytes) -> tuple[bytes, str]:
+    """Перевести одну строку. Возвращает (строка, что с ней): ascii/native/recoded."""
+    try:
+        line.decode('ascii')
+        return line, 'ascii'
+    except UnicodeDecodeError:
+        pass
+    try:
+        line.decode('utf-8')
+        return line, 'native'          # уже переведена -- не трогаем
+    except UnicodeDecodeError:
+        pass
+    return line.decode('koi8-r').encode('utf-8'), 'recoded'
+
+
+def fix_declaration(data: bytes) -> tuple[bytes, bool]:
+    """encoding="koi8-r" -> encoding="utf-8" в шапке XML."""
+    match = DECLARATION.match(data)
+    if not match or match.group(2).lower() in (b'utf-8', b'utf8'):
+        return data, False
+    return DECLARATION.sub(rb'\g<1>utf-8\g<3>', data, count=1), True
+
+
+def write_atomically(path: str, data: bytes) -> None:
+    """Запись через временный файл рядом: прерывание не оставит половину файла."""
+    temp = path + '.utf8.tmp'
+    with open(temp, 'wb') as handle:
+        handle.write(data)
+    os.replace(temp, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Перевод файлов состояния из KOI8-R в UTF-8')
+    parser.add_argument('root', help='каталог состояния (обычно lib/state)')
+    parser.add_argument('--apply', action='store_true', help='записать изменения (иначе только показать)')
+    parser.add_argument('--quiet', action='store_true', help='не перечислять каждый файл')
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.root):
+        print(f'нет такого каталога: {args.root}', file=sys.stderr)
+        return 2
+
+    binary = touched = already = 0
+    native_lines = 0
+
+    for dirpath, _, names in os.walk(args.root):
+        for name in sorted(names):
+            path = os.path.join(dirpath, name)
+            relative = os.path.relpath(path, args.root)
+            try:
+                with open(path, 'rb') as handle:
+                    data = handle.read()
+            except OSError as error:
+                print(f'  не прочитать {relative}: {error}', file=sys.stderr)
+                continue
+
+            if b'\0' in data:
+                binary += 1
+                if not args.quiet:
+                    print(f'  {relative}  [двоичный, пропущен]')
+                continue
+
+            data, declaration_fixed = fix_declaration(data)
+            out = bytearray()
+            recoded = native = 0
+            for index, line in enumerate(data.split(b'\n')):
+                if index:
+                    out += b'\n'
+                tail = b''
+                if line.endswith(b'\r'):          # CRLF: перевод не должен его съесть
+                    line, tail = line[:-1], b'\r'
+                converted, what = convert_line(line)
+                out += converted + tail
+                if what == 'recoded':
+                    recoded += 1
+                elif what == 'native':
+                    native += 1
+
+            if not recoded and not declaration_fixed:
+                already += 1
+                continue
+            native_lines += native   # считаем только там, где что-то меняли
+
+            marks = []
+            if recoded:
+                marks.append(f'строк переведено: {recoded}')
+            if native:
+                marks.append(f'уже нативных: {native}')
+            if declaration_fixed:
+                marks.append('шапка')
+            touched += 1
+            if not args.quiet:
+                print(f'  {relative}  [{", ".join(marks)}]')
+            if args.apply:
+                write_atomically(path, bytes(out))
+
+    print()
+    print(f"{'переведено файлов:' if args.apply else 'будет переведено файлов:':<26} {touched}")
+    print(f"{'уже в UTF-8:':<26} {already}")
+    print(f"{'двоичных (пропущено):':<26} {binary}")
+    if native_lines:
+        print()
+        print(f'Внутри переведённых файлов {native_lines} строк уже были нативными -- они оставлены как есть.')
+
+    if not args.apply and touched:
+        print()
+        print('Это был просмотр. Чтобы записать, повторите с --apply')
+        print('Сервер при этом должен быть остановлен.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Продолжение перевода на UTF-8 (#3787): после мира и cfg (#3794) остались файлы состояния сервера — `lib/state`.

Хорошая новость сразу: **ничего из `lib/state` не трекается в git**. Значит, вся возня с `.gitattributes`, блобами и двойной кодировкой, которая была у cfg, здесь не возникает — только диск.

## Как сейчас

Чтение уже всеядное: `StateManager::LoadLines` решает о кодировке для **каждой строки отдельно** (`native_text::from_disk_line`). А запись всегда переводила в KOI8-R:

```cpp
out << native_text::to_disk(l) << '\n';   // граница записи, зеркало к LoadLines
```

То есть первое же сохранение возвращало файл в старую кодировку — ровно та же история, что была у cfg до #3794.

## Проверка перед правкой

Раз чтение построчное, а строки тут короткие (имена в столбик), стоило убедиться, что построчный разбор не ошибётся: KOI8-строка теоретически может случайно оказаться валидным UTF-8, и тогда `from_disk_line` примет её за уже переведённую.

Посчитал по живым данным боевого `lib/state`: **7470 не-ASCII строк, двусмысленных — 0**. Единственная нашлась в `README.md`, который движок не читает. Переключение безопасно.

## Что сделано

Запись стала зеркалом чтения: `SaveLines` и `AppendLine` кладут нативный текст как есть. Это закрывает 10 списочных файлов одним местом.

По дороге вылезли три дыры, которые чинятся тем же заходом:

* **`registered-email.lst` не имел границы кодировки вообще — ни на чтении, ни на записи.** Комментарий там держит имя того, кто регистрировал, и причину («Феофан -> Registered by Женя [офис]»), то есть русский текст. Он уходил в память дисковыми байтами и показывался богам в `stat` мусором (`do_stat.cpp:178`). А новые записи движок дописывал уже нативными, так что файл ещё и расходился сам с собой по мере пополнения.
* **`unique_mobs.xml`** читался сырым `pugi::load_file` мимо границы, а писался через `to_disk` — несимметрично.
* **`zone_traffic.xml`** и тот же `unique_mobs.xml` писались в кодировку диска.

Для файлов, которые читаются и пишутся целиком, добавлены `LoadText`/`SaveText` — пара к `LoadLines`/`SaveLines`, чтобы граница жила в одном месте, а не у каждого вызывающего. `SaveLines` теперь выражен через `SaveText`, атомарная запись (`.tmp` + `rename`) общая.

## Данные

`tools/convert_state_to_utf8.py` — пара к `convert_cfg_to_utf8.py`, но разбор **построчный**, как у `from_disk_line`. Так файл, переведённый наполовину, доводится до конца, а не портится повторным переводом, и результат по построению совпадает с тем, что прочитает движок. Двоичное (`statistics/mob_stat.bin`, там чистые числа) не трогает.

На копии боевого `lib/state`: 8 файлов, 7469 строк, содержимое построчно совпало с тем, что прочитает движок; повторный прогон — ноль изменений.

## Проверено

* Сборка без предупреждений, **686 тестов зелёные**.
* Новый `tests/state_manager.encoding.cpp` — 5 тестов на обе стороны границы, включая наполовину переведённый список. Отдельно проверил, что он **ловит регресс**: вернул `to_disk` — `SaveLinesWritesNativeBytes` упал. Показательно, что `SaveLoadSaveIsByteIdentical` при этом остался зелёным: цикл load/save симметричен в любой кодировке, поэтому такого теста для закрепления новой границы не хватает.
* Тестовый мир поднимается с новым бинарём, `proxy.lst` после старта лежит в UTF-8 и читается, жалоб `to_disk got non-UTF-8` в логе нет.

---

# Инструкция по переезду

Проще, чем у cfg: коммитить нечего, `.gitattributes` не трогается.

## Шаг 0. Бэкап

```
tar czf ~/state-before-utf8-$(date +%F).tgz -C /home/mud/mud/lib state
```

## Шаг 1. Погасить сервер и поставить новый бинарь

Гасить нужно не ради кодировки — чтение принимает обе, — а чтобы скрипт и сервер не переписали один файл одновременно.

## Шаг 2. Перевести

```
./tools/convert_state_to_utf8.py /home/mud/mud/lib/state            # посмотреть
./tools/convert_state_to_utf8.py /home/mud/mud/lib/state --apply
```

Скрипт идемпотентен, прерванный прогон можно просто повторить.

## Шаг 3. Поднять сервер и проверить

```
find /home/mud/mud/lib/state -type f ! -name '*.bin' -exec file {} + | grep -v 'UTF-8\|ASCII\|empty'
```

Должно быть пусто. И в игре: `реестр` / `бан` показывают русский, а не мусор.

## Откат

Данные откатывать не нужно: чтение принимает обе кодировки. Если понадобится вернуть старый бинарь — он прочитает переведённые списки нормально, но при первом же сохранении переведёт файл обратно в KOI8-R.

## Что осталось за рамками

* `lib.template/state` — проверил, там всё пустое или ASCII, переводить нечего.
* `statistics/spellstat.txt` пишется дозаписью без границы, но уже нативным текстом; после конвертации файла всё сходится само. Кода не трогал: статистика сейчас выключена (`is_active = false`), файл не менялся с июля 2025.
* **`lib/state/proxy`** (без `.lst`, 18 КБ) — в движке не упоминается нигде, в `EStateFile` такого нет. Остаток старого формата рядом с живым `proxy.lst` на 100 байт. Скрипт переведёт его заодно, но по-хорошему файл стоит просто убрать в архив.
* `lib/etc/board/**` — доски пишет сам движок, там нужен отдельный разбор пути записи.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141fe9QufFGkvAjncr1y6mb
