### PR TITLE
fix(rent): stop cutting the "cannot rent" line; drop the static currency buffer

### DIFF
--- a/src/engine/db/obj_save.cpp
+++ b/src/engine/db/obj_save.cpp
@@ -2243,18 +2243,20 @@ void Crash_rent_deadline(CharData *ch, CharData *recep, long cost) {
 }
 
 int Crash_report_unrentables(CharData *ch, CharData *recep, ObjData *obj) {
-	char buf[128];
 	int has_norents = 0;
 
 	if (obj) {
 		if (Crash_is_unrentable(ch, obj)) {
 			has_norents = 1;
-			if (SetSystem::is_norent_set(ch, obj)) {
-				snprintf(buf, sizeof(buf), "%s", fmt::format(fmt::runtime(specials::RentMsg(specials::ERentMsg::kUnrentSet)), fmt::arg("item", OBJN(obj, ch, grammar::ECase::kAcc))).c_str());
-			} else {
-				snprintf(buf, sizeof(buf), "%s", fmt::format(fmt::runtime(specials::RentMsg(specials::ERentMsg::kUnrent)), fmt::arg("item", OBJN(obj, ch, grammar::ECase::kAcc))).c_str());
-			}
-			act(buf, false, recep, 0, ch, kToVict);
+			// Фраза собирается в строку, а не в буфер на 128 байт: под UTF-8 в него не влезало
+			// длинное имя предмета, и snprintf резал по байтам -- игрок получал оборванную
+			// фразу с половиной буквы в конце ("...лесной деревн?").
+			const auto message = SetSystem::is_norent_set(ch, obj)
+								 ? specials::ERentMsg::kUnrentSet
+								 : specials::ERentMsg::kUnrent;
+			act(fmt::format(fmt::runtime(specials::RentMsg(message)),
+							fmt::arg("item", OBJN(obj, ch, grammar::ECase::kAcc))),
+				false, recep, 0, ch, kToVict);
 		}
 		has_norents += Crash_report_unrentables(ch, recep, obj->get_contains());
 		has_norents += Crash_report_unrentables(ch, recep, obj->get_next_content());

--- a/src/engine/ui/cmd/do_drop.cpp
+++ b/src/engine/ui/cmd/do_drop.cpp
@@ -58,7 +58,7 @@ void PerformDropGold(CharData *ch, int amount) {
 							   MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kNom)),
 				   NRM, kLvlGreatGod, MONEY_LOG, true);
 			act(fmt::format("$n бросил$g {} на землю.",
-							MUD::Currency(currencies::kGoldVnum).GetObjCName(amount, grammar::ECase::kAcc)),
+							MUD::Currency(currencies::kGoldVnum).GetObjName(amount, grammar::ECase::kAcc)),
 				true, ch, nullptr, nullptr, kToRoom | kToArenaListen);
 		}
 		PlaceObjToRoom(obj.get(), ch->in_room);
@@ -107,7 +107,7 @@ void PerformDropCurrency(CharData *ch, const currencies::CurrencyInfo &cur, int 
 						   ch->get_name(), GET_ROOM_VNUM(ch->in_room), amount,
 						   cur.GetNameWithAmount(amount, grammar::ECase::kNom)),
 			   NRM, kLvlGreatGod, MONEY_LOG, true);
-		act(fmt::format("$n бросил$g {} на землю.", cur.GetObjCName(amount, grammar::ECase::kAcc)),
+		act(fmt::format("$n бросил$g {} на землю.", cur.GetObjName(amount, grammar::ECase::kAcc)),
 			true, ch, nullptr, nullptr, kToRoom | kToArenaListen);
 	}
 	PlaceObjToRoom(obj.get(), ch->in_room);

