### PR TITLE
refactor(olc): drop global buffers from zedit and redit (#3814)

### DIFF
--- a/src/engine/olc/redit.cpp
+++ b/src/engine/olc/redit.cpp
@@ -280,8 +280,8 @@ void redit_save_to_disk(ZoneRnum zone_num) {
 	RoomData *room;
 
 	if (zone_table[zone_num].vnum >= dungeons::kZoneStartDungeons) {
-			snprintf(buf, sizeof(buf), "Отказ сохранения зоны %d на диск.", zone_table[zone_num].vnum);
-			mudlog(buf, CMP, kLvlGreatGod, SYSLOG, true);
+			mudlog(fmt::format("Отказ сохранения зоны {} на диск.", zone_table[zone_num].vnum),
+				   CMP, kLvlGreatGod, SYSLOG, true);
 			return;
 	}
 	if (zone_num < 0 || zone_num >= static_cast<int>(zone_table.size())) {
@@ -289,8 +289,9 @@ void redit_save_to_disk(ZoneRnum zone_num) {
 		return;
 	}
 
-	snprintf(buf, sizeof(buf), "%s/%d.new", WLD_PREFIX, zone_table[zone_num].vnum);
-	if (!(fp = fopen(buf, "w+"))) {
+	// Пишем во временный файл, потом переименовываем поверх боевого.
+	const std::string tmp_name = fmt::format("{}/{}.new", WLD_PREFIX, zone_table[zone_num].vnum);
+	if (!(fp = fopen(tmp_name.c_str(), "w+"))) {
 		mudlog("SYSERR: OLC: Cannot open room file!", BRF, kLvlBuilder, SYSLOG, true);
 		return;
 	}
@@ -301,47 +302,43 @@ void redit_save_to_disk(ZoneRnum zone_num) {
 			room = world[realcounter];
 
 #if defined(REDIT_LIST)
-			snprintf(buf1, sizeof(buf1), "OLC: Saving room %d.", room->number);
-			log(buf1);
+			log(fmt::format("OLC: Saving room {}.", room->number));
 #endif
 
 			// * Remove the '\r\n' sequences from description.
-			snprintf(buf1, sizeof(buf1), "%s", GlobalObjects::descriptions().get(room->description_num).c_str());
-			strip_string(buf1);
+			const std::string description =
+				strip_string(GlobalObjects::descriptions().get(room->description_num));
 
-			// * Forget making a buffer, lets just write the thing now.
-			*buf2 = '\0';
-			room->flags_tascii(kFlagPlanes, buf2, sizeof(buf2));
+			char flags[kMaxStringLength] = {};   // приёмник flags_tascii, ему нужен char *
+			room->flags_tascii(kFlagPlanes, flags, sizeof(flags));
 			fprintf(fp, "#%d\n%s~\n%s~\n%d %s %d\n", counter,
-					room->name ? room->name : "неопределено", buf1,
-					zone_table[room->zone_rn].vnum, buf2, room->sector_type);
+					room->name ? room->name : "неопределено", description.c_str(),
+					zone_table[room->zone_rn].vnum, flags, room->sector_type);
 
 			// * Handle exits.
 			for (counter2 = 0; counter2 < EDirection::kMaxDirNum; counter2++) {
 				if (room->dir_option_proto[counter2]) {
 					// * Again, strip out the garbage.
-					if (!room->dir_option_proto[counter2]->general_description.empty()) {
-						const std::string &description = room->dir_option_proto[counter2]->general_description;
-						snprintf(buf1, sizeof(buf1), "%s", description.c_str());
-						strip_string(buf1);
-					} else {
-						*buf1 = 0;
-					}
+					const std::string exit_description =
+						room->dir_option_proto[counter2]->general_description.empty()
+							? std::string()
+							: strip_string(room->dir_option_proto[counter2]->general_description);
 
 					// * Check for keywords.
+					std::string keywords;
 					if (room->dir_option_proto[counter2]->keyword) {
-						snprintf(buf2, sizeof(buf2), "%s", room->dir_option_proto[counter2]->keyword);
+						keywords = room->dir_option_proto[counter2]->keyword;
 					}
 
 					// алиас в винительном падеже пишется сюда же через ;
 					if (room->dir_option_proto[counter2]->vkeyword) {
-						size_t buf2_len = strlen(buf2);
-						snprintf(buf2 + buf2_len, sizeof(buf2) - buf2_len, "|%s", room->dir_option_proto[counter2]->vkeyword);
-					} else
-						*buf2 = '\0';
+						keywords += fmt::format("|{}", room->dir_option_proto[counter2]->vkeyword);
+					} else {
+						keywords.clear();
+					}
 					REMOVE_BIT(room->dir_option_proto[counter2]->exit_info, EExitFlag::kBrokenLock);
 					fprintf(fp, "D%d\n%s~\n%s~\n%d %d %d %d\n",
-							counter2, buf1, buf2,
+							counter2, exit_description.c_str(), keywords.c_str(),
 							room->dir_option_proto[counter2]->exit_info.get_plane(0), room->dir_option_proto[counter2]->key,
 							room->dir_option_proto[counter2]->to_room() != kNowhere ?
 							world[room->dir_option_proto[counter2]->to_room()]->vnum : kNowhere,
@@ -352,9 +349,8 @@ void redit_save_to_disk(ZoneRnum zone_num) {
 			{
 				for (const auto &ex_desc : room->ex_description) {
 					if (!ex_desc.keyword.empty() && !ex_desc.description.empty()) {
-						snprintf(buf1, sizeof(buf1), "%s", ex_desc.description.c_str());
-						strip_string(buf1);
-						fprintf(fp, "E\n%s~\n%s~\n", ex_desc.keyword.c_str(), buf1);
+						const std::string text = strip_string(ex_desc.description);
+						fprintf(fp, "E\n%s~\n%s~\n", ex_desc.keyword.c_str(), text.c_str());
 					}
 				}
 			}
@@ -365,10 +361,10 @@ void redit_save_to_disk(ZoneRnum zone_num) {
 	// * Write final line and close.
 	fprintf(fp, "$\n$\n");
 	fclose(fp);
-	snprintf(buf2, sizeof(buf2), "%s/%d.wld", WLD_PREFIX, zone_table[zone_num].vnum);
+	const std::string final_name = fmt::format("{}/{}.wld", WLD_PREFIX, zone_table[zone_num].vnum);
 	// * We're fubar'd if we crash between the two lines below.
-	remove(buf2);
-	rename(buf, buf2);
+	remove(final_name.c_str());
+	rename(tmp_name.c_str(), final_name.c_str());
 	olc_remove_from_save_list(zone_table[zone_num].vnum, OLC_SAVE_ROOM);
 }
 
@@ -384,16 +380,14 @@ void redit_disp_extradesc_menu(DescriptorData *d) {
 	const ExtraDescription &extra_desc = descs[idx];
 	const bool has_next = (idx + 1 < static_cast<int>(descs.size()));
 
-	snprintf(buf, sizeof(buf),
-			"&g1&n) Ключ: &y%s\r\n"
-			"&g2&n) Описание:\r\n&y%s\r\n"
-			"&g3&n) Следующее описание: ",
-			!extra_desc.keyword.empty() ? extra_desc.keyword.c_str() : "<NONE>",
-			!extra_desc.description.empty() ? extra_desc.description.c_str() : "<NONE>");
-
-	strncat(buf, !has_next ? "<NOT SET>\r\n" : "Set.\r\n", sizeof(buf) - strlen(buf) - 1);
-	strncat(buf, "Enter choice (0 to quit) : ", sizeof(buf) - strlen(buf) - 1);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("&g1&n) Ключ: &y{}\r\n"
+							  "&g2&n) Описание:\r\n&y{}\r\n"
+							  "&g3&n) Следующее описание: {}"
+							  "Enter choice (0 to quit) : ",
+							  !extra_desc.keyword.empty() ? extra_desc.keyword.c_str() : "<NONE>",
+							  !extra_desc.description.empty() ? extra_desc.description.c_str() : "<NONE>",
+							  !has_next ? "<NOT SET>\r\n" : "Set.\r\n"),
+				  d->character.get());
 	OLC_MODE(d) = REDIT_EXTRADESC_MENU;
 }
 
@@ -406,31 +400,31 @@ void redit_disp_exit_menu(DescriptorData *d) {
 	}
 
 	// * Weird door handling!
+	std::string door;
 	if (IS_SET(OLC_EXIT(d)->exit_info, EExitFlag::kHasDoor)) {
-		snprintf(buf2, sizeof(buf2), "Дверь ");
+		door = "Дверь ";
 		if (IS_SET(OLC_EXIT(d)->exit_info, EExitFlag::kPickroof)) {
-			strncat(buf2, "Невзламываемая ", sizeof(buf2) - strlen(buf2) - 1);
+			door += "Невзламываемая ";
 		}
-		size_t buf2_len = strlen(buf2);
-		snprintf(buf2 + buf2_len, sizeof(buf2) - buf2_len, " (Сложность замка [%d])", OLC_EXIT(d)->lock_complexity);
+		door += fmt::format(" (Сложность замка [{}])", OLC_EXIT(d)->lock_complexity);
 	} else {
-		snprintf(buf2, sizeof(buf2), "Нет двери");
+		door = "Нет двери";
 	}
 
 	if (IS_SET(OLC_EXIT(d)->exit_info, EExitFlag::kHidden)) {
-		strncat(buf2, " (Выход скрыт)", sizeof(buf2) - strlen(buf2) - 1);
+		door += " (Выход скрыт)";
 	}
 
-	snprintf(buf, kMaxStringLength,
+	SendMsgToChar(fmt::format(
 #if defined(CLEAR_SCREEN)
 		"[H[J"
 #endif
-			 "%s1%s) Ведет в        : %s%d\r\n"
-			 "%s2%s) Описание       :-\r\n%s%s\r\n"
-			 "%s3%s) Синонимы двери : %s%s (%s)\r\n"
-			 "%s4%s) Номер ключа    : %s%d\r\n"
-			 "%s5%s) Флаги двери    : %s%s\r\n"
-			 "%s6%s) Очистить выход.\r\n"
+			 "{}1{}) Ведет в        : {}{}\r\n"
+			 "{}2{}) Описание       :-\r\n{}{}\r\n"
+			 "{}3{}) Синонимы двери : {}{} ({})\r\n"
+			 "{}4{}) Номер ключа    : {}{}\r\n"
+			 "{}5{}) Флаги двери    : {}{}\r\n"
+			 "{}6{}) Очистить выход.\r\n"
 			 "Ваш выбор (0 - конец) : ",
 			 grn, nrm, cyn,
 			 OLC_EXIT(d)->to_room() != kNowhere ? world[OLC_EXIT(d)->to_room()]->vnum : kNowhere,
@@ -440,42 +434,39 @@ void redit_disp_exit_menu(DescriptorData *d) {
 			 grn, nrm, yel,
 			 OLC_EXIT(d)->keyword ? OLC_EXIT(d)->keyword : "<NONE>",
 			 OLC_EXIT(d)->vkeyword ? OLC_EXIT(d)->vkeyword : "<NONE>", grn, nrm,
-			 cyn, OLC_EXIT(d)->key, grn, nrm, cyn, buf2, grn, nrm);
+			 cyn, OLC_EXIT(d)->key, grn, nrm, cyn, door, grn, nrm),
 
-	SendMsgToChar(buf, d->character.get());
+				  d->character.get());
 	OLC_MODE(d) = REDIT_EXIT_MENU;
 }
 
 // * For exit flags.
 void redit_disp_exit_flag_menu(DescriptorData *d) {
-	snprintf(buf, sizeof(buf),
-			"%s1%s) [%c]Дверь\r\n"
-			"%s2%s) [%c]Невзламываемая\r\n"
-			"%s3%s) [%c]Скрытый выход\r\n"
-			"%s4%s) [%c]Закрыто\r\n"
-			"%s5%s) [%c]Заперто\r\n"
-			"%s6%s) [%d]Сложность замка\r\n"
+	SendMsgToChar(fmt::format(
+			"{}1{}) [{}]Дверь\r\n"
+			"{}2{}) [{}]Невзламываемая\r\n"
+			"{}3{}) [{}]Скрытый выход\r\n"
+			"{}4{}) [{}]Закрыто\r\n"
+			"{}5{}) [{}]Заперто\r\n"
+			"{}6{}) [{}]Сложность замка\r\n"
 			"Ваш выбор (0 - выход): ",
 			grn, nrm, IS_SET(OLC_EXIT(d)->exit_info, EExitFlag::kHasDoor) ? 'x' : ' ',
 			grn, nrm, IS_SET(OLC_EXIT(d)->exit_info, EExitFlag::kPickroof) ? 'x' : ' ',
 			grn, nrm, IS_SET(OLC_EXIT(d)->exit_info, EExitFlag::kHidden) ? 'x' : ' ',
 			grn, nrm, IS_SET(OLC_EXIT(d)->exit_info, EExitFlag::kClosed) ? 'x' : ' ',
 			grn, nrm, IS_SET(OLC_EXIT(d)->exit_info, EExitFlag::kLocked) ? 'x' : ' ',
-			grn, nrm, OLC_EXIT(d)->lock_complexity);
-	SendMsgToChar(buf, d->character.get());
+			grn, nrm, OLC_EXIT(d)->lock_complexity),
+				  d->character.get());
 }
 
 // * For room flags.
 void redit_disp_flag_menu(DescriptorData *d) {
 	disp_planes_values(d, room_bits, 2);
-	OLC_ROOM(d)->flags_sprint(buf1, sizeof(buf1), ",", true);
-	snprintf(buf,
-			 kMaxStringLength,
-			 "\r\nФлаги комнаты: %s%s%s\r\n" "Введите флаг комнаты (0 - выход) : ",
-			 cyn,
-			 buf1,
-			 nrm);
-	SendMsgToChar(buf, d->character.get());
+	char flags[kMaxStringLength];   // приёмник flags_sprint, ему нужен char *
+	OLC_ROOM(d)->flags_sprint(flags, sizeof(flags), ",", true);
+	SendMsgToChar(fmt::format("\r\nФлаги комнаты: {}{}{}\r\n"
+							  "Введите флаг комнаты (0 - выход) : ", cyn, flags, nrm),
+				  d->character.get());
 	OLC_MODE(d) = REDIT_FLAGS;
 }
 
@@ -499,33 +490,35 @@ void redit_disp_sector_menu(DescriptorData *d) {
 void redit_disp_menu(DescriptorData *d) {
 	RoomData *room;
 	room = OLC_ROOM(d);
-	room->flags_sprint(buf1, sizeof(buf1), ",");
-	sprinttype(room->sector_type, sector_types, buf2);
-	snprintf(buf, kMaxStringLength,
+	char flags[kMaxStringLength];    // приёмники flags_sprint/sprinttype -- им нужен char *
+	char sector[kMaxInputLength];
+	room->flags_sprint(flags, sizeof(flags), ",");
+	sprinttype(room->sector_type, sector_types, sector);
+	SendMsgToChar(fmt::format(
 #if defined(CLEAR_SCREEN)
 		"[H[J"
 #endif
-			 "-- Комната : [%s%d%s]  	Зона: [%s%d%s]\r\n"
-			 "%s1%s) Название    : &C&q%s&e&Q\r\n"
-			 "%s2&n) Описание    :\r\n%s&e"
-			 "%s3%s) Флаги       : %s%s\r\n"
-			 "%s4%s) Поверхность : %s%s\r\n"
-			 "%s5%s) На севере   : %s%d\r\n"
-			 "%s6%s) На востоке  : %s%d\r\n"
-			 "%s7%s) На юге      : %s%d\r\n"
-			 "%s8%s) На западе   : %s%d\r\n"
-			 "%s9%s) Вверху      : %s%d\r\n"
-			 "%sA%s) Внизу       : %s%d\r\n"
-			 "%sB%s) Меню экстраописаний\r\n"
-			 //		"%sН%s) Ингредиенты : %s%s\r\n"
-			 "%sS%s) Скрипты     : %s%s\r\n"
-			 "%sQ%s) Quit\r\n"
+			 "-- Комната : [{}{}{}]  	Зона: [{}{}{}]\r\n"
+			 "{}1{}) Название    : &C&q{}&e&Q\r\n"
+			 "{}2&n) Описание    :\r\n{}&e"
+			 "{}3{}) Флаги       : {}{}\r\n"
+			 "{}4{}) Поверхность : {}{}\r\n"
+			 "{}5{}) На севере   : {}{}\r\n"
+			 "{}6{}) На востоке  : {}{}\r\n"
+			 "{}7{}) На юге      : {}{}\r\n"
+			 "{}8{}) На западе   : {}{}\r\n"
+			 "{}9{}) Вверху      : {}{}\r\n"
+			 "{}A{}) Внизу       : {}{}\r\n"
+			 "{}B{}) Меню экстраописаний\r\n"
+			 //		"{}Н{}) Ингредиенты : {}{}\r\n"
+			 "{}S{}) Скрипты     : {}{}\r\n"
+			 "{}Q{}) Quit\r\n"
 			 "Ваш выбор : ",
 			 cyn, OLC_NUM(d), nrm,
 			 cyn, zone_table[OLC_ZNUM(d)].vnum, nrm,
 			 grn, nrm, room->name,
 			 grn, room->temp_description,
-			 grn, nrm, cyn, buf1, grn, nrm, cyn, buf2, grn, nrm, cyn,
+			 grn, nrm, cyn, flags, grn, nrm, cyn, sector, grn, nrm, cyn,
 			 room->dir_option_proto[EDirection::kNorth] && room->dir_option_proto[EDirection::kNorth]->to_room() != kNowhere
 			 ? world[room->dir_option_proto[EDirection::kNorth]->to_room()]->vnum : kNowhere,
 			 grn, nrm, cyn,
@@ -545,8 +538,8 @@ void redit_disp_menu(DescriptorData *d) {
 			 ? world[room->dir_option_proto[EDirection::kDown]->to_room()]->vnum : kNowhere,
 			 grn, nrm, grn, nrm, cyn,
 			 !room->proto_script->empty() ? "Set." : "Not Set.",
-			 grn, nrm);
-	SendMsgToChar(buf, d->character.get());
+			 grn, nrm),
+				  d->character.get());
 
 	OLC_MODE(d) = REDIT_MAIN_MENU;
 }
@@ -564,9 +557,9 @@ void redit_parse(DescriptorData *d, char *arg) {
 				case 'Y':
 				case rus::kDe:
 				case rus::kDeUpper: redit_save_internally(d);
-					snprintf(buf, sizeof(buf), "OLC: %s edits room %d.", GET_NAME(d->character), OLC_NUM(d));
 					olc_log("%s edit room %d", GET_NAME(d->character), OLC_NUM(d));
-					mudlog(buf, NRM, std::max(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
+					mudlog(fmt::format("OLC: {} edits room {}.", GET_NAME(d->character), OLC_NUM(d)),
+						   NRM, std::max(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
 					// * Do NOT free strings! Just the room structure.
 					cleanup_olc(d, CLEANUP_STRUCTS);
 					SendMsgToChar("Комната сохранена.\r\n", d->character.get());

--- a/src/engine/olc/zedit.cpp
+++ b/src/engine/olc/zedit.cpp
@@ -441,14 +441,14 @@ void zedit_save_to_disk(ZoneRnum zone_num) {
 	FILE *zfile;
 
 	if (zone_table[zone_num].vnum >= dungeons::kZoneStartDungeons) {
-			sprintf(buf, "Отказ сохранения зоны %d на диск.", zone_table[zone_num].vnum);
-			mudlog(buf, CMP, kLvlGreatGod, SYSLOG, true);
+			mudlog(fmt::format("Отказ сохранения зоны {} на диск.", zone_table[zone_num].vnum),
+				   CMP, kLvlGreatGod, SYSLOG, true);
 			return;
 	}
 	sprintf(fname, "%s/%d.new", ZON_PREFIX, zone_table[zone_num].vnum);
 	if (!(zfile = fopen(fname, "w"))) {
-		sprintf(buf, "SYSERR: OLC: zedit_save_to_disk:  Can't write zone %d.", zone_table[zone_num].vnum);
-		mudlog(buf, BRF, kLvlBuilder, SYSLOG, true);
+		mudlog(fmt::format("SYSERR: OLC: zedit_save_to_disk:  Can't write zone {}.",
+						   zone_table[zone_num].vnum), BRF, kLvlBuilder, SYSLOG, true);
 		return;
 	}
 
@@ -581,8 +581,9 @@ void zedit_save_to_disk(ZoneRnum zone_num) {
 				// * Invalid commands are replaced with '*' - Ignore them.
 				continue;
 
-			default: sprintf(buf, "SYSERR: OLC: z_save_to_disk(): Unknown cmd '%c' - NOT saving", ZCMD.command);
-				mudlog(buf, BRF, kLvlBuilder, SYSLOG, true);
+			default:
+				mudlog(fmt::format("SYSERR: OLC: z_save_to_disk(): Unknown cmd '{}' - NOT saving",
+								   ZCMD.command), BRF, kLvlBuilder, SYSLOG, true);
 				continue;
 		}
 
@@ -596,10 +597,10 @@ void zedit_save_to_disk(ZoneRnum zone_num) {
 	}
 	fprintf(zfile, "S\n$\n");
 	fclose(zfile);
-	sprintf(buf2, "%s/%d.zon", ZON_PREFIX, zone_table[zone_num].vnum);
+	const std::string final_name = fmt::format("{}/{}.zon", ZON_PREFIX, zone_table[zone_num].vnum);
 	// * We're fubar'd if we crash between the two lines below.
-	remove(buf2);
-	rename(fname, buf2);
+	remove(final_name.c_str());
+	rename(fname, final_name.c_str());
 	olc_remove_from_save_list(zone_table[zone_num].vnum, OLC_SAVE_ZONE);
 }
 
@@ -639,7 +640,10 @@ const char *name_by_vnum(int vnum, int type) {
 			break;
 
 		case ROOM_NAME: rnum = GetRoomRnum(vnum);
-			if (rnum >= 0) {
+			// У комнаты без имени name остаётся нулевым (см. конструктор RoomData). Раньше такой
+			// указатель уходил в printf("%s") и печатался как "(null)", а fmt на нём бросает
+			// исключение -- отдаём документированное "???".
+			if (rnum >= 0 && world[rnum]->name) {
 				return world[rnum]->name;
 			}
 			break;
@@ -683,7 +687,7 @@ void zedit_disp_commands(DescriptorData *d) {
 
 	// Проверка допустимости индекса start
 	stop = zedit_count_cmdlist(head);    // количество элементов
-	sprintf(buf, "[Command list (0:%d)]\r\n", stop - 1);
+	std::string out = fmt::format("[Command list (0:{})]\r\n", stop - 1);
 	if (show_all) {
 		if (start > stop - CMD_PAGE_SIZE)
 			start = stop - CMD_PAGE_SIZE;
@@ -696,21 +700,22 @@ void zedit_disp_commands(DescriptorData *d) {
 
 	// Вывод всех команд зоны
 	// Подсветка команд, относящихся к данной комнате
+	std::string cmd_text;   // описание одной команды зоны
 	for (item = head->next; item != head; item = item->next, ++counter) {
 		// Разбор аргументов, выяснение подсветки
 		// if_flag и подсветка с номером - ниже
 		switch (item->cmd.command) {
 			case 'M':
-				sprintf(buf2,
-						"загрузить моба %d [%s] в комнату %d [%s], Max(игра/комната) : %d/%d",
+				cmd_text = fmt::format(
+						"загрузить моба {} [{}] в комнату {} [{}], Max(игра/комната) : {}/{}",
 						item->cmd.arg1, name_by_vnum(item->cmd.arg1, MOB_NAME),
 						item->cmd.arg3, name_by_vnum(item->cmd.arg3, ROOM_NAME), item->cmd.arg2, item->cmd.arg4);
 				hl = (item->cmd.arg3 == room);
 				break;
 
 			case 'F':
-				sprintf(buf2,
-						"%d [%s] следует за %d [%s] в комнате %d [%s]",
+				cmd_text = fmt::format(
+						"{} [{}] следует за {} [{}] в комнате {} [{}]",
 						item->cmd.arg3, name_by_vnum(item->cmd.arg3, MOB_NAME),
 						item->cmd.arg2, name_by_vnum(item->cmd.arg2, MOB_NAME),
 						item->cmd.arg1, name_by_vnum(item->cmd.arg1, ROOM_NAME));
@@ -718,24 +723,24 @@ void zedit_disp_commands(DescriptorData *d) {
 				break;
 
 			case 'Q':
-				sprintf(buf2,
-						"убрать всех мобов %d [%s]",
+				cmd_text = fmt::format(
+						"убрать всех мобов {} [{}]",
 						item->cmd.arg1,
 						name_by_vnum(item->cmd.arg1, MOB_NAME));
 				hl = 0;
 				break;
 
 			case 'O':
-				sprintf(buf2,
-						"загрузить объект %d [%s] в комнату %d [%s], Load%% %d",
+				cmd_text = fmt::format(
+						"загрузить объект {} [{}] в комнату {} [{}], Load% {}",
 						item->cmd.arg1, name_by_vnum(item->cmd.arg1, OBJ_NAME),
 						item->cmd.arg3, name_by_vnum(item->cmd.arg3, ROOM_NAME), item->cmd.arg4);
 				hl = (item->cmd.arg3 == room);
 				break;
 
 			case 'P':
-				sprintf(buf2,
-						"поместить %d [%s] в %d [%s] (в комнате %d [%s]), Load%% %d",
+				cmd_text = fmt::format(
+						"поместить {} [{}] в {} [{}] (в комнате {} [{}]), Load% {}",
 						item->cmd.arg1, name_by_vnum(item->cmd.arg1, OBJ_NAME),
 						item->cmd.arg3, name_by_vnum(item->cmd.arg3, OBJ_NAME), 
 						item->cmd.arg2, item->cmd.arg2 == 0? "везде" : name_by_vnum(item->cmd.arg2, ROOM_NAME),
@@ -744,8 +749,8 @@ void zedit_disp_commands(DescriptorData *d) {
 				break;
 
 			case 'G':
-				sprintf(buf2,
-						"дать %d [%s], Load%% %d",
+				cmd_text = fmt::format(
+						"дать {} [{}], Load% {}",
 						item->cmd.arg1, name_by_vnum(item->cmd.arg1, OBJ_NAME), item->cmd.arg4);
 				// hl - не изменяется
 				break;
@@ -755,23 +760,23 @@ void zedit_disp_commands(DescriptorData *d) {
 				const char *str = equipment_types[rnum];
 				if (*str == '\n')
 					str = "???";
-				sprintf(buf2,
-						"экипировать %d [%s], %s, Load%% %d",
+				cmd_text = fmt::format(
+						"экипировать {} [{}], {}, Load% {}",
 						item->cmd.arg1, name_by_vnum(item->cmd.arg1, OBJ_NAME), str, item->cmd.arg4);
 				// hl - не изменяется
 				break;
 			}
 			case 'R':
-				sprintf(buf2,
-						"удалить %d [%s] из комнаты %d [%s]",
+				cmd_text = fmt::format(
+						"удалить {} [{}] из комнаты {} [{}]",
 						item->cmd.arg2, name_by_vnum(item->cmd.arg2, OBJ_NAME),
 						item->cmd.arg1, name_by_vnum(item->cmd.arg1, ROOM_NAME));
 				hl = (item->cmd.arg1 == room);
 				break;
 
 			case 'D':
-				sprintf(buf2,
-						"для комнаты %d [%s] установить выход %s как %s",
+				cmd_text = fmt::format(
+						"для комнаты {} [{}] установить выход {} как {}",
 						item->cmd.arg1, name_by_vnum(item->cmd.arg1, ROOM_NAME),
 						dirs[item->cmd.arg2],
 						item->cmd.arg3 == 0 ? "открытый" :
@@ -782,101 +787,99 @@ void zedit_disp_commands(DescriptorData *d) {
 				break;
 
 			case 'T':
-				sprintf(buf2,
-						"привязать тригер %d [%s] к ",
+				cmd_text = fmt::format(
+						"привязать тригер {} [{}] к ",
 						item->cmd.arg2,
 						name_by_vnum(item->cmd.arg2, TRIG_NAME));
 				switch (item->cmd.arg1) {
-					case MOB_TRIGGER: strcat(buf2, "мобу");
+					case MOB_TRIGGER: cmd_text += "мобу";
 						break;
-					case OBJ_TRIGGER: strcat(buf2, "предмету");
+					case OBJ_TRIGGER: cmd_text += "предмету";
 						break;
 					case WLD_TRIGGER:
-						sprintf(buf2 + strlen(buf2),
-								"комнате %d [%s]", item->cmd.arg3, name_by_vnum(item->cmd.arg3, ROOM_NAME));
+						cmd_text += fmt::format(
+								"комнате {} [{}]", item->cmd.arg3, name_by_vnum(item->cmd.arg3, ROOM_NAME));
 						hl = (item->cmd.arg3 == room);
 						break;
-					default: strcat(buf2, "???");
+					default: cmd_text += "???";
 						break;
 				}
 				break;
 
 			case 'V':
 				switch (item->cmd.arg1) {
-					case MOB_TRIGGER: strcpy(buf2, "для моба ");
+					case MOB_TRIGGER: cmd_text = "для моба ";
 						break;
-					case OBJ_TRIGGER: strcpy(buf2, "для предмета ");
+					case OBJ_TRIGGER: cmd_text = "для предмета ";
 						break;
 					case WLD_TRIGGER:
-						sprintf(buf2,
-								"для комнаты %d [%s] ",
+						cmd_text = fmt::format(
+								"для комнаты {} [{}] ",
 								item->cmd.arg2,
 								name_by_vnum(item->cmd.arg2, ROOM_NAME));
 						hl = (item->cmd.arg2 == room);
 						break;
-					default: strcpy(buf2, "для??? ");
+					default: cmd_text = "для??? ";
 						break;
 				}
-				sprintf(buf2 + strlen(buf2),
-						"установить глобальную переменную %s:%d = %s",
-						item->cmd.sarg1, item->cmd.arg3, item->cmd.sarg2);
+				cmd_text += fmt::format(
+						"установить глобальную переменную {}:{} = {}",
+						item->cmd.sarg1 ? item->cmd.sarg1 : "",
+						item->cmd.arg3,
+						item->cmd.sarg2 ? item->cmd.sarg2 : "");
 				break;
 
-			default: strcpy(buf2, "<Неизвестная команда>");
+			default: cmd_text = "<Неизвестная команда>";
 				break;
 
 		}
 
 		// Build the display buffer for this command
 		if ((show_all && start <= counter && stop > counter) || (!show_all && hl)) {
-			snprintf(buf1, kMaxStringLength, "%s%d - %s%s%s\r\n", nrm, counter, hl ? iyel : yel,
-					 if_flag_text(item->cmd.if_flag), buf2);
-			strcat(buf, buf1);
+			out += fmt::format("{}{} - {}{}{}\r\n", nrm, counter, hl ? iyel : yel,
+					 if_flag_text(item->cmd.if_flag), cmd_text);
 		}
 	}
 
 	// Последняя команда
 	if (!show_all || (start <= counter && stop > counter)) {
-		sprintf(buf1, "%s%d - <END>\r\n", nrm, counter);
-		strcat(buf, buf1);
+		out += fmt::format("{}{} - <END>\r\n", nrm, counter);
 	}
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(out, d->character.get());
 	return;
 }
 
 // the main menu
 void zedit_disp_menu(DescriptorData *d) {
-//	char *buf = (char *) malloc(32 * 1024);
-	char *type1_zones = (char *) malloc(1024);
-	char *type2_zones = (char *) malloc(1024);
+	std::string menu;
 	int i;
-	type1_zones[0] = '\0';
-	type2_zones[0] = '\0';
+	// Списки зон собирались перекладыванием через общий буфер (buf -> type1_zones и обратно),
+	// причём буферы брались из malloc и освобождались в конце. Теперь просто строки.
+	std::string type1_zones;
+	std::string type2_zones;
 	for (i = 0; i < OLC_ZONE(d)->typeA_count; i++) {
-		sprintf(buf, "%s %d", type1_zones, OLC_ZONE(d)->typeA_list[i]);
-		snprintf(type1_zones, 1024, "%s", buf);
+		type1_zones += fmt::format(" {}", OLC_ZONE(d)->typeA_list[i]);
 	}
 	for (i = 0; i < OLC_ZONE(d)->typeB_count; i++) {
-		sprintf(buf, "%s %d", type2_zones, OLC_ZONE(d)->typeB_list[i]);
-		snprintf(type2_zones, 1024, "%s", buf);
+		type2_zones += fmt::format(" {}", OLC_ZONE(d)->typeB_list[i]);
 	}
 
 	// Menu header
-	sprintf(buf,
+	SendMsgToChar(fmt::format(
 #if defined(CLEAR_SCREEN)
 		"[H[J"
 #endif
-			"Room number: %s%d%s		Room zone: %s%d\r\n"
-			"%sZ%s) Имя зоны         : %s%s\r\n"
-			"%sC%s) Комментарий      : %s%s\r\n"
-			"%sW%s) Местоположение   : %s%s\r\n"
-			"%sO%s) Описание         : %s%s\r\n"
-			"%sU%s) Автор зоны       : %s%s\r\n"
-			"%sS%s) Уровень зоны     : %s%d (качество ингридиентов)\r\n"
-			"%sY%s) Тип зоны         : %s%s\r\n"
-			"%sL%s) Время жизни      : %s%d minutes\r\n"
-			"%sR%s) Тип очистки      : %s%s\r\n"
-			"%sI%s) Оч. никто не был : %s%s%s\r\n",
+			"Room number: {}{}{}		Room zone: {}{}\r\n"
+			"{}Z{}) Имя зоны         : {}{}\r\n"
+			"{}C{}) Комментарий      : {}{}\r\n"
+			"{}W{}) Местоположение   : {}{}\r\n"
+			"{}O{}) Описание         : {}{}\r\n"
+			"{}U{}) Автор зоны       : {}{}\r\n"
+			"{}S{}) Уровень зоны     : {}{} (качество ингридиентов)\r\n"
+			"{}Y{}) Тип зоны         : {}{}\r\n"
+			"{}L{}) Время жизни      : {}{} minutes\r\n"
+			"{}R{}) Тип очистки      : {}{}\r\n"
+			"{}I{}) Оч. никто не был : {}{}{}\r\n",
 			cyn,
 			OLC_NUM(d),
 			nrm,
@@ -926,13 +929,14 @@ void zedit_disp_menu(DescriptorData *d) {
 			nrm,
 			yel,
 			OLC_ZONE(d)->reset_idle ? "Да" : "Нет",
-			nrm);
-	SendMsgToChar(buf, d->character.get());
+			nrm),
+				  d->character.get());
 	if (OLC_ZONE(d)->reset_mode == 3) {
-		snprintf(buf, kMaxStringLength, "%sA%s) Зоны первого типа       : %s%s%s\r\n"
-										 "%sB%s) Зоны второго типа       : %s%s%s\r\n",
-				 grn, nrm, ired, type1_zones, nrm, grn, nrm, grn, type2_zones, nrm);
-		SendMsgToChar(buf, d->character.get());
+		SendMsgToChar(fmt::format("{}A{}) Зоны первого типа       : {}{}{}\r\n"
+								  "{}B{}) Зоны второго типа       : {}{}{}\r\n",
+								  grn, nrm, ired, type1_zones, nrm,
+								  grn, nrm, grn, type2_zones, nrm),
+					  d->character.get());
 	}
 	SendMsgToChar(fmt::format("{}T{}) Режим            : {}{}{}\r\n",
 								  grn, nrm, yel, OLC_ZONE(d)->under_construction ? "ТЕСТИРУЕТСЯ" : "подключена", nrm),
@@ -949,31 +953,29 @@ void zedit_disp_menu(DescriptorData *d) {
 	// Finish off menu
 	if (d->olc->bitmask & OLC_BM_SHOWALLCMD) {
 		// Режим отображения всех команд
-		sprintf(buf1,
-				"%sF%s) Фильтр - ВСЕ КОМАНДЫ   %s8%s) Вверх\r\n"
-				"%sN%s) Добавить команду       %s2%s) Вниз\r\n"
-				"%sE%s) Редактировать команду  %s9%s) Страница вверх\r\n"
-				"%sM%s) Перенести команду      %s3%s) Страница вниз\r\n"
-				"%sD%s) Удалить команду        %s7%s) В начало списка\r\n"
-				"%sX%s) Выход                  %s1%s) В конец списка\r\n"
+		menu = fmt::format(
+				"{}F{}) Фильтр - ВСЕ КОМАНДЫ   {}8{}) Вверх\r\n"
+				"{}N{}) Добавить команду       {}2{}) Вниз\r\n"
+				"{}E{}) Редактировать команду  {}9{}) Страница вверх\r\n"
+				"{}M{}) Перенести команду      {}3{}) Страница вниз\r\n"
+				"{}D{}) Удалить команду        {}7{}) В начало списка\r\n"
+				"{}X{}) Выход                  {}1{}) В конец списка\r\n"
 				"Ваш выбор : ",
 				grn, nrm, grn, nrm,
 				grn, nrm, grn, nrm,
 				grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm);
 	} else {
 		// Режим отображения команд комнаты
-		sprintf(buf1,
-				"%sF%s) Фильтр - КОМАНДЫ КОМНАТЫ\r\n"
-				"%sN%s) Добавить команду\r\n"
-				"%sE%s) Редактировать команду\r\n"
-				"%sM%s) Перенести команду\r\n"
-				"%sD%s) Удалить команду\r\n"
-				"%sX%s) Выход\r\n" "Ваш выбор : ", grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm);
+		menu = fmt::format(
+				"{}F{}) Фильтр - КОМАНДЫ КОМНАТЫ\r\n"
+				"{}N{}) Добавить команду\r\n"
+				"{}E{}) Редактировать команду\r\n"
+				"{}M{}) Перенести команду\r\n"
+				"{}D{}) Удалить команду\r\n"
+				"{}X{}) Выход\r\n" "Ваш выбор : ", grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm);
 	}
 
-	SendMsgToChar(buf1, d->character.get());
-	free(type1_zones);
-	free(type2_zones);
+	SendMsgToChar(menu, d->character.get());
 
 	OLC_MODE(d) = ZEDIT_MAIN_MENU;
 }
@@ -1001,23 +1003,24 @@ void zedit_disp_type_menu(DescriptorData *d) {
 
 // * Print the command type menu and setup response catch.
 void zedit_disp_comtype(DescriptorData *d) {
+	std::string buf_out;
 	pzcmd item = SEEK_CMD(d);
 	SendMsgToChar("\r\n", d->character.get());
-	sprintf(buf,
+	buf_out = fmt::format(
 #if defined(CLEAR_SCREEN)
 		"[H[J"
 #endif
-			"%sM%s) Загрузить моба в комнату        %sO%s) Загрузить предмет в комнату\r\n"
-			"%sE%s) Экипировать моба                %sG%s) Дать предмет мобу\r\n"
-			"%sP%s) Поместить предмет в контейнер   %sD%s) Установить выход\r\n"
-			"%sR%s) Удалить предмет из комнаты      %sQ%s) Удалить всех мобов данного типа\r\n"
-			"%sF%s) Создать цепочку последователей\r\n"
-			"%sT%s) Назначить тригер                %sV%s) Установить глобальную переменную\r\n"
-			"Редактируемая команда : %c\r\n"
+			"{}M{}) Загрузить моба в комнату        {}O{}) Загрузить предмет в комнату\r\n"
+			"{}E{}) Экипировать моба                {}G{}) Дать предмет мобу\r\n"
+			"{}P{}) Поместить предмет в контейнер   {}D{}) Установить выход\r\n"
+			"{}R{}) Удалить предмет из комнаты      {}Q{}) Удалить всех мобов данного типа\r\n"
+			"{}F{}) Создать цепочку последователей\r\n"
+			"{}T{}) Назначить тригер                {}V{}) Установить глобальную переменную\r\n"
+			"Редактируемая команда : {}\r\n"
 			"Укажите тип команды   : ",
 			grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm,
 			grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm, grn, nrm, item->cmd.command);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(buf_out, d->character.get());
 	OLC_MODE(d) = ZEDIT_COMMAND_TYPE;
 }
 
@@ -1027,6 +1030,7 @@ void zedit_disp_comtype(DescriptorData *d) {
  * up the input catch clause
  */
 void zedit_disp_arg1(DescriptorData *d) {
+	std::string buf_out;
 	pzcmd item = SEEK_CMD(d);
 
 	SendMsgToChar("\r\n", d->character.get());
@@ -1034,9 +1038,9 @@ void zedit_disp_arg1(DescriptorData *d) {
 	switch (item->cmd.command) {
 		case 'M':
 		case 'Q':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор моба\r\n"
-					"Текущий моб  : %d [%s]\r\n" "Введите номер: ",
+					"Текущий моб  : {} [{}]\r\n" "Введите номер: ",
 					item->cmd.arg1,
 					name_by_vnum(item->cmd.arg1, MOB_NAME));
 			break;
@@ -1045,9 +1049,9 @@ void zedit_disp_arg1(DescriptorData *d) {
 		case 'E':
 		case 'P':
 		case 'G':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор предмета\r\n"
-					"Текущий предмет: %d [%s]\r\n" "Введите номер  : ",
+					"Текущий предмет: {} [{}]\r\n" "Введите номер  : ",
 					item->cmd.arg1,
 					name_by_vnum(item->cmd.arg1, OBJ_NAME));
 			break;
@@ -1057,19 +1061,19 @@ void zedit_disp_arg1(DescriptorData *d) {
 		case 'F':
 			if (item->cmd.arg1 == -1)
 				item->cmd.arg1 = OLC_NUM(d);
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор комнаты\r\n"
-					"Текущая комната: %d [%s]\r\n" "Введите номер  : ",
+					"Текущая комната: {} [{}]\r\n" "Введите номер  : ",
 					item->cmd.arg1,
 					name_by_vnum(item->cmd.arg1, ROOM_NAME));
 			break;
 
 		case 'T':
 		case 'V':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор типа триггера\r\n"
 					"  0 - моб\r\n"
-					"  1 - предмет\r\n" "  2 - комната\r\n" "Текущий тип: %d\r\n" "Введите тип: ", item->cmd.arg1);
+					"  1 - предмет\r\n" "  2 - комната\r\n" "Текущий тип: {}\r\n" "Введите тип: ", item->cmd.arg1);
 			break;
 
 		default:
@@ -1079,7 +1083,7 @@ void zedit_disp_arg1(DescriptorData *d) {
 			SendMsgToChar("Oops...\r\n", d->character.get());
 			return;
 	}
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(buf_out, d->character.get());
 	OLC_MODE(d) = ZEDIT_ARG1;
 }
 
@@ -1089,6 +1093,7 @@ void zedit_disp_arg1(DescriptorData *d) {
  * up the input catch clause.
  */
 void zedit_disp_arg2(DescriptorData *d) {
+	std::string buf_out;
 	pzcmd item = SEEK_CMD(d);
 
 	int i = 0;
@@ -1096,45 +1101,45 @@ void zedit_disp_arg2(DescriptorData *d) {
 	SendMsgToChar("\r\n", d->character.get());
 
 	switch (item->cmd.command) {
-		case 'P':sprintf(buf, "Комната в которой искать контейнер (0 искать по всему миру)\r\n"
-					"Текущее значение: %d\r\n" "Введите номер: ", item->cmd.arg2);
+		case 'P':buf_out = fmt::format("Комната в которой искать контейнер (0 искать по всему миру)\r\n"
+					"Текущее значение: {}\r\n" "Введите номер: ", item->cmd.arg2);
 			break;
 		case 'M':
 		case 'O':
 		case 'E':
 		case 'G':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Максимальное количество в мире\r\n"
-					"Текущее значение: %d\r\n" "Введите значение: ", item->cmd.arg2);
+					"Текущее значение: {}\r\n" "Введите значение: ", item->cmd.arg2);
 			break;
 
-		case 'D': sprintf(buf, "Выбор направления выхода\r\n");
+		case 'D': buf_out = fmt::format("Выбор направления выхода\r\n");
 			for (i = 0; *dirs[i] != '\n'; ++i)
-				sprintf(buf + strlen(buf), "   %d - %s\r\n", i, dirs[i]);
-			sprintf(buf + strlen(buf),
-					"Текущее направление выхода: %d\r\n" "Введите направление выхода: ", item->cmd.arg2);
+				buf_out += fmt::format("   {} - {}\r\n", i, dirs[i]);
+			buf_out += fmt::format(
+					"Текущее направление выхода: {}\r\n" "Введите направление выхода: ", item->cmd.arg2);
 			break;
 
 		case 'R':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор предмета\r\n"
-					"Текущий предмет: %d [%s]\r\n" "Введите номер: ",
+					"Текущий предмет: {} [{}]\r\n" "Введите номер: ",
 					item->cmd.arg2,
 					name_by_vnum(item->cmd.arg2, OBJ_NAME));
 			break;
 
 		case 'F':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор моба-лидера\r\n"
-					"Текущий моб  : %d [%s]\r\n" "Введите номер: ",
+					"Текущий моб  : {} [{}]\r\n" "Введите номер: ",
 					item->cmd.arg2,
 					name_by_vnum(item->cmd.arg2, MOB_NAME));
 			break;
 
 		case 'T':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор триггера\r\n"
-					"Текущий триггер: %d [%s]\r\n" "Введите номер: ",
+					"Текущий триггер: {} [{}]\r\n" "Введите номер: ",
 					item->cmd.arg2,
 					name_by_vnum(item->cmd.arg2, TRIG_NAME));
 			break;
@@ -1142,9 +1147,9 @@ void zedit_disp_arg2(DescriptorData *d) {
 		case 'V':
 			if (item->cmd.arg2 == -1)
 				item->cmd.arg2 = OLC_NUM(d);
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор комнаты\r\n"
-					"Текущая комната: %d [%s]\r\n" "Введите номер: ",
+					"Текущая комната: {} [{}]\r\n" "Введите номер: ",
 					item->cmd.arg2,
 					name_by_vnum(item->cmd.arg2, ROOM_NAME));
 			break;
@@ -1158,7 +1163,7 @@ void zedit_disp_arg2(DescriptorData *d) {
 			return;
 	}
 
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(buf_out, d->character.get());
 	OLC_MODE(d) = ZEDIT_ARG2;
 }
 
@@ -1169,6 +1174,7 @@ void zedit_disp_arg2(DescriptorData *d) {
  * up the input catch clause.
  */
 void zedit_disp_arg3(DescriptorData *d) {
+	std::string buf_out;
 	pzcmd item = SEEK_CMD(d);
 
 	int i = 0;
@@ -1176,40 +1182,40 @@ void zedit_disp_arg3(DescriptorData *d) {
 	SendMsgToChar("\r\n", d->character.get());
 
 	switch (item->cmd.command) {
-		case 'E': sprintf(buf, "Выбор позиции\r\n");
+		case 'E': buf_out = fmt::format("Выбор позиции\r\n");
 			for (i = 0; *equipment_types[i] != '\n'; ++i)
-				sprintf(buf + strlen(buf), "   %2d - %s\r\n", i, equipment_types[i]);
-			sprintf(buf + strlen(buf), "Текущая позиция: %d\r\n" "Введите позицию: ", item->cmd.arg3);
+				buf_out += fmt::format("   {:2} - {}\r\n", i, equipment_types[i]);
+			buf_out += fmt::format("Текущая позиция: {}\r\n" "Введите позицию: ", item->cmd.arg3);
 			break;
 
 		case 'P':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор контейнера\r\n"
-					"Текущий предмет: %d [%s]\r\n" "Введите номер  : ",
+					"Текущий предмет: {} [{}]\r\n" "Введите номер  : ",
 					item->cmd.arg3,
 					name_by_vnum(item->cmd.arg3, OBJ_NAME));
 			break;
 
 		case 'D':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор состояния двери\r\n"
 					"  0 - Дверь открыта\r\n"
 					"  1 - Дверь закрыта\r\n"
 					"  2 - Дверь заперта\r\n"
 					"  3 - Выход скрыт\r\n"
-					"  4 - Выход явный\r\n" "Текущее состояние: %d\r\n" "Введите состояние: ", item->cmd.arg3);
+					"  4 - Выход явный\r\n" "Текущее состояние: {}\r\n" "Введите состояние: ", item->cmd.arg3);
 			break;
 
 		case 'V':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор контекста переменной\r\n"
-					"Текущий контекст: %d\r\n" "Введите контекст: ", item->cmd.arg3);
+					"Текущий контекст: {}\r\n" "Введите контекст: ", item->cmd.arg3);
 			break;
 
 		case 'F':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор моба-последователя\r\n"
-					"Текущий моб  : %d [%s]\r\n" "Введите номер: ",
+					"Текущий моб  : {} [{}]\r\n" "Введите номер: ",
 					item->cmd.arg3,
 					name_by_vnum(item->cmd.arg3, MOB_NAME));
 			break;
@@ -1219,9 +1225,9 @@ void zedit_disp_arg3(DescriptorData *d) {
 		case 'T':
 			if (item->cmd.arg3 == -1)
 				item->cmd.arg3 = OLC_NUM(d);
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор комнаты\r\n"
-					"Текущая комната: %d [%s]\r\n" "Введите номер  : ",
+					"Текущая комната: {} [{}]\r\n" "Введите номер  : ",
 					item->cmd.arg3,
 					name_by_vnum(item->cmd.arg3, ROOM_NAME));
 			break;
@@ -1237,29 +1243,30 @@ void zedit_disp_arg3(DescriptorData *d) {
 			return;
 	}
 
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(buf_out, d->character.get());
 	OLC_MODE(d) = ZEDIT_ARG3;
 }
 
 void zedit_disp_arg4(DescriptorData *d) {
+	std::string buf_out;
 	pzcmd item = SEEK_CMD(d);
 
 	SendMsgToChar("\r\n", d->character.get());
 
 	switch (item->cmd.command) {
 		case 'M':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Максимальное количество в комнате\r\n"
-					"Текущее значение: %d\r\n" "Введите значение: ", item->cmd.arg4);
+					"Текущее значение: {}\r\n" "Введите значение: ", item->cmd.arg4);
 			break;
 
 		case 'O':
 		case 'E':
 		case 'P':
 		case 'G':
-			sprintf(buf,
-					"Вероятность загрузки (-1 = 100%%)\r\n"
-					"Текущее значение: %d\r\n" "Введите значение: ", item->cmd.arg4);
+			buf_out = fmt::format(
+					"Вероятность загрузки (-1 = 100%)\r\n"
+					"Текущее значение: {}\r\n" "Введите значение: ", item->cmd.arg4);
 			break;
 
 		case 'Q':
@@ -1276,20 +1283,21 @@ void zedit_disp_arg4(DescriptorData *d) {
 			return;
 	}
 
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(buf_out, d->character.get());
 	OLC_MODE(d) = ZEDIT_ARG4;
 }
 
 void zedit_disp_sarg1(DescriptorData *d) {
+	std::string buf_out;
 	pzcmd item = SEEK_CMD(d);
 
 	SendMsgToChar("\r\n", d->character.get());
 
 	switch (item->cmd.command) {
 		case 'V':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор имени глобальной переменной\r\n"
-					"Текущее имя: %s\r\n" "Введите имя: ", item->cmd.sarg1 ? item->cmd.sarg1 : "<NULL>");
+					"Текущее имя: {}\r\n" "Введите имя: ", item->cmd.sarg1 ? item->cmd.sarg1 : "<NULL>");
 			break;
 
 		case 'M':
@@ -1310,20 +1318,21 @@ void zedit_disp_sarg1(DescriptorData *d) {
 			return;
 	}
 
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(buf_out, d->character.get());
 	OLC_MODE(d) = ZEDIT_SARG1;
 }
 
 void zedit_disp_sarg2(DescriptorData *d) {
+	std::string buf_out;
 	pzcmd item = SEEK_CMD(d);
 
 	SendMsgToChar("\r\n", d->character.get());
 
 	switch (item->cmd.command) {
 		case 'V':
-			sprintf(buf,
+			buf_out = fmt::format(
 					"Выбор значения глобальной переменной\r\n"
-					"Текущее значение: %s\r\n" "Введите значение: ", item->cmd.sarg2 ? item->cmd.sarg2 : "<NULL>");
+					"Текущее значение: {}\r\n" "Введите значение: ", item->cmd.sarg2 ? item->cmd.sarg2 : "<NULL>");
 			break;
 
 		case 'M':
@@ -1344,7 +1353,7 @@ void zedit_disp_sarg2(DescriptorData *d) {
 			return;
 	}
 
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(buf_out, d->character.get());
 	OLC_MODE(d) = ZEDIT_SARG2;
 }
 
@@ -1373,9 +1382,10 @@ void zedit_parse(DescriptorData *d, char *arg) {
 					// * Save the zone in memory, hiding invisible people.
 					SendMsgToChar("Зона сохранена.\r\n", d->character.get());
 					zedit_save_internally(d);
-					sprintf(buf, "OLC: %s edits zone info for room %d.", GET_NAME(d->character), OLC_NUM(d));
+					mudlog(fmt::format("OLC: {} edits zone info for room {}.",
+									   GET_NAME(d->character), OLC_NUM(d)),
+						   NRM, MAX(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
 					olc_log("%s edit zone %d", GET_NAME(d->character), OLC_NUM(d));
-					mudlog(buf, NRM, MAX(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
 					// FALL THROUGH
 				case 'n':
 				case 'N':
@@ -1579,14 +1589,14 @@ void zedit_parse(DescriptorData *d, char *arg) {
 			if (!item->cmd.command || (strchr("MFQOPEDGRTV", item->cmd.command) == nullptr))
 				SendMsgToChar("Неверный выбор, повторите : ", d->character.get());
 			else {
-				sprintf(buf,
+				SendMsgToChar(fmt::format(
 						"Режимы исполнения команды:\r\n"
 						"  0 - выполняется всегда\r\n"
 						"  1 - выполняется только в случае успешного выполнения предыдущей\r\n"
 						"  2 - выполняется всегда, не изменяет признак успешного выполнения\r\n"
 						"  3 - выполняется только в случае успешного выполнения предыдущей, не изменяет признак успешного выполнения\r\n"
-						"Текущий режим  : %d\r\n" "Выберите режим : ", item->cmd.if_flag);
-				SendMsgToChar(buf, d->character.get());
+						"Текущий режим  : {}\r\n" "Выберите режим : ", item->cmd.if_flag),
+							  d->character.get());
 				OLC_MODE(d) = ZEDIT_IF_FLAG;
 			}
 			break;


### PR DESCRIPTION
Два редактора сразу: **zedit — 92 → 0, redit — 81 → 0.** Взял их вместе, потому что проверяются они одинаково — обходом меню.

Меню и приглашения (главное меню комнаты, флаги комнаты, меню выхода, флаги двери, экстраописания; главное меню зоны, список команд, тип команды и все приглашения аргументов) собираются `fmt::format` и уходят одной строкой.

## Места, где пришлось думать

**Список команд зоны** собирал описание каждой команды в `buf2` — вперемешку присваиванием (`sprintf`) и дописыванием (`strcat`), — потом строку в `buf1`, и всё вместе в `buf`. Теперь две локальные строки, и присваивание с дописыванием разведены ровно так, как было (это тот самый шаг, на котором механическая замена «всё в `+=`» ломает вывод).

**В главном меню зоны** списки зон первого и второго типа перекладывались через общий буфер:

```c
sprintf(buf, "%s %d", type1_zones, OLC_ZONE(d)->typeA_list[i]);
snprintf(type1_zones, 1024, "%s", buf);
```

причём сами приёмники брались `malloc(1024)` и освобождались в конце функции. Теперь обычные строки, `malloc`/`free` ушли.

**Запись legacy-файлов** — имена файлов и описания через строки; приёмники `flags_tascii`/`flags_sprint` остались локальными char-буферами, им нужен `char *`. Заодно `strip_string` в redit перешёл на строковую форму из прошлого PR.

## Про нулевые указатели

Опять тот же капкан: `name_by_vnum` для комнаты отдавала `world[rnum]->name`, а он у комнаты без имени нулевой (конструктор `RoomData` ставит `nullptr`). `printf("%s")` печатал `(null)`, `fmt` бросает исключение. Теперь возвращается документированное `"???"`. Так же прикрыты `sarg1`/`sarg2` у команды `V` (глобальная переменная зоны).

## Чего я НЕ проверял вживую

Обе функции `*_save_to_disk`. Это путь только для legacy-формата мира (`legacy_world_data_source.cpp`), а тестовый мир — YAML, до них не добраться без отдельной сборки с `-Dyaml=disabled`. Формат записи не менялся, менялось только чем собирается строка — но проверено это чтением, а не запуском.

## Проверено вживую

Обход меню: `redit` (главное, флаги комнаты, выход, флаги двери, экстраописания), `zedit` (главное меню, список команд в обоих режимах фильтра, правка команды), выход без сохранения. **280 строк вывода на `master` и на этой ветке совпадают полностью**, без исключений и нормализации.

Сборка без предупреждений, **712 тестов** зелёные.

Часть #3814, родительская задача #3807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
