### PR TITLE
refactor(ui): drop global buffers from score, give and drop (#3814)

### DIFF
--- a/src/engine/core/target_resolver.cpp
+++ b/src/engine/core/target_resolver.cpp
@@ -867,7 +867,7 @@ int generic_find(const char *arg, Bitvector bitvector, CharData *ch, CharData **
 	return (0);
 }
 
-int find_all_dots(std::string &arg) {
+int ParseAllPrefix(std::string &arg) {
 	if (!str_cmp(arg, "all") || !str_cmp(arg, "все")) {
 		return kFindAll;
 	}
@@ -880,7 +880,7 @@ int find_all_dots(std::string &arg) {
 	return kFindIndiv;
 }
 
-int find_all_dots(char *arg) {
+int ParseAllPrefix(char *arg) {
 	char tmpname[kMaxInputLength];
 
 	if (!str_cmp(arg, "all") || !str_cmp(arg, "все")) {

--- a/src/engine/core/target_resolver.cpp
+++ b/src/engine/core/target_resolver.cpp
@@ -867,6 +867,19 @@ int generic_find(const char *arg, Bitvector bitvector, CharData *ch, CharData **
 	return (0);
 }
 
+int find_all_dots(std::string &arg) {
+	if (!str_cmp(arg, "all") || !str_cmp(arg, "все")) {
+		return kFindAll;
+	}
+	for (const char *prefix : {"all.", "все."}) {
+		if (utils::IsAbbr(prefix, arg.c_str())) {
+			arg.erase(0, strlen(prefix));
+			return kFindAlldot;
+		}
+	}
+	return kFindIndiv;
+}
+
 int find_all_dots(char *arg) {
 	char tmpname[kMaxInputLength];
 

--- a/src/engine/core/target_resolver.h
+++ b/src/engine/core/target_resolver.h
@@ -270,6 +270,8 @@ inline int generic_find(const std::string &arg, Bitvector bitvector, CharData *c
 	return generic_find(arg.c_str(), bitvector, ch, tar_ch, tar_obj);
 }
 int find_all_dots(char *arg);
+// Строковая форма: префикс "все."/"all." срезается у самой строки, буфер не нужен (#3807).
+int find_all_dots(std::string &arg);
 RoomRnum FindRoomRnum(CharData *ch, char *rawroomstr, int trig);
 
 }; // namespace target_resolver

--- a/src/engine/core/target_resolver.h
+++ b/src/engine/core/target_resolver.h
@@ -269,9 +269,13 @@ inline int generic_find(const std::string &arg, Bitvector bitvector, CharData *c
 						CharData **tar_ch, ObjData **tar_obj) {
 	return generic_find(arg.c_str(), bitvector, ch, tar_ch, tar_obj);
 }
-int find_all_dots(char *arg);
-// Строковая форма: префикс "все."/"all." срезается у самой строки, буфер не нужен (#3807).
-int find_all_dots(std::string &arg);
+// Разобрать префикс выборки: "все"/"all" -> kFindAll, "все.<имя>"/"all.<имя>" -> kFindAlldot
+// (префикс при этом срезается, в arg остаётся само имя), иначе kFindIndiv. Прежнее имя
+// find_all_dots досталось от дику и говорило про точки, а не про то, что тут решается (#3814).
+// Форма с char * срезает префикс прямо в буфере вызывающего, с оглядкой на kMaxInputLength;
+// строковой буфер не нужен.
+int ParseAllPrefix(char *arg);
+int ParseAllPrefix(std::string &arg);
 RoomRnum FindRoomRnum(CharData *ch, char *rawroomstr, int trig);
 
 }; // namespace target_resolver
@@ -282,7 +286,7 @@ RoomRnum FindRoomRnum(CharData *ch, char *rawroomstr, int trig);
 using target_resolver::get_obj_vis_for_locate;
 using target_resolver::try_locate_obj;
 using target_resolver::generic_find;
-using target_resolver::find_all_dots;
+using target_resolver::ParseAllPrefix;
 using target_resolver::FindRoomRnum;
 
 const int kFindIndiv = 0;

--- a/src/engine/ui/cmd/do_drop.cpp
+++ b/src/engine/ui/cmd/do_drop.cpp
@@ -177,7 +177,7 @@ void DoDrop(CharData *ch, char *argument, int/* cmd*/, int /*subcmd*/) {
 		return;
 	}
 
-	const auto dotmode = find_all_dots(what);
+	const auto dotmode = ParseAllPrefix(what);
 	// Can't junk or donate all
 	if (dotmode == kFindAll) {
 		if (!ch->carrying) {

--- a/src/engine/ui/cmd/do_drop.cpp
+++ b/src/engine/ui/cmd/do_drop.cpp
@@ -9,6 +9,9 @@
 #include "gameplay/mechanics/inventory.h"
 #include "gameplay/fight/pk.h"
 #include "engine/db/global_objects.h"
+#include "utils/utils_string.h"
+
+#include <fmt/format.h>
 
 extern ObjData::shared_ptr CreateCurrencyObj(long quantity);
 extern ObjData::shared_ptr CreateCurrencyObj(long quantity, int currency_vnum);
@@ -50,16 +53,13 @@ void PerformDropGold(CharData *ch, int amount) {
 		if (!ch->IsNpc() || !ch->IsFlagged(EMobFlag::kCorpse)) {
 			SendMsgToChar(ch, "Вы бросили %d %s на землю.\r\n",
 						  amount, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kNom).c_str());
-			sprintf(buf,
-					"<%s> {%d} выбросил %d %s на землю.",
-					ch->get_name().c_str(),
-					GET_ROOM_VNUM(ch->in_room),
-					amount,
-					MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kNom).c_str());
-			mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
-			sprintf(buf, "$n бросил$g %s на землю.",
-					MUD::Currency(currencies::kGoldVnum).GetObjCName(amount, grammar::ECase::kAcc));
-			act(buf, true, ch, nullptr, nullptr, kToRoom | kToArenaListen);
+			mudlog(fmt::format("<{}> {{{}}} выбросил {} {} на землю.",
+							   ch->get_name(), GET_ROOM_VNUM(ch->in_room), amount,
+							   MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kNom)),
+				   NRM, kLvlGreatGod, MONEY_LOG, true);
+			act(fmt::format("$n бросил$g {} на землю.",
+							MUD::Currency(currencies::kGoldVnum).GetObjCName(amount, grammar::ECase::kAcc)),
+				true, ch, nullptr, nullptr, kToRoom | kToArenaListen);
 		}
 		PlaceObjToRoom(obj.get(), ch->in_room);
 
@@ -103,12 +103,12 @@ void PerformDropCurrency(CharData *ch, const currencies::CurrencyInfo &cur, int 
 	if (!ch->IsNpc() || !ch->IsFlagged(EMobFlag::kCorpse)) {
 		SendMsgToChar(ch, "Вы бросили %d %s на землю.\r\n",
 					  amount, cur.GetNameWithAmount(amount, grammar::ECase::kNom).c_str());
-		sprintf(buf, "<%s> {%d} выбросил %d %s на землю.",
-				ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), amount,
-				cur.GetNameWithAmount(amount, grammar::ECase::kNom).c_str());
-		mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
-		sprintf(buf, "$n бросил$g %s на землю.", cur.GetObjCName(amount, grammar::ECase::kAcc));
-		act(buf, true, ch, nullptr, nullptr, kToRoom | kToArenaListen);
+		mudlog(fmt::format("<{}> {{{}}} выбросил {} {} на землю.",
+						   ch->get_name(), GET_ROOM_VNUM(ch->in_room), amount,
+						   cur.GetNameWithAmount(amount, grammar::ECase::kNom)),
+			   NRM, kLvlGreatGod, MONEY_LOG, true);
+		act(fmt::format("$n бросил$g {} на землю.", cur.GetObjCName(amount, grammar::ECase::kAcc)),
+			true, ch, nullptr, nullptr, kToRoom | kToArenaListen);
 	}
 	PlaceObjToRoom(obj.get(), ch->in_room);
 	currencies::RemoveHand(*ch, currency_vnum, amount);
@@ -128,14 +128,11 @@ void PerformDrop(CharData *ch, ObjData *obj) {
 		return;
 
 	if (obj->has_flag(EObjFlag::kNodrop)) {
-		sprintf(buf, "Вы не можете %s $o3!", drop_op[0]);
-		act(buf, false, ch, obj, nullptr, kToChar);
+		act(fmt::format("Вы не можете {} $o3!", drop_op[0]), false, ch, obj, nullptr, kToChar);
 		return;
 	}
-	sprintf(buf, "Вы %s $o3.", drop_op[1]);
-	act(buf, false, ch, obj, nullptr, kToChar);
-	sprintf(buf, "$n %s$g $o3.", drop_op[2]);
-	act(buf, true, ch, obj, nullptr, kToRoom | kToArenaListen);
+	act(fmt::format("Вы {} $o3.", drop_op[1]), false, ch, obj, nullptr, kToChar);
+	act(fmt::format("$n {}$g $o3.", drop_op[2]), true, ch, obj, nullptr, kToRoom | kToArenaListen);
 	RemoveObjFromChar(obj);
 	PlaceObjToRoom(obj, ch->in_room);
 	RunObjAffectTrigger(obj, ch, talents_actions::EActionTrigger::kDrop);   // issue.obj-affects
@@ -145,73 +142,78 @@ void PerformDrop(CharData *ch, ObjData *obj) {
 void DoDrop(CharData *ch, char *argument, int/* cmd*/, int /*subcmd*/) {
 	ObjData *obj, *next_obj;
 
-	argument = one_argument(argument, arg);
+	std::string remains;
+	std::string what = utils::ExtractFirstArgumentLower(argument, remains);
 
-	if (!*arg) {
-		sprintf(buf, "Что вы хотите %s?\r\n", drop_op[0]);
-		SendMsgToChar(buf, ch);
+	if (what.empty()) {
+		SendMsgToChar(fmt::format("Что вы хотите {}?\r\n", drop_op[0]), ch);
 		return;
-	} else if (is_number(arg)) {
-		auto multi = std::stoi(arg);
-		one_argument(argument, arg);
-		if (!str_cmp("coins", arg) || !str_cmp("coin", arg) || !str_cmp("кун", arg) || !str_cmp("денег", arg))
+	}
+
+	if (is_number(what.c_str())) {
+		auto multi = std::stoi(what);
+		what = utils::ExtractFirstArgumentLower(remains, remains);
+		if (!str_cmp("coins", what) || !str_cmp("coin", what) || !str_cmp("кун", what) || !str_cmp("денег", what)) {
 			PerformDropGold(ch, multi);
-		else if (const auto *cur = currencies::FindBySearch(arg); cur && cur->IsObjectable())
+		} else if (const auto *cur = currencies::FindBySearch(what); cur && cur->IsObjectable()) {
 			PerformDropCurrency(ch, *cur, multi);
-		else if (multi <= 0)
+		} else if (multi <= 0) {
 			SendMsgToChar("Не имеет смысла.\r\n", ch);
-		else if (!*arg) {
-			sprintf(buf, "%s %d чего?\r\n", drop_op[0], multi);
-			SendMsgToChar(buf, ch);
-		} else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-			if (const auto *cur = currencies::FindBySearch(arg); cur && !cur->IsObjectable()) {
+		} else if (what.empty()) {
+			SendMsgToChar(fmt::format("{} {} чего?\r\n", drop_op[0], multi), ch);
+		} else if (!(obj = get_obj_in_list_vis(ch, what, ch->carrying))) {
+			if (const auto *cur = currencies::FindBySearch(what); cur && !cur->IsObjectable()) {
 				SendMsgToChar("Эту валюту нельзя бросить на землю.\r\n", ch);
 			} else {
-				snprintf(buf, kMaxInputLength, "У вас нет ничего похожего на %s.\r\n", arg);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("У вас нет ничего похожего на {}.\r\n", what), ch);
 			}
 		} else {
 			do {
-				next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
+				next_obj = get_obj_in_list_vis(ch, what, obj->get_next_content());
 				PerformDrop(ch, obj);
 				obj = next_obj;
 			} while (obj && --multi);
 		}
-	} else {
-		const auto dotmode = find_all_dots(arg);
-		// Can't junk or donate all
-		if (dotmode == kFindAll) {
-			if (!ch->carrying)
-				SendMsgToChar("А у вас ничего и нет.\r\n", ch);
-			else
-				for (obj = ch->carrying; obj; obj = next_obj) {
-					next_obj = obj->get_next_content();
-					if (obj->get_extracted_list())
-						continue;
-					PerformDrop(ch, obj);
-				}
-		} else if (dotmode == kFindAlldot) {
-			if (!*arg) {
-				sprintf(buf, "%s \"все\" какого типа предметов?\r\n", drop_op[0]);
-				SendMsgToChar(buf, ch);
-				return;
-			}
-			if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-				snprintf(buf, kMaxInputLength, "У вас нет ничего похожего на '%s'.\r\n", arg);
-				SendMsgToChar(buf, ch);
-			}
-			while (obj) {
-				next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
-				PerformDrop(ch, obj);
-				obj = next_obj;
-			}
-		} else {
-			if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-				snprintf(buf, kMaxInputLength, "У вас нет '%s'.\r\n", arg);
-				SendMsgToChar(buf, ch);
-			} else
-				PerformDrop(ch, obj);
+		return;
+	}
+
+	const auto dotmode = find_all_dots(what);
+	// Can't junk or donate all
+	if (dotmode == kFindAll) {
+		if (!ch->carrying) {
+			SendMsgToChar("А у вас ничего и нет.\r\n", ch);
+			return;
 		}
+		for (obj = ch->carrying; obj; obj = next_obj) {
+			next_obj = obj->get_next_content();
+			if (obj->get_extracted_list()) {
+				continue;
+			}
+			PerformDrop(ch, obj);
+		}
+		return;
+	}
+
+	if (dotmode == kFindAlldot) {
+		if (what.empty()) {
+			SendMsgToChar(fmt::format("{} \"все\" какого типа предметов?\r\n", drop_op[0]), ch);
+			return;
+		}
+		if (!(obj = get_obj_in_list_vis(ch, what, ch->carrying))) {
+			SendMsgToChar(fmt::format("У вас нет ничего похожего на '{}'.\r\n", what), ch);
+		}
+		while (obj) {
+			next_obj = get_obj_in_list_vis(ch, what, obj->get_next_content());
+			PerformDrop(ch, obj);
+			obj = next_obj;
+		}
+		return;
+	}
+
+	if (!(obj = get_obj_in_list_vis(ch, what, ch->carrying))) {
+		SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", what), ch);
+	} else {
+		PerformDrop(ch, obj);
 	}
 }
 

--- a/src/engine/ui/cmd/do_equip.cpp
+++ b/src/engine/ui/cmd/do_equip.cpp
@@ -313,7 +313,7 @@ void do_wear(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		SendMsgToChar("Что вы собрались надеть?\r\n", ch);
 		return;
 	}
-	dotmode = find_all_dots(arg1);
+	dotmode = ParseAllPrefix(arg1);
 
 	if (*arg2 && (dotmode != kFindIndiv)) {
 		SendMsgToChar("И на какую часть тела вы желаете это надеть?!\r\n", ch);

--- a/src/engine/ui/cmd/do_get.cpp
+++ b/src/engine/ui/cmd/do_get.cpp
@@ -172,7 +172,7 @@ void get_from_container(CharData *ch, ObjData *cont, char *local_arg, int mode, 
 	ObjData *obj, *next_obj;
 	int obj_dotmode, found = 0;
 
-	obj_dotmode = find_all_dots(local_arg);
+	obj_dotmode = ParseAllPrefix(local_arg);
 	if (IS_SET(GET_OBJ_VAL((cont), 1), (EContainerFlag::kShutted)))
 		act("$o закрыт$A.", false, ch, cont, nullptr, kToChar);
 	else if (obj_dotmode == kFindIndiv) {
@@ -258,7 +258,7 @@ void get_from_room(CharData *ch, char *local_arg, int howmany) {
 		return;
 	}
 
-	dotmode = find_all_dots(local_arg);
+	dotmode = ParseAllPrefix(local_arg);
 
 	if (dotmode == kFindIndiv) {
 		if (!(obj = get_obj_in_list_vis(ch, local_arg, world[ch->in_room]->contents))) {
@@ -344,7 +344,7 @@ void do_get(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		else if (isname(theplace, "экипировка equipment"))
 			where_bits = EFind::kObjEquip;
 
-		cont_dotmode = find_all_dots(thecont);
+		cont_dotmode = ParseAllPrefix(thecont);
 		if (cont_dotmode == kFindIndiv) {
 			mode = generic_find(thecont, where_bits, ch, &tmp_char, &cont);
 			if (!cont) {

--- a/src/engine/ui/cmd/do_give.cpp
+++ b/src/engine/ui/cmd/do_give.cpp
@@ -208,7 +208,7 @@ void do_give(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (!(vict = give_find_vict(ch, utils::ExtractFirstArgumentLower(remains)))) {
 		return;
 	}
-	auto dotmode = find_all_dots(what);
+	auto dotmode = ParseAllPrefix(what);
 	if (dotmode == kFindIndiv) {
 		if (!(obj = get_obj_in_list_vis(ch, what, ch->carrying))) {
 			SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", what), ch);

--- a/src/engine/ui/cmd/do_give.cpp
+++ b/src/engine/ui/cmd/do_give.cpp
@@ -10,6 +10,9 @@
 #include "engine/core/utils_char_obj.inl"
 #include "engine/core/target_resolver.h"
 #include "engine/db/global_objects.h"
+#include "utils/utils_string.h"
+
+#include <fmt/format.h>
 
 extern void get_check_money(CharData *ch, ObjData *obj, ObjData *cont);
 extern void split_or_clan_tax(CharData *ch, long amount);
@@ -30,9 +33,9 @@ void perform_give(CharData *ch, CharData *vict, ObjData *obj) {
 	if (vict->IsNpc() && mob_index[vict->get_rnum()].func && mob_index[vict->get_rnum()].func != guilds::GuildInfo::DoGuildLearn) {
 		act("$N не нуждается в ваших подачках, своего барахла навалом.",
 			false, ch, nullptr, vict, kToChar);
-		sprintf(buf, "Попытка мобу с спецпроцедурой дать предмет: Моб %s (%d) в комнате #%d, игрок: %s", 
-			GET_NAME(vict), GET_MOB_VNUM(vict), GET_ROOM_VNUM(vict->in_room), GET_NAME(ch));
-		mudlog(buf, CMP, kLvlGod, SYSLOG, true);
+		mudlog(fmt::format("Попытка мобу с спецпроцедурой дать предмет: Моб {} #{} в комнате #{}, игрок: {}",
+						   GET_NAME(vict), GET_MOB_VNUM(vict), GET_ROOM_VNUM(vict->in_room), GET_NAME(ch)),
+			   CMP, kLvlGod, SYSLOG, true);
 		return;
 	}
 	if (obj->has_flag(EObjFlag::kNodrop)) {
@@ -77,10 +80,10 @@ void perform_give(CharData *ch, CharData *vict, ObjData *obj) {
 }
 
 // utility function for give
-CharData *give_find_vict(CharData *ch, char *local_arg) {
+CharData *give_find_vict(CharData *ch, const std::string &local_arg) {
 	CharData *vict;
 
-	if (!*local_arg) {
+	if (local_arg.empty()) {
 		SendMsgToChar("Кому?\r\n", ch);
 		return (nullptr);
 	} else if (!(vict = target_resolver::FindCharInRoom(ch, local_arg))) {
@@ -107,21 +110,16 @@ void perform_give_gold(CharData *ch, CharData *vict, int amount) {
 			false, ch, nullptr, nullptr, kToChar);
 		return;
 	}
-	sprintf(buf, "Вы дали %d %s $N2.", amount, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kAcc).c_str());
-	act(buf, false, ch, nullptr, vict, kToChar);
-	sprintf(buf, "$n дал$g вам %d %s.", amount, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kAcc).c_str());
-	act(buf, false, ch, nullptr, vict, kToVict);
-	sprintf(buf, "$n дал$g %s $N2.",
-			MUD::Currency(currencies::kGoldVnum).GetObjCName(amount, grammar::ECase::kAcc));
-	act(buf, true, ch, nullptr, vict, kToNotVict | kToArenaListen);
+	const std::string gold = MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kAcc);
+	act(fmt::format("Вы дали {} {} $N2.", amount, gold), false, ch, nullptr, vict, kToChar);
+	act(fmt::format("$n дал$g вам {} {}.", amount, gold), false, ch, nullptr, vict, kToVict);
+	act(fmt::format("$n дал$g {} $N2.",
+					MUD::Currency(currencies::kGoldVnum).GetObjCName(amount, grammar::ECase::kAcc)),
+		true, ch, nullptr, vict, kToNotVict | kToArenaListen);
 	if (!(ch->IsNpc() || vict->IsNpc())) {
-		sprintf(buf,
-				"<%s> {%d} передал %d кун при личной встрече c %s.",
-				ch->get_name().c_str(),
-				GET_ROOM_VNUM(ch->in_room),
-				amount,
-				GET_PAD(vict, 4));
-		mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
+		mudlog(fmt::format("<{}> {{{}}} передал {} кун при личной встрече c {}.",
+						   ch->get_name(), GET_ROOM_VNUM(ch->in_room), amount, GET_PAD(vict, 4)),
+			   NRM, kLvlGreatGod, MONEY_LOG, true);
 	}
 	if (ch->IsNpc() || !privilege::IsImpl(ch)) {
 		currencies::RemoveHand(*ch, currencies::kGold, amount);
@@ -150,12 +148,10 @@ void perform_give_currency(CharData *ch, CharData *vict, const currencies::Curre
 			false, ch, nullptr, nullptr, kToChar);
 		return;
 	}
-	sprintf(buf, "Вы дали %d %s $N2.", amount, cur.GetNameWithAmount(amount, grammar::ECase::kAcc).c_str());
-	act(buf, false, ch, nullptr, vict, kToChar);
-	sprintf(buf, "$n дал$g вам %d %s.", amount, cur.GetNameWithAmount(amount, grammar::ECase::kAcc).c_str());
-	act(buf, false, ch, nullptr, vict, kToVict);
-	sprintf(buf, "$n дал$g %d %s $N2.", amount, cur.GetNameWithAmount(amount, grammar::ECase::kAcc).c_str());
-	act(buf, true, ch, nullptr, vict, kToNotVict | kToArenaListen);
+	const std::string money = cur.GetNameWithAmount(amount, grammar::ECase::kAcc);
+	act(fmt::format("Вы дали {} {} $N2.", amount, money), false, ch, nullptr, vict, kToChar);
+	act(fmt::format("$n дал$g вам {} {}.", amount, money), false, ch, nullptr, vict, kToVict);
+	act(fmt::format("$n дал$g {} {} $N2.", amount, money), true, ch, nullptr, vict, kToNotVict | kToArenaListen);
 	if (ch->IsNpc() || !privilege::IsImpl(ch)) {
 		currencies::RemoveHand(*ch, cur.GetTextId(), amount);
 	}
@@ -166,81 +162,87 @@ void do_give(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	CharData *vict;
 	ObjData *obj, *next_obj;
 
-	argument = one_argument(argument, arg);
+	std::string remains;
+	std::string what = utils::ExtractFirstArgumentLower(argument, remains);
 
-	if (!*arg)
+	if (what.empty()) {
 		SendMsgToChar("Дать что и кому?\r\n", ch);
-	else if (is_number(arg)) {
-		auto amount = std::stoi(arg);
-		argument = one_argument(argument, arg);
-		if (utils::IsAbbr("coin", arg) || utils::IsAbbr("кун", arg) || !str_cmp("денег", arg)) {
-			one_argument(argument, arg);
-			if ((vict = give_find_vict(ch, arg)) != nullptr)
+		return;
+	}
+
+	if (is_number(what.c_str())) {
+		auto amount = std::stoi(what);
+		what = utils::ExtractFirstArgumentLower(remains, remains);
+		if (utils::IsAbbr("coin", what.c_str()) || utils::IsAbbr("кун", what.c_str()) || !str_cmp("денег", what)) {
+			if ((vict = give_find_vict(ch, utils::ExtractFirstArgumentLower(remains))) != nullptr) {
 				perform_give_gold(ch, vict, amount);
+			}
 			return;
 		}
-		if (const auto *cur = currencies::FindBySearch(arg); cur && cur->IsGiveable()) {
-			one_argument(argument, arg);
-			if ((vict = give_find_vict(ch, arg)) != nullptr)
+		if (const auto *cur = currencies::FindBySearch(what); cur && cur->IsGiveable()) {
+			if ((vict = give_find_vict(ch, utils::ExtractFirstArgumentLower(remains))) != nullptr) {
 				perform_give_currency(ch, vict, *cur, amount);
+			}
 			return;
 		}
-		if (!*arg) {
-			sprintf(buf, "Чего %d вы хотите дать?\r\n", amount);
-			SendMsgToChar(buf, ch);
-		} else if (!(vict = give_find_vict(ch, argument))) {
+		if (what.empty()) {
+			SendMsgToChar(fmt::format("Чего {} вы хотите дать?\r\n", amount), ch);
+		} else if (!(vict = give_find_vict(ch, remains))) {
 			return;
-		} else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-			if (const auto *cur = currencies::FindBySearch(arg); cur && !cur->IsGiveable()) {
+		} else if (!(obj = get_obj_in_list_vis(ch, what, ch->carrying))) {
+			if (const auto *cur = currencies::FindBySearch(what); cur && !cur->IsGiveable()) {
 				SendMsgToChar("Эту валюту нельзя передать другому.\r\n", ch);
 			} else {
-				snprintf(buf, kMaxInputLength, "У вас нет '%s'.\r\n", arg);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", what), ch);
 			}
 		} else {
 			while (obj && amount--) {
-				next_obj = get_obj_in_list_vis(ch, arg, obj->get_next_content());
+				next_obj = get_obj_in_list_vis(ch, what, obj->get_next_content());
 				perform_give(ch, vict, obj);
 				obj = next_obj;
 			}
 		}
-	} else {
-		one_argument(argument, buf1);
-		if (!(vict = give_find_vict(ch, buf1)))
-			return;
-		auto dotmode = find_all_dots(arg);
-		if (dotmode == kFindIndiv) {
-			if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-				snprintf(buf, kMaxInputLength, "У вас нет '%s'.\r\n", arg);
-				SendMsgToChar(buf, ch);
-			} else
-				perform_give(ch, vict, obj);
+		return;
+	}
+
+	if (!(vict = give_find_vict(ch, utils::ExtractFirstArgumentLower(remains)))) {
+		return;
+	}
+	auto dotmode = find_all_dots(what);
+	if (dotmode == kFindIndiv) {
+		if (!(obj = get_obj_in_list_vis(ch, what, ch->carrying))) {
+			SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", what), ch);
 		} else {
-			if (dotmode == kFindAlldot && !*arg) {
-				SendMsgToChar("Дать \"все\" какого типа предметов?\r\n", ch);
-				return;
-			}
-			if (!ch->carrying)
-				SendMsgToChar("У вас ведь ничего нет.\r\n", ch);
-			else {
-				bool has_items = false;
-				for (obj = ch->carrying; obj; obj = next_obj) {
-					next_obj = obj->get_next_content();
-					if (obj->get_extracted_list())
-						continue;
-					if (sight::CanSeeObj(ch, obj)
-						&& (dotmode == kFindAll
-							|| isname(arg, obj->get_aliases())
-							|| CHECK_CUSTOM_LABEL(arg, obj, ch))) {
-						perform_give(ch, vict, obj);
-						has_items = true;
-					}
-				}
-				if (!has_items) {
-					SendMsgToChar(ch, "У вас нет '%s'.\r\n", arg);
-				}
-			}
+			perform_give(ch, vict, obj);
 		}
+		return;
+	}
+
+	if (dotmode == kFindAlldot && what.empty()) {
+		SendMsgToChar("Дать \"все\" какого типа предметов?\r\n", ch);
+		return;
+	}
+	if (!ch->carrying) {
+		SendMsgToChar("У вас ведь ничего нет.\r\n", ch);
+		return;
+	}
+
+	bool has_items = false;
+	for (obj = ch->carrying; obj; obj = next_obj) {
+		next_obj = obj->get_next_content();
+		if (obj->get_extracted_list()) {
+			continue;
+		}
+		if (sight::CanSeeObj(ch, obj)
+			&& (dotmode == kFindAll
+				|| isname(what, obj->get_aliases())
+				|| CHECK_CUSTOM_LABEL(what.c_str(), obj, ch))) {
+			perform_give(ch, vict, obj);
+			has_items = true;
+		}
+	}
+	if (!has_items) {
+		SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", what), ch);
 	}
 }
 

--- a/src/engine/ui/cmd/do_put.cpp
+++ b/src/engine/ui/cmd/do_put.cpp
@@ -170,9 +170,9 @@ void do_put(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 		obj_dotmode = kFindIndiv;
 	} else
-		obj_dotmode = find_all_dots(theobj);
+		obj_dotmode = ParseAllPrefix(theobj);
 
-	cont_dotmode = find_all_dots(thecont);
+	cont_dotmode = ParseAllPrefix(thecont);
 
 	if (!*theobj)
 		SendMsgToChar("Положить что и куда?\r\n", ch);

--- a/src/engine/ui/cmd/do_remove.cpp
+++ b/src/engine/ui/cmd/do_remove.cpp
@@ -51,7 +51,7 @@ void do_remove(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		SendMsgToChar("Снять что?\r\n", ch);
 		return;
 	}
-	dotmode = find_all_dots(arg);
+	dotmode = ParseAllPrefix(arg);
 
 	if (dotmode == kFindAll) {
 		found = 0;

--- a/src/engine/ui/cmd/do_score.cpp
+++ b/src/engine/ui/cmd/do_score.cpp
@@ -43,7 +43,7 @@ void PrintScoreBase(CharData *ch);
 void PrintScoreList(CharData *ch);
 void PrintScoreAll(CharData *ch);
 void PrintRentableInfo(CharData *ch, std::ostringstream &out);
-const char *GetPositionStr(CharData *ch);
+std::string GetPositionStr(CharData *ch);
 const char *GetShortPositionStr(CharData *ch);
 int CalcHitroll(CharData *ch);
 
@@ -118,16 +118,21 @@ void PrintBonusStateInfo(CharData *ch, std::ostringstream &out);
 
 // \todo Переписать на вывод в поток с использованием общих со "счет все" функций
 void PrintScoreList(CharData *ch) {
-	sprintf(buf, "%s", MUD::RaceMessages().GetMessage(GET_RACE(ch), ch->get_sex()).c_str());
-	native_text::copy_lower_char(buf, buf);
-	sprintf(buf1, "%s", religion_name[GET_RELIGION(ch)][static_cast<int>(ch->get_sex())]);
-	native_text::copy_lower_char(buf1, buf1);
-	SendMsgToChar(ch, "Вы %s, %s, %s, %s, уровень %d, перевоплощений %d.\r\n", ch->get_name().c_str(),
-				  buf,
-				  MUD::Class(ch->GetClass()).GetCName(),
-				  buf1,
-				  GetRealLevel(ch),
-				  remort::GetRealRemort(ch));
+	// Раса и религия стоят в середине фразы, поэтому первая буква строчная -- как и раньше,
+	// понижается ровно она одна (copy_lower_char работает с одним символом).
+	auto lower_first = [](std::string word) {
+		if (!word.empty()) {
+			char lowered[8] = {};
+			const std::size_t bytes = native_text::copy_lower_char(word.c_str(), lowered);
+			word.replace(0, native_text::char_bytes(word.c_str()), lowered, bytes);
+		}
+		return word;
+	};
+	const std::string race = lower_first(MUD::RaceMessages().GetMessage(GET_RACE(ch), ch->get_sex()));
+	const std::string religion = lower_first(religion_name[GET_RELIGION(ch)][static_cast<int>(ch->get_sex())]);
+	SendMsgToChar(fmt::format("Вы {}, {}, {}, {}, уровень {}, перевоплощений {}.\r\n",
+							  ch->get_name(), race, MUD::Class(ch->GetClass()).GetCName(), religion,
+							  GetRealLevel(ch), remort::GetRealRemort(ch)), ch);
 	SendMsgToChar(ch, "Ваш возраст: %d, размер: %d(%d), рост: %d(%d), вес %d(%d).\r\n",
 				  CalcCharAge(ch)->year,
 				  GET_SIZE(ch), GET_REAL_SIZE(ch),
@@ -205,7 +210,7 @@ void PrintScoreList(CharData *ch) {
 				  ch->get_exp(),
 				  privilege::IsImmortal(ch) ? 1 : experience::GetExpUntilNextLvl(ch, GetRealLevel(ch) + 1) - ch->get_exp());
 	if (!mount::IsOnHorse(ch))
-		SendMsgToChar(ch, "Ваша позиция: %s", GetPositionStr(ch));
+		SendMsgToChar("Ваша позиция: " + GetPositionStr(ch), ch);
 	else
 		SendMsgToChar(ch, "Ваша позиция: Вы верхом на %s.\r\n", GET_PAD(mount::GetHorse(ch), 5));
 	if (ch->IsFlagged(EPrf::KSummonable))
@@ -218,13 +223,13 @@ void PrintScoreList(CharData *ch) {
 	if (label_room) {
 		const int timer_room_label = room_spells::GetUniqueAffectDuration(ch->get_uid(), room_spells::ERoomAffect::kRuneLabel);
 		if (timer_room_label > 0) {
-			*buf2 = '\0';
-			(timer_room_label + 1) / kSecsPerMudHour ? sprintf(buf2, "%d %s.", (timer_room_label + 1) / kSecsPerMudHour + 1,
-															   grammar::GetDeclensionInNumber(
-																   (timer_room_label + 1) / kSecsPerMudHour + 1,
-																   grammar::EWhat::kHour)) : sprintf(buf2, "менее часа.");
-			SendMsgToChar(ch, "Вы поставили рунную метку в комнате: '%s', она продержится еще %s\r\n", label_room->name, buf2);
-			*buf2 = '\0';
+			const int hours = (timer_room_label + 1) / kSecsPerMudHour;
+			const std::string left = hours
+				? fmt::format("{} {}.", hours + 1,
+							  grammar::GetDeclensionInNumber(hours + 1, grammar::EWhat::kHour))
+				: std::string("менее часа.");
+			SendMsgToChar(fmt::format("Вы поставили рунную метку в комнате: '{}', она продержится еще {}\r\n",
+									  label_room->name, left), ch);
 		}
 	}
 	if (!(ch)->player_specials->saved.NameGod && GetRealLevel(ch) <= kNameLevel) {
@@ -723,45 +728,43 @@ void PrintScoreBase(CharData *ch) {
 	SendMsgToChar(out.str(), ch);
 	// Продолжить с этого места
 
-	sprintf(buf,
-			"Вы можете выдержать %d(%d) %s повреждения, и пройти %d(%d) %s по ровной местности.\r\n",
-			ch->get_hit(), ch->get_real_max_hit(), grammar::GetDeclensionInNumber(ch->get_hit(),
-																	 grammar::EWhat::kOneU),
-			ch->get_move(), ch->get_real_max_move(), grammar::GetDeclensionInNumber(ch->get_move(), grammar::EWhat::kMoveU));
+	std::string body = fmt::format(
+		"Вы можете выдержать {}({}) {} повреждения, и пройти {}({}) {} по ровной местности.\r\n",
+		ch->get_hit(), ch->get_real_max_hit(),
+		grammar::GetDeclensionInNumber(ch->get_hit(), grammar::EWhat::kOneU),
+		ch->get_move(), ch->get_real_max_move(),
+		grammar::GetDeclensionInNumber(ch->get_move(), grammar::EWhat::kMoveU));
 
 	if (IS_MANA_CASTER(ch)) {
-		sprintf(buf + strlen(buf),
-				"Ваша магическая энергия %d(%d) и вы восстанавливаете %d в сек.\r\n",
-				ch->mem_queue.stored, Mana(GetRealWis(ch)), CalcManaGain(ch));
+		body += fmt::format("Ваша магическая энергия {}({}) и вы восстанавливаете {} в сек.\r\n",
+							ch->mem_queue.stored, Mana(GetRealWis(ch)), CalcManaGain(ch));
 	}
 
-	sprintf(buf + strlen(buf),
-			"%sВаши характеристики :\r\n"
-			"  Сила : %2d(%2d)"
-			"  Подв : %2d(%2d)"
-			"  Тело : %2d(%2d)"
-			"  Мудр : %2d(%2d)"
-			"  Ум   : %2d(%2d)"
-			"  Обаян: %2d(%2d)\r\n"
-			"  Размер %3d(%3d)"
-			"  Рост   %3d(%3d)"
-			"  Вес    %3d(%3d)%s\r\n",
-			kColorBoldCyn, ch->get_str(), GetRealStr(ch),
-			ch->get_dex(), GetRealDex(ch),
-			ch->get_con(), GetRealCon(ch),
-			ch->get_wis(), GetRealWis(ch),
-			ch->get_int(), GetRealInt(ch),
-			ch->get_cha(), GetRealCha(ch),
-			GET_SIZE(ch), GET_REAL_SIZE(ch),
-			GET_HEIGHT(ch), GET_REAL_HEIGHT(ch), GET_WEIGHT(ch), GET_REAL_WEIGHT(ch), kColorNrm);
+	body += fmt::format(
+		"&CВаши характеристики :\r\n"
+		"  Сила : {:2}({:2})"
+		"  Подв : {:2}({:2})"
+		"  Тело : {:2}({:2})"
+		"  Мудр : {:2}({:2})"
+		"  Ум   : {:2}({:2})"
+		"  Обаян: {:2}({:2})\r\n"
+		"  Размер {:3}({:3})"
+		"  Рост   {:3}({:3})"
+		"  Вес    {:3}({:3})&n\r\n",
+		ch->get_str(), GetRealStr(ch),
+		ch->get_dex(), GetRealDex(ch),
+		ch->get_con(), GetRealCon(ch),
+		ch->get_wis(), GetRealWis(ch),
+		ch->get_int(), GetRealInt(ch),
+		ch->get_cha(), GetRealCha(ch),
+		GET_SIZE(ch), GET_REAL_SIZE(ch),
+		GET_HEIGHT(ch), GET_REAL_HEIGHT(ch), GET_WEIGHT(ch), GET_REAL_WEIGHT(ch));
 
 	if (privilege::IsImmortal(ch)) {
-		sprintf(buf + strlen(buf),
-				"%sВаши боевые качества :\r\n"
-				"  AC   : %4d(%4d)"
-				"  DR   : %4d(%4d)%s\r\n",
-				kColorBoldGrn, GET_AC(ch), CalcBaseAc(ch),
-				GET_DR(ch), GetRealDamroll(ch), kColorNrm);
+		body += fmt::format("&GВаши боевые качества :\r\n"
+							"  AC   : {:4}({:4})"
+							"  DR   : {:4}({:4})&n\r\n",
+							GET_AC(ch), CalcBaseAc(ch), GET_DR(ch), GetRealDamroll(ch));
 	} else {
 		int ac = CalcBaseAc(ch) / 10;
 
@@ -771,34 +774,35 @@ void PrintScoreBase(CharData *ch) {
 		}
 
 		int ac_t = std::clamp(ac + 30, 0, 40);
-		sprintf(buf + strlen(buf), "&GВаши боевые качества :\r\n"
-								   "  Защита  (AC)     : %4d - %s&G\r\n"
-								   "  Броня/Поглощение : %4d/%d&n\r\n",
-				ac, ac_text[ac_t], GET_ARMOUR(ch), GET_ABSORBE(ch));
+		body += fmt::format("&GВаши боевые качества :\r\n"
+							"  Защита  (AC)     : {:4} - {}&G\r\n"
+							"  Броня/Поглощение : {:4}/{}&n\r\n",
+							ac, ac_text[ac_t], GET_ARMOUR(ch), GET_ABSORBE(ch));
 	}
-	sprintf(buf + strlen(buf), "Ваш опыт - %ld %s, бонус %d %c. ", ch->get_exp(),
-			grammar::GetDeclensionInNumber(ch->get_exp(), grammar::EWhat::kPoint), ch->add_abils.percent_exp_add, '%');
+	body += fmt::format("Ваш опыт - {} {}, бонус {} %. ", ch->get_exp(),
+						grammar::GetDeclensionInNumber(ch->get_exp(), grammar::EWhat::kPoint),
+						ch->add_abils.percent_exp_add);
 	if (GetRealLevel(ch) < kLvlImmortal) {
 		if (ch->IsFlagged(EPrf::kBlindMode)) {
-			sprintf(buf + strlen(buf), "\r\n");
+			body += "\r\n";
 		}
-		sprintf(buf + strlen(buf),
-				"Вам осталось набрать %ld %s до следующего уровня.\r\n",
-				experience::GetExpUntilNextLvl(ch, GetRealLevel(ch) + 1) - ch->get_exp(),
-				grammar::GetDeclensionInNumber(experience::GetExpUntilNextLvl(ch, GetRealLevel(ch) + 1) - ch->get_exp(), grammar::EWhat::kPoint));
-	} else
-		sprintf(buf + strlen(buf), "\r\n");
+		const long left = experience::GetExpUntilNextLvl(ch, GetRealLevel(ch) + 1) - ch->get_exp();
+		body += fmt::format("Вам осталось набрать {} {} до следующего уровня.\r\n",
+							left, grammar::GetDeclensionInNumber(left, grammar::EWhat::kPoint));
+	} else {
+		body += "\r\n";
+	}
 
-	sprintf(buf + strlen(buf),
-			"У вас на руках %ld %s",
-			currencies::GetHand(*ch, currencies::kGold),
-			MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(currencies::GetHand(*ch, currencies::kGold)).c_str());
-	if (currencies::GetBank(*ch, currencies::kGold) > 0)
-		sprintf(buf + strlen(buf), " (и еще %ld %s припрятано в лежне).\r\n",
-				currencies::GetBank(*ch, currencies::kGold),
-				MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(currencies::GetBank(*ch, currencies::kGold)).c_str());
-	else
-		strncat(buf, ".\r\n", sizeof(buf) - strlen(buf) - 1);
+	const long hand_gold = currencies::GetHand(*ch, currencies::kGold);
+	body += fmt::format("У вас на руках {} {}", hand_gold,
+						MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(hand_gold));
+	const long bank_gold = currencies::GetBank(*ch, currencies::kGold);
+	if (bank_gold > 0) {
+		body += fmt::format(" (и еще {} {} припрятано в лежне).\r\n", bank_gold,
+							MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(bank_gold));
+	} else {
+		body += ".\r\n";
+	}
 
 	// Прочие валюты (гривны, ногаты и т.п.), кроме кун и славы (они выводятся отдельно):
 	// одной строкой с переносом по ширине, запятые ставит разделитель OutWordsList.
@@ -817,180 +821,137 @@ void PrintScoreBase(CharData *ch) {
 	if (!money_parts.empty()) {
 		const size_t width = ch->player_specials->saved.stringLength > 0
 				? ch->player_specials->saved.stringLength : 80;
-		const std::string money_line =
-				"Также у вас: " + utils::OutWordsList(money_parts, width, ", ") + ".\r\n";
-		strncat(buf, money_line.c_str(), sizeof(buf) - strlen(buf) - 1);
+		body += "Также у вас: " + utils::OutWordsList(money_parts, width, ", ") + ".\r\n";
 	}
 
 	if (GetRealLevel(ch) < kLvlImmortal) {
-		sprintf(buf + strlen(buf),
-				"Вы можете вступить в группу с максимальной разницей в %d %s без потерь для опыта.\r\n",
-				grouping[ch->GetClass()][static_cast<int>(remort::GetRealRemort(ch))],
-				grammar::GetDeclensionInNumber(grouping[ch->GetClass()][static_cast<int>(remort::GetRealRemort(ch))],
-									  grammar::EWhat::kLvl));
+		const int diff = grouping[ch->GetClass()][static_cast<int>(remort::GetRealRemort(ch))];
+		body += fmt::format("Вы можете вступить в группу с максимальной разницей в {} {} "
+							"без потерь для опыта.\r\n",
+							diff, grammar::GetDeclensionInNumber(diff, grammar::EWhat::kLvl));
 	}
 
 	//Напоминаем о метке, если она есть.
 	RoomData *label_room = room_spells::FindAffectedRoomByCasterID(ch->get_uid(), room_spells::ERoomAffect::kRuneLabel);
 	if (label_room) {
-		sprintf(buf + strlen(buf),
-				"&G&qВы поставили рунную метку в комнате '%s'.&Q&n\r\n",
-				std::string(label_room->name).c_str());
+		body += fmt::format("&G&qВы поставили рунную метку в комнате '{}'.&Q&n\r\n", label_room->name);
 	}
 
 	int glory = currencies::GetHand(*ch, currencies::kGlory);
 	if (glory) {
-		sprintf(buf + strlen(buf), "Вы заслужили %d %s.\r\n",
-				glory, MUD::Currency(currencies::kGloryVnum).GetNameWithAmount(glory, grammar::ECase::kGen).c_str());
+		body += fmt::format("Вы заслужили {} {}.\r\n", glory,
+							MUD::Currency(currencies::kGloryVnum).GetNameWithAmount(glory, grammar::ECase::kGen));
 	}
 
 	TimeInfoData playing_time = *CalcRealTimePassed((time(nullptr) - ch->player_data.time.logon) + ch->player_data.time.played, 0);
-	sprintf(buf + strlen(buf), "Вы играете %d %s %d %s реального времени.\r\n",
-			playing_time.day, grammar::GetDeclensionInNumber(playing_time.day, grammar::EWhat::kDay),
-			playing_time.hours, grammar::GetDeclensionInNumber(playing_time.hours, grammar::EWhat::kHour));
-	SendMsgToChar(buf, ch);
+	body += fmt::format("Вы играете {} {} {} {} реального времени.\r\n",
+						playing_time.day, grammar::GetDeclensionInNumber(playing_time.day, grammar::EWhat::kDay),
+						playing_time.hours, grammar::GetDeclensionInNumber(playing_time.hours, grammar::EWhat::kHour));
+	SendMsgToChar(body, ch);
 
 	if (!mount::IsOnHorse(ch))
-		SendMsgToChar(ch, "%s", GetPositionStr(ch));
+		SendMsgToChar(GetPositionStr(ch), ch);
 
-	snprintf(buf, sizeof(buf), "%s", kColorBoldGrn);
+	std::string state("&G");
 	const auto value_drunked = GET_COND(ch, condition::kDrunk);
 	if (value_drunked >= kDrunked) {
-		if (IsAffected(ch, EAffect::kAbstinent))
-			strncat(buf, "Привет с большого бодуна!\r\n", sizeof(buf) - strlen(buf) - 1);
-		else {
-			if (value_drunked >= kMortallyDrunked)
-				strncat(buf, "Вы так пьяны, что ваши ноги не хотят слушаться вас...\r\n", sizeof(buf) - strlen(buf) - 1);
-			else if (value_drunked >= 10)
-				strncat(buf, "Вы так пьяны, что вам хочется петь песни.\r\n", sizeof(buf) - strlen(buf) - 1);
-			else if (value_drunked >= 5)
-				strncat(buf, "Вы пьяны.\r\n", sizeof(buf) - strlen(buf) - 1);
-			else
-				strncat(buf, "Вы немного пьяны.\r\n", sizeof(buf) - strlen(buf) - 1);
+		if (IsAffected(ch, EAffect::kAbstinent)) {
+			state += "Привет с большого бодуна!\r\n";
+		} else if (value_drunked >= kMortallyDrunked) {
+			state += "Вы так пьяны, что ваши ноги не хотят слушаться вас...\r\n";
+		} else if (value_drunked >= 10) {
+			state += "Вы так пьяны, что вам хочется петь песни.\r\n";
+		} else if (value_drunked >= 5) {
+			state += "Вы пьяны.\r\n";
+		} else {
+			state += "Вы немного пьяны.\r\n";
 		}
-
 	}
-	if (condition::GetCondAboveNorm(ch, condition::kFull))
-		strncat(buf, "Вы голодны.\r\n", sizeof(buf) - strlen(buf) - 1);
-	if (condition::GetCondAboveNorm(ch, condition::kThirst))
-		strncat(buf, "Вас мучает жажда.\r\n", sizeof(buf) - strlen(buf) - 1);
-	/*
-	   strcat(buf, KICYN);
-	   strcat(buf,"Аффекты :\r\n");
-	   snprintf(buf2, sizeof(buf2), "%s", affects::DescribeActive((ch)->char_specials.saved.affected_by, "\r\n").c_str());
-	   strcat(buf,buf2);
-	 */
-	if (ch->IsFlagged(EPrf::KSummonable))
-		strncat(buf, "Вы можете быть призваны.\r\n", sizeof(buf) - strlen(buf) - 1);
+	if (condition::GetCondAboveNorm(ch, condition::kFull)) {
+		state += "Вы голодны.\r\n";
+	}
+	if (condition::GetCondAboveNorm(ch, condition::kThirst)) {
+		state += "Вас мучает жажда.\r\n";
+	}
+	if (ch->IsFlagged(EPrf::KSummonable)) {
+		state += "Вы можете быть призваны.\r\n";
+	}
 
 	if (mount::HasHorse(ch, false)) {
-		size_t buf_len = strlen(buf);
-		if (mount::IsOnHorse(ch))
-			snprintf(buf + buf_len, sizeof(buf) - buf_len, "Вы верхом на %s.\r\n", GET_PAD(mount::GetHorse(ch), 5));
-		else
-			snprintf(buf + buf_len, sizeof(buf) - buf_len, "У вас есть %s.\r\n", GET_NAME(mount::GetHorse(ch)));
+		state += mount::IsOnHorse(ch)
+			? fmt::format("Вы верхом на {}.\r\n", GET_PAD(mount::GetHorse(ch), 5))
+			: fmt::format("У вас есть {}.\r\n", GET_NAME(mount::GetHorse(ch)));
 	}
-	strncat(buf, kColorNrm, sizeof(buf) - strlen(buf) - 1);
-	SendMsgToChar(buf, ch);
+	state += "&n";
+	SendMsgToChar(state, ch);
 	if (NORENTABLE(ch)) {
-		snprintf(buf, sizeof(buf),
-				"%sВ связи с боевыми действиями вы не можете уйти на постой.%s\r\n",
-				kColorBoldRed, kColorNrm);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar("&RВ связи с боевыми действиями вы не можете уйти на постой.&n\r\n", ch);
 	} else if ((ch->in_room != kNowhere) && ROOM_FLAGGED(ch->in_room, ERoomFlag::kPeaceful) && !ch->IsFlagged(EPlrFlag::kKiller)) {
-		snprintf(buf, sizeof(buf), "%sТут вы чувствуете себя в безопасности.%s\r\n", kColorBoldGrn, kColorNrm);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar("&GТут вы чувствуете себя в безопасности.&n\r\n", ch);
 	}
 
 	if (ROOM_FLAGGED(ch->in_room, ERoomFlag::kForge)
 		&& (GetSkill(ch, ESkill::kJewelry) || GetSkill(ch, ESkill::kRepair) || GetSkill(ch, ESkill::kReforging))) {
-		snprintf(buf, sizeof(buf),
-				"%sЭто место отлично подходит для занятий кузнечным делом.%s\r\n",
-				kColorBoldGrn,
-				kColorNrm);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar("&GЭто место отлично подходит для занятий кузнечным делом.&n\r\n", ch);
 	}
 
 	if (mail::has_mail(ch->get_uid())) {
-		snprintf(buf, sizeof(buf), "%sВас ожидает новое письмо, зайдите на почту!%s\r\n", kColorBoldGrn, kColorNrm);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar("&GВас ожидает новое письмо, зайдите на почту!&n\r\n", ch);
 	}
 
 	if (Parcel::has_parcel(ch)) {
-		snprintf(buf, sizeof(buf), "%sВас ожидает посылка, зайдите на почту!%s\r\n", kColorBoldGrn, kColorNrm);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar("&GВас ожидает посылка, зайдите на почту!&n\r\n", ch);
 	}
 
-	if (ch->IsFlagged(EPlrFlag::kHelled) && punishments::Get(ch, punishments::EType::kHell).duration && punishments::Get(ch, punishments::EType::kHell).duration > time(nullptr)) {
-		const int hrs = (punishments::Get(ch, punishments::EType::kHell).duration - time(nullptr)) / 3600;
-		const int mins = ((punishments::Get(ch, punishments::EType::kHell).duration - time(nullptr)) % 3600 + 59) / 60;
-		snprintf(buf, sizeof(buf),
-				"Вам предстоит провести в темнице еще %d %s %d %s [%s].\r\n",
-				hrs, grammar::GetDeclensionInNumber(hrs, grammar::EWhat::kHour), mins, grammar::GetDeclensionInNumber(mins,
-																						   grammar::EWhat::kMinU),
-				punishments::Get(ch, punishments::EType::kHell).reason.empty() ? "-" : punishments::Get(ch, punishments::EType::kHell).reason.c_str());
-		SendMsgToChar(buf, ch);
-	}
-	if (ch->IsFlagged(EPlrFlag::kMuted) && punishments::Get(ch, punishments::EType::kMute).duration != 0 && punishments::Get(ch, punishments::EType::kMute).duration > time(nullptr)) {
-		const int hrs = (punishments::Get(ch, punishments::EType::kMute).duration - time(nullptr)) / 3600;
-		const int mins = ((punishments::Get(ch, punishments::EType::kMute).duration - time(nullptr)) % 3600 + 59) / 60;
-		snprintf(buf, sizeof(buf), "Вы не сможете кричать еще %d %s %d %s [%s].\r\n",
-				hrs, grammar::GetDeclensionInNumber(hrs, grammar::EWhat::kHour),
-				mins, grammar::GetDeclensionInNumber(mins, grammar::EWhat::kMinU), punishments::Get(ch, punishments::EType::kMute).reason.empty() ? "-" : punishments::Get(ch, punishments::EType::kMute).reason.c_str());
-		SendMsgToChar(buf, ch);
-	}
-	if (ch->IsFlagged(EPlrFlag::kDumbed) && punishments::Get(ch, punishments::EType::kDumb).duration != 0 && punishments::Get(ch, punishments::EType::kDumb).duration > time(nullptr)) {
-		const int hrs = (punishments::Get(ch, punishments::EType::kDumb).duration - time(nullptr)) / 3600;
-		const int mins = ((punishments::Get(ch, punishments::EType::kDumb).duration - time(nullptr)) % 3600 + 59) / 60;
-		snprintf(buf, sizeof(buf), "Вы будете молчать еще %d %s %d %s [%s].\r\n",
-				hrs, grammar::GetDeclensionInNumber(hrs, grammar::EWhat::kHour),
-				mins, grammar::GetDeclensionInNumber(mins, grammar::EWhat::kMinU), punishments::Get(ch, punishments::EType::kDumb).reason.empty() ? "-" : punishments::Get(ch, punishments::EType::kDumb).reason.c_str());
-		SendMsgToChar(buf, ch);
-	}
-	if (ch->IsFlagged(EPlrFlag::kFrozen) && punishments::Get(ch, punishments::EType::kFreeze).duration != 0 && punishments::Get(ch, punishments::EType::kFreeze).duration > time(nullptr)) {
-		const int hrs = (punishments::Get(ch, punishments::EType::kFreeze).duration - time(nullptr)) / 3600;
-		const int mins = ((punishments::Get(ch, punishments::EType::kFreeze).duration - time(nullptr)) % 3600 + 59) / 60;
-		snprintf(buf, sizeof(buf), "Вы будете заморожены еще %d %s %d %s [%s].\r\n",
-				hrs, grammar::GetDeclensionInNumber(hrs, grammar::EWhat::kHour),
-				mins, grammar::GetDeclensionInNumber(mins, grammar::EWhat::kMinU), punishments::Get(ch, punishments::EType::kFreeze).reason.empty() ? "-" : punishments::Get(ch, punishments::EType::kFreeze).reason.c_str());
-		SendMsgToChar(buf, ch);
-	}
+	// Пять наказаний печатались пятью одинаковыми блоками, отличалась только фраза.
+	auto print_punishment = [ch](punishments::EType type, const char *phrase) {
+		const auto &punishment = punishments::Get(ch, type);
+		if (punishment.duration == 0 || punishment.duration <= time(nullptr)) {
+			return;
+		}
+		const int hrs = (punishment.duration - time(nullptr)) / 3600;
+		const int mins = ((punishment.duration - time(nullptr)) % 3600 + 59) / 60;
+		SendMsgToChar(fmt::format("{} {} {} {} {} [{}].\r\n", phrase,
+								  hrs, grammar::GetDeclensionInNumber(hrs, grammar::EWhat::kHour),
+								  mins, grammar::GetDeclensionInNumber(mins, grammar::EWhat::kMinU),
+								  punishment.reason.empty() ? "-" : punishment.reason.c_str()), ch);
+	};
 
-	if (!ch->IsFlagged(EPlrFlag::kRegistred) && punishments::Get(ch, punishments::EType::kUnreg).duration != 0 && punishments::Get(ch, punishments::EType::kUnreg).duration > time(nullptr)) {
-		const int hrs = (punishments::Get(ch, punishments::EType::kUnreg).duration - time(nullptr)) / 3600;
-		const int mins = ((punishments::Get(ch, punishments::EType::kUnreg).duration - time(nullptr)) % 3600 + 59) / 60;
-		snprintf(buf, sizeof(buf), "Вы не сможете заходить с одного IP еще %d %s %d %s [%s].\r\n",
-				hrs, grammar::GetDeclensionInNumber(hrs, grammar::EWhat::kHour),
-				mins, grammar::GetDeclensionInNumber(mins, grammar::EWhat::kMinU), punishments::Get(ch, punishments::EType::kUnreg).reason.empty() ? "-" : punishments::Get(ch, punishments::EType::kUnreg).reason.c_str());
-		SendMsgToChar(buf, ch);
+	if (ch->IsFlagged(EPlrFlag::kHelled)) {
+		print_punishment(punishments::EType::kHell, "Вам предстоит провести в темнице еще");
+	}
+	if (ch->IsFlagged(EPlrFlag::kMuted)) {
+		print_punishment(punishments::EType::kMute, "Вы не сможете кричать еще");
+	}
+	if (ch->IsFlagged(EPlrFlag::kDumbed)) {
+		print_punishment(punishments::EType::kDumb, "Вы будете молчать еще");
+	}
+	if (ch->IsFlagged(EPlrFlag::kFrozen)) {
+		print_punishment(punishments::EType::kFreeze, "Вы будете заморожены еще");
+	}
+	if (!ch->IsFlagged(EPlrFlag::kRegistred)) {
+		print_punishment(punishments::EType::kUnreg, "Вы не сможете заходить с одного IP еще");
 	}
 
 	if (GET_GOD_FLAG(ch, EGf::kGodscurse) && punishments::Get(ch, punishments::EType::kGcurse).duration) {
-		const int hrs = (punishments::Get(ch, punishments::EType::kGcurse).duration - time(nullptr)) / 3600;
-		const int mins = ((punishments::Get(ch, punishments::EType::kGcurse).duration - time(nullptr)) % 3600 + 59) / 60;
-		snprintf(buf, sizeof(buf), "Вы прокляты Богами на %d %s %d %s.\r\n",
-				hrs, grammar::GetDeclensionInNumber(hrs, grammar::EWhat::kHour), mins, grammar::GetDeclensionInNumber(mins, grammar::EWhat::kMinU));
-		SendMsgToChar(buf, ch);
+		const auto &curse = punishments::Get(ch, punishments::EType::kGcurse);
+		const int hrs = (curse.duration - time(nullptr)) / 3600;
+		const int mins = ((curse.duration - time(nullptr)) % 3600 + 59) / 60;
+		SendMsgToChar(fmt::format("Вы прокляты Богами на {} {} {} {}.\r\n",
+								  hrs, grammar::GetDeclensionInNumber(hrs, grammar::EWhat::kHour),
+								  mins, grammar::GetDeclensionInNumber(mins, grammar::EWhat::kMinU)), ch);
 	}
 
 	if (CanUseFeat(ch, EFeat::kSoulsCollector)) {
 		const int souls = ch->get_souls();
 		if (souls == 0) {
-			snprintf(buf, sizeof(buf), "Вы не имеете чужих душ.\r\n");
-			SendMsgToChar(buf, ch);
+			SendMsgToChar("Вы не имеете чужих душ.\r\n", ch);
+		} else if (souls == 1) {
+			SendMsgToChar("Вы имеете всего одну душу в запасе.\r\n", ch);
+		} else if (souls < 5) {
+			SendMsgToChar(fmt::format("Вы имеете {} души в запасе.\r\n", souls), ch);
 		} else {
-			if (souls == 1) {
-				snprintf(buf, sizeof(buf), "Вы имеете всего одну душу в запасе.\r\n");
-				SendMsgToChar(buf, ch);
-			}
-			if (souls > 1 && souls < 5) {
-				snprintf(buf, sizeof(buf), "Вы имеете %d души в запасе.\r\n", souls);
-				SendMsgToChar(buf, ch);
-			}
-			if (souls >= 5) {
-				snprintf(buf, sizeof(buf), "Вы имеете %d чужих душ в запасе.\r\n", souls);
-				SendMsgToChar(buf, ch);
-			}
+			SendMsgToChar(fmt::format("Вы имеете {} чужих душ в запасе.\r\n", souls), ch);
 		}
 	}
 }
@@ -1063,7 +1024,8 @@ int CalcHitroll(CharData *ch) {
 	return hr;
 }
 
-const char *GetPositionStr(CharData *ch) {
+// Возвращает строку, а не указатель на общий буфер: в бою фраза собирается на месте (#3807).
+std::string GetPositionStr(CharData *ch) {
 	switch (ch->GetPosition()) {
 		case EPosition::kDead:
 			return "Вы МЕРТВЫ!\r\n";
@@ -1081,11 +1043,10 @@ const char *GetPositionStr(CharData *ch) {
 			return "Вы сидите.\r\n";
 		case EPosition::kFight:
 			if (ch->GetEnemy()) {
-				sprintf(buf1, "Вы сражаетесь с %s.\r\n", GET_PAD(ch->GetEnemy(), 4));
-				return buf1;
-			}
-			else
+				return fmt::format("Вы сражаетесь с {}.\r\n", GET_PAD(ch->GetEnemy(), 4));
+			} else {
 				return "Вы машете кулаками по воздуху.\r\n";
+			}
 		case EPosition::kStand:
 			return "Вы стоите.\r\n";
 		default:

--- a/src/engine/ui/cmd/do_score.cpp
+++ b/src/engine/ui/cmd/do_score.cpp
@@ -44,7 +44,7 @@ void PrintScoreList(CharData *ch);
 void PrintScoreAll(CharData *ch);
 void PrintRentableInfo(CharData *ch, std::ostringstream &out);
 std::string GetPositionStr(CharData *ch);
-const char *GetShortPositionStr(CharData *ch);
+std::string_view GetShortPositionStr(CharData *ch);
 int CalcHitroll(CharData *ch);
 
 /* extern */
@@ -523,7 +523,7 @@ int PrintBaseInfoToTable(CharData *ch, table_wrapper::Table &table, std::size_t 
 	}
 	table[++row][col] = MUD::Currency(currencies::kGoldVnum).GetPluralName(grammar::ECase::kGen) + ": " + PrintNumberByDigits(currencies::GetHand(*ch, currencies::kGold));
 	table[++row][col] = std::string("На счету: ") + PrintNumberByDigits(currencies::GetBank(*ch, currencies::kGold));
-	table[++row][col] = GetShortPositionStr(ch);
+	table[++row][col] = std::string(GetShortPositionStr(ch));
 	table[++row][col] = std::string("Голоден: ") + (GET_COND(ch, condition::kFull) > kNormCondition ? "Угу :(" : "Нет");
 	table[++row][col] = std::string("Жажда: ") + (condition::GetCondAboveNorm(ch, condition::kThirst) ? "Наливай!" : "Нет");
 	if (GET_COND(ch, condition::kDrunk) >= kDrunked) {
@@ -1055,7 +1055,9 @@ std::string GetPositionStr(CharData *ch) {
 	return "Вы незнамо что делаете!!!\r\n";
 }
 
-const char *GetShortPositionStr(CharData *ch) {
+// Только литералы, поэтому string_view: копий не делаем, но тип строковый -- как у
+// соседней GetPositionStr, которой пришлось стать std::string (там собиралась фраза).
+std::string_view GetShortPositionStr(CharData *ch) {
 	if (!mount::IsOnHorse(ch)) {
 		switch (ch->GetPosition()) {
 			case EPosition::kDead: return "Вы МЕРТВЫ!";

--- a/src/engine/ui/cmd_god/do_mark.cpp
+++ b/src/engine/ui/cmd_god/do_mark.cpp
@@ -18,7 +18,7 @@ void do_mark(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	} else if (!*arg2 || !is_number(arg2)) {
 		SendMsgToChar("Не указан или неверный маркер.\r\n", ch);
 	} else {
-		cont_dotmode = find_all_dots(arg1);
+		cont_dotmode = ParseAllPrefix(arg1);
 		if (cont_dotmode == kFindIndiv) {
 			generic_find(arg1, EFind::kObjInventory | EFind::kObjRoom | EFind::kObjEquip, ch, &tmp_char, &cont);
 			if (!cont) {

--- a/src/gameplay/communication/parcel.cpp
+++ b/src/gameplay/communication/parcel.cpp
@@ -321,7 +321,7 @@ void send(CharData *ch, CharData *mailman, long vict_uid, char *arg) {
 			}
 		}
 	} else {
-		int dotmode = find_all_dots(tmp_arg);
+		int dotmode = ParseAllPrefix(tmp_arg);
 		if (dotmode == kFindIndiv) {
 			if (!(obj = get_obj_in_list_vis(ch, tmp_arg, ch->carrying))) {
 				SendMsgToChar(ch, "У вас нет '%s'.\r\n", tmp_arg);

--- a/src/gameplay/economics/shops_implementation.cpp
+++ b/src/gameplay/economics/shops_implementation.cpp
@@ -600,7 +600,7 @@ void shop_node::process_cmd(CharData *ch, CharData *keeper, char *argument, cons
 		}
 	} else {
 		skip_spaces(&argument);
-		int i, dotmode = find_all_dots(argument);
+		int i, dotmode = ParseAllPrefix(argument);
 		std::string buffer2(argument);
 		switch (dotmode) {
 			case kFindIndiv: {

--- a/src/gameplay/mechanics/depot.cpp
+++ b/src/gameplay/mechanics/depot.cpp
@@ -1138,7 +1138,7 @@ bool CharNode::obj_from_obj_list(char *name, CharData *vict) {
 void CharNode::take_item(CharData *vict, char *arg, int howmany) {
 	ObjListType &cont = pers_online;
 
-	int obj_dotmode = find_all_dots(arg);
+	int obj_dotmode = ParseAllPrefix(arg);
 	if (obj_dotmode == kFindIndiv) {
 		bool result = obj_from_obj_list(arg, vict);
 		if (!result) {


### PR DESCRIPTION
Слой 1 из #3807, следующий пункт плана #3814 — команды, которые видит игрок. **234 обращения к глобальным `buf`/`buf1`/`buf2`/`arg` в трёх файлах → ноль.** Счётчик по коду: 5128 → 4894.

## «Счёт» (137)

Ответ копился в общем буфере через `sprintf(buf + strlen(buf), ...)` и `strncat` — длина строки пересчитывалась на каждом куске. Теперь это локальная `std::string` и `fmt::format`.

Пять блоков про наказания (темница, немота, молчание, заморозка, нерегистрация) были копипастой: отличались только фразой, а расчёт часов и минут повторялся дословно пять раз. Сведены к одному помощнику.

**`GetPositionStr` возвращала указатель на глобальный буфер:**

```cpp
const char *GetPositionStr(CharData *ch) {
	...
	case EPosition::kFight:
		if (ch->GetEnemy()) {
			sprintf(buf1, "Вы сражаетесь с %s.\r\n", GET_PAD(ch->GetEnemy(), 4));
			return buf1;      // <-- указатель на общий буфер
		}
```

Любой чужой вывод между вызовом и печатью затёр бы строку. Теперь возвращает `std::string`.

## «Дать» (49) и «бросить» (48)

Разбор шёл через глобальный `arg`, сообщения — через `sprintf(buf)`. Оба переведены на `utils::ExtractFirstArgumentLower` и `fmt::format`, `give_find_vict` принимает `std::string`.

Для разбора `все.<предмет>` понадобилась строковая форма этой функции: прежняя срезает префикс прямо в буфере вызывающего, с оглядкой на `kMaxInputLength`, — `std::string` ей передать нельзя.

**Вторым коммитом — переименование `find_all_dots` → `ParseAllPrefix`.** Имя досталось от дику и говорило про точки, а не про то, что функция решает: она разбирает префикс выборки («все» → взять всё, «все.<имя>» → все такие, иначе — один предмет) и срезает его. 18 вызовов в 10 файлах, правка механическая; константы `kFind*` не трогал.

## Цвета

Сырые ANSI-константы `kColor*` в тронутых сообщениях заменены цветовыми кодами движка (`&C`, `&G`, `&R`, `&n`): `kColor*` уходят игроку мимо настройки цвета, а `&`-коды движок разбирает по настройкам клиента.

## Проверено вживую

Не только чтением диффа. Собрал отдельный `build_test` с `-DTEST_BUILD` (там создание персонажа не требует кода с почты), поднял тестовый мир и снял вывод одним и тем же персонажем на `master` и на этой ветке:

```
счет, счет все, позиция,
бросить, бросить кун, бросить 5 кун, бросить все.мусор,
дать, дать меч, дать 5 кун <имя>
```

Тексты совпали дословно. Единственное расхождение — текущее число жизней (41 против 60), это регенерация между прогонами.

Сборка чистая, **712 тестов** зелёные.

Часть #3814, родительская задача #3807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
