### PR TITLE
fix(who): выровнять колонки короткого списка

### DIFF
--- a/src/engine/ui/cmd/do_who.cpp
+++ b/src/engine/ui/cmd/do_who.cpp
@@ -6,6 +6,7 @@
 #include "utils/russian_keys.h"
 #include "utils/native_text.h"
 #include "utils/utils_string.h"
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <fmt/format.h>
@@ -65,6 +66,13 @@ std::string FormatShortCell(int level, const std::string &class_name, std::size_
 	return fmt::format("{:<{}} {}{:<{}}{}",
 					   prefix, PrefixWidth(class_width),
 					   name_color, name, kNameWidth, color_end);
+}
+
+int ShortColumns(int screen_width, std::size_t cell_width) {
+	if (screen_width <= 0 || cell_width == 0) {
+		return kDefaultColumns;
+	}
+	return std::max(1, static_cast<int>(static_cast<std::size_t>(screen_width) / cell_width));
 }
 
 } // namespace who_format
@@ -163,6 +171,17 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (PerformWhoSpamcontrol(ch, name_search.empty() ? kWhoListall : kWhoListname))
 		return;
 
+	// Колонок в короткий список -- сколько влезает в ширину экрана игрока ("режим ширина").
+	// Ширина ячейки зависит от того, показывать ли уровень с классом: у остальных в ячейке
+	// только имя.
+	const bool detailed_short = privilege::IsImpl(ch) || ch->IsFlagged(EPrf::kCoderinfo);
+	const std::size_t short_cell = detailed_short
+									   ? who_format::PrefixWidth(MaxClassNameWidth()) + 1
+										   + who_format::kNameWidth
+									   : who_format::kNameWidth;
+	const int short_columns =
+		who_format::ShortColumns(ch->IsNpc() ? 0 : ch->player_specials->saved.stringLength, short_cell);
+
 	// Строки содержащие имена
 	std::string imms = fmt::format("{}БОГИ{}\r\n", kColorBoldCyn, kColorNrm);
 	std::string demigods = fmt::format("{}Привилегированные{}\r\n", kColorCyn, kColorNrm);
