### PR TITLE
feat(utf8): логи пишутся в нативной кодировке (#3787)

### DIFF
--- a/src/gameplay/mechanics/bonus.cpp
+++ b/src/gameplay/mechanics/bonus.cpp
@@ -7,6 +7,7 @@
 #include "engine/ui/modify.h"
 #include "engine/entities/char_player.h"
 #include "engine/db/global_objects.h"
+#include "utils/native_text.h"
 #include "gameplay/core/remort.h"
 
 namespace Bonus {
@@ -212,7 +213,10 @@ void bonus_log_load() {
 	std::string temp_buf;
 	bonus_log.clear();
 	while (std::getline(fin, temp_buf)) {
-		bonus_log.push_back(temp_buf);
+		// Граница чтения: в строке дата через rustime и имя игрока, то есть русский текст.
+		// Записывается он нативным, а читался дисковыми байтами -- и показывался мусором
+		// всё, что осталось от старой сборки (issue #3787).
+		bonus_log.push_back(native_text::from_disk_line(temp_buf.c_str()));
 	}
 	fin.close();
 }

--- a/src/gameplay/mechanics/glory_misc.cpp
+++ b/src/gameplay/mechanics/glory_misc.cpp
@@ -12,6 +12,7 @@
 #include "engine/entities/char_player.h"
 #include "engine/ui/modify.h"
 #include "engine/db/global_objects.h"
+#include "utils/native_text.h"
 #include "gameplay/core/remort.h"
 
 namespace GloryMisc {
@@ -76,7 +77,10 @@ void load_log() {
 		GloryLogPtr temp_node(new GloryLog);
 		temp_node->type = type;
 		temp_node->num = num;
-		temp_node->karma = buffer;
+		// Границы чтения тут не было вовсе, хотя в karma лежит русский текст наказания:
+		// он уходил в память дисковыми байтами и показывался богам мусором. Запись при этом
+		// всегда шла нативной, так что файл ещё и расходился сам с собой (issue #3787).
+		temp_node->karma = native_text::from_disk_line(buffer.c_str());
 		glory_log.insert(std::make_pair(time, temp_node));
 	}
 }
@@ -94,6 +98,7 @@ void save_log() {
 		log("GloryLog: не удалось открыть файл на запись: %s", glory_file.c_str());
 		return;
 	}
+	// Зеркало к чтению: лог лежит в нативной кодировке, пишем как есть.
 	file << out.rdbuf();
 	file.close();
 }

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -32,10 +32,9 @@
 std::list<FILE *> opened_files;
 
 namespace {
-// Граница записи для логов, которые пишутся прямо в файл мимо LogManager (shop/olc/imm
-// и персональные). Логи -- внешне видимые файлы и остаются в кодировке мира, KOI8-R,
-// поэтому текст переводится здесь, а не уходит нативным (issue #3681).
-void vfprintf_on_disk(FILE *file, const char *format, va_list args) {
+// Запись логов, которые идут прямо в файл мимо LogManager (shop/olc/imm и персональные).
+// Лог лежит в нативной кодировке, поэтому текст уходит как есть (issue #3787).
+void vfprintf_native(FILE *file, const char *format, va_list args) {
 	va_list measure;
 	va_copy(measure, args);
 	const int need = vsnprintf(nullptr, 0, format, measure);
@@ -46,7 +45,7 @@ void vfprintf_on_disk(FILE *file, const char *format, va_list args) {
 	std::string text(static_cast<std::size_t>(need) + 1, '\0');
 	vsnprintf(&text[0], text.size(), format, args);
 	text.resize(static_cast<std::size_t>(need));
-	fputs(native_text::to_disk(text).c_str(), file);
+	fputs(text.c_str(), file);
 }
 }  // namespace
 
@@ -78,7 +77,7 @@ void pers_log(CharData *ch, const char *format, ...) {
 	write_time(ch->desc->pers_log);
 	va_list args;
 	va_start(args, format);
-	vfprintf_on_disk(ch->desc->pers_log, format, args);
+	vfprintf_native(ch->desc->pers_log, format, args);
 	va_end(args);
 	fprintf(ch->desc->pers_log, "\n");
 }
@@ -274,7 +273,7 @@ void shop_log(const char *format, ...) {
 	write_time(file);
 	va_list args;
 	va_start(args, format);
-	vfprintf_on_disk(file, format, args);
+	vfprintf_native(file, format, args);
 	va_end(args);
 	fprintf(file, "\n");
 
@@ -296,7 +295,7 @@ void olc_log(const char *format, ...) {
 	write_time(file);
 	va_list args;
 	va_start(args, format);
-	vfprintf_on_disk(file, format, args);
+	vfprintf_native(file, format, args);
 	va_end(args);
 	fprintf(file, "\n");
 
@@ -318,7 +317,7 @@ void imm_log(const char *format, ...) {
 	write_time(file);
 	va_list args;
 	va_start(args, format);
-	vfprintf_on_disk(file, format, args);
+	vfprintf_native(file, format, args);
 	va_end(args);
 	fprintf(file, "\n");
 
@@ -520,10 +519,14 @@ void Logger::operator()(const char *format, ...) {
 		// instead of output just onto console:
 		const auto syslog_converter = runtime_config.syslog_converter();
 		if (syslog_converter) {
-			syslog_converter(buffer, static_cast<int>(length));
+			// Таблицы koi_to_win/koi_to_alt индексируются koi8-байтами, а текст у нас
+			// нативный, поэтому приводим его к KOI8-R прямо перед подстановкой (#3787).
+			std::string legacy = native_text::to_koi8(std::string(buffer, length));
+			syslog_converter(legacy.data(), static_cast<int>(legacy.size()));
+			std::cerr << legacy;
+		} else {
+			std::cerr << buffer;
 		}
-
-		std::cerr << buffer;
 	}
 }
 
@@ -554,7 +557,11 @@ void OutputThread::output_loop() {
 			if (!runtime_config.log_stderr().empty()) {
 				const auto syslog_converter = runtime_config.syslog_converter();
 				if (syslog_converter) {
-					syslog_converter(message.text.get(), static_cast<int>(message.size));
+					// То же, что и выше: таблица ждёт koi8-байты, текст в очереди нативный.
+					std::string legacy = native_text::to_koi8(std::string(message.text.get(), message.size));
+					syslog_converter(legacy.data(), static_cast<int>(legacy.size()));
+					output_message(legacy.c_str(), message.channel);
+					continue;
 				}
 			}
 

--- a/src/utils/logging/file_log_sender.cpp
+++ b/src/utils/logging/file_log_sender.cpp
@@ -13,10 +13,11 @@ static void write_log_message(const std::string& native_message, FILE* file) {
 	if (!file) {
 		return;
 	}
-	// Граница записи: логи -- внешне видимый файл, и кодировка у них прежняя, KOI8-R.
-	// Дальше syslog_converter (koi_to_win/koi_to_alt) правит буфер на месте, считая
-	// байты кои-восьмыми, так что перевести надо именно здесь (issue #3681).
-	const std::string message = native_text::to_disk(native_message);
+	// Граница записи: лог лежит в нативной кодировке, поэтому уходит на диск как есть
+	// (issue #3787). Отдельный случай -- вывод в клиентской кодировке (log_stderr =
+	// cp1251/alt): его таблицы индексируются koi8-байтами, поэтому такой вывод приводится
+	// к KOI8-R прямо перед подстановкой в таблицу, а не хранится в ней.
+	const std::string &message = native_message;
 	if (!runtime_config.output_thread() && runtime_config.log_stderr().empty()) {
 		fputs(message.c_str(), file);
 		fputs("\n", file);

--- a/tests/utils.encoding.cpp
+++ b/tests/utils.encoding.cpp
@@ -1,5 +1,6 @@
 #include "utils/utils.h"
 #include "utils/utils_encoding.h"
+#include "utils/native_text.h"
 
 #include <gtest/gtest.h>
 
@@ -136,4 +137,32 @@ TEST(Utils_Encoding, Utf8ToKoi_BoxDrawingChars)
 	EXPECT_EQ(HexToString({0xA0}), koi_box);
 }
 
+// Вывод лога в клиентской кодировке (log_stderr = cp1251/alt) -- issue #3787.
+//
+// Таблицы koi_to_win/koi_to_alt индексируются koi8-байтами и правят буфер побайтно.
+// Движок держит текст нативным (UTF-8), где русская буква занимает два байта, поэтому
+// нативный текст обязан пройти через to_koi8 ПЕРЕД таблицей. Отдай его таблице как есть --
+// и на выходе будет мусор двойной длины, а не cp1251.
+TEST(Utils_Encoding, NativeLogLineConvertsToWindowsCodepage)
+{
+	// "Ага" в UTF-8 -- три русские буквы, шесть байт.
+	const std::string native = native_text::from_koi8(Utf8ToKoi("\xD0\x90\xD0\xB3\xD0\xB0"));
+
+	std::string legacy = native_text::to_koi8(native);
+	ASSERT_EQ(legacy.size(), 3u) << "к таблице текст должен приходить однобайтным koi8";
+
+	codepages::koi_to_win(legacy.data(), static_cast<int>(legacy.size()));
+
+	// cp1251: А = 0xC0, г = 0xE3, а = 0xE0.
+	EXPECT_EQ(legacy, HexToString({0xC0, 0xE3, 0xE0}));
+}
+
+TEST(Utils_Encoding, NativeLogLineKeepsAsciiIntact)
+{
+	// Ровно тот случай, ради которого конверсия и включается: латиница и цифры в логе
+	// не должны меняться ни на шаг.
+	std::string legacy = native_text::to_koi8("SYSERR: boot failed (code 42)");
+	codepages::koi_to_win(legacy.data(), static_cast<int>(legacy.size()));
+	EXPECT_EQ(legacy, "SYSERR: boot failed (code 42)");
+}
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :


### PR DESCRIPTION
Хвост после мира, cfg (#3794), state (#3816) и userdata (#3818): логи.

## Как сейчас

Две точки записи переводили текст в KOI8-R — `FileLogSender::write_log_message` для всего, что идёт через `LogManager` (syslog, errlog, imlog), и `vfprintf_on_disk` для логов мимо него (shop, olc, imm, персональные).

Но не все: `ip.log` и `accesadminpanel.log` (там в строке логин бога) пишутся нативным уже сейчас. То есть логи и без всякого переезда расходятся сами с собой.

## Что сделано

Запись везде нативная. Заодно закрыты два места, где границы не было **вовсе**, хотя движок читает файл обратно:

* **`glory.log`** — в поле `karma` лежит русский текст наказания. Читался `getline`'ом как есть, то есть дисковыми байтами, и показывался богам мусором; писался при этом нативным. Файл уже сейчас смешанный.
* **`bonus.log`** — то же самое: в строке дата через `rustime` и имя игрока.

Оба теперь читаются через `from_disk_line`, **построчно** — поэтому старые записи и новые уживаются в одном файле, и конверсия данных для них не нужна вообще.

`profiler.log` (его читает `loadstat`) не трогается: он чисто английский.

## Клиентская кодировка вывода — то, что было бы миной

`log_stderr = cp1251/alt` подставляет байты через `koi_to_win`/`koi_to_alt`:

```cpp
void koi_to_win(char *str, int size) {
    for (; size > 0; *str = KtoW(*str), size--, str++);
}
```

Таблица индексируется koi8-байтами и правит буфер побайтно, на месте. Нативный текст ей отдавать нельзя — русская буква занимает два байта, и на выходе была бы каша двойной длины вместо cp1251. Теперь текст приводится к KOI8-R прямо перед таблицей, как это и задумано для клиентских кодировок (`to_koi8`).

На боевом это выключено — в `configuration.xml` секция `<logging>` не содержит `<stderr>`, — но код остался бы взведённым.

## Проверено

* Сборка без предупреждений, **688 тестов зелёные**.
* Два новых теста в `tests/utils.encoding.cpp` держат путь клиентской кодировки: нативная строка приходит к таблице однобайтной (`to_koi8` даёт 3 байта из 6) и превращается в правильный cp1251 (`А`=0xC0, `г`=0xE3, `а`=0xE0), а латиница не меняется ни на шаг.
* Тестовый мир поднимается.

Честная оговорка: смоук-прогон не доказывает русскую ветку — все сообщения при старте английские. Правку `to_disk` для обычной записи проверяет глазами (одна строка), а нетривиальную часть — кодировку клиентского вывода — держат тесты.

---

# Инструкция по переезду

Самая короткая из всех: **конвертировать нечего**.

## glory.log и bonus.log

Ничего делать не надо. Разбор построчный, старые KOI8-строки и новые нативные читаются в одном файле. Заодно перестанут показываться мусором старые записи, которые мусором показываются сейчас.

## Остальные логи

Это append-only история, и после смены бинаря файл станет смешанным с точки переключения. Для `less`/`grep` это терпимо (строки независимы), но Loki на старых строках будет спотыкаться о невалидный UTF-8. Поэтому проще ротировать в момент выката:

```
cd /home/mud/mud/log
for f in syslog errlog.txt imlog.txt shop.log olc.log imm.log depot.log parcel.log \
         death_trap.log glory_transfer.log ip.log accesadminpanel.log money.txt msdp.txt; do
    [ -f "$f" ] && mv "$f" "$f.koi8"
done
mkdir -p perslog.koi8 && mv perslog/*.log perslog.koi8/ 2>/dev/null
```

Старые файлы остаются в KOI8-R как есть — это история, переводить её незачем; понадобится прочитать — `iconv -f koi8-r`.

## Проверка

После первого же русского сообщения в логе:

```
file /home/mud/mud/log/syslog        # UTF-8
```

И `бонус`/`слава` в игре — записи должны читаться, включая старые.

## Что остаётся после этого

`craft.cpp:1554` (`export_object`) — последний писатель мимо новой границы: ставит `encoding="koi8-r"` и гонит через `to_disk`. В боевом мире цели нет (`craft/metacraft/index.xml` отсутствует), так что это чистка, а не почин.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141fe9QufFGkvAjncr1y6mb
