### PR TITLE
refactor(core): drop the byte alias, its fields are plain int now

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -303,7 +303,7 @@ void TriggersFile::parse_trigger(int vnum) {
 	int trigger_type = 0;
 	asciiflag_conv(flags, &trigger_type);
 	const auto rnum = top_of_trigt;
-	Trigger *trig = new Trigger(rnum, std::move(name), static_cast<byte>(attach_type), trigger_type);
+	Trigger *trig = new Trigger(rnum, std::move(name), attach_type, trigger_type);
 	if (k == 5 && !strcmp(language, "lua")) {
 		trig->set_script_language(TriggerScriptLanguage::Lua);
 	}
@@ -1333,23 +1333,23 @@ void MobileFile::interpret_espec(const char *keyword, const char *value, int i, 
 	}
 
 	CASE("Size") {
-		mob_proto[i].real_abils.size = std::clamp<byte>(num_arg, 0, 100);
+		mob_proto[i].real_abils.size = std::clamp<int>(num_arg, 0, 100);
 	}
 
 	CASE("LikeWork") {
-		mob_proto[i].mob_specials.like_work = std::clamp<byte>(num_arg, 0, 100);
+		mob_proto[i].mob_specials.like_work = std::clamp<int>(num_arg, 0, 100);
 	}
 
 	CASE("MaxFactor") {
-		mob_proto[i].mob_specials.MaxFactor = std::clamp<byte>(num_arg, 0, 127);
+		mob_proto[i].mob_specials.MaxFactor = std::clamp<int>(num_arg, 0, 127);
 	}
 
 	CASE("ExtraAttack") {
-		mob_proto[i].mob_specials.extra_attack = std::clamp<byte>(num_arg, 0, 127);
+		mob_proto[i].mob_specials.extra_attack = std::clamp<int>(num_arg, 0, 127);
 	}
 
 	CASE("MobRemort") {
-		mob_proto[i].set_remort(std::clamp<byte>(num_arg, 0, 100));
+		mob_proto[i].set_remort(std::clamp<int>(num_arg, 0, 100));
 	}
 
 	CASE("Height") {

--- a/src/engine/db/sqlite_world_data_source.cpp
+++ b/src/engine/db/sqlite_world_data_source.cpp
@@ -1157,7 +1157,7 @@ std::vector<LoadedTrigger> SqliteWorldDataSource::LoadTriggers(const std::vector
 		std::string script = GetText(stmt, 6);
 		int add_flag = sqlite3_column_int(stmt, 7);
 
-		byte attach_type = static_cast<byte>(attach_type_id);
+		int attach_type = attach_type_id;
 
 		// Compute trigger_type bitmask from type_chars
 		long trigger_type = 0;
@@ -1520,7 +1520,7 @@ LoadedMob SqliteWorldDataSource::LoadMobRow(sqlite3_stmt *stmt)
 
 	// Physical attributes -- bounds mirror MobileFile::interpret_espec
 	// (boot_data_files.cpp). Без них старые данные расходятся с легаси.
-	GET_SIZE(&mob) = std::clamp<byte>(sqlite3_column_int(stmt, 28), 0, 100);
+	GET_SIZE(&mob) = std::clamp<int>(sqlite3_column_int(stmt, 28), 0, 100);
 	GET_HEIGHT(&mob) = std::clamp(sqlite3_column_int(stmt, 29), 0, 200);
 	GET_WEIGHT(&mob) = std::clamp(sqlite3_column_int(stmt, 30), 0, 200);
 
@@ -1551,10 +1551,10 @@ LoadedMob SqliteWorldDataSource::LoadMobRow(sqlite3_stmt *stmt)
 	mob.add_abils.mresist = std::clamp(sqlite3_column_int(stmt, 48), 0, 100);
 	mob.add_abils.presist = std::clamp(sqlite3_column_int(stmt, 49), 0, 100);
 	mob.mob_specials.attack_type = std::clamp(sqlite3_column_int(stmt, 50), 0, 99);
-	mob.mob_specials.like_work = std::clamp<byte>(sqlite3_column_int(stmt, 51), 0, 100);
-	mob.mob_specials.MaxFactor = std::clamp<byte>(sqlite3_column_int(stmt, 52), 0, 127);
-	mob.mob_specials.extra_attack = std::clamp<byte>(sqlite3_column_int(stmt, 53), 0, 127);
-	mob.set_remort(std::clamp<byte>(sqlite3_column_int(stmt, 54), 0, 100));
+	mob.mob_specials.like_work = std::clamp<int>(sqlite3_column_int(stmt, 51), 0, 100);
+	mob.mob_specials.MaxFactor = std::clamp<int>(sqlite3_column_int(stmt, 52), 0, 127);
+	mob.mob_specials.extra_attack = std::clamp<int>(sqlite3_column_int(stmt, 53), 0, 127);
+	mob.set_remort(std::clamp<int>(sqlite3_column_int(stmt, 54), 0, 100));
 
 	// special_bitvector (TEXT - FlagData)
 	std::string special_bv = GetText(stmt, 55);

--- a/src/engine/db/yaml_world_data_source.cpp
+++ b/src/engine/db/yaml_world_data_source.cpp
@@ -1276,7 +1276,7 @@ Trigger* YamlWorldDataSource::ParseTriggerNode(const YAML::Node &root)
 	const auto script_language = ParseTriggerScriptLanguage(root);
 
 	// Create trigger (note: rnum will be assigned during merge)
-	auto trig = new Trigger(-1, std::move(name), static_cast<byte>(attach_type), trigger_type);
+	auto trig = new Trigger(-1, std::move(name), attach_type, trigger_type);
 	GET_TRIG_NARG(trig) = narg;
 	trig->add_flag = GetInt(root, "add_flag", 0) != 0;
 	trig->arglist = arglist;
@@ -1842,7 +1842,7 @@ CharData YamlWorldDataSource::ParseMobNode(const YAML::Node &root)
 									  ENpcRace::kBasic, ENpcRace::kLastNpcRace);
 
 	// Physical attributes -- bounds mirror legacy interpret_espec.
-	GET_SIZE(&mob) = std::clamp<byte>(GetInt(root, "size", 0), 0, 100);
+	GET_SIZE(&mob) = std::clamp<int>(GetInt(root, "size", 0), 0, 100);
 	GET_HEIGHT(&mob) = std::clamp(GetInt(root, "height", 0), 0, 200);
 	GET_WEIGHT(&mob) = std::clamp(GetInt(root, "weight", 0), 0, 200);
 
@@ -1927,10 +1927,10 @@ CharData YamlWorldDataSource::ParseMobNode(const YAML::Node &root)
 		mob.add_abils.mresist = std::clamp(GetInt(enhanced, "mresist", 0), 0, 100);
 		mob.add_abils.presist = std::clamp(GetInt(enhanced, "presist", 0), 0, 100);
 		mob.mob_specials.attack_type = std::clamp(GetInt(enhanced, "bare_hand_attack", 0), 0, 99);
-		mob.mob_specials.like_work = std::clamp<byte>(GetInt(enhanced, "like_work", 0), 0, 100);
-		mob.mob_specials.MaxFactor = std::clamp<byte>(GetInt(enhanced, "max_factor", 0), 0, 127);
-		mob.mob_specials.extra_attack = std::clamp<byte>(GetInt(enhanced, "extra_attack", 0), 0, 127);
-		mob.set_remort(std::clamp<byte>(GetInt(enhanced, "mob_remort", 0), 0, 100));
+		mob.mob_specials.like_work = std::clamp<int>(GetInt(enhanced, "like_work", 0), 0, 100);
+		mob.mob_specials.MaxFactor = std::clamp<int>(GetInt(enhanced, "max_factor", 0), 0, 127);
+		mob.mob_specials.extra_attack = std::clamp<int>(GetInt(enhanced, "extra_attack", 0), 0, 127);
+		mob.set_remort(std::clamp<int>(GetInt(enhanced, "mob_remort", 0), 0, 100));
 
 		if (enhanced["special_bitvector"])
 		{
@@ -3828,10 +3828,10 @@ void YamlWorldDataSource::EmitMobBody(Koi8rYamlEmitter &yaml, std::ostream &out,
 	yaml.IncreaseIndent();
 
 	yaml.Key("dice_count");
-	yaml.Value(static_cast<int>(mob.mem_queue.total));  // byte -> int
+	yaml.Value(mob.mem_queue.total);
 
 	yaml.Key("dice_size");
-	yaml.Value(static_cast<int>(mob.mem_queue.stored));  // byte -> int
+	yaml.Value(mob.mem_queue.stored);
 
 	yaml.Key("bonus");
 	yaml.Value(mob.get_hit());
@@ -3844,10 +3844,10 @@ void YamlWorldDataSource::EmitMobBody(Koi8rYamlEmitter &yaml, std::ostream &out,
 	yaml.IncreaseIndent();
 
 	yaml.Key("dice_count");
-	yaml.Value(static_cast<int>(mob.mob_specials.damnodice));  // byte -> int
+	yaml.Value(mob.mob_specials.damnodice);
 
 	yaml.Key("dice_size");
-	yaml.Value(static_cast<int>(mob.mob_specials.damsizedice));  // byte -> int
+	yaml.Value(mob.mob_specials.damsizedice);
 
 	yaml.Key("bonus");
 	yaml.Value(mob.real_abils.damroll);
@@ -3861,10 +3861,10 @@ void YamlWorldDataSource::EmitMobBody(Koi8rYamlEmitter &yaml, std::ostream &out,
 	yaml.IncreaseIndent();
 
 	yaml.Key("dice_count");
-	yaml.Value(static_cast<int>(mob.mob_specials.GoldNoDs));  // byte -> int
+	yaml.Value(mob.mob_specials.GoldNoDs);
 
 	yaml.Key("dice_size");
-	yaml.Value(static_cast<int>(mob.mob_specials.GoldSiDs));  // byte -> int
+	yaml.Value(mob.mob_specials.GoldSiDs);
 
 	yaml.Key("bonus");
 	yaml.Value(currencies::GetHand(mob, currencies::kGold));

--- a/src/engine/entities/char_data.h
+++ b/src/engine/entities/char_data.h
@@ -153,20 +153,20 @@ struct char_special_data {
 
 // Specials used by NPCs, not PCs
 struct mob_special_data {
-	byte last_direction;    // The last direction the monster went
+	int last_direction;    // The last direction the monster went
 	int attack_type;        // The Attack Type Bitvector for NPC's
 	EPosition default_pos;    // Default position for NPC
 	mob_ai::MemoryRecord *memory;    // List of attackers to remember
-	byte damnodice;        // The number of damage dice's
-	byte damsizedice;    // The size of the damage dice's
+	int damnodice;        // The number of damage dice's
+	int damsizedice;    // The size of the damage dice's
 	std::array<int, kMaxDest> dest;
 	int dest_dir;
 	int dest_pos;
 	int dest_count;
 	int activity;
 	BitsetFlags<ENpcFlag> npc_flags;
-	byte extra_attack;
-	byte like_work;
+	int extra_attack;
+	int like_work;
 	int MaxFactor;
 	int GoldNoDs;
 	int GoldSiDs;

--- a/src/engine/entities/room_data.h
+++ b/src/engine/entities/room_data.h
@@ -88,9 +88,9 @@ struct RoomData {
 	std::array<exit_data_ptr, EDirection::kMaxDirNum> dir_option;    // Directions //
 	std::array<exit_data_ptr, EDirection::kMaxDirNum> dir_option_proto;
 
-	byte light;        // Number of lightsources in room //
-	byte glight;        // Number of lightness person     //
-	byte gdark;        // Number of darkness  person     //
+	int light;        // Number of lightsources in room //
+	int glight;        // Number of lightness person     //
+	int gdark;        // Number of darkness  person     //
 	struct WeatherControl weather;        // Weather state for room //
 	int (*func)(CharData *, void *, int, char *);
 

--- a/src/engine/network/admin_api/crud_handlers.cpp
+++ b/src/engine/network/admin_api/crud_handlers.cpp
@@ -1086,7 +1086,7 @@ void HandleCreateTrigger(DescriptorData* d, int zone_vnum, const char* json_data
 		}
 		if (data.contains("attach_type"))
 		{
-			trig->set_attach_type(static_cast<byte>(data["attach_type"].get<int>()));
+			trig->set_attach_type(data["attach_type"].get<int>());
 		}
 
 		// Script

--- a/src/engine/network/admin_api/parsers.cpp
+++ b/src/engine/network/admin_api/parsers.cpp
@@ -200,11 +200,11 @@ void ParseMobUpdate(CharData* mob, const nlohmann::json& data)
 		}
 		if (HasNumber(physical, "extra_attack"))
 		{
-			mob->mob_specials.extra_attack = static_cast<byte>(physical["extra_attack"].get<int>());
+			mob->mob_specials.extra_attack = physical["extra_attack"].get<int>();
 		}
 		if (HasNumber(physical, "like_work"))
 		{
-			mob->mob_specials.like_work = static_cast<byte>(physical["like_work"].get<int>());
+			mob->mob_specials.like_work = physical["like_work"].get<int>();
 		}
 		if (HasNumber(physical, "maxfactor"))
 		{
@@ -886,7 +886,7 @@ void ParseTriggerUpdate(Trigger* trig, const nlohmann::json& data)
 	}
 	if (data.contains("attach_type"))
 	{
-		trig->set_attach_type(static_cast<byte>(data["attach_type"].get<int>()));
+		trig->set_attach_type(data["attach_type"].get<int>());
 	}
 
 	// Boolean flags

--- a/src/engine/network/descriptor_data.h
+++ b/src/engine/network/descriptor_data.h
@@ -119,8 +119,8 @@ struct DescriptorData {
 
 	socket_t descriptor{};    // file descriptor for socket    //
 	char host[kHostLength + 1]{};    // hostname          //
-	byte bad_pws;        // number of bad pw attemps this login //
-	byte idle_tics;        // tics idle at password prompt     //
+	int bad_pws;        // number of bad pw attemps this login //
+	int idle_tics;        // tics idle at password prompt     //
 	EConState state;        // state of 'connectedness'    //
 	int desc_num;        // unique num assigned to desc      //
 	time_t input_time;

--- a/src/engine/olc/medit.cpp
+++ b/src/engine/olc/medit.cpp
@@ -580,8 +580,8 @@ void medit_save_to_disk(ZoneRnum zone_num) {
 		fprintf(mob_file, "%s%d E\n" "%d %d %d %dd%d+%d %dd%d+%d\n" "%dd%d+%ld %ld\n" "%d %d %d\n",
 				flags, alignment::GetAlignment(mob),
 				GetRealLevel(mob), 20 - GET_HR(mob), GET_AC(mob) / 10, mob->mem_queue.total,
-				mob->mem_queue.stored, mob->get_hit(), static_cast<int>(GET_NDD(mob)), static_cast<int>(GET_SDD(mob)), GET_DR(mob), static_cast<int>(GET_GOLD_NoDs(mob)),
-				static_cast<int>(GET_GOLD_SiDs(mob)), currencies::GetHand(*mob, currencies::kGold), mob->get_exp(), static_cast<int>(mob->GetPosition()),
+				mob->mem_queue.stored, mob->get_hit(), GET_NDD(mob), GET_SDD(mob), GET_DR(mob), GET_GOLD_NoDs(mob),
+				GET_GOLD_SiDs(mob), currencies::GetHand(*mob, currencies::kGold), mob->get_exp(), static_cast<int>(mob->GetPosition()),
 				static_cast<int>(GET_DEFAULT_POS(mob)), static_cast<int>(mob->get_sex()));
 		// * Deal with Extra stats in case they are there.
 		sum = 0;
@@ -1082,11 +1082,11 @@ void medit_disp_menu(DescriptorData *d) {
 			GET_LDESC(mob), GET_DDESC(mob),
 			mob->GetLevel(), alignment::GetAlignment(mob),
 			GET_HR(mob), GET_DR(mob),
-			static_cast<int>(GET_NDD(mob)), static_cast<int>(GET_SDD(mob)),
+			GET_NDD(mob), GET_SDD(mob),
 			mob->mem_queue.total, mob->mem_queue.stored, mob->get_hit(),
 			GET_AC(mob), mob->get_exp(),
 			currencies::GetHand(*mob, currencies::kGold),
-			static_cast<int>(GET_GOLD_NoDs(mob)), static_cast<int>(GET_GOLD_SiDs(mob))), d->character.get());
+			GET_GOLD_NoDs(mob), GET_GOLD_SiDs(mob)), d->character.get());
 
 	const std::string mob_flags = mob->char_specials.saved.mob_flags.sprintbits(action_bits, ",", 4);
 	const std::string aff_flags = affects::DescribeActive(mob->char_specials.saved.affected_by, ",");
@@ -1150,14 +1150,14 @@ void medit_disp_menu(DescriptorData *d) {
 			mob->get_str(), mob->get_dex(), mob->get_con(),
 			mob->get_wis(), mob->get_int(), mob->get_cha(),
 			static_cast<int>(GET_HEIGHT(mob)), static_cast<int>(GET_WEIGHT(mob)), static_cast<int>(GET_SIZE(mob)),
-			static_cast<int>(mob->mob_specials.extra_attack),
+			mob->mob_specials.extra_attack,
 			static_cast<int>(mob->get_remort()),
-			static_cast<int>(mob->mob_specials.like_work),
+			mob->mob_specials.like_work,
 			mob->dl_list.empty() ? "Нет" : "Есть",
 			roles_str,
 			npc_race_types[GET_RACE(mob) - ENpcRace::kBasic],
 			!mob->proto_script->empty() ? "Set." : "Not Set.",
-			static_cast<int>(mob->mob_specials.MaxFactor)), d->character.get());
+			mob->mob_specials.MaxFactor), d->character.get());
 
 	OLC_MODE(d) = MEDIT_MAIN_MENU;
 }

--- a/src/engine/olc/olc.cpp
+++ b/src/engine/olc/olc.cpp
@@ -400,7 +400,7 @@ void olc_saveinfo(CharData *ch) {
 // ------------------------------------------------------------
 
 // * Add an entry to the 'to be saved' list.
-void olc_add_to_save_list(int zone, byte type) {
+void olc_add_to_save_list(int zone, int type) {
 	struct olc_save_info *lnew;
 
 	// * Return if it's already in the list.
@@ -416,7 +416,7 @@ void olc_add_to_save_list(int zone, byte type) {
 }
 
 // * Remove an entry from the 'to be saved' list.
-void olc_remove_from_save_list(int zone, byte type) {
+void olc_remove_from_save_list(int zone, int type) {
 	struct olc_save_info **entry;
 	struct olc_save_info *temp;
 
@@ -480,7 +480,7 @@ void strip_string(char *buffer) {
  * attatched to a descriptor, sets all flags back to how they
  * should be.
  */
-void cleanup_olc(DescriptorData *d, byte cleanup_type) {
+void cleanup_olc(DescriptorData *d, int cleanup_type) {
 	if (d->olc) {
 		TrigeditSavePendingLuaOnCleanup(d);
 

--- a/src/engine/olc/olc.h
+++ b/src/engine/olc/olc.h
@@ -68,10 +68,10 @@ inline constexpr int kScmdOlcSaveinfo{5};
 void strip_string(char *);
 // Строковая форма: та же чистка от '\r', но без буфера у вызывающего (#3814).
 std::string strip_string(std::string text);
-void cleanup_olc(DescriptorData *d, byte cleanup_type);
+void cleanup_olc(DescriptorData *d, int cleanup_type);
 void disp_planes_values(DescriptorData *d, const char *names[], short num_column);
-void olc_add_to_save_list(int zone, byte type);
-void olc_remove_from_save_list(int zone, byte type);
+void olc_add_to_save_list(int zone, int type);
+void olc_remove_from_save_list(int zone, int type);
 
 // * OLC structures.
 
@@ -159,14 +159,14 @@ extern struct olc_save_info *olc_save_list;
 #define GET_OLC_ZONE(c)    ((c)->player_specials->saved.olc_zone)
 
 // * Cleanup types.
-#define CLEANUP_ALL        (byte)    1    // Free the whole lot.
-#define CLEANUP_STRUCTS    (byte)    2    // Don't free strings.
+#define CLEANUP_ALL        1    // Free the whole lot.
+#define CLEANUP_STRUCTS    2    // Don't free strings.
 
 // * Add/Remove save list types.
-#define OLC_SAVE_ROOM        (byte)    0
-#define OLC_SAVE_OBJ        (byte)    1
-#define OLC_SAVE_ZONE        (byte)    2
-#define OLC_SAVE_MOB        (byte)    3
+#define OLC_SAVE_ROOM        0
+#define OLC_SAVE_OBJ        1
+#define OLC_SAVE_ZONE        2
+#define OLC_SAVE_MOB        3
 
 // * Submodes of OEDIT connectedness.
 #define OEDIT_MAIN_MENU                 1

--- a/src/engine/scripting/dg_comm.cpp
+++ b/src/engine/scripting/dg_comm.cpp
@@ -116,7 +116,7 @@ void sub_write_to_char(CharData *ch, char *tokens[], void *otokens[], char type[
 	SendMsgToChar(sb, ch);
 }
 
-void sub_write(char *arg, CharData *ch, byte find_invis, int targets) {
+void sub_write(char *arg, CharData *ch, int find_invis, int targets) {
 	char str[kMaxInputLength * 2];
 	char type[kMaxInputLength], name[kMaxInputLength];
 	char *tokens[kMaxInputLength], *s, *p;

--- a/src/engine/scripting/dg_mobcmd.cpp
+++ b/src/engine/scripting/dg_mobcmd.cpp
@@ -64,7 +64,7 @@ struct mob_command_info {
 extern int reloc_target;
 extern Trigger *cur_trig;
 
-void sub_write(char *arg, CharData *ch, byte find_invis, int targets);
+void sub_write(char *arg, CharData *ch, int find_invis, int targets);
 RoomData *get_room(const char *name);
 ObjData *get_obj_by_char(CharData *ch, char *name);
 // * Local functions.

--- a/src/engine/scripting/dg_objcmd.cpp
+++ b/src/engine/scripting/dg_objcmd.cpp
@@ -38,7 +38,7 @@ extern int reloc_target;
 
 CharData *get_char_by_obj(ObjData *obj, const char *name);
 ObjData *get_obj_by_obj(ObjData *obj, const char *name);
-void sub_write(char *arg, CharData *ch, byte find_invis, int targets);
+void sub_write(char *arg, CharData *ch, int find_invis, int targets);
 void die(CharData *ch, CharData *killer);
 void obj_command_interpreter(ObjData *obj, char *argument, Trigger *trig);
 void send_to_zone(char *messg, int zone_rnum);

--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -6697,7 +6697,7 @@ Trigger::Trigger() :
 	halted(false) {
 }
 
-Trigger::Trigger(const int rnum, const char *name, const byte attach_type, const long trigger_type) :
+Trigger::Trigger(const int rnum, const char *name, const int attach_type, const long trigger_type) :
 	cmdlist(new cmdlist_element::shared_ptr()),
 	narg(0),
 	add_flag{false},
@@ -6713,7 +6713,7 @@ Trigger::Trigger(const int rnum, const char *name, const byte attach_type, const
 	halted(false) {
 }
 
-Trigger::Trigger(const int rnum, std::string &&name, const byte attach_type, const long trigger_type) :
+Trigger::Trigger(const int rnum, std::string &&name, const int attach_type, const long trigger_type) :
 	cmdlist(new cmdlist_element::shared_ptr()),
 	narg(0),
 	add_flag{false},

--- a/src/engine/scripting/dg_scripts.h
+++ b/src/engine/scripting/dg_scripts.h
@@ -172,14 +172,14 @@ class Trigger {
 	Trigger(const Trigger &from);
 	Trigger &operator=(const Trigger &right);
 	Trigger(int rnum, const char *name, long trigger_type);
-	Trigger(int rnum, const char *name, byte attach_type, long trigger_type);
-	Trigger(int rnum, std::string &&name, byte attach_type, long trigger_type);
+	Trigger(int rnum, const char *name, int attach_type, long trigger_type);
+	Trigger(int rnum, std::string &&name, int attach_type, long trigger_type);
 
 	virtual ~Trigger() = default;    // make constructor virtual to be able to create a mock for this class
 
 	[[nodiscard]] auto get_rnum() const { return nr; }
 	void set_rnum(const sh_int _) { nr = _; }
-	void set_attach_type(const byte _) { attach_type = _; }
+	void set_attach_type(const int _) { attach_type = _; }
 	[[nodiscard]] auto get_attach_type() const { return attach_type; }
 	[[nodiscard]] const auto &get_name() const { return name; }
 	void set_name(const std::string &_) { name = _; }
@@ -210,7 +210,7 @@ class Trigger {
 	void reset();
 
 	int nr;            // trigger's rnum                  //
-	byte attach_type;    // mob/obj/wld intentions          //
+	int attach_type;    // mob/obj/wld intentions          //
 	std::string name;    // name of trigger
 	long trigger_type;    // type of trigger (for bitvector) //
 	TriggerScriptLanguage script_language = TriggerScriptLanguage::Dg;

--- a/src/engine/scripting/dg_wldcmd.cpp
+++ b/src/engine/scripting/dg_wldcmd.cpp
@@ -35,7 +35,7 @@
 extern const char *dirs[];
 
 void die(CharData *ch, CharData *killer);
-void sub_write(char *arg, CharData *ch, byte find_invis, int targets);
+void sub_write(char *arg, CharData *ch, int find_invis, int targets);
 void send_to_zone(char *messg, int zone_rnum);
 CharData *get_char_by_room(RoomData *room, const char *name);
 RoomData *get_room(const char *name);

--- a/src/engine/scripting/scripting.cpp
+++ b/src/engine/scripting/scripting.cpp
@@ -332,12 +332,12 @@ class CharacterWrapper : public Wrapper<CharacterData> {
 		ch->set_cha(v);
 	}
 
-	byte get_sex() const {
+	int get_sex() const {
 		Ensurer ch(*this);
 		return to_underlying(ch->get_sex());
 	}
 
-	void set_sex(const byte v) {
+	void set_sex(const int v) {
 		Ensurer ch(*this);
 		ch->set_sex(static_cast<EGender>(v));
 	}
@@ -2483,13 +2483,13 @@ struct PythonUserCommand {
 	std::string command;
 	std::string command_koi8r;
 	object callable;
-	byte minimum_position;
+	int minimum_position;
 	sh_int minimum_level;
 	int unhide_percent;
 	PythonUserCommand(const std::string &command_,
 					  const std::string &command____,
 					  const object &callable_,
-					  byte minimum_position_,
+					  int minimum_position_,
 					  sh_int minimum_level_,
 					  int unhide_percent_) :
 		command(command_),

--- a/src/engine/structs/structs.h
+++ b/src/engine/structs/structs.h
@@ -54,10 +54,6 @@ using MobRnum = Rnum;
 using ZoneRnum = Rnum;
 using TrgRnum = Rnum;
 
-#if !defined(CIRCLE_WINDOWS) || defined(LCC_WIN32)    // Hm, sysdep.h?
-using byte = char;
-#endif
-
 const int kMinRemort = 0;
 const int kMaxRemort = 99;
 const int kMaxPlayerLevel = 30;

--- a/src/gameplay/classes/pc_classes.cpp
+++ b/src/gameplay/classes/pc_classes.cpp
@@ -48,9 +48,9 @@
 extern int siteok_everyone;
 
 // local functions
-byte saving_throws(int class_num, int type, int level);
+int saving_throws(int class_num, int type, int level);
 int invalid_anti_class(CharData *ch, const ObjData *obj);
-byte GetExtendSavingThrows(ECharClass class_id, ESaving save, int level);
+int GetExtendSavingThrows(ECharClass class_id, ESaving save, int level);
 int invalid_unique(CharData *ch, const ObjData *obj);
 extern bool char_to_pk_clan(CharData *ch);
 // Names first
@@ -96,7 +96,7 @@ ECharClass FindAvailableCharClassId(const std::string &class_name) {
 
 // Таблицы бызовых спасбросков
 
-const byte sav_01[50] =
+const int sav_01[50] =
 	{
 		90, 90, 90, 90, 90, 89, 89, 88, 88, 87,    // 00-09
 		86, 85, 84, 83, 81, 79, 78, 75, 73, 71,    // 10-19
@@ -104,7 +104,7 @@ const byte sav_01[50] =
 		30, 0, 0, 0, 0, 0, 0, 0, 0, 0,    // 30-39
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
-const byte sav_02[50] =
+const int sav_02[50] =
 	{
 		90, 90, 90, 90, 90, 89, 89, 88, 87, 87,    // 00-09
 		86, 84, 83, 81, 80, 78, 75, 73, 70, 68,    // 10-19
@@ -112,7 +112,7 @@ const byte sav_02[50] =
 		20, 15, 10, 9, 8, 7, 6, 5, 4, 3,    // 30-39
 		2, 1, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
-const byte sav_03[50] =
+const int sav_03[50] =
 	{
 		90, 90, 90, 90, 90, 89, 89, 88, 88, 87,    // 00-09
 		86, 85, 83, 82, 80, 79, 76, 74, 72, 69,    // 10-19
@@ -120,7 +120,7 @@ const byte sav_03[50] =
 		25, 0, 0, 0, 0, 0, 0, 0, 0, 0,    // 30-39
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
-const byte sav_04[50] =
+const int sav_04[50] =
 	{
 		90, 90, 90, 90, 90, 90, 89, 89, 89, 88,    // 00-09
 		87, 87, 86, 85, 84, 83, 82, 80, 79, 77,    // 10-19
@@ -128,7 +128,7 @@ const byte sav_04[50] =
 		50, 45, 40, 35, 30, 25, 20, 15, 10, 5,    // 30-39
 		4, 3, 2, 1, 0, 0, 0, 0, 0, 0    // 40-49
 	};
-const byte sav_05[50] =
+const int sav_05[50] =
 	{
 		90, 90, 90, 90, 90, 89, 89, 89, 88, 87,    // 00-09
 		86, 86, 84, 83, 82, 80, 79, 77, 75, 72,    // 10-19
@@ -137,7 +137,7 @@ const byte sav_05[50] =
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
 //kClassMob
-const byte sav_06[100] =
+const int sav_06[100] =
 	{
 		90, 90, 90, 90, 90, 90, 89, 89, 88, 88,    // 00-09
 		87, 86, 85, 84, 82, 80, 78, 76, 74, 72,    // 10-19
@@ -150,7 +150,7 @@ const byte sav_06[100] =
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,            // 80-89
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0            // 90-99
 	};
-const byte sav_08[50] =
+const int sav_08[50] =
 	{
 		90, 90, 90, 90, 90, 89, 89, 89, 88, 88,    // 00-09
 		87, 86, 85, 84, 83, 81, 80, 78, 76, 74,    // 10-19
@@ -158,7 +158,7 @@ const byte sav_08[50] =
 		40, 0, 0, 0, 0, 0, 0, 0, 0, 0,    // 30-39
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
-const byte sav_09[50] =
+const int sav_09[50] =
 	{
 		90, 75, 73, 71, 69, 67, 65, 63, 61, 60,    // 00-09
 		59, 57, 55, 53, 51, 50, 49, 47, 45, 43,    // 10-19
@@ -166,7 +166,7 @@ const byte sav_09[50] =
 		23, 0, 0, 0, 0, 0, 0, 0, 0, 0,    // 30-39
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
-const byte sav_10[50] =
+const int sav_10[50] =
 	{
 		90, 80, 79, 78, 76, 75, 73, 70, 67, 65,    // 00-09
 		64, 63, 61, 60, 59, 57, 56, 55, 54, 53,    // 10-19
@@ -174,7 +174,7 @@ const byte sav_10[50] =
 		37, 0, 0, 0, 0, 0, 0, 0, 0, 0,    // 30-39
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
-const byte sav_11[50] =
+const int sav_11[50] =
 	{
 		90, 80, 79, 78, 77, 76, 75, 74, 73, 72,    // 00-09
 		71, 70, 69, 68, 67, 66, 65, 64, 63, 62,    // 10-19
@@ -182,7 +182,7 @@ const byte sav_11[50] =
 		51, 0, 0, 0, 0, 0, 0, 0, 0, 0,    // 30-39
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
-const byte sav_12[50] =
+const int sav_12[50] =
 	{
 		90, 85, 83, 82, 80, 75, 70, 65, 63, 62,    // 00-09
 		60, 55, 50, 45, 43, 42, 40, 37, 33, 30,    // 10-19
@@ -191,7 +191,7 @@ const byte sav_12[50] =
 		7, 6, 5, 4, 3, 2, 1, 0, 0, 0    // 40-49
 	};
 //kClassMob
-const byte sav_13[100] =
+const int sav_13[100] =
 	{
 		90, 83, 81, 79, 77, 75, 72, 68, 65, 63,    // 00-09
 		61, 58, 56, 53, 50, 47, 45, 43, 42, 41,    // 10-19
@@ -204,7 +204,7 @@ const byte sav_13[100] =
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0,            // 80-89
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0            // 90-99
 	};
-const byte sav_14[50] =
+const int sav_14[50] =
 	{
 		100, 100, 100, 100, 100, 100, 100, 100, 100, 100,    // 00-09
 		100, 100, 100, 100, 100, 100, 100, 100, 100, 100,    // 10-19
@@ -212,7 +212,7 @@ const byte sav_14[50] =
 		100, 70, 70, 70, 70, 70, 70, 70, 70, 70,    // 30-39
 		70, 70, 70, 70, 70, 70, 70, 70, 70, 70    // 40-49
 	};
-const byte sav_15[50] =
+const int sav_15[50] =
 	{
 		100, 99, 98, 97, 96, 95, 94, 93, 92, 91,    // 00-09
 		90, 89, 88, 87, 86, 85, 84, 83, 82, 81,    // 10-19
@@ -220,7 +220,7 @@ const byte sav_15[50] =
 		70, 50, 50, 50, 50, 50, 50, 50, 50, 50,    // 30-39
 		50, 50, 50, 50, 50, 50, 50, 50, 50, 50    // 40-49
 	};
-const byte sav_16[50] =
+const int sav_16[50] =
 	{
 		100, 99, 97, 96, 95, 94, 92, 91, 89, 88,    // 00-09
 		86, 85, 84, 83, 81, 80, 79, 77, 76, 75,    // 10-19
@@ -228,7 +228,7 @@ const byte sav_16[50] =
 		60, 58, 57, 56, 54, 52, 51, 49, 47, 46,    // 30-39
 		45, 43, 42, 41, 39, 37, 35, 34, 32, 31    // 40-49
 	};
-const byte sav_17[50] =
+const int sav_17[50] =
 	{
 		100, 99, 97, 96, 95, 94, 92, 91, 89, 88,    // 00-09
 		86, 84, 82, 80, 78, 76, 74, 72, 70, 68,    // 10-19
@@ -237,7 +237,7 @@ const byte sav_17[50] =
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0    // 40-49
 	};
 //kClassMob
-const byte sav_18[100] =
+const int sav_18[100] =
 	{
 		100, 100, 100, 100, 100, 99, 99, 99, 99, 99,    // 00-09
 		98, 98, 98, 98, 98, 97, 97, 97, 97, 97,            // 10-19
@@ -254,7 +254,7 @@ const byte sav_18[100] =
 // {CLASS,{PARA,ROD,AFFECT,BREATH,SPELL,BASIC}}
 struct ClassSavings {
 	ECharClass chclass;
-	const byte *saves[to_underlying(ESaving::kLast) + 1];
+	const int *saves[to_underlying(ESaving::kLast) + 1];
 };
 
 const ClassSavings std_saving[] = {
@@ -276,11 +276,11 @@ const ClassSavings std_saving[] = {
 	{ECharClass::kUndefined, {sav_02, sav_12, sav_02, sav_16}}
 };
 
-byte GetSavingThrows(ECharClass class_id, ESaving type, int level) {
+int GetSavingThrows(ECharClass class_id, ESaving type, int level) {
 	return GetExtendSavingThrows(class_id, type, level);
 }
 
-byte GetExtendSavingThrows(ECharClass class_id, ESaving save, int level) {
+int GetExtendSavingThrows(ECharClass class_id, ESaving save, int level) {
 	int i;
 	if (save < ESaving::kFirst || save > ESaving::kLast) {
 		return 100; // Что за 100? Почему 100? kMaxSaving равен 400. Идиотизм.

--- a/src/gameplay/magic/magic.cpp
+++ b/src/gameplay/magic/magic.cpp
@@ -72,7 +72,7 @@
 
 extern int interpolate(int min_value, int pulse);
 
-byte GetSavingThrows(ECharClass class_id, ESaving type, int level);    // class.cpp
+int GetSavingThrows(ECharClass class_id, ESaving type, int level);    // class.cpp
 void ReactToCast(CharData *victim, CharData *caster, ESpell spell_id);
 
 bool IsRoomForbidden(RoomData *room) {

--- a/src/gameplay/magic/spells.h
+++ b/src/gameplay/magic/spells.h
@@ -15,7 +15,7 @@
 #include "gameplay/skills/skills.h"
 #include "gameplay/classes/classes_constants.h"
 #include "spells_constants.h"
-#include "engine/structs/structs.h"    // there was defined type "byte" if it had been missing
+#include "engine/structs/structs.h"
 
 class ActionContext;   // defined in magic.h (issue.spell-pipeline)
 enum class EStageResult;  // defined in magic.h; manual handlers return it (issue.manual-cast)

--- a/src/gameplay/mechanics/animate_dead.cpp
+++ b/src/gameplay/mechanics/animate_dead.cpp
@@ -314,15 +314,15 @@ void SetupUndeadStats(CharData * /*ch*/, CharData *mob, double competence) {
 		mob->set_max_hit(hp);
 		mob->set_hit(hp);
 	}
-	// Damage dice count (additive; guard the signed-byte damnodice).
+	// Damage dice count (additive).
 	if (s.damage_dice.beta != 0.0) {
 		const int dice = std::clamp(up(s.damage_dice, mob->mob_specials.damnodice), 1, 100);
-		mob->mob_specials.damnodice = static_cast<ubyte>(dice);
+		mob->mob_specials.damnodice = dice;
 	}
-	// Damage die SIZE / magnitude (additive; same signed-byte guard as the count).
+	// Damage die SIZE / magnitude (additive).
 	if (s.damage_size.beta != 0.0) {
 		const int size = std::clamp(up(s.damage_size, mob->mob_specials.damsizedice), 1, 100);
-		mob->mob_specials.damsizedice = static_cast<ubyte>(size);
+		mob->mob_specials.damsizedice = size;
 	}
 	// Flat damage bonus (+B added to every hit): the mob's damroll.
 	if (s.damage_bonus.beta != 0.0) {

--- a/src/gameplay/mechanics/saving.cpp
+++ b/src/gameplay/mechanics/saving.cpp
@@ -19,7 +19,7 @@
 #include <cstdio>
 
 // Defined in pc_classes.cpp (no header); the class/level base saving table.
-byte GetExtendSavingThrows(ECharClass class_id, ESaving save, int level);
+int GetExtendSavingThrows(ECharClass class_id, ESaving save, int level);
 
 typedef std::map<ESaving, std::string> ESaving_name_by_value_t;
 typedef std::map<const std::string, ESaving> ESaving_value_by_name_t;

--- a/src/utils/grammar/gender.h
+++ b/src/utils/grammar/gender.h
@@ -11,8 +11,9 @@
 
 // Grammatical gender of a character or object. Lives here (the grammar module) because gender is
 // a language concept the rest of the engine reads from -- entities_constants.h re-exports it by
-// including this header. Underlying type `char` matches the engine's `byte` alias (byte = char).
-enum class EGender : char {
+// including this header. Underlying type is int: a char-sized underlying type turns every
+// to_underlying()/cast into a character for fmt, which is the trap the `byte` alias used to be.
+enum class EGender : int {
 	kNeutral = 0,
 	kMale = 1,
 	kFemale = 2,


### PR DESCRIPTION
`byte` был объявлен как `char` (`structs.h`), и это ловушка: **`fmt` печатает `char` символом, а не числом.**

В #3837 из-за этого поле `F) NumDamDice` в меню `medit` выводилось пустым — значение 3 уходило в терминал управляющим символом ETX. В диффе такое не видно вообще, ловится только на живом выводе. Наступить может кто угодно, кто переведёт очередной `sprintf` на `fmt`, поэтому убран сам тип.

```
char=[^C   ]  signed char=[   3]  unsigned char=[   3]  int8_t=[   3]  uint8_t=[   3]
```

Проверял отдельной программкой на нашем же `fmt`: страдает ровно `char`, то есть ровно наш `byte`.

## Что сделано

Alias `byte` удалён из `structs.h`, все объявления переведены на `int`:

* поля мобов — `damnodice`, `damsizedice`, `extra_attack`, `like_work`, `last_direction`;
* поля комнаты — `light`, `glight`, `gdark`; поля дескриптора — `bad_pws`, `idle_tics`;
* таблицы спас-бросков в `pc_classes.cpp` и возврат `GetSavingThrows`/`GetExtendSavingThrows`;
* `attach_type` у триггера, `cleanup_type` и тип записи в OLC, `find_invis` в `sub_write`, пол и минимальная позиция в биндингах скриптов;
* приведения на загрузке мира (yaml/sqlite/legacy) и в admin API: было `clamp<byte>`/`static_cast<byte>`, стало `clamp<int>`, лишние приведения убраны.

`EGender` был `enum class EGender : char` с комментарием, что подогнано под `byte`. Подгонять больше не подо что, а `char` как основа enum'а — та же ловушка при `to_underlying`, так что тоже `int`.

Заодно убраны ставшие ненужными `static_cast<int>` в `medit` и в yaml-выгрузке — часть комментариев `// byte -> int` там врала и раньше: `mem_queue.total`, `GoldNoDs`, `GoldSiDs` уже давно `int`. И `static_cast<ubyte>` в `animate_dead`, где целое присваивалось int-полю через 8 бит.

## Что осталось намеренно

`sbyte` (`int8_t`) и `ubyte` (`uint8_t`). Они форматируются как числа и в `fmt`, и в `printf` — ловушки не создают. А `ubyte`-массивы `SplMem`/`SplKnw` — это по паре килобайт на каждого персонажа, в `int` они превратятся в восемь.

Отдельно стоит знать: `std::ostream <<` ведёт себя не как `fmt` — он печатает `signed char`/`unsigned char` символом. В `world_checksum.cpp` эти поля уже везде выводятся через `static_cast<int>`, но если где-то появится новый `oss << ch->get_height()`, будет тот же сюрприз.

## Проверено

Сборка чистая (ноль предупреждений), **712 тестов** зелёные. На тестовом мире снят вывод `смотреть`, `stat room`, `stat mob`, `опознать` и обход меню `medit` — на `master` и на этой ветке.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