@@ -213,7 +232,7 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		std::string line;
 		num_can_see++;
 		if (short_list) {
-			if (privilege::IsImpl(ch) || ch->IsFlagged(EPrf::kCoderinfo)) {
+			if (detailed_short) {
 				const bool god = privilege::IsGod(tch.get());
 				line = fmt::format("{}{}{}",
 								   god ? kColorWht : "",
@@ -303,20 +322,20 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		if (privilege::IsImmortal(tch.get())) {
 			imms_num++;
 			imms += line;
-			if (!short_list || !(imms_num % 4)) {
+			if (!short_list || !(imms_num % short_columns)) {
 				imms += "\r\n";
 			}
 		} else if (GET_GOD_FLAG(tch, EGf::kDemigod)
 			&& (privilege::IsImmortal(ch) || ch->IsFlagged(EPrf::kCoderinfo) || GET_GOD_FLAG(tch, EGf::kDemigod))) {
 			demigods_num++;
 			demigods += line;
-			if (!short_list || !(demigods_num % 4)) {
+			if (!short_list || !(demigods_num % short_columns)) {
 				demigods += "\r\n";
 			}
 		} else {
 			morts_num++;
 			morts += line;
-			if (!short_list || !(morts_num % 4))
+			if (!short_list || !(morts_num % short_columns))
 				morts += "\r\n";
 		}
 	}            // end of for

--- a/src/engine/ui/cmd/do_who.cpp
+++ b/src/engine/ui/cmd/do_who.cpp
@@ -28,6 +28,19 @@ const char *IMM_WHO_FORMAT =
 
 const char *MORT_WHO_FORMAT = "Формат: кто [имя] [-?]\r\n";
 
+// Ширина под самое длинное название класса -- по конфигу, а не константой: новый класс иначе
+// снова разъедет колонку короткого списка.
+std::size_t MaxClassNameWidth() {
+	static const std::size_t width = []() {
+		std::size_t widest = 0;
+		for (const auto &char_class : MUD::Classes()) {
+			widest = std::max(widest, native_text::char_count(char_class.GetCName()));
+		}
+		return widest;
+	}();
+	return width;
+}
+
 // Первое слово в нижнем регистре и остаток -- utils::ExtractFirstArgument плюс то, что
 // half_chop делал сам: понижение регистра (сравнения ниже рассчитывают на него) и срез
 // ведущих пробелов в остатке.
@@ -40,6 +53,21 @@ std::pair<std::string, std::string> ChopWord(const std::string &line) {
 }
 
 } // namespace
+
+namespace who_format {
+
+static_assert(kNameWidth == kMaxNameLength + 1, "колонка имени должна вмещать самое длинное имя");
+
+std::string FormatShortCell(int level, const std::string &class_name, std::size_t class_width,
+							const std::string &name, const std::string &name_color,
+							const std::string &color_end) {
+	const std::string prefix = fmt::format("[{:2} {}]", level, class_name);
+	return fmt::format("{:<{}} {}{:<{}}{}",
+					   prefix, PrefixWidth(class_width),
+					   name_color, name, kNameWidth, color_end);
+}
+
+} // namespace who_format
 
 void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	std::string name_search;
@@ -185,21 +213,25 @@ void DoWho(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		std::string line;
 		num_can_see++;
 		if (short_list) {
-			// Ширину добираем ВНУТРИ цветовых кодов, а не поверх них: код цвета -- семь невидимых
-			// символов, и "{:<30}" по строке вместе с ними давал колонку не в 30 знаков, а в 16.
-			const std::string colored_name =
-				fmt::format("{}{:<30}{}", GetPkNameColor(tch), GET_NAME(tch), kColorNrm);
 			if (privilege::IsImpl(ch) || ch->IsFlagged(EPrf::kCoderinfo)) {
-				line = fmt::format("{}[{:2} {}] {}{}",
-								   privilege::IsGod(tch.get()) ? kColorWht : "",
-								   GetRealLevel(tch), MUD::Class(tch->GetClass()).GetCName(),
-								   colored_name,
-								   privilege::IsGod(tch.get()) ? kColorNrm : "");
-			} else {
+				const bool god = privilege::IsGod(tch.get());
 				line = fmt::format("{}{}{}",
-								   privilege::IsImmortal(tch.get()) ? kColorWht : "",
-								   colored_name,
-								   privilege::IsImmortal(tch.get()) ? kColorNrm : "");
+								   god ? kColorWht : "",
+								   who_format::FormatShortCell(GetRealLevel(tch),
+															   MUD::Class(tch->GetClass()).GetCName(),
+															   MaxClassNameWidth(),
+															   GET_NAME(tch),
+															   GetPkNameColor(tch), kColorNrm),
+								   god ? kColorNrm : "");
+			} else {
+				// Ширину добираем ВНУТРИ цветовых кодов, а не поверх них: код цвета -- семь
+				// невидимых символов, и "{:<21}" по строке вместе с ними дал бы колонку в семь.
+				const bool imm = privilege::IsImmortal(tch.get());
+				line = fmt::format("{}{}{:<{}}{}{}",
+								   imm ? kColorWht : "",
+								   GetPkNameColor(tch), GET_NAME(tch), who_format::kNameWidth,
+								   kColorNrm,
+								   imm ? kColorNrm : "");
 			}
 		} else {
 			if (privilege::IsImpl(ch)

--- a/src/engine/ui/cmd/do_who.h
+++ b/src/engine/ui/cmd/do_who.h
@@ -5,7 +5,33 @@
 #ifndef BYLINS_SRC_CMD_WHO_H_
 #define BYLINS_SRC_CMD_WHO_H_
 
+#include <cstddef>
+#include <string>
+
 class CharData;
+
+// Вёрстка короткого списка ("кто -с"). Ячейки просто склеиваются по четыре в строку, поэтому
+// ширина ячейки обязана быть постоянной: иначе разница в длине названия класса ("тать" против
+// "чернокнижника" -- восемь знаков) уезжает в отступ следующей колонки, и список съезжает.
+namespace who_format {
+
+// Колонка имени: kMaxNameLength (20) плюс пробел-разделитель.
+inline constexpr std::size_t kNameWidth = 21;
+
+// Ширина префикса "[<уровень> <класс>]": скобки, два знака уровня и пробел.
+[[nodiscard]] constexpr std::size_t PrefixWidth(std::size_t class_width) {
+	return class_width + 5;
+}
+
+// Ячейка короткого списка. Цвет вставляется ВОКРУГ уже добитого пробелами имени: цветовой код --
+// невидимые символы, и добирать ширину поверх них нельзя. class_width задаётся снаружи (ширина
+// самого длинного названия класса в конфиге), чтобы вёрстку можно было проверить без конфига.
+[[nodiscard]] std::string FormatShortCell(int level, const std::string &class_name,
+										  std::size_t class_width, const std::string &name,
+										  const std::string &name_color,
+										  const std::string &color_end);
+
+} // namespace who_format
 
 // константы для спам-контроля команды кто
 // если кто захочет и сможет вынести их во внешний конфиг, то почет ему и слава

--- a/src/engine/ui/cmd/do_who.h
+++ b/src/engine/ui/cmd/do_who.h
@@ -18,6 +18,10 @@ namespace who_format {
 // Колонка имени: kMaxNameLength (20) плюс пробел-разделитель.
 inline constexpr std::size_t kNameWidth = 21;
 
+// Сколько колонок ставить, если ширина экрана у игрока не задана (в "режим ширина" её
+// выставляют не все). Ровно столько их и было прибито гвоздями до появления расчёта.
+inline constexpr int kDefaultColumns = 4;
+
 // Ширина префикса "[<уровень> <класс>]": скобки, два знака уровня и пробел.
 [[nodiscard]] constexpr std::size_t PrefixWidth(std::size_t class_width) {
 	return class_width + 5;
@@ -30,6 +34,12 @@ inline constexpr std::size_t kNameWidth = 21;
 										  std::size_t class_width, const std::string &name,
 										  const std::string &name_color,
 										  const std::string &color_end);
+
+// Сколько ячеек ставить в строку при ширине экрана screen_width. Ширина 0 означает "не задана"
+// (так её и трактует остальной вывод -- перенос тогда не делается), для неё берётся
+// kDefaultColumns. Меньше одной колонки не бывает: узкий экран даст список в один столбец,
+// а не пустую строку.
+[[nodiscard]] int ShortColumns(int screen_width, std::size_t cell_width);
 
 } // namespace who_format
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -91,6 +91,7 @@ test_sources = files(
     'file_crc.cpp',
     'buffered_file_writer.cpp',
     'where.format.cpp',
+    'who.short_format.cpp',
     # Balance simulator (issue #2967)
     'random.seed.cpp',
     'file_event_sink.cpp',

--- a/tests/who.short_format.cpp
+++ b/tests/who.short_format.cpp
@@ -1,0 +1,86 @@
+// Вёрстка короткого списка команды "кто" (who_format::FormatShortCell).
+//
+// Ячейки короткого списка склеиваются по четыре в строку, без разделителей, поэтому вся
+// вёрстка держится на том, что ячейка всегда одной ширины. Название класса в префиксе
+// не добиралось до общей ширины, и разница между "татью" (4 буквы) и "чернокнижником"
+// (12) уезжала в отступ следующей колонки: список съезжал ступеньками.
+
+#include "engine/ui/cmd/do_who.h"
+#include "utils/native_text.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+using who_format::FormatShortCell;
+using who_format::kNameWidth;
+using who_format::PrefixWidth;
+
+// Самое длинное название класса в конфиге -- "чернокнижник".
+constexpr std::size_t kClassWidth = 12;
+
+// Ожидаемая видимая ширина ячейки: префикс, пробел, колонка имени.
+constexpr std::size_t kCellWidth = PrefixWidth(kClassWidth) + 1 + kNameWidth;
+
+std::string Cell(int level, const std::string &char_class, const std::string &name) {
+	return FormatShortCell(level, char_class, kClassWidth, name, "", "");
+}
+
+}  // namespace
+
+TEST(WhoShortFormat, CellWidthDoesNotDependOnClassName) {
+	// Классы разной длины: короткое имя класса раньше давало короткую ячейку.
+	for (const auto *char_class : {"тать", "колдун", "богатырь", "чернокнижник"}) {
+		const std::string cell = Cell(29, char_class, "Рогоза");
+		EXPECT_EQ(native_text::char_count(cell), kCellWidth)
+			<< "класс \"" << char_class << "\" даёт ячейку другой ширины";
+	}
+}
+
+TEST(WhoShortFormat, CellWidthDoesNotDependOnName) {
+	// Имя добирается до kNameWidth, самое длинное (kMaxNameLength) обязано влезать.
+	for (const auto *name : {"Ян", "Рогоза", "Елизавета", "Твердиславополозий"}) {
+		const std::string cell = Cell(30, "колдун", name);
+		EXPECT_EQ(native_text::char_count(cell), kCellWidth)
+			<< "имя \"" << name << "\" даёт ячейку другой ширины";
+	}
+}
+
+TEST(WhoShortFormat, CellWidthIsMeasuredInCharactersNotBytes) {
+	// Кириллица в UTF-8 двухбайтовая: байтовая ширина ячейки с русским именем больше
+	// видимой, и колонка, отмеренная в байтах, оказалась бы короче нужной.
+	const std::string cyrillic = Cell(29, "колдун", "Рогоза");
+	const std::string latin = Cell(29, "conjurer", "Rogoza");
+	EXPECT_EQ(native_text::char_count(cyrillic), native_text::char_count(latin));
+	EXPECT_GT(cyrillic.size(), latin.size()) << "иначе тест не про UTF-8";
+}
+
+TEST(WhoShortFormat, NamesStartAtTheSameColumn) {
+	// Главное свойство для читаемости списка: имена выстраиваются в колонку независимо
+	// от класса. Проверяется по позиции первой буквы имени.
+	std::vector<std::size_t> positions;
+	for (const auto *char_class : {"тать", "колдун", "чернокнижник"}) {
+		const std::string cell = Cell(29, char_class, "Рогоза");
+		const auto at = cell.find("Рогоза");
+		ASSERT_NE(at, std::string::npos);
+		positions.push_back(native_text::char_count(cell.substr(0, at)));
+	}
+	EXPECT_EQ(positions[0], positions[1]);
+	EXPECT_EQ(positions[1], positions[2]);
+}
+
+TEST(WhoShortFormat, ColorCodesDoNotEatTheWidth) {
+	// Цветовой код -- невидимые символы, и ширина добирается внутри них: ячейка с цветом
+	// отличается от бесцветной ровно на длину кодов, а не на добитые пробелы.
+	const std::string colour = "\x1B[1;32m";
+	const std::string reset = "\x1B[0;37m";
+	const std::string plain = Cell(29, "колдун", "Рогоза");
+	const std::string colored =
+		FormatShortCell(29, "колдун", kClassWidth, "Рогоза", colour, reset);
+	EXPECT_EQ(colored.size(), plain.size() + colour.size() + reset.size());
+}
+
+// vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/tests/who.short_format.cpp
+++ b/tests/who.short_format.cpp
@@ -72,6 +72,33 @@ TEST(WhoShortFormat, NamesStartAtTheSameColumn) {
 	EXPECT_EQ(positions[1], positions[2]);
 }
 
+TEST(WhoShortColumns, CountComesFromTheScreenWidth) {
+	// Ячейка в 39 знаков: в 80 знаков влезают две, в 160 -- четыре, в 175 (окно со скриншота
+	// в issue) -- тоже четыре, пятая уже не помещается.
+	EXPECT_EQ(who_format::ShortColumns(80, kCellWidth), 2);
+	EXPECT_EQ(who_format::ShortColumns(160, kCellWidth), 4);
+	EXPECT_EQ(who_format::ShortColumns(175, kCellWidth), 4);
+	EXPECT_EQ(who_format::ShortColumns(300, kCellWidth), 7);
+}
+
+TEST(WhoShortColumns, UnsetWidthKeepsTheOldFourColumns) {
+	// Ширина 0 -- "не задана", так её трактует и остальной вывод. Прибитые гвоздями четыре
+	// колонки остаются поведением по умолчанию, чтобы никому не сузило список молча.
+	EXPECT_EQ(who_format::ShortColumns(0, kCellWidth), who_format::kDefaultColumns);
+	EXPECT_EQ(who_format::ShortColumns(-1, kCellWidth), who_format::kDefaultColumns);
+}
+
+TEST(WhoShortColumns, NarrowScreenStillGetsOneColumn) {
+	// Экран уже ячейки: список в один столбец, а не строка без переносов вовсе.
+	EXPECT_EQ(who_format::ShortColumns(30, kCellWidth), 1);
+	EXPECT_EQ(who_format::ShortColumns(1, kCellWidth), 1);
+}
+
+TEST(WhoShortColumns, NameOnlyCellIsDenser) {
+	// У богов без коддинфо в ячейке только имя, значит колонок влезает больше.
+	EXPECT_EQ(who_format::ShortColumns(160, kNameWidth), 7);
+}
+
 TEST(WhoShortFormat, ColorCodesDoNotEatTheWidth) {
 	// Цветовой код -- невидимые символы, и ширина добирается внутри них: ячейка с цветом
 	// отличается от бесцветной ровно на длину кодов, а не на добитые пробелы.


### PR DESCRIPTION
Короткий список `кто -с` съезжает ступеньками — на скриншоте это видно на каждой строке.

## Причина

Ячейки короткого списка склеиваются по четыре в строку, без разделителей
(`if (!short_list || !(imms_num % 4)) imms += "\r\n";`), поэтому вся вёрстка держится
на постоянной ширине ячейки. Имя добиралось до тридцати знаков, а название класса
в префиксе — ни до чего:

```
line = fmt::format("{}[{:2} {}] {}{}", ..., GetRealLevel(tch), MUD::Class(...).GetCName(), colored_name, ...);
                          ^^ без ширины
```

Названия классов — от «тати» (4 буквы) до «чернокнижника» (12), то есть префикс гуляет
от 10 знаков до 18, и разница уезжает в отступ следующей колонки.

К UTF-8 это отношения не имеет: `fmt` 12.1 считает ширину по символам (проверено), а тот же
`%s` без ширины стоял здесь и до перевода кодировки. Видно только богам с `-с` и коддинфо.

## Что сделано

Ширина под название класса берётся **из конфига**, а не константой, — иначе новый класс
разъедет колонку снова. Колонка имени заодно сжата с тридцати знаков до двадцати одного
(`kMaxNameLength` плюс пробел): тридцать — это десять пустых знаков в каждой ячейке, а строка
из четырёх ячеек и без того шире восьмидесяти. Итог: ячейка 39 знаков вместо 42–49 и без
ступенек.

```
БЫЛО:
[29 колдун] Рогоза                        [27 богатырь] Клифф                         [29 чернокнижник] Курусан                       [29 колдун] Криня
[29 богатырь] Есгар                         [29 витязь] Вайнард                       [25 кузнец] Осин                          [28 лекарь] Цисса

СТАЛО:
[29 колдун]       Рогоза               [27 богатырь]     Клифф                [29 чернокнижник] Курусан              [29 колдун]       Криня
[29 богатырь]     Есгар                [29 витязь]       Вайнард              [25 кузнец]       Осин                 [28 лекарь]       Цисса
```

## Тесты

Вёрстка ячейки вынесена в `who_format::FormatShortCell` — чистую функцию без `CharData`,
по образцу `where_format::FormatWhere`, и накрыта пятью тестами: ширина не зависит ни от
класса, ни от имени, считается в символах, а не в байтах, и не съедается цветовыми кодами.
Проверено, что тесты падают на прежнем поведении и проходят на новом; сборка без предупреждений,
693 теста проходят.