--- a/src/engine/ui/cmd/do_give.cpp
+++ b/src/engine/ui/cmd/do_give.cpp
@@ -114,7 +114,7 @@ void perform_give_gold(CharData *ch, CharData *vict, int amount) {
 	act(fmt::format("Вы дали {} {} $N2.", amount, gold), false, ch, nullptr, vict, kToChar);
 	act(fmt::format("$n дал$g вам {} {}.", amount, gold), false, ch, nullptr, vict, kToVict);
 	act(fmt::format("$n дал$g {} $N2.",
-					MUD::Currency(currencies::kGoldVnum).GetObjCName(amount, grammar::ECase::kAcc)),
+					MUD::Currency(currencies::kGoldVnum).GetObjName(amount, grammar::ECase::kAcc)),
 		true, ch, nullptr, vict, kToNotVict | kToArenaListen);
 	if (!(ch->IsNpc() || vict->IsNpc())) {
 		mudlog(fmt::format("<{}> {{{}}} передал {} кун при личной встрече c {}.",

--- a/src/engine/ui/cmd/do_put.cpp
+++ b/src/engine/ui/cmd/do_put.cpp
@@ -283,18 +283,17 @@ ObjData::shared_ptr CreateCurrencyObj(long quantity, int currency_vnum) {
 	}
 	obj->set_aliases(aliases);
 
-	obj->set_short_description(cur.GetObjCName(quantity, grammar::ECase::kNom));
+	obj->set_short_description(cur.GetObjName(quantity, grammar::ECase::kNom));
 	for (int i = grammar::ECase::kFirstCase; i <= grammar::ECase::kLastCase; ++i) {
 		const auto name_case = static_cast<grammar::ECase>(i);
-		obj->set_PName(name_case, cur.GetObjCName(quantity, name_case));
+		obj->set_PName(name_case, cur.GetObjName(quantity, name_case));
 	}
 
-	char descr_buf[256];
-	snprintf(descr_buf, sizeof(descr_buf), "Здесь лежит %s.", cur.GetObjCName(quantity, grammar::ECase::kNom));
-	obj->set_description(utils::CAP(descr_buf));
+	obj->set_description(utils::CAP(fmt::format("Здесь лежит {}.",
+												cur.GetObjName(quantity, grammar::ECase::kNom))));
 
 	new_descr.keyword = aliases;
-	new_descr.description = cur.GetObjCName(quantity, grammar::ECase::kNom);
+	new_descr.description = cur.GetObjName(quantity, grammar::ECase::kNom);
 	obj->ex_descriptions().assign(1, std::move(new_descr));
 
 	obj->set_type(EObjType::kMoney);
@@ -314,8 +313,6 @@ ObjData::shared_ptr CreateCurrencyObj(long quantity, int currency_vnum) {
 }
 
 ObjData::shared_ptr CreateCurrencyObj(long quantity) {
-	char buf[200];
-
 	if (quantity <= 0) {
 		log("SYSERR: Try to create negative or 0 money. (%ld)", quantity);
 		return (nullptr);
@@ -324,9 +321,8 @@ ObjData::shared_ptr CreateCurrencyObj(long quantity) {
 	ExtraDescription new_descr;
 
 	if (quantity == 1) {
-		sprintf(buf, "coin gold кун деньги денег монет %s",
-				MUD::Currency(currencies::kGoldVnum).GetObjCName(quantity, grammar::ECase::kNom));
-		obj->set_aliases(buf);
+		obj->set_aliases(fmt::format("coin gold кун деньги денег монет {}",
+									 MUD::Currency(currencies::kGoldVnum).GetObjName(quantity, grammar::ECase::kNom)));
 		obj->set_short_description("куна");
 		obj->set_description("Одна куна лежит здесь.");
 		new_descr.keyword = "coin gold монет кун денег";
@@ -334,21 +330,20 @@ ObjData::shared_ptr CreateCurrencyObj(long quantity) {
 		for (int i = grammar::ECase::kFirstCase; i <= grammar::ECase::kLastCase; i++) {
 			auto name_case = static_cast<grammar::ECase>(i);
 			obj->set_PName(name_case,
-						   MUD::Currency(currencies::kGoldVnum).GetObjCName(quantity, name_case));
+						   MUD::Currency(currencies::kGoldVnum).GetObjName(quantity, name_case));
 		}
 	} else {
-		sprintf(buf, "coins gold кун денег %s",
-				MUD::Currency(currencies::kGoldVnum).GetObjCName(quantity, grammar::ECase::kNom));
-		obj->set_aliases(buf);
-		obj->set_short_description(MUD::Currency(currencies::kGoldVnum).GetObjCName(quantity, grammar::ECase::kNom));
+		obj->set_aliases(fmt::format("coins gold кун денег {}",
+									 MUD::Currency(currencies::kGoldVnum).GetObjName(quantity, grammar::ECase::kNom)));
+		obj->set_short_description(MUD::Currency(currencies::kGoldVnum).GetObjName(quantity, grammar::ECase::kNom));
 		for (int i = grammar::ECase::kFirstCase; i <= grammar::ECase::kLastCase; i++) {
 			auto name_case = static_cast<grammar::ECase>(i);
-			obj->set_PName(name_case, MUD::Currency(currencies::kGoldVnum).GetObjCName(quantity, name_case));
+			obj->set_PName(name_case, MUD::Currency(currencies::kGoldVnum).GetObjName(quantity, name_case));
 		}
 
-		sprintf(buf, "Здесь лежит %s.",
-				MUD::Currency(currencies::kGoldVnum).GetObjCName(quantity, grammar::ECase::kNom));
-		obj->set_description(utils::CAP(buf));
+		obj->set_description(utils::CAP(fmt::format("Здесь лежит {}.",
+													MUD::Currency(currencies::kGoldVnum).GetObjName(quantity,
+																								   grammar::ECase::kNom))));
 
 		new_descr.keyword = "coins gold кун денег";
 	}

--- a/src/gameplay/economics/currencies.cpp
+++ b/src/gameplay/economics/currencies.cpp
@@ -405,12 +405,6 @@ std::string CurrencyInfo::GetObjName(long amount, grammar::ECase gram_case) cons
 	fill("{currency_name}", GetPluralName(grammar::ECase::kGen));
 	return result;
 }
-const char *CurrencyInfo::GetObjCName(long amount, grammar::ECase gram_case) const {
-	static char buf[128];
-	sprintf(buf, "%s", GetObjName(amount, gram_case).c_str());
-	return buf;
-}
-
 // EPurse is an internal hand/bank selector; the public API is GetHand/GetBank/etc.
 enum class EPurse { kHand, kBank };
 

--- a/src/gameplay/economics/currencies.h
+++ b/src/gameplay/economics/currencies.h
@@ -187,7 +187,6 @@ class CurrencyInfo : public info_container::BaseItem<int> {
 	 * @return - строка-описание объекта.
 	 */
 	[[nodiscard]] std::string GetObjName(long amount, grammar::ECase gram_case) const;
-	[[nodiscard]] const char *GetObjCName(long amount, grammar::ECase gram_case) const;
 
 	void Print(CharData */*ch*/, std::ostringstream &buffer) const;
 };


### PR DESCRIPTION
Жалоба Мородея: при постое фраза хозяина обрывается, причём последняя буква приезжает половиной байта.

```
Хозяин сказал вам : "Я не приму на постой карту окрестностей лесной деревн�
```

## Причина

`src/engine/db/obj_save.cpp:2246`, `Crash_report_unrentables`:

```cpp
char buf[128];
...
snprintf(buf, sizeof(buf), "%s", fmt::format(fmt::runtime(specials::RentMsg(...)),
                                             fmt::arg("item", OBJN(obj, ch, grammar::ECase::kAcc))).c_str());
act(buf, false, recep, 0, ch, kToVict);
```

Шаблон из конфига — `$n сказал$g вам : "Я не приму на постой {item}."` — с именем «карту окрестностей лесной деревни» даёт **130 байт**. В буфер влезло 127, и `snprintf` обрезал ровно посередине буквы «и». Дальше `act` подставил `$n` → «Хозяин», отсюда 134 байта в том, что увидел игрок — сходится с жалобой байт в байт.

Под KOI8-R те же 130 байт занимали бы 68, и порог был недостижим. Под UTF-8 русская буква весит два байта — тот же класс, что #3751/#3752.

## Правка

Фраза собирается в строку и уходит в `act` целиком, без промежуточного буфера. Заодно ушло дублирование двух почти одинаковых веток (`kUnrentSet` / `kUnrent`).

## Проверено

Сборка чистая, **712 тестов** зелёные. Длины сверены с жалобой: 130 байт исходной строки → 127 влезших → 134 у игрока после подстановки `$n`.

## Вторым коммитом — та же мина в валютах

`CurrencyInfo::GetObjCName` (`currencies.cpp:409`) отдавала наружу указатель на `static char buf[128]` и заполняла его `sprintf` **без ограничения длины**:

```cpp
const char *CurrencyInfo::GetObjCName(long amount, grammar::ECase gram_case) const {
	static char buf[128];
	sprintf(buf, "%s", GetObjName(amount, gram_case).c_str());
	return buf;
}
```

Буфер один на все вызовы, поэтому два имени в одном выражении затёрли бы друг друга, а длинное имя валюты писало бы мимо буфера. Имена сейчас короткие, так что не стреляло.

Функция удалена, все 13 вызовов переведены на `GetObjName`, который и так возвращает `std::string`. Заодно в `do_put` ушли три `sprintf` в общий буфер и локальный `char buf[200]` — на них компилятор сразу показал `format '%s' expects char*, but argument has type std::string`, то есть после смены типа они были бы честным UB.

Сборка чистая, предупреждений нет, 712 тестов зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
