### PR TITLE
Телеметрия базара и аукциона одним механизмом

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -489,6 +489,7 @@ main_sources = files(
   'src/gameplay/statistics/dps.cpp',
   'src/engine/entities/entities_constants.cpp',
   'src/gameplay/economics/exchange.cpp',
+  'src/gameplay/economics/trade_log.cpp',
   'src/engine/core/external_trigger.cpp',
   'src/gameplay/abilities/feats.cpp',
   'src/gameplay/abilities/timed_abilities.cpp',

--- a/src/gameplay/economics/auction.cpp
+++ b/src/gameplay/economics/auction.cpp
@@ -26,9 +26,7 @@
 #include "gameplay/mechanics/named_stuff.h"
 #include "gameplay/fight/pk.h"
 #include "gameplay/ai/spec_procs.h"
-#include "engine/observability/helpers.h"
-#include "engine/observability/metrics.h"
-#include "utils/tracing/trace_manager.h"
+#include "gameplay/economics/trade_log.h"
 
 const int kMaxAuctionLot = 3;
 const int kMaxAuctionTactBuy = 5;
@@ -67,6 +65,34 @@ const char *auction_cmd[] = {"поставить", "set",
 							 "характеристики", "identify",
 							 "\n"
 };
+
+// Лот на аукционе живёт тактами, а не с отметкой времени: восстанавливаем
+// момент выставления, чтобы время до продажи считалось так же, как на базаре.
+static time_t auction_listed_at(int lot) {
+	return time(nullptr) - static_cast<time_t>((GET_LOT(lot)->tact * kAuctionPulses) / 10);
+}
+
+static void auction_sold(int lot) {
+	trade_log::Sold(trade_log::EMarket::kAuction, lot, GET_LOT(lot)->item, GET_LOT(lot)->cost,
+					GET_LOT(lot)->seller_unique, GET_LOT(lot)->buyer_unique, auction_listed_at(lot));
+}
+
+static void auction_withdrawn(int lot, const char *reason) {
+	trade_log::Withdrawn(trade_log::EMarket::kAuction, lot, GET_LOT(lot)->item, GET_LOT(lot)->cost,
+						 GET_LOT(lot)->seller_unique, reason);
+}
+
+static void record_active_lots() {
+	int count = 0;
+	long value = 0;
+	for (int j = 0; j < kMaxAuctionLot; j++) {
+		if (GET_LOT(j)->seller && GET_LOT(j)->item) {
+			++count;
+			value += GET_LOT(j)->cost;
+		}
+	}
+	trade_log::ActiveLots(trade_log::EMarket::kAuction, count, value);
+}
 
 void showlots(CharData *ch) {
 	char tmpbuf[kMaxInputLength];
@@ -214,6 +240,7 @@ bool auction_drive(CharData *ch, char *argument) {
 					"Аукцион : новый лот %d - %s - начальная ставка %d %s. \r\n",
 					lot, obj->get_PName(grammar::ECase::kNom).c_str(), value, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str());
 			message_auction(tmpbuf, nullptr);
+			trade_log::Listed(trade_log::EMarket::kAuction, lot, obj, value, ch->get_uid());
 			SetWait(ch, 1, false);
 			return true;
 			break;
@@ -233,6 +260,7 @@ bool auction_drive(CharData *ch, char *argument) {
 			act("Вы сняли $O3 с аукциона.\r\n", false, ch, 0, GET_LOT(lot)->item, kToChar);
 			sprintf(tmpbuf, "Аукцион : лот %d(%s) снят%s с аукциона владельцем.\r\n", lot,
 					GET_LOT(lot)->item->get_PName(grammar::ECase::kNom).c_str(), grammar::ObjSexEnding((GET_LOT(lot)->item)->get_sex(), 6));
+			auction_withdrawn(lot, "owner");
 			clear_auction(lot);
 			message_auction(tmpbuf, nullptr);
 			SetWait(ch, 1, false);
@@ -265,6 +293,7 @@ bool auction_drive(CharData *ch, char *argument) {
 				SendMsgToChar("Вещь утеряна владельцем.\r\n", ch);
 				sprintf(tmpbuf, "Аукцион : лот %d (%s) снят, ввиду смены владельца.", lot,
 						GET_LOT(lot)->item->get_PName(grammar::ECase::kNom).c_str());
+				auction_withdrawn(lot, "owner_changed");
 				clear_auction(lot);
 				message_auction(tmpbuf, nullptr);
 				return true;
@@ -296,6 +325,8 @@ bool auction_drive(CharData *ch, char *argument) {
 					value,
 					MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str());
 			SendMsgToChar(tmpbuf, GET_LOT(lot)->seller);
+			trade_log::Bid(trade_log::EMarket::kAuction, lot, GET_LOT(lot)->item, value,
+						   GET_LOT(lot)->seller_unique, ch->get_uid());
 			sprintf(tmpbuf, "Аукцион : лот %d(%s) - новая ставка %d %s.", lot,
 					GET_LOT(lot)->item->get_PName(grammar::ECase::kNom).c_str(), value, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str());
 			message_auction(tmpbuf, nullptr);
@@ -520,6 +551,7 @@ int check_sell(int lot) {
 	if (obj->get_carried_by() != ch) {
 		sprintf(tmpbuf, "Аукцион : лот %d(%s) снят, ввиду смены владельца", lot, obj->get_PName(grammar::ECase::kNom).c_str());
 		message_auction(tmpbuf, nullptr);
+		auction_withdrawn(lot, "owner_changed");
 		clear_auction(lot);
 		return (false);
 	}
@@ -533,6 +565,7 @@ int check_sell(int lot) {
 					lot,
 					obj->get_PName(grammar::ECase::kNom).c_str());
 			message_auction(tmpbuf, nullptr);
+			auction_withdrawn(lot, "trader");
 			clear_auction(lot);
 			return (false);
 		}
@@ -545,6 +578,7 @@ int check_sell(int lot) {
 		SendMsgToChar(tmpbuf, ch);
 		sprintf(tmpbuf, "Аукцион : лот %d(%s) снят с аукциона распорядителем торгов.", lot, obj->get_PName(grammar::ECase::kNom).c_str());
 		message_auction(tmpbuf, nullptr);
+		auction_withdrawn(lot, "no_money");
 		clear_auction(lot);
 		return (false);
 	}
@@ -690,45 +724,9 @@ void trans_auction(int lot) {
 	currencies::AddBank(*ch, currencies::kGold, GET_LOT(lot)->cost);
 	currencies::RemoveTotal(*tch, currencies::kGold, GET_LOT(lot)->cost + (GET_LOT(lot)->cost / 10));
 
+	auction_sold(lot);
 	clear_auction(lot);
 	return;
-}
-
-class AuctionSaleMetrics {
-public:
-	explicit AuctionSaleMetrics(int lot)
-		: m_span(tracing::TraceManager::Instance().StartSpan("Auction Sale"))
-		, m_cost(GET_LOT(lot)->cost)
-		, m_duration((GET_LOT(lot)->tact * kAuctionPulses) / 10.0)
-	{
-		m_span->SetAttribute("lot",              static_cast<int64_t>(lot));
-		m_span->SetAttribute("seller_id",        static_cast<int64_t>(GET_LOT(lot)->seller_unique));
-		m_span->SetAttribute("buyer_id",         static_cast<int64_t>(GET_LOT(lot)->buyer_unique));
-		m_span->SetAttribute("cost",             static_cast<int64_t>(m_cost));
-		m_span->SetAttribute("item_id",          static_cast<int64_t>(GET_LOT(lot)->item_id));
-		m_span->SetAttribute("duration_seconds", m_duration);
-	}
-
-	void send() {
-		observability::OtelMetrics::RecordCounter("auction.sale.total",    1);
-		observability::OtelMetrics::RecordCounter("auction.revenue.total", m_cost);
-		observability::OtelMetrics::RecordHistogram("auction.duration.seconds", m_duration);
-	}
-
-private:
-	std::unique_ptr<tracing::ISpan> m_span;
-	int m_cost;
-	double m_duration;
-};
-
-static void record_active_lots() {
-	int count = 0;
-	for (int j = 0; j < kMaxAuctionLot; j++) {
-		if (GET_LOT(j)->seller && GET_LOT(j)->item) {
-			++count;
-		}
-	}
-	observability::OtelMetrics::RecordGauge("auction.lots.active", count);
 }
 
 void sell_auction(int lot) {
@@ -744,8 +742,6 @@ void sell_auction(int lot) {
 	if (!check_sell(lot))
 		return;
 
-	AuctionSaleMetrics metrics(lot);
-
 	if (ch->in_room != tch->in_room
 		|| !ROOM_FLAGGED(ch->in_room, ERoomFlag::kPeaceful)) {
 		if (GET_LOT(lot)->tact >= kMaxAuctionTact) {
@@ -755,6 +751,7 @@ void sell_auction(int lot) {
 					obj->get_PName(grammar::ECase::kNom).c_str());
 
 			message_auction(tmpbuff, nullptr);
+			auction_withdrawn(lot, "trader");
 			clear_auction(lot);
 			return;
 		}
@@ -789,7 +786,7 @@ void sell_auction(int lot) {
 	currencies::RemoveTotal(*tch, currencies::kGold, GET_LOT(lot)->cost);
 
 
-	metrics.send();
+	auction_sold(lot);
 	clear_auction(lot);
 	return;
 }
@@ -807,6 +804,7 @@ void check_auction(CharData *ch, ObjData *obj) {
 				sprintf(tmpbuf, "Аукцион : лот %d(%s) снят с аукциона распорядителем.",
 						i, GET_LOT(i)->item->get_PName(grammar::ECase::kNom).c_str());
 				message_auction(tmpbuf, ch);
+				auction_withdrawn(i, "trader");
 				clear_auction(i);
 			}
 		}
@@ -818,6 +816,7 @@ void check_auction(CharData *ch, ObjData *obj) {
 				sprintf(tmpbuf, "Аукцион : лот %d(%s) снят с аукциона распорядителем.",
 						i, GET_LOT(i)->item->get_PName(grammar::ECase::kNom).c_str());
 				message_auction(tmpbuf, obj->get_carried_by());
+				auction_withdrawn(i, "trader");
 				clear_auction(i);
 			}
 		}
@@ -833,6 +832,7 @@ void check_auction(CharData *ch, ObjData *obj) {
 				sprintf(tmpbuf, "Аукцион : лот %d(%s) снят с аукциона распорядителем.",
 						i, GET_LOT(i)->item->get_PName(grammar::ECase::kNom).c_str());
 				message_auction(tmpbuf, nullptr);
+				auction_withdrawn(i, "trader");
 				clear_auction(i);
 			}
 		}
@@ -859,6 +859,7 @@ void tact_auction(void) {
 				sprintf(tmpbuf, "Аукцион : лот %d(%s) снят распорядителем ввиду отсутствия спроса.",
 						i, GET_LOT(i)->item->get_PName(grammar::ECase::kNom).c_str());
 				message_auction(tmpbuf, nullptr);
+				auction_withdrawn(i, "no_demand");
 				clear_auction(i);
 				continue;
 			}

--- a/src/gameplay/economics/exchange.cpp
+++ b/src/gameplay/economics/exchange.cpp
@@ -52,6 +52,7 @@
 #include "engine/core/sysdep.h"
 #include "gameplay/mechanics/stable_objs.h"
 #include "gameplay/core/remort.h"
+#include "gameplay/economics/trade_log.h"
 
 #include <stdexcept>
 #include <sstream>
@@ -295,6 +296,7 @@ int exchange_exhibit(CharData *ch, char *arg) {
 	act(tmpbuf, false, ch, 0, obj, kToChar);
 	snprintf(tmpbuf, kMaxInputLength, "%s", (fmt::format(fmt::runtime(specials::ExchMsg(specials::EExchMsg::kBcastNew)), fmt::arg("lot", GET_EXCHANGE_ITEM_LOT(item)), fmt::arg("item", obj->get_PName(grammar::ECase::kNom)), fmt::arg("amount", item_cost), fmt::arg("currency", MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(item_cost, grammar::ECase::kNom).c_str())) + "\r\n").c_str());
 	message_exchange(tmpbuf, ch, item);
+	trade_log::Listed(trade_log::EMarket::kBazaar, GET_EXCHANGE_ITEM_LOT(item), obj, item_cost, ch->get_uid());
 
 	currencies::RemoveTotal(*ch, currencies::kGold, tax);
 
@@ -351,6 +353,7 @@ int exchange_change_cost(CharData *ch, char *arg) {
 			return false;
 		}
 
+	const int oldcost = GET_EXCHANGE_ITEM_COST(item);
 	GET_EXCHANGE_ITEM_COST(item) = newcost;
 	if (pay > 0) {
 		currencies::RemoveTotal(*ch, currencies::kGold, static_cast<long>(pay * EXCHANGE_EXHIBIT_PAY_COEFF));
@@ -360,6 +363,8 @@ int exchange_change_cost(CharData *ch, char *arg) {
 	SendMsgToChar(tmpbuf, ch);
 	snprintf(tmpbuf, kMaxInputLength, "%s", (fmt::format(fmt::runtime(specials::ExchMsg(specials::EExchMsg::kBcastNewCost)), fmt::arg("lot", GET_EXCHANGE_ITEM_LOT(item)), fmt::arg("item", GET_EXCHANGE_ITEM(item)->get_PName(grammar::ECase::kNom)), fmt::arg("amount", newcost), fmt::arg("currency", MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(newcost, grammar::ECase::kNom).c_str())) + "\r\n").c_str());
 	message_exchange(tmpbuf, ch, item);
+	trade_log::Repriced(trade_log::EMarket::kBazaar, GET_EXCHANGE_ITEM_LOT(item), GET_EXCHANGE_ITEM(item),
+						oldcost, newcost, GET_EXCHANGE_ITEM_SELLERID(item));
 	SetWait(ch, 2, false);
 
 	return true;
@@ -405,6 +410,9 @@ int exchange_withdraw(CharData *ch, char *arg) {
 	message_exchange(tmpbuf, ch, item);
 	if (stable_objs::IsTimerUnlimited(GET_EXCHANGE_ITEM(item))) // если нерушима фрешим таймер из прототипа
 		GET_EXCHANGE_ITEM(item)->set_timer(obj_proto.at(GET_EXCHANGE_ITEM(item)->get_rnum())->get_timer());
+	trade_log::Withdrawn(trade_log::EMarket::kBazaar, lot, GET_EXCHANGE_ITEM(item), GET_EXCHANGE_ITEM_COST(item),
+						 GET_EXCHANGE_ITEM_SELLERID(item),
+						 GET_EXCHANGE_ITEM_SELLERID(item) != ch->get_uid() ? "god" : "owner");
 	PlaceObjToInventory(GET_EXCHANGE_ITEM(item), ch);
 	clear_exchange_lot(item);
 
@@ -578,6 +586,8 @@ int exchange_purchase(CharData *ch, char *arg) {
 			snprintf(tmpbuf, kMaxInputLength, "%s", (fmt::format(fmt::runtime(specials::ExchMsg(specials::EExchMsg::kBcastSold)), fmt::arg("lot", lot), fmt::arg("item", GET_EXCHANGE_ITEM(item)->get_PName(grammar::ECase::kNom)), fmt::arg("suf", grammar::ObjSexEnding((GET_EXCHANGE_ITEM(item))->get_sex(), 6)), fmt::arg("amount", GET_EXCHANGE_ITEM_COST(item)), fmt::arg("currency", MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(GET_EXCHANGE_ITEM_COST(item), grammar::ECase::kNom).c_str())) + "\r\n").c_str());
 
 			message_exchange(tmpbuf, ch, item);
+			trade_log::Sold(trade_log::EMarket::kBazaar, lot, GET_EXCHANGE_ITEM(item), GET_EXCHANGE_ITEM_COST(item),
+							GET_EXCHANGE_ITEM_SELLERID(item), ch->get_uid(), item->time);
 			if (stable_objs::IsTimerUnlimited(GET_EXCHANGE_ITEM(item))) // если нерушима фрешим таймер из прототипа
 				GET_EXCHANGE_ITEM(item)->set_timer(obj_proto.at(GET_EXCHANGE_ITEM(item)->get_rnum())->get_timer());
 			PlaceObjToInventory(GET_EXCHANGE_ITEM(item), ch);
@@ -604,6 +614,8 @@ int exchange_purchase(CharData *ch, char *arg) {
 		act(specials::ExchMsg(specials::EExchMsg::kBought), false, ch, 0, GET_EXCHANGE_ITEM(item), kToChar);
 		snprintf(tmpbuf, kMaxInputLength, "%s", (fmt::format(fmt::runtime(specials::ExchMsg(specials::EExchMsg::kBcastSold)), fmt::arg("lot", lot), fmt::arg("item", GET_EXCHANGE_ITEM(item)->get_PName(grammar::ECase::kNom)), fmt::arg("suf", grammar::ObjSexEnding((GET_EXCHANGE_ITEM(item))->get_sex(), 6)), fmt::arg("amount", GET_EXCHANGE_ITEM_COST(item)), fmt::arg("currency", MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(GET_EXCHANGE_ITEM_COST(item), grammar::ECase::kNom).c_str())) + "\r\n").c_str());
 		message_exchange(tmpbuf, ch, item);
+		trade_log::Sold(trade_log::EMarket::kBazaar, lot, GET_EXCHANGE_ITEM(item), GET_EXCHANGE_ITEM_COST(item),
+						GET_EXCHANGE_ITEM_SELLERID(item), ch->get_uid(), item->time);
 		if (stable_objs::IsTimerUnlimited(GET_EXCHANGE_ITEM(item))) // если нерушима фрешим таймер из прототипа
 			GET_EXCHANGE_ITEM(item)->set_timer(obj_proto.at(GET_EXCHANGE_ITEM(item)->get_rnum())->get_timer());
 		PlaceObjToInventory(GET_EXCHANGE_ITEM(item), ch);
@@ -622,6 +634,8 @@ int exchange_purchase(CharData *ch, char *arg) {
 		act(specials::ExchMsg(specials::EExchMsg::kBought), false, ch, 0, GET_EXCHANGE_ITEM(item), kToChar);
 		snprintf(tmpbuf, kMaxInputLength, "%s", (fmt::format(fmt::runtime(specials::ExchMsg(specials::EExchMsg::kBcastSold)), fmt::arg("lot", lot), fmt::arg("item", GET_EXCHANGE_ITEM(item)->get_PName(grammar::ECase::kNom)), fmt::arg("suf", grammar::ObjSexEnding((GET_EXCHANGE_ITEM(item))->get_sex(), 6)), fmt::arg("amount", GET_EXCHANGE_ITEM_COST(item)), fmt::arg("currency", MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(GET_EXCHANGE_ITEM_COST(item), grammar::ECase::kNom).c_str())) + "\r\n").c_str());
 		message_exchange(tmpbuf, seller, item);
+		trade_log::Sold(trade_log::EMarket::kBazaar, lot, GET_EXCHANGE_ITEM(item), GET_EXCHANGE_ITEM_COST(item),
+						GET_EXCHANGE_ITEM_SELLERID(item), ch->get_uid(), item->time);
 		snprintf(tmpbuf, kMaxInputLength, "%s", (fmt::format(fmt::runtime(specials::ExchMsg(specials::EExchMsg::kSellerSold)), fmt::arg("lot", lot), fmt::arg("item", GET_EXCHANGE_ITEM(item)->get_PName(grammar::ECase::kNom)), fmt::arg("suf", grammar::ObjSexEnding((GET_EXCHANGE_ITEM(item))->get_sex(), 6)), fmt::arg("amount", GET_EXCHANGE_ITEM_COST(item)), fmt::arg("currency", MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(GET_EXCHANGE_ITEM_COST(item), grammar::ECase::kNom).c_str())) + "\r\n").c_str());
 		act(tmpbuf, false, seller, 0, nullptr, kToChar);
 
@@ -1035,11 +1049,20 @@ void exchange_database_save(bool backup) {
 	std::stringstream out;
 	out << "!NEW!\n";
 	ExchangeItem *j, *next_thing;
+	int lots_count = 0;
+	long lots_value = 0;
 	for (j = exchange_item_list; j; j = next_thing) {
 		next_thing = j->next;
 		exchange_write_one_object_new(out, j);
+		++lots_count;
+		lots_value += GET_EXCHANGE_ITEM_COST(j);
 	}
 	out << "$\n$\n";
+
+	// Бэкап пишется тем же кодом, но снимок витрины нужен один на автосохранение.
+	if (!backup) {
+		trade_log::ActiveLots(trade_log::EMarket::kBazaar, lots_count, lots_value);
+	}
 
 	const char *filename = backup ? EXCHANGE_DATABASE_BACKUPFILE : EXCHANGE_DATABASE_FILE;
 	std::ofstream file(filename);

--- a/src/gameplay/economics/trade_log.cpp
+++ b/src/gameplay/economics/trade_log.cpp
@@ -1,0 +1,151 @@
+/**
+\file trade_log.cpp - a part of the Bylins engine.
+\brief Единая телеметрия торговых площадок (базар и аукцион).
+*/
+
+#include "trade_log.h"
+
+#include "engine/entities/entities_constants.h"
+#include "engine/entities/obj_data.h"
+#include "engine/observability/metrics.h"
+#include "utils/logger.h"
+#include "utils/utils_string.h"
+
+#include <map>
+#include <stdexcept>
+#include <string>
+
+namespace trade_log {
+
+namespace {
+
+using Attrs = std::map<std::string, std::string>;
+
+// Событий торговли в syslog быть не должно -- они только для аналитики,
+// поэтому тип перечислен в logging::kOtlpOnlyLogTypes и на диск не пишется.
+constexpr const char *kTradeLogType = "trade";
+
+const char *MarketName(EMarket market) {
+	return market == EMarket::kAuction ? "auction" : "bazaar";
+}
+
+// Единственный атрибут предмета, который допустим в Prometheus: значений десятки.
+std::string ObjTypeName(const ObjData *obj) {
+	if (!obj) {
+		return "unknown";
+	}
+	try {
+		return NAME_BY_ITEM<EObjType>(obj->get_type());
+	} catch (const std::out_of_range &) {
+		return "unknown";
+	}
+}
+
+// Название без цветовых кодов: с ними одна и та же вещь дала бы разные значения
+// атрибута item, и группировка по товару в Grafana развалилась бы.
+std::string ItemName(const ObjData *obj) {
+	return obj ? utils::RemoveColors(obj->get_short_description()) : std::string("?");
+}
+
+int ItemVnum(const ObjData *obj) {
+	return obj ? obj->get_vnum() : -1;
+}
+
+Attrs BaseAttrs(EMarket market, const char *event, int lot, const ObjData *obj, long price, long seller_id) {
+	Attrs attrs{
+		{"market", MarketName(market)},
+		{"event", event},
+		{"lot", std::to_string(lot)},
+		{"price", std::to_string(price)},
+		{"seller_id", std::to_string(seller_id)},
+		{"obj_type", ObjTypeName(obj)},
+		{"vnum", std::to_string(ItemVnum(obj))},
+	};
+	if (obj) {
+		// Строка остаётся в KOI8-R: в UTF-8 её переведёт OTLP-сендер.
+		attrs["item"] = ItemName(obj);
+	}
+	return attrs;
+}
+
+// Атрибуты метрик -- строго подмножество атрибутов лога с низкой кардинальностью.
+Attrs MetricAttrs(EMarket market, const ObjData *obj) {
+	return Attrs{
+		{"market", MarketName(market)},
+		{"obj_type", ObjTypeName(obj)},
+	};
+}
+
+}  // namespace
+
+void Listed(EMarket market, int lot, const ObjData *obj, long price, long seller_id) {
+	log_event(kTradeLogType, BaseAttrs(market, "listed", lot, obj, price, seller_id),
+			  "[trade] %s listed lot=%d vnum=%d price=%ld seller=%ld item=%s",
+			  MarketName(market), lot, ItemVnum(obj), price, seller_id, ItemName(obj).c_str());
+
+	observability::OtelMetrics::RecordCounter("trade.listed.total", 1, MetricAttrs(market, obj));
+}
+
+void Repriced(EMarket market, int lot, const ObjData *obj, long old_price, long new_price, long seller_id) {
+	auto attrs = BaseAttrs(market, "repriced", lot, obj, new_price, seller_id);
+	attrs["old_price"] = std::to_string(old_price);
+	log_event(kTradeLogType, attrs,
+			  "[trade] %s repriced lot=%d vnum=%d old_price=%ld price=%ld seller=%ld item=%s",
+			  MarketName(market), lot, ItemVnum(obj), old_price, new_price, seller_id, ItemName(obj).c_str());
+
+	observability::OtelMetrics::RecordCounter("trade.repriced.total", 1, MetricAttrs(market, obj));
+}
+
+void Bid(EMarket market, int lot, const ObjData *obj, long price, long seller_id, long buyer_id) {
+	auto attrs = BaseAttrs(market, "bid", lot, obj, price, seller_id);
+	attrs["buyer_id"] = std::to_string(buyer_id);
+	log_event(kTradeLogType, attrs,
+			  "[trade] %s bid lot=%d vnum=%d price=%ld seller=%ld buyer=%ld item=%s",
+			  MarketName(market), lot, ItemVnum(obj), price, seller_id, buyer_id, ItemName(obj).c_str());
+
+	observability::OtelMetrics::RecordCounter("trade.bid.total", 1, MetricAttrs(market, obj));
+}
+
+void Withdrawn(EMarket market, int lot, const ObjData *obj, long price, long seller_id, const char *reason) {
+	const char *why = reason ? reason : "unknown";
+	auto attrs = BaseAttrs(market, "withdrawn", lot, obj, price, seller_id);
+	attrs["reason"] = why;
+	log_event(kTradeLogType, attrs,
+			  "[trade] %s withdrawn lot=%d vnum=%d price=%ld seller=%ld reason=%s item=%s",
+			  MarketName(market), lot, ItemVnum(obj), price, seller_id, why, ItemName(obj).c_str());
+
+	auto metric_attrs = MetricAttrs(market, obj);
+	metric_attrs["reason"] = why;
+	observability::OtelMetrics::RecordCounter("trade.withdrawn.total", 1, metric_attrs);
+}
+
+void Sold(EMarket market, int lot, const ObjData *obj, long price, long seller_id, long buyer_id, time_t listed_at) {
+	const long listed_seconds = listed_at > 0 ? static_cast<long>(time(nullptr) - listed_at) : -1;
+
+	auto attrs = BaseAttrs(market, "sold", lot, obj, price, seller_id);
+	attrs["buyer_id"] = std::to_string(buyer_id);
+	attrs["listed_seconds"] = std::to_string(listed_seconds);
+	log_event(kTradeLogType, attrs,
+			  "[trade] %s sold lot=%d vnum=%d price=%ld seller=%ld buyer=%ld listed_seconds=%ld item=%s",
+			  MarketName(market), lot, ItemVnum(obj), price, seller_id, buyer_id, listed_seconds, ItemName(obj).c_str());
+
+	const auto metric_attrs = MetricAttrs(market, obj);
+	observability::OtelMetrics::RecordCounter("trade.sale.total", 1, metric_attrs);
+	observability::OtelMetrics::RecordCounter("trade.turnover.total", price, metric_attrs);
+	observability::OtelMetrics::RecordHistogram("trade.price", static_cast<double>(price), metric_attrs);
+	if (listed_seconds >= 0) {
+		observability::OtelMetrics::RecordHistogram("trade.time_to_sale.seconds",
+												   static_cast<double>(listed_seconds),
+												   {{"market", MarketName(market)}});
+	}
+}
+
+void ActiveLots(EMarket market, int count, long total_value) {
+	const Attrs attrs{{"market", MarketName(market)}};
+	observability::OtelMetrics::RecordGauge("trade.lots.active", count, attrs);
+	observability::OtelMetrics::RecordGauge("trade.lots.value", static_cast<double>(total_value), attrs);
+}
+
+}  // namespace trade_log
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/gameplay/economics/trade_log.h
+++ b/src/gameplay/economics/trade_log.h
@@ -1,0 +1,54 @@
+/**
+\file trade_log.h - a part of the Bylins engine.
+\brief Единая телеметрия торговых площадок (базар и аукцион).
+\detail Один механизм на оба рынка: событие уезжает по OTLP в Loki,
+        машиночитаемые поля -- в атрибутах (structured metadata), поэтому в
+        Grafana они фильтруются и агрегируются без regex. На диск события не
+        пишутся: это телеметрия для аналитики, а не syslog для чтения глазами.
+
+        Разделение труда между логом и метриками принципиальное:
+        * имя предмета и внум идут ТОЛЬКО в лог -- это тысячи значений,
+          в лейбле Prometheus они бы навсегда размножили серии в TSDB;
+        * в метрики уходит лишь тип предмета (десятки значений) и рынок.
+        Тренды по конкретным товарам считаются в Loki: sum by (item) (...).
+*/
+
+#ifndef BYLINS_SRC_GAMEPLAY_ECONOMICS_TRADE_LOG_H_
+#define BYLINS_SRC_GAMEPLAY_ECONOMICS_TRADE_LOG_H_
+
+#include <ctime>
+
+class ObjData;
+
+namespace trade_log {
+
+enum class EMarket {
+	kBazaar,
+	kAuction
+};
+
+// Лот выставлен на продажу.
+void Listed(EMarket market, int lot, const ObjData *obj, long price, long seller_id);
+
+// Владелец изменил цену лота.
+void Repriced(EMarket market, int lot, const ObjData *obj, long old_price, long new_price, long seller_id);
+
+// Новая ставка (аукцион).
+void Bid(EMarket market, int lot, const ObjData *obj, long price, long seller_id, long buyer_id);
+
+// Лот ушёл с площадки без продажи.
+// reason: "owner", "god", "no_demand", "trader".
+void Withdrawn(EMarket market, int lot, const ObjData *obj, long price, long seller_id, const char *reason);
+
+// Сделка состоялась. listed_at -- момент выставления (0, если неизвестен):
+// по нему считается время до продажи, то есть ликвидность товара.
+void Sold(EMarket market, int lot, const ObjData *obj, long price, long seller_id, long buyer_id, time_t listed_at);
+
+// Снимок витрины: сколько лотов стоит и на какую сумму.
+void ActiveLots(EMarket market, int count, long total_value);
+
+}  // namespace trade_log
+
+#endif  // BYLINS_SRC_GAMEPLAY_ECONOMICS_TRADE_LOG_H_
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -124,18 +124,24 @@ static std::string format_log_message(const char *format, va_list args) {
     return ts + " :: " + msg;
 }
 
+// Имя потока, которое уезжает в атрибут log_type: по нему FileLogSender выбирает
+// файл, а Loki кладёт его в structured metadata (фильтр `| log_type="trade"`).
+static const char* stream_name_for_stream(EOutputStream stream) {
+	switch (stream) {
+		case SYSLOG:    return "syslog";
+		case ERRLOG:    return "errlog";
+		case IMLOG:     return "imlog";
+		case MSDP_LOG:  return "msdp";
+		case MONEY_LOG: return "money";
+		default:        return "syslog";
+	}
+}
+
 static const char* stream_name_for_file(FILE* file) {
 	for (int i = 0; i <= LAST_LOG; i++) {
 		const auto stream = static_cast<EOutputStream>(i);
 		if (runtime_config.logs(stream).handle() == file) {
-			switch (stream) {
-				case SYSLOG:    return "syslog";
-				case ERRLOG:    return "errlog";
-				case IMLOG:     return "imlog";
-				case MSDP_LOG:  return "msdp";
-				case MONEY_LOG: return "money";
-				default:        return "syslog";
-			}
+			return stream_name_for_stream(stream);
 		}
 	}
 	return "syslog";
@@ -187,16 +193,32 @@ void vlog(const EOutputStream steam, const char *format, va_list rargs) {
 		return;
 	}
 
-	const char* stream_name;
-	switch (steam) {
-		case SYSLOG:    stream_name = "syslog"; break;
-		case ERRLOG:    stream_name = "errlog"; break;
-		case IMLOG:     stream_name = "imlog"; break;
-		case MSDP_LOG:  stream_name = "msdp"; break;
-		case MONEY_LOG: stream_name = "money"; break;
-		default:        stream_name = "syslog"; break;
+	logging::LogManager::Info(message, {{"log_type", stream_name_for_stream(steam)}});
+}
+
+void log_event(const char *log_type, const std::map<std::string, std::string> &attributes, const char *format, ...) {
+	if (!runtime_config.logging_enabled()) {
+		return;
 	}
-	logging::LogManager::Info(message, {{"log_type", stream_name}});
+
+	if (format == nullptr) {
+		format = "SYSERR: log_event() received a NULL format.";
+	}
+
+	va_list args;
+	va_start(args, format);
+	const std::string message = format_log_message(format, args);
+	va_end(args);
+	if (message.empty()) {
+		return;
+	}
+
+	// Атрибуты уходят в OTLP как structured metadata (Loki умеет по ним фильтровать
+	// и агрегировать без regex). Пишется ли событие ещё и в файл, решает
+	// FileLogSender по log_type: у чисто телеметрических типов файла нет.
+	std::map<std::string, std::string> attrs(attributes);
+	attrs["log_type"] = log_type ? log_type : "syslog";
+	logging::LogManager::Info(message, attrs);
 }
 
 void log(std::string format) {

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <list>
+#include <map>
 #include <string>
 #include <thread>
 
@@ -19,6 +20,11 @@ void log(std::string format);
 void log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void vlog(const char *format, va_list args) __attribute__((format(printf, 1, 0)));
 void vlog(const EOutputStream steam, const char *format, va_list args) __attribute__((format(printf, 2, 0)));
+// Строка в лог + произвольные атрибуты. Атрибуты доезжают до Loki как structured
+// metadata, поэтому машиночитаемые поля события надо класть туда, а не в текст.
+// log_type задаёт назначение: типы из logging::kOtlpOnlyLogTypes на диск не пишутся.
+void log_event(const char *log_type, const std::map<std::string, std::string> &attributes,
+			   const char *format, ...) __attribute__((format(printf, 3, 4)));
 void shop_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void olc_log(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void imm_log(const char *format, ...) __attribute__((format(printf, 1, 2)));

--- a/src/utils/logging/file_log_sender.cpp
+++ b/src/utils/logging/file_log_sender.cpp
@@ -1,4 +1,5 @@
 #include "file_log_sender.h"
+#include "log_sender.h"
 #include "utils/logger.h"
 #include "engine/core/config.h"
 #include "engine/db/global_objects.h"
@@ -77,6 +78,10 @@ void FileLogSender::write_to_file(const std::string& message,
 FILE* FileLogSender::get_log_file(const std::map<std::string, std::string>& attributes) {
     auto it = attributes.find("log_type");
     const std::string& log_type = (it != attributes.end()) ? it->second : "syslog";
+
+    if (logging::kOtlpOnlyLogTypes.contains(log_type)) {
+        return nullptr;
+    }
 
     if (log_type == "syslog")  return runtime_config.logs(SYSLOG).handle();
     if (log_type == "errlog")  return runtime_config.logs(ERRLOG).handle();

--- a/src/utils/logging/log_sender.h
+++ b/src/utils/logging/log_sender.h
@@ -1,10 +1,16 @@
 #ifndef BYLINS_LOG_SENDER_H
 #define BYLINS_LOG_SENDER_H
 
-#include <string>
 #include <map>
+#include <set>
+#include <string>
 
 namespace logging {
+
+// Типы логов, у которых нет файла на диске: событие уходит только по OTLP
+// (в Loki). Это чистая телеметрия -- машиночитаемые события, которые нужны для
+// аналитики, а не для чтения глазами в syslog. FileLogSender их пропускает.
+inline const std::set<std::string> kOtlpOnlyLogTypes{"trade"};
 
 enum class LogLevel {
     kDebug,

--- a/tools/observability/METRICS.md
+++ b/tools/observability/METRICS.md
@@ -134,18 +134,58 @@ Prometheus: `combat_active_count_gauge_{bucket,sum,count}`
 
 ---
 
-## Аукцион
+## Торговля (базар и аукцион)
+
+Обе площадки инструментированы одним механизмом (`gameplay/economics/trade_log.h`).
+Атрибут `market` разделяет их: `bazaar` — команда `базар`, `auction` — команда `аукцион`.
 
 | Метрика | Тип | Атрибуты | Описание |
 |---------|-----|----------|----------|
-| `auction_lots_active` | gauge | — | Количество активных лотов |
-| `auction_sale_total` | counter | — | Количество завершённых продаж |
-| `auction_revenue_total` | counter | — | Суммарная выручка (в кунах) |
-| `auction_duration_seconds` | histogram | — | Время от выставления лота до продажи |
+| `trade_sale_total` | counter | `market`, `obj_type` | Завершённые сделки |
+| `trade_turnover_total` | counter | `market`, `obj_type` | Оборот в кунах |
+| `trade_price` | histogram | `market`, `obj_type` | Распределение цен сделок |
+| `trade_time_to_sale_seconds` | histogram | `market` | Время от выставления до продажи (ликвидность) |
+| `trade_listed_total` | counter | `market`, `obj_type` | Выставлено лотов |
+| `trade_repriced_total` | counter | `market`, `obj_type` | Смен цены владельцем |
+| `trade_withdrawn_total` | counter | `market`, `obj_type`, `reason` | Снято без продажи |
+| `trade_bid_total` | counter | `market`, `obj_type` | Ставки (только аукцион) |
+| `trade_lots_active` | gauge | `market` | Лотов на витрине |
+| `trade_lots_value` | gauge | `market` | Суммарный ценник витрины |
 
-Prometheus: `auction_lots_active_gauge_{bucket,sum,count}`
+Prometheus: `trade_lots_active_gauge_{bucket,sum,count}`, `trade_lots_value_gauge_{bucket,sum,count}`.
 
-> Детали по конкретным сделкам (продавец, покупатель, предмет, стоимость) доступны через трейсы (спан `"Auction Sale"`).
+`reason`: `owner` (снял владелец), `god` (снято Богами), `trader` (снято распорядителем),
+`no_demand` (не нашлось покупателя), `no_money` (у покупателя не хватило денег),
+`owner_changed` (предмет ушёл от продавца).
+
+**Почему в метриках нет названия предмета.** Каждое уникальное значение лейбла — это
+отдельная серия в TSDB навсегда. `item`/`vnum` дали бы тысячи серий, поэтому в Prometheus
+уходит только тип предмета (`obj_type`, десятки значений). Аналитика по конкретным товарам
+живёт в логах — см. ниже.
+
+### Лог сделок (Loki)
+
+Каждое событие уходит только по OTLP в Loki (в файлы на диске не пишется -- это
+телеметрия, а не syslog) с атрибутами в structured metadata: `market`, `event`, `lot`, `vnum`, `item`, `obj_type`, `price`,
+`seller_id`, `buyer_id`, `listed_seconds`, `old_price`, `reason`.
+Фильтровать и агрегировать по ним можно без regex:
+
+```logql
+# лента сделок
+{service_name="bylins-bylins-new-4000"} | log_type="trade" | event="sold"
+
+# топ товаров по обороту за сутки
+topk(20, sum by (item) (sum_over_time(
+  {service_name="bylins-bylins-new-4000"} | log_type="trade" | event="sold" | unwrap price [24h])))
+
+# динамика цены конкретного предмета
+avg_over_time({service_name="bylins-bylins-new-4000"} | log_type="trade"
+  | event="sold" | item=~"$item" | unwrap price [$__auto])
+
+# что выставляют, но не покупают
+topk(20, sum by (item) (count_over_time(
+  {service_name="bylins-bylins-new-4000"} | log_type="trade" | event="withdrawn" [7d])))
+```
 
 ---
 

--- a/tools/observability/dashboards/business-logic-dashboard.json
+++ b/tools/observability/dashboards/business-logic-dashboard.json
@@ -30,7 +30,7 @@
       },
       "options": {
         "mode": "markdown",
-        "content": "> **\u0414\u0430\u0448\u0431\u043e\u0440\u0434 \u0442\u043e\u043b\u044c\u043a\u043e \u0434\u043b\u044f \u0447\u0442\u0435\u043d\u0438\u044f.** \u0423\u043f\u0440\u0430\u0432\u043b\u044f\u0435\u0442\u0441\u044f \u0438\u0437 \u0444\u0430\u0439\u043b\u0430 \u0432 \u0440\u0435\u043f\u043e\u0437\u0438\u0442\u043e\u0440\u0438\u0438. \u0427\u0442\u043e\u0431\u044b \u0432\u043d\u0435\u0441\u0442\u0438 \u0438\u0437\u043c\u0435\u043d\u0435\u043d\u0438\u044f \u2014 \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0439\u0442\u0435 **Save As** (\u0441\u043e\u0437\u0434\u0430\u0439\u0442\u0435 \u043a\u043e\u043f\u0438\u044e).\n>\n> \u041f\u0430\u043d\u0435\u043b\u0438 \u0430\u0443\u043a\u0446\u0438\u043e\u043d\u0430 \u0438 \u043a\u0440\u0430\u0444\u0442\u0430 \u043f\u043e\u043a\u0430\u0437\u044b\u0432\u0430\u044e\u0442 \u0434\u0430\u043d\u043d\u044b\u0435 \u0442\u043e\u043b\u044c\u043a\u043e \u043f\u043e\u0441\u043b\u0435 \u0441\u043e\u043e\u0442\u0432\u0435\u0442\u0441\u0442\u0432\u0443\u044e\u0449\u0438\u0445 \u0438\u0433\u0440\u043e\u0432\u044b\u0445 \u0441\u043e\u0431\u044b\u0442\u0438\u0439."
+        "content": "> **Дашборд только для чтения.** Управляется из файла в репозитории. Чтобы внести изменения — используйте **Save As** (создайте копию).\n>\n> Панели аукциона и крафта показывают данные только после соответствующих игровых событий."
       },
       "transparent": true
     },
@@ -111,7 +111,7 @@
           "refId": "A"
         }
       ],
-      "title": "\u0422\u043e\u043f 10 \u0441\u0430\u043c\u044b\u0445 \u0438\u0441\u043f\u043e\u043b\u044c\u0437\u0443\u0435\u043c\u044b\u0445 \u0437\u0430\u043a\u043b\u0438\u043d\u0430\u043d\u0438\u0439 (\u0447\u0430\u0441\u0442\u043e\u0442\u0430)",
+      "title": "Топ 10 самых используемых заклинаний (частота)",
       "type": "timeseries"
     },
     {
@@ -192,11 +192,11 @@
         },
         {
           "expr": "histogram_quantile(0.99, rate(spell_cast_duration_bucket{job=~\"$service\"}[5m]))",
-          "legendFormat": "p99 (\u0432\u0441\u0435)",
+          "legendFormat": "p99 (все)",
           "refId": "B"
         }
       ],
-      "title": "\u0414\u043b\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u044c \u0432\u044b\u043f\u043e\u043b\u043d\u0435\u043d\u0438\u044f \u0437\u0430\u043a\u043b\u0438\u043d\u0430\u043d\u0438\u044f",
+      "title": "Длительность выполнения заклинания",
       "type": "timeseries"
     },
     {
@@ -276,7 +276,7 @@
           "refId": "A"
         }
       ],
-      "title": "\u0417\u0430\u043a\u043b\u0438\u043d\u0430\u043d\u0438\u044f \u043f\u043e \u043a\u043b\u0430\u0441\u0441\u0443 (\u0447\u0430\u0441\u0442\u043e\u0442\u0430)",
+      "title": "Заклинания по классу (частота)",
       "type": "timeseries"
     },
     {
@@ -361,7 +361,7 @@
           "refId": "B"
         }
       ],
-      "title": "\u0414\u043b\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u044c \u0442\u0440\u0438\u0433\u0433\u0435\u0440\u043e\u0432 DG Scripts (\u043f\u043e \u0442\u0438\u043f\u0443)",
+      "title": "Длительность триггеров DG Scripts (по типу)",
       "type": "timeseries"
     },
     {
@@ -437,11 +437,11 @@
       "targets": [
         {
           "expr": "rate(player_deaths_total{job=~\"$service\"}[5m])",
-          "legendFormat": "\u0421\u043c\u0435\u0440\u0442\u0435\u0439/\u0441\u0435\u043a ({{death_type}})",
+          "legendFormat": "Смертей/сек ({{death_type}})",
           "refId": "A"
         }
       ],
-      "title": "\u0421\u043c\u0435\u0440\u0442\u0438 \u0438\u0433\u0440\u043e\u043a\u043e\u0432 (PvP / PvE)",
+      "title": "Смерти игроков (PvP / PvE)",
       "type": "timeseries"
     },
     {
@@ -517,16 +517,16 @@
       "targets": [
         {
           "expr": "rate(craft_completed_total{job=~\"$service\"}[5m])",
-          "legendFormat": "\u0423\u0441\u043f\u0435\u0448\u043d\u043e ({{recipe_id}})",
+          "legendFormat": "Успешно ({{recipe_id}})",
           "refId": "A"
         },
         {
           "expr": "rate(craft_failures_total{job=~\"$service\"}[5m])",
-          "legendFormat": "\u041d\u0435\u0443\u0434\u0430\u0447\u0430 ({{failure_reason}})",
+          "legendFormat": "Неудача ({{failure_reason}})",
           "refId": "B"
         }
       ],
-      "title": "\u041a\u0440\u0430\u0444\u0442: \u0443\u0441\u043f\u0435\u0445\u0438 \u0438 \u043d\u0435\u0443\u0434\u0430\u0447\u0438 (\u043f\u043e\u044f\u0432\u0438\u0442\u0441\u044f \u043f\u0440\u0438 \u043f\u0435\u0440\u0432\u043e\u043c \u043a\u0440\u0430\u0444\u0442\u0435)",
+      "title": "Крафт: успехи и неудачи (появится при первом крафте)",
       "type": "timeseries"
     },
     {
@@ -581,11 +581,11 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "rate(auction_lots_active_gauge_sum{job=~\"$service\"}[5m]) / rate(auction_lots_active_gauge_count{job=~\"$service\"}[5m])",
+          "expr": "sum(rate(trade_lots_active_gauge_sum{job=~\"$service\"}[5m]) / rate(trade_lots_active_gauge_count{job=~\"$service\"}[5m]))",
           "refId": "A"
         }
       ],
-      "title": "\u0410\u043a\u0442\u0438\u0432\u043d\u044b\u0435 \u043b\u043e\u0442\u044b \u0430\u0443\u043a\u0446\u0438\u043e\u043d\u0430",
+      "title": "Лотов на витрине (базар + аукцион)",
       "type": "gauge"
     },
     {
@@ -660,17 +660,17 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "rate(auction_lots_active_gauge_sum{job=~\"$service\"}[5m]) / rate(auction_lots_active_gauge_count{job=~\"$service\"}[5m])",
-          "legendFormat": "\u0410\u043a\u0442\u0438\u0432\u043d\u044b\u0435 \u043b\u043e\u0442\u044b",
+          "expr": "sum by (market) (rate(trade_sale_total{job=~\"$service\"}[$__rate_interval]))",
+          "legendFormat": "{{market}}: сделок/сек",
           "refId": "A"
         },
         {
-          "expr": "rate(auction_sale_total{job=~\"$service\"}[5m])",
-          "legendFormat": "\u041f\u0440\u043e\u0434\u0430\u0436/\u0441\u0435\u043a",
+          "expr": "sum by (market) (rate(trade_turnover_total{job=~\"$service\"}[$__rate_interval]))",
+          "legendFormat": "{{market}}: кун/сек",
           "refId": "B"
         }
       ],
-      "title": "\u0410\u0443\u043a\u0446\u0438\u043e\u043d (\u043f\u0440\u043e\u0434\u0430\u0436\u0438 \u043f\u043e\u044f\u0432\u044f\u0442\u0441\u044f \u043f\u043e\u0441\u043b\u0435 \u043f\u0435\u0440\u0432\u043e\u0439 \u0441\u0434\u0435\u043b\u043a\u0438)",
+      "title": "Торговля: сделки и оборот",
       "type": "timeseries"
     },
     {
@@ -745,12 +745,17 @@
       "pluginVersion": "8.0.0",
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, rate(auction_duration_seconds_bucket{job=~\"$service\"}[5m]))",
-          "legendFormat": "p95 \u0414\u043b\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u044c (\u043e\u0442 \u0432\u044b\u0441\u0442\u0430\u0432\u043b\u0435\u043d\u0438\u044f \u0434\u043e \u043f\u0440\u043e\u0434\u0430\u0436\u0438)",
+          "expr": "histogram_quantile(0.5, sum by (market, le) (rate(trade_time_to_sale_seconds_bucket{job=~\"$service\"}[$__rate_interval])))",
+          "legendFormat": "{{market}} p50",
           "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (market, le) (rate(trade_time_to_sale_seconds_bucket{job=~\"$service\"}[$__rate_interval])))",
+          "legendFormat": "{{market}} p95",
+          "refId": "B"
         }
       ],
-      "title": "\u0414\u043b\u0438\u0442\u0435\u043b\u044c\u043d\u043e\u0441\u0442\u044c \u0430\u0443\u043a\u0446\u0438\u043e\u043d\u043e\u0432 (\u043f\u043e\u044f\u0432\u0438\u0442\u0441\u044f \u043f\u043e\u0441\u043b\u0435 \u043f\u0435\u0440\u0432\u043e\u0439 \u043f\u0440\u043e\u0434\u0430\u0436\u0438)",
+      "title": "Время от выставления до продажи",
       "type": "timeseries"
     },
     {
@@ -826,11 +831,11 @@
       "targets": [
         {
           "expr": "rate(zone_reset_total{job=~\"$service\"}[5m])",
-          "legendFormat": "\u0421\u0431\u0440\u043e\u0441\u043e\u0432/\u0441\u0435\u043a ({{reset_mode}})",
+          "legendFormat": "Сбросов/сек ({{reset_mode}})",
           "refId": "A"
         }
       ],
-      "title": "\u0421\u0431\u0440\u043e\u0441\u044b \u0437\u043e\u043d (\u043f\u043e \u0440\u0435\u0436\u0438\u043c\u0443)",
+      "title": "Сбросы зон (по режиму)",
       "type": "timeseries"
     }
   ],
@@ -877,8 +882,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Bylins MUD - \u0414\u0430\u0448\u0431\u043e\u0440\u0434 \u0438\u0433\u0440\u043e\u0432\u043e\u0439 \u043b\u043e\u0433\u0438\u043a\u0438",
-  "description": "\u0422\u043e\u043b\u044c\u043a\u043e \u0434\u043b\u044f \u0447\u0442\u0435\u043d\u0438\u044f. \u0427\u0442\u043e\u0431\u044b \u0432\u043d\u0435\u0441\u0442\u0438 \u0438\u0437\u043c\u0435\u043d\u0435\u043d\u0438\u044f \u2014 \u043a\u043b\u043e\u043d\u0438\u0440\u0443\u0439\u0442\u0435 \u0434\u0430\u0448\u0431\u043e\u0440\u0434 \u0432 Grafana (\u043a\u043d\u043e\u043f\u043a\u0430 Save As).",
+  "title": "Bylins MUD - Дашборд игровой логики",
+  "description": "Только для чтения. Чтобы внести изменения — клонируйте дашборд в Grafana (кнопка Save As).",
   "uid": "bylins-business-logic",
   "version": 0
 }

--- a/tools/observability/dashboards/trade-dashboard.json
+++ b/tools/observability/dashboards/trade-dashboard.json
@@ -1,0 +1,912 @@
+{
+  "uid": "bylins-trade",
+  "title": "Bylins MUD — Базар и аукцион",
+  "description": "Что торгуется, почём и как меняется цена. Детали по товарам — из логов (Loki), долгие тренды — из метрик (Prometheus).",
+  "tags": [
+    "bylins",
+    "economy"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "1m",
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "editable": true,
+  "templating": {
+    "list": [
+      {
+        "name": "service",
+        "label": "Сервер",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(heartbeat_total_duration_sum, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": false,
+        "multi": false,
+        "current": {}
+      },
+      {
+        "name": "market",
+        "label": "Площадка",
+        "type": "custom",
+        "query": "bazaar,auction",
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "options": []
+      },
+      {
+        "name": "item",
+        "label": "Предмет (regex)",
+        "type": "textbox",
+        "query": ".*",
+        "current": {
+          "text": ".*",
+          "value": ".*"
+        },
+        "description": "Подстрока или регулярка по названию предмета для графика цены"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Сделок за период",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(count_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"sold\" [$__range]))",
+          "refId": "A",
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Оборот, кун",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 0
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "sum(sum_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"sold\" | unwrap price [$__range]))",
+          "refId": "A",
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Средний чек, кун",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 10,
+        "y": 0
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "avg(avg_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"sold\" | unwrap price [$__range]))",
+          "refId": "A",
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Лотов на витрине",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 15,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(trade_lots_active_gauge_sum{job=~\"$service\"}[5m]) / rate(trade_lots_active_gauge_count{job=~\"$service\"}[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Ценник витрины, кун",
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(trade_lots_value_gauge_sum{job=~\"$service\"}[5m]) / rate(trade_lots_value_gauge_count{job=~\"$service\"}[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "logs",
+      "title": "Лента торгов",
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "prettifyLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "{service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\"",
+          "refId": "A",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "table",
+      "title": "Топ товаров по обороту",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 0,
+        "y": 15
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Оборот, кун"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "topk(20, sum by (item) (sum_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"sold\" | unwrap price [$__range])))",
+          "refId": "A",
+          "queryType": "instant"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value": "Оборот, кун",
+              "item": "Предмет"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "table",
+      "title": "Топ товаров по числу сделок",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 8,
+        "y": 15
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Сделок"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "topk(20, sum by (item) (count_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"sold\" [$__range])))",
+          "refId": "A",
+          "queryType": "instant"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value": "Сделок",
+              "item": "Предмет"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "table",
+      "title": "Снято без продажи (что не берут)",
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 15
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto"
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Снятий"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "topk(20, sum by (item) (count_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"withdrawn\" [$__range])))",
+          "refId": "A",
+          "queryType": "instant"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "renameByName": {
+              "Value": "Снятий",
+              "item": "Предмет"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Цена предмета: $item (min / avg / max по сделкам)",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "avg_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"sold\" | item=~\"$item\" | unwrap price [$__auto])",
+          "refId": "A",
+          "queryType": "range",
+          "legendFormat": "avg"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "min_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"sold\" | item=~\"$item\" | unwrap price [$__auto])",
+          "refId": "B",
+          "queryType": "range",
+          "legendFormat": "min"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "expr": "max_over_time({service_name=\"$service\"} | log_type=\"trade\" | market=~\"$market\" | event=\"sold\" | item=~\"$item\" | unwrap price [$__auto])",
+          "refId": "C",
+          "queryType": "range",
+          "legendFormat": "max"
+        }
+      ]
+    },
+    {
+      "id": 21,
+      "type": "timeseries",
+      "title": "Сделки по типам предметов",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (obj_type) (rate(trade_sale_total{job=~\"$service\", market=~\"$market\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "{{obj_type}}"
+        }
+      ]
+    },
+    {
+      "id": 22,
+      "type": "timeseries",
+      "title": "Витрина: лотов и суммарный ценник",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (market) (rate(trade_lots_active_gauge_sum{job=~\"$service\"}[5m]) / rate(trade_lots_active_gauge_count{job=~\"$service\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{market}}: лотов"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (market) (rate(trade_lots_value_gauge_sum{job=~\"$service\"}[5m]) / rate(trade_lots_value_gauge_count{job=~\"$service\"}[5m]))",
+          "refId": "B",
+          "legendFormat": "{{market}}: кун"
+        }
+      ]
+    },
+    {
+      "id": 23,
+      "type": "timeseries",
+      "title": "Время от выставления до продажи",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum by (market, le) (rate(trade_time_to_sale_seconds_bucket{job=~\"$service\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "{{market}} p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (market, le) (rate(trade_time_to_sale_seconds_bucket{job=~\"$service\"}[$__rate_interval])))",
+          "refId": "B",
+          "legendFormat": "{{market}} p95"
+        }
+      ]
+    },
+    {
+      "id": 24,
+      "type": "timeseries",
+      "title": "Выставлено / продано / снято",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(trade_listed_total{job=~\"$service\", market=~\"$market\"}[$__rate_interval]))",
+          "refId": "A",
+          "legendFormat": "выставлено/сек"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(trade_sale_total{job=~\"$service\", market=~\"$market\"}[$__rate_interval]))",
+          "refId": "B",
+          "legendFormat": "продано/сек"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (reason) (rate(trade_withdrawn_total{job=~\"$service\", market=~\"$market\"}[$__rate_interval]))",
+          "refId": "C",
+          "legendFormat": "снято: {{reason}}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Зачем

Сделки на базаре не логировались вообще — ни `log()`, ни `mudlog()`, ни метрик. Единственный след торговли в Loki сейчас — набранные игроками команды (`базар куп 926`), из которых видно кто и когда торговал, но не что и почём: команда содержит только номер лота, а номера переиспользуются (`get_unique_lot()` отдаёт первый свободный индекс), так что связать лот с предметом нельзя.

У аукциона своя инструментация была — спан `"Auction Sale"` и счётчики `auction.*`. Толку от неё ноль: `auction_lots_active_gauge_sum` = 0 за всё время хранения, `auction_sale_total` в Prometheus не существует. Аукцион практически не используется (`kMaxAuctionLot = 3`), а панели «Аукцион» в `business-logic-dashboard.json` рисуют пустоту.

Два механизма на две площадки не нужны, поэтому они сведены в один.

## Что сделано

Новый модуль `gameplay/economics/trade_log.{h,cpp}` — события `listed`, `repriced`, `bid`, `sold`, `withdrawn` и снимок витрины, с атрибутом `market` = `bazaar` | `auction`.

Событие уходит по OTLP в Loki, машиночитаемые поля — в атрибутах (structured metadata), поэтому в Grafana они фильтруются и агрегируются без regex:

```logql
{service_name="bylins-bylins-new-4000"} | log_type="trade" | event="sold"

topk(20, sum by (item) (sum_over_time(
  {service_name="bylins-bylins-new-4000"} | log_type="trade" | event="sold" | unwrap price [24h])))
```

**На диск торговые события не пишутся** — это телеметрия для аналитики, а не syslog для чтения глазами. Для этого в `logging` добавлены:

* `kOtlpOnlyLogTypes` — типы логов без файла, `FileLogSender` их пропускает;
* `log_event(log_type, attrs, fmt, ...)` — строка плюс произвольные атрибуты. Раньше писать лог с атрибутами было нечем: `vlog` умеет только проставить `log_type`.

**Разделение лога и метрик.** Название предмета и внум идут только в лог: в лейбле Prometheus это тысячи серий навсегда (см. историю с 300 ГБ TSDB). В метрики уходит тип предмета (`obj_type`, десятки значений) и площадка. Из названия вырезаются цветовые коды через `utils::RemoveColors` — иначе одна и та же вещь даёт разные значения `item` и группировка по товару разваливается.

Метрики: `trade_sale_total`, `trade_turnover_total`, `trade_price`, `trade_time_to_sale_seconds`, `trade_listed_total`, `trade_repriced_total`, `trade_withdrawn_total{reason}`, `trade_bid_total`, `trade_lots_active`, `trade_lots_value`. Время до продажи берётся из `ExchangeItem::time` (на аукционе восстанавливается из тактов) — это ликвидность, а не только цена.

Заодно закрыты две дыры прежней инструментации аукциона: продажа через ямщика (`trans_auction`) сделкой не считалась, а снятия лотов не считались вовсе.

Спаны `"Auction Sale"` убраны: агрегировать по ним неудобно, а всё, что они давали, есть в логе сделки.

## Дашборды

Новый `tools/observability/dashboards/trade-dashboard.json`: лента торгов, топ товаров по обороту и по частоте, «что выставляют, но не берут», график цены предмета по regex-переменной, состояние витрины, время до продажи. Три мёртвые auction-панели в `business-logic-dashboard.json` переведены на `trade_*` и показывают обе площадки. `METRICS.md` обновлён.

## Проверено

Локально: сборка, 601 тест зелёный.

На живом стенде — circle в докере с `WITH_OTEL=true`, отдельная копия мира и свой `service_name`, два созданных персонажа:

* базар: выставление → смена цены → снятие → выставление → покупка;
* аукцион: выставление → ставка → продажа.

Все 11 событий доехали в Loki с полным набором атрибутов (`item`, `vnum`, `price`, `old_price`, `seller_id`, `buyer_id`, `listed_seconds`, `reason`), метрики — в Prometheus с лейблами `market`/`obj_type`/`reason`. При `logs/mode = duplicate`, когда обычные логи пишутся и в файл, и в OTLP, в `syslog` и `log/*.txt` оказалось 0 строк `[trade]` при 29859 строках обычного лога — разделение работает.

Запросы дашборда прогнаны на этих данных.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
