### PR TITLE
chore: убрать мёртвое правило /lib/etc/board из .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 *.md              working-tree-encoding=UTF-8 eol=lf
 /.githooks/**     working-tree-encoding=UTF-8 eol=lf
 /lib.template/**  working-tree-encoding=KOI8-R eol=lf
-/lib/etc/board/** working-tree-encoding=KOI8-R eol=lf
 /lib/cfg/** eol=lf
 /bin.win/**       working-tree-encoding=windows-1251 eol=crlf
 *.dll             -diff -working-tree-encoding


### PR DESCRIPTION
Правило указывало на каталог, которого больше нет:

```
-/lib/etc/board/** working-tree-encoding=KOI8-R eol=lf
```

Доски переехали в `lib/userdata/boards` — перенос делает `tools/migrate_lib_layout.sh`, и это единственное место, где старый путь ещё упоминается (там он и нужен, скрипт читает старую раскладку). В движке `etc/board` не встречается вовсе, под правило не подпадает ни одного файла в git.

Заодно это значит, что доски уже полностью переведены на UTF-8: они лежат внутри `lib/userdata`, то есть попали и под конвертер из #3818, и под правку границы записи там же (`boards_types.cpp`, `Board::Save`). Проверка на боевом после перевода — 11380 файлов, 0 не-UTF-8, доски в их числе.

## Зачем убирать

Само по себе правило безвредно — оно ни на что не натягивается. Но именно такой залежавшийся атрибут в этот заход уже дорого обошёлся: про `working-tree-encoding` на `/lib/cfg/**` никто не помнил, и два блоба (`torc_msg.scheme`, `exchange_msg.scheme`) уехали в двойную кодировку — git молча перекодировал их при `git add`, а `git status` при этом молчал, потому что обратная конверсия сходилась.

## Проверено

Снятие ничего не сдвигает: после правки в рабочем дереве изменён только сам `.gitattributes`, ни один файл не «поехал».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141fe9QufFGkvAjncr1y6mb
