### PR TITLE
fix(olc): stop asking for the unused weapon value

### DIFF
--- a/src/engine/olc/oedit.cpp
+++ b/src/engine/olc/oedit.cpp
@@ -628,8 +628,9 @@ void oedit_disp_val1_menu(DescriptorData *d) {
 			break;
 
 		case EObjType::kWeapon:
-			// val[0] у оружия в бою не читается (см. fight_hit.cpp).
-			SendMsgToChar("Не используется : ", d->character.get());
+			// val[0] у оружия в бою не читается (см. fight_hit.cpp), так что и спрашивать
+			// его незачем -- сразу к кубикам урона, как это сделано для источников света.
+			oedit_disp_val2_menu(d);
 			break;
 
 		case EObjType::kArmor:


### PR DESCRIPTION
У оружия `value[0]` движок не читает нигде: урон берётся из `value[1]`/`value[2]`, тип атаки из `value[3]`. В июле подпись поля честно поменяли на «Не используется» (#3593), но само приглашение ввода осталось — билдер до сих пор обязан что-то набрать, прежде чем дойдёт до кубиков урона.

Теперь редактор перепрыгивает этот слот и начинает сразу с количества бросков кубика — ровно так же, как он давно делает для источников света:

```cpp
case EObjType::kLightSource:
    // * values 0 and 1 are unused.. jump to 2
    oedit_disp_val3_menu(d);
    break;
```

Спрашивали это поле, кстати, с самого первого коммита репозитория (`1720dd2e2`, 2005). Там оно называлось «Модификатор попадания», и рядом уже стоял комментарий `This doesn't seem to be used if I remembe right`.

## Побочное следствие, которое стоит знать

Вход в меню values и раньше обнулял все четыре слота:

```cpp
// * Clear any old values
OLC_OBJ(d)->set_val(0, 0);
...
```

а дальше билдер вводил их заново. Раз нулевой слот теперь не спрашивается, он так и остаётся нулём. То есть у предмета, которому правят кубики, мусор вроде `- 5` в первом слоте превратится в `0`. На игру это не влияет (поле не читается), но в диффе мира такая строчка будет видна.

Если хочется сохранять старое значение — скажи, добавлю запоминание value[0] до очистки.

## Проверено вживую

На тестовом мире взято оружие с `value[0] = 5`, в меню values введены 7 бросков, 3 грани, тип удара 0:

```
до:    O) Values      : 5 5 6 7
после: O) Values      : 0 7 3 0
```

Числа легли в те слоты, в которые нужно; первым приглашением теперь «Количество бросков кубика».

Сборка без предупреждений, **712 тестов** зелёные.

Задача #3593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
