### PR TITLE
refactor(dg): parse the remaining dg command arguments as strings (#3814)

### DIFF
--- a/src/engine/scripting/dg_scripts.cpp
+++ b/src/engine/scripting/dg_scripts.cpp
@@ -4954,8 +4954,7 @@ bool process_halt(Trigger *trig, char *cmd) {
 		  false  - trigger not runned
 */
 int process_run(void *go, Script **sc, Trigger **trig, int type, char *cmd, int *retval) {
-	char arg[kMaxInputLength], trignum_s[kMaxInputLength];
-	char result[kMaxInputLength], *id_p;
+	char result[kMaxInputLength];
 	Trigger *runtrig = nullptr;
 	//	Script *runsc = NULL;
 	CharData *c = nullptr;
@@ -4964,39 +4963,43 @@ int process_run(void *go, Script **sc, Trigger **trig, int type, char *cmd, int 
 	void *trggo = nullptr;
 	int trgtype = 0, num = 0;
 
-	id_p = two_arguments(cmd, arg, trignum_s);
-	skip_spaces(&id_p);
+	std::string rest(cmd ? cmd : "");
+	utils::ExtractFirstArgumentLower(rest, rest);    // имя команды нам не нужно
+	const std::string trignum_s = utils::ExtractFirstArgumentLower(rest, rest);
+	// цель -- весь остаток строки, регистр у неё не понижается
+	const std::string id_str = rest;
 
-	if (!*trignum_s) {
+	if (trignum_s.empty()) {
 		trig_log(*trig, fmt::format("run w/o an arg, команда: '{}'", cmd));
 		return (false);
 	}
 
-	if (!id_p || !*id_p) {
+	if (id_str.empty()) {
 		trig_log(*trig, fmt::format("run invalid id arg(2), команда: '{}'", cmd));
 		return (false);
 	}
 
 	// parse and locate the id specified
-	eval_expr(id_p, result, sizeof(result), go, *sc, *trig, type);
+	eval_expr(id_str.c_str(), result, sizeof(result), go, *sc, *trig, type);
 
-	if (is_plain_vnum_string(id_p)) {
-		trig_log(*trig, fmt::format("run: 2-й аргумент '{}' -- голый vnum, используйте UID, строка отменена. Команда: '{}'", id_p, cmd));
+	if (is_plain_vnum_string(id_str.c_str())) {
+		trig_log(*trig, fmt::format("run: 2-й аргумент '{}' -- голый vnum, используйте UID, строка отменена. Команда: '{}'",
+								   id_str, cmd));
 		return false;
 	}
 
-	c = get_char(id_p);
+	c = get_char(id_str.c_str());
 	if (!c) {
-		o = get_obj(id_p);
+		o = get_obj(id_str.c_str());
 		if (!o) {
-			r = get_room(id_p);
+			r = get_room(id_str.c_str());
 			if (!r) {
 				trig_log(*trig, fmt::format("id not found - arg(2), команда: '{}'", cmd));
 				return (false);
 			}
 		}
 	}
-	num = atoi(trignum_s);
+	num = atoi(trignum_s.c_str());
 	if (num == 0) {
 		trig_log(*trig, fmt::format("run invalid trignum, команда: '{}'", cmd));
 		return (false);
@@ -5411,13 +5414,12 @@ void ClearContextVar(Trigger *trig,char *cmd) {
  * or the local vars of trig if not found in global list.
  */
 void process_unset(Script *sc, Trigger *trig, char *cmd) {
-	char arg[kMaxInputLength], *var;
+	// var -- это весь остаток строки после имени команды, а не первое слово,
+	// и регистр у него не понижается: one_argument правит только first_arg.
+	std::string var(cmd ? cmd : "");
+	utils::ExtractFirstArgumentLower(var, var);
 
-	var = one_argument(cmd, arg);
-
-	skip_spaces(&var);
-
-	if (!*var) {
+	if (var.empty()) {
 		trig_log(trig, fmt::format("unset w/o an arg, команда: '{}'", cmd));
 		return;
 	}
@@ -5619,13 +5621,12 @@ void process_rdelete(Script * /*sc*/, Trigger *trig, char *cmd) {
 
 // * makes a local variable into a global variable
 void process_global(Script *sc, Trigger *trig, char *cmd, long id) {
-	char arg[kMaxInputLength], *var;
+	// var -- это весь остаток строки после имени команды, а не первое слово,
+	// и регистр у него не понижается: one_argument правит только first_arg.
+	std::string var(cmd ? cmd : "");
+	utils::ExtractFirstArgumentLower(var, var);
 
-	var = one_argument(cmd, arg);
-
-	skip_spaces(&var);
-
-	if (!*var) {
+	if (var.empty()) {
 		trig_log(trig, fmt::format("global w/o an arg, команда: '{}'", cmd));
 		return;
 	}
@@ -5643,13 +5644,12 @@ void process_global(Script *sc, Trigger *trig, char *cmd, long id) {
 
 // * makes a local variable into a world variable
 void process_worlds(Script * /*sc*/, Trigger *trig, char *cmd, long id) {
-	char arg[kMaxInputLength], *var;
+	// var -- это весь остаток строки после имени команды, а не первое слово,
+	// и регистр у него не понижается: one_argument правит только first_arg.
+	std::string var(cmd ? cmd : "");
+	utils::ExtractFirstArgumentLower(var, var);
 
-	var = one_argument(cmd, arg);
-
-	skip_spaces(&var);
-
-	if (!*var) {
+	if (var.empty()) {
 		trig_log(trig, fmt::format("worlds w/o an arg, команда: '{}'", cmd));
 		return;
 	}
@@ -5667,17 +5667,16 @@ void process_worlds(Script * /*sc*/, Trigger *trig, char *cmd, long id) {
 
 // set the current context for a script
 void process_context(Script * /*sc*/, Trigger *trig, char *cmd) {
-	char arg[kMaxInputLength], *var;
+	// var -- это весь остаток строки после имени команды, а не первое слово,
+	// и регистр у него не понижается: one_argument правит только first_arg.
+	std::string var(cmd ? cmd : "");
+	utils::ExtractFirstArgumentLower(var, var);
 
-	var = one_argument(cmd, arg);
-
-	skip_spaces(&var);
-
-	if (!*var) {
+	if (var.empty()) {
 		trig_log(trig, fmt::format("context w/o an arg, команда: '{}'", cmd));
 		return;
 	}
-	trig->context = atol(var);
+	trig->context = atol(var.c_str());
 }
 
 void extract_value(Script * /*sc*/, Trigger *trig, char *cmd) {


### PR DESCRIPTION
Хвост к #3840: те же правки для `process_run`, `process_global`, `process_worlds`, `process_context`, `process_unset`. Глобальных буферов там не было, но разбор такой же — локальный `char[]` плюс указатель на остаток строки.

## Тонкость: var -- это остаток строки, а не слово

В четырёх функциях (`global`, `worlds`, `context`, `unset`) переменная `var` — это **не первое слово, а весь остаток строки** после имени команды:

```c
var = one_argument(cmd, arg);   // arg = "global", var = всё, что после
```

То есть `global myvar лишнее` отдаёт в `find_var_cntx` строку `myvar лишнее` целиком, а не `myvar`. Строковая версия делает ровно то же — берёт остаток, а не слово.

Про регистр отдельно, потому что в первой редакции этого описания я написал неверно. **Имена переменных в триггерах регистронезависимы:** `find_var_cntx`, `add_var_cntx` и `remove_var_cntx` сами зовут `utils::ConvertToLow(name)`, а `add_var_cntx` вдобавок понижает и значение. Так что `MyVar` и `myvar` — одна и та же переменная, и понизь я тут регистр или нет, разницы бы не было. Код всё равно оставляет остаток как есть — просто потому, что так делал `one_argument`.

То же в `process_run`: второй аргумент (номер триггера) читается как слово, а цель — весь остаток строки.

Заодно убраны мёртвые локальные переменные и вызовы `skip_spaces`, которым нечего было делать: `one_argument`/`two_arguments` возвращают остаток уже без ведущих пробелов.

## Что осталось как было

В `process_run` результат `eval_expr` пишется в локальный `result` и дальше нигде не читается — разбирается по-прежнему сам `id_p`. Не трогал: к разбору аргументов отношения не имеет, а выкидывать вызов вслепую не стоит.

Ещё наблюдение из проверки: голые `global`/`worlds`/`context`/`unset` в комнатном триггере до этих функций вообще не доходят — их отбивает диспетчер мировых команд («Unknown world cmd»). Ветки «w/o an arg» живые только для мобных и предметных триггеров.

## Проверено вживую

В тестовом мире написан триггер, который дёргает `set`/`global`/`worlds`/`context`/`unset` с переменной `MixedCase` (заодно видно, что регистр никого не волнует: `set MyVar Hello` печатается как `hello`), те же команды без аргумента, с несуществующей переменной, и `run` — как удачный (`run 100 %self%`, вложенный триггер отработал), так и с нехваткой аргументов.

Сняты и вывод игроку:

```
GLOBAL=[hello]
WORLDS=[world]
CTX SET
UNSET=[]
Нашел
```

и строки `SCRIPT LOG` из syslog:

```
SCRIPT LOG (Trigger: dgtest, VNum: 299) : local var 'NoSuchVar' not found in global call [строка: 15]
SCRIPT LOG (Trigger: dgtest, VNum: 299) : local var 'NoSuchVar' not found in worlds call [строка: 16]
```

На `master` и на этой ветке всё совпадает. Триггер из тестового мира убран, в репозиторий он не попадал.

Сборка без предупреждений, **712 тестов** зелёные.

Часть #3814, родительская задача #3807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr