### PR TITLE
refactor(named): drop global buffers from named items and reload (#3814)

### DIFF
--- a/src/engine/ui/cmd_god/do_reload.cpp
+++ b/src/engine/ui/cmd_god/do_reload.cpp
@@ -34,12 +34,13 @@
 extern char *help;
 
 void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-	argument = one_argument(argument, arg);
+	char target[kMaxInputLength];
+	argument = one_argument(argument, target);
 
 	// issue.thing-names: list the available reload targets when called with no argument. Option names
 	// avoid '_' on purpose -- the client renders '_' as a space, which is ambiguous (is "spell
 	// messages" one option or two?), so e.g. spellmsg / skillmsg / hitmsg / mobclasses.
-	if (!*arg) {
+	if (!*target) {
 		SendMsgToChar(
 			"Usage: reload <what>. Available targets:\r\n"
 			"  all  *  -- everything below\r\n"
@@ -54,7 +55,7 @@ void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	if (!str_cmp(arg, "all") || *arg == '*') {
+	if (!str_cmp(target, "all") || *target == '*') {
 		AllocateBufferForFile(HELP_PAGE_FILE, &help);
 		MUD::CfgManager().ReloadCfg("system_msg");
 		MUD::CfgManager().ReloadCfg("affect_msg");
@@ -85,72 +86,72 @@ void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		Bonus::bonus_log_load();
 		MUD::CfgManager().ReloadCfg("daily_quest");   // issue.daily-quest
 		MUD::CfgManager().ReloadCfg("obj_affects");   // issue.obj-affects
-	} else if (!str_cmp(arg, "portals")) {
+	} else if (!str_cmp(target, "portals")) {
 		MUD::CfgManager().ReloadCfg("rune_stone_msg");
 		MUD::CfgManager().ReloadCfg("rune_stones");
 		MUD::Runestones().SpawnStones();   // phase 3: (re)place physical stones for any new rooms
-	} else if (!str_cmp(arg, "abilities")) {
+	} else if (!str_cmp(target, "abilities")) {
 		MUD::CfgManager().ReloadCfg("abilities");
-	} else if (!str_cmp(arg, "stableobjs")) {
+	} else if (!str_cmp(target, "stableobjs")) {
 		MUD::CfgManager().ReloadCfg("stable_objs");
-	} else if (!str_cmp(arg, "skills")) {
+	} else if (!str_cmp(target, "skills")) {
 		MUD::CfgManager().ReloadCfg("skills");
-	} else if (!str_cmp(arg, "spells")) {
+	} else if (!str_cmp(target, "spells")) {
 		MUD::CfgManager().ReloadCfg("spells");
-	} else if (!str_cmp(arg, "spellmsg")) {
+	} else if (!str_cmp(target, "spellmsg")) {
 		MUD::CfgManager().ReloadCfg("spell_msg");
-	} else if (!str_cmp(arg, "objaffects")) {
+	} else if (!str_cmp(target, "objaffects")) {
 		MUD::CfgManager().ReloadCfg("obj_affects");   // issue.obj-affects
-	} else if (!str_cmp(arg, "skillmsg")) {
+	} else if (!str_cmp(target, "skillmsg")) {
 		MUD::CfgManager().ReloadCfg("skill_msg");
-    } else if (!str_cmp(arg, "hitmsg")) {
+    } else if (!str_cmp(target, "hitmsg")) {
         MUD::CfgManager().ReloadCfg("hit_msg");
-	} else if (!str_cmp(arg, "affectmsg")) {
+	} else if (!str_cmp(target, "affectmsg")) {
 		MUD::CfgManager().ReloadCfg("affect_msg");
-	} else if (!str_cmp(arg, "roomaffectmsg")) {
+	} else if (!str_cmp(target, "roomaffectmsg")) {
 		MUD::CfgManager().ReloadCfg("room_affect_msg");
-	} else if (!str_cmp(arg, "feats")) {
+	} else if (!str_cmp(target, "feats")) {
 		MUD::CfgManager().ReloadCfg("feats");
-	} else if (!str_cmp(arg, "animatedead")) {
+	} else if (!str_cmp(target, "animatedead")) {
 		MUD::CfgManager().ReloadCfg("animate_dead");   // issue.animate-dead
-	} else if (!str_cmp(arg, "classes")) {
+	} else if (!str_cmp(target, "classes")) {
 		MUD::CfgManager().ReloadCfg("pc_classes");
-	} else if (!str_cmp(arg, "mobclasses")) {
+	} else if (!str_cmp(target, "mobclasses")) {
 		MUD::CfgManager().ReloadCfg("mob_classes");
-	} else if (!str_cmp(arg, "guilds")) {
+	} else if (!str_cmp(target, "guilds")) {
 		MUD::CfgManager().ReloadCfg("guilds");
-	} else if (!str_cmp(arg, "cities")) {
+	} else if (!str_cmp(target, "cities")) {
 		MUD::CfgManager().ReloadCfg("cities_msg");
 		MUD::CfgManager().ReloadCfg("cities");
-	} else if (!str_cmp(arg, "regions")) {
+	} else if (!str_cmp(target, "regions")) {
 		MUD::CfgManager().ReloadCfg("region_msg");
 		MUD::CfgManager().ReloadCfg("regions");
-	} else if (!str_cmp(arg, "pcraces")) {
+	} else if (!str_cmp(target, "pcraces")) {
 		MUD::CfgManager().ReloadCfg("pc_race_msg");
 		MUD::CfgManager().ReloadCfg("pc_races");
-	} else if (!str_cmp(arg, "currencies")) {
+	} else if (!str_cmp(target, "currencies")) {
 		MUD::CfgManager().ReloadCfg("currencies");
-	} else if (!str_cmp(arg, "imagic"))
+	} else if (!str_cmp(target, "imagic"))
 		initIngredientsMagic();
-	else if (!str_cmp(arg, "ztypes"))
+	else if (!str_cmp(target, "ztypes"))
 		MUD::CfgManager().ReloadCfg("zone_types");
-	else if (!str_cmp(arg, "runes"))
+	else if (!str_cmp(target, "runes"))
 		MUD::CfgManager().ReloadCfg("rune_spells");
-	else if (!str_cmp(arg, "oloadtable"))
+	else if (!str_cmp(target, "oloadtable"))
 		oload_table.init();
-	else if (!str_cmp(arg, "systemmsg"))
+	else if (!str_cmp(target, "systemmsg"))
 		MUD::CfgManager().ReloadCfg("system_msg");
-	else if (!str_cmp(arg, "help"))
+	else if (!str_cmp(target, "help"))
 		AllocateBufferForFile(HELP_PAGE_FILE, &help);
-	else if (!str_cmp(arg, "xhelp")) {
+	else if (!str_cmp(target, "xhelp")) {
 		HelpSystem::reload_all();
-	} else if (!str_cmp(arg, "socials"))
+	} else if (!str_cmp(target, "socials"))
 		MUD::CfgManager().ReloadCfg("social_msg");
-	else if (!str_cmp(arg, "specials"))
+	else if (!str_cmp(target, "specials"))
 		ReloadSpecProcs();
-	else if (!str_cmp(arg, "schedule"))
+	else if (!str_cmp(target, "schedule"))
 		LoadSheduledReboot();
-	else if (!str_cmp(arg, "clan")) {
+	else if (!str_cmp(target, "clan")) {
 		skip_spaces(&argument);
 		if (!*argument) {
 			Clan::ClanLoad();
@@ -166,20 +167,20 @@ void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				break;
 			}
 		}
-	} else if (!str_cmp(arg, "proxy"))
+	} else if (!str_cmp(target, "proxy"))
 		RegisterSystem::LoadProxyList();
-	else if (!str_cmp(arg, "boards"))
+	else if (!str_cmp(target, "boards"))
 		Boards::Static::reload_all();
-	else if (!str_cmp(arg, "titles"))
+	else if (!str_cmp(target, "titles"))
 		TitleSystem::load_title_list();
-	else if (!str_cmp(arg, "emails"))
+	else if (!str_cmp(target, "emails"))
 		RegisterSystem::load();
-	else if (!str_cmp(arg, "privilege")) {
+	else if (!str_cmp(target, "privilege")) {
 		MUD::CfgManager().ReloadCfg("privilege");
 	}
-	else if (!str_cmp(arg, "mobraces"))
+	else if (!str_cmp(target, "mobraces"))
 		MUD::CfgManager().ReloadCfg("mob_races");
-	else if (!str_cmp(arg, "depot") && ch->IsFlagged(EPrf::kCoderinfo)) {
+	else if (!str_cmp(target, "depot") && ch->IsFlagged(EPrf::kCoderinfo)) {
 		skip_spaces(&argument);
 		if (*argument) {
 			long uid = GetUniqueByName(argument);
@@ -192,49 +193,49 @@ void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		} else {
 			SendMsgToChar("Формат команды: reload depot <имя чара>.\r\n", ch);
 		}
-	} else if (!str_cmp(arg, "globaldrop")) {
+	} else if (!str_cmp(target, "globaldrop")) {
 		GlobalDrop::init();
-	} else if (!str_cmp(arg, "grouping")) {
+	} else if (!str_cmp(target, "grouping")) {
 		MUD::CfgManager().ReloadCfg("group_exp_handicap");
-	} else if (!str_cmp(arg, "offtop")) {
+	} else if (!str_cmp(target, "offtop")) {
 		offtop_system::Init();
-	} else if (!str_cmp(arg, "shop")) {
+	} else if (!str_cmp(target, "shop")) {
 		// Каталог наборов, а следом магазины: ShopItemSetsLoader::Reload сам зовет
 		// ShopExt::load(true). Звать load(true) отсюда мало -- внумы и цены живут в
 		// наборах, и правка в них иначе не доедет (issue #3700).
 		MUD::CfgManager().ReloadCfg("shop_item_sets");
-	} else if (!str_cmp(arg, "named")) {
+	} else if (!str_cmp(target, "named")) {
 		NamedStuff::load();
-	} else if (!str_cmp(arg, "celebrates")) {
+	} else if (!str_cmp(target, "celebrates")) {
 		MUD::CfgManager().ReloadCfg("celebrates");
-	} else if (!str_cmp(arg, "setsdrop") && ch->IsFlagged(EPrf::kCoderinfo)) {
+	} else if (!str_cmp(target, "setsdrop") && ch->IsFlagged(EPrf::kCoderinfo)) {
 		skip_spaces(&argument);
 		if (*argument && is_number(argument)) {
 			SetsDrop::reload(atoi(argument));
 		} else {
 			SetsDrop::reload();
 		}
-	} else if (!str_cmp(arg, "noobhelp")) {
+	} else if (!str_cmp(target, "noobhelp")) {
 		MUD::CfgManager().ReloadCfg("noob");
-	} else if (!str_cmp(arg, "resetstats")) {
+	} else if (!str_cmp(target, "resetstats")) {
 		MUD::CfgManager().ReloadCfg("reset_stats");
-	} else if (!str_cmp(arg, "remort")) {
+	} else if (!str_cmp(target, "remort")) {
 		MUD::CfgManager().ReloadCfg("remort");
-	} else if (!str_cmp(arg, "digging")) {
+	} else if (!str_cmp(target, "digging")) {
 		MUD::CfgManager().ReloadCfg("digging");
-	} else if (!str_cmp(arg, "guards")) {
+	} else if (!str_cmp(target, "guards")) {
 		MUD::CfgManager().ReloadCfg("guards");
-	} else if (!str_cmp(arg, "jewelry")) {
+	} else if (!str_cmp(target, "jewelry")) {
 		MUD::CfgManager().ReloadCfg("jewelry");
-	} else if (!str_cmp(arg, "makeitems")) {
+	} else if (!str_cmp(target, "makeitems")) {
 		MUD::CfgManager().ReloadCfg("item_creation");
-	} else if (!str_cmp(arg, "basic")) {
+	} else if (!str_cmp(target, "basic")) {
 		MUD::CfgManager().ReloadCfg("basic");
-	} else if (!str_cmp(arg, "objsets")) {
+	} else if (!str_cmp(target, "objsets")) {
 		MUD::CfgManager().ReloadCfg("obj_sets");
-	} else if (!str_cmp(arg, "cases")) {
+	} else if (!str_cmp(target, "cases")) {
 		MUD::CfgManager().ReloadCfg("cases");
-	} else if (!str_cmp(arg, "daily")) {
+	} else if (!str_cmp(target, "daily")) {
 		MUD::CfgManager().ReloadCfg("daily_quest");
 		SendMsgToChar(DailyQuest::GetLastLoadMessage(), ch);
 		SendMsgToChar("\r\n", ch);
@@ -243,8 +244,7 @@ void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	std::string str = fmt::format("{} reload {}.", ch->get_name(), arg);
-	mudlog(str.c_str(), NRM, kLvlImmortal, SYSLOG, true);
+	mudlog(fmt::format("{} reload {}.", ch->get_name(), target), NRM, kLvlImmortal, SYSLOG, true);
 
 	// issue.thing-names: some containers cache data from another file at build time, so reloading the
 	// source string file alone is not enough -- remind the admin to reload the dependent file too.
@@ -253,7 +253,7 @@ void DoReload(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		{"spellmsg", "Reminder: spell names are cached when spells.xml is loaded. "
 		                   "Run 'reload spells' as well for the name changes to take effect."},
 	};
-	if (const auto it = kReloadReminders.find(arg); it != kReloadReminders.end()) {
+	if (const auto it = kReloadReminders.find(target); it != kReloadReminders.end()) {
 		SendMsgToChar(it->second + "\r\n", ch);
 	}
 	SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);

--- a/src/gameplay/mechanics/named_stuff.cpp
+++ b/src/gameplay/mechanics/named_stuff.cpp
@@ -167,47 +167,47 @@ bool wear_msg(CharData *ch, ObjData *obj) {
 bool parse_nedit_menu(CharData *ch, char *arg) {
 	int num;
 	StuffNodePtr tmp_node(new stuff_node);
-	char i[256];
-	half_chop(arg, buf1, buf2);
-	i[0] = 0;
-	if (!*buf1) {
+	char param[kMaxInputLength], value[kMaxInputLength];
+	half_chop(arg, param, value);
+	if (!*param) {
 		return false;
 	}
-	if ((*buf1 < '1' || *buf1 > '8') && (native_text::first_char_code_lower(buf1) != rus::kVe
-			&& native_text::first_char_code_lower(buf1) != rus::kHa
-			&& native_text::first_char_code_lower(buf1) != rus::kU)) {
+	if ((*param < '1' || *param > '8') && (native_text::first_char_code_lower(param) != rus::kVe
+			&& native_text::first_char_code_lower(param) != rus::kHa
+			&& native_text::first_char_code_lower(param) != rus::kU)) {
 		// Печатаем символ целиком, а не первый байт: под UTF-8 русская буква в char не влезает,
 		// и игрок получал в ответ обломок вместо своей буквы (issue #3797).
 		SendMsgToChar(fmt::format("Неверный параметр {}!\r\n",
-								  std::string_view(buf1, native_text::char_bytes(buf1))), ch);
+								  std::string_view(param, native_text::char_bytes(param))), ch);
 		return false;
 	}
-	if (!*buf2 && native_text::first_char_code_lower(buf1) != rus::kVe
-		&& native_text::first_char_code_lower(buf1) != rus::kHa
-		&& native_text::first_char_code_lower(buf1) != rus::kU) {
-		if (*buf1 < '5' || *buf1 > '8') {
+	if (!*value && native_text::first_char_code_lower(param) != rus::kVe
+		&& native_text::first_char_code_lower(param) != rus::kHa
+		&& native_text::first_char_code_lower(param) != rus::kU) {
+		if (*param < '5' || *param > '8') {
 			SendMsgToChar("Не указан второй параметр!\r\n", ch);
 		} else {
-			switch (*buf1) {
-				case '5': snprintf(i, 256, "&S%s&s\r\n", ch->desc->named_obj->wear_msg_v.c_str());
+			std::string msg;
+			switch (*param) {
+				case '5': msg = fmt::format("&S{}&s\r\n", ch->desc->named_obj->wear_msg_v);
 					break;
-				case '6': snprintf(i, 256, "&S%s&s\r\n", ch->desc->named_obj->wear_msg_a.c_str());
+				case '6': msg = fmt::format("&S{}&s\r\n", ch->desc->named_obj->wear_msg_a);
 					break;
-				case '7': snprintf(i, 256, "&S%s&s\r\n", ch->desc->named_obj->cant_msg_v.c_str());
+				case '7': msg = fmt::format("&S{}&s\r\n", ch->desc->named_obj->cant_msg_v);
 					break;
-				case '8': snprintf(i, 256, "&S%s&s\r\n", ch->desc->named_obj->cant_msg_a.c_str());
+				case '8': msg = fmt::format("&S{}&s\r\n", ch->desc->named_obj->cant_msg_a);
 					break;
-				default: snprintf(i, 256, "&RОшибка.&n\r\n");
+				default: msg = "&RОшибка.&n\r\n";
 					break;
 			}
-			SendMsgToChar(i, ch);
+			SendMsgToChar(msg, ch);
 		}
 		return false;
 	}
 
-	switch (native_text::first_char_code_lower(buf1)) {
+	switch (native_text::first_char_code_lower(param)) {
 		case '1':
-			if (a_isdigit(*buf2) && sscanf(buf2, "%d", &num)) {
+			if (a_isdigit(*value) && sscanf(value, "%d", &num)) {
 				if (GetObjRnum(num) < 0) {
 					SendMsgToChar(ch, "Такого объекта не существует.\r\n");
 					return false;
@@ -216,7 +216,7 @@ bool parse_nedit_menu(CharData *ch, char *arg) {
 			}
 			break;
 
-		case '2': num = GetUniqueByName(buf2);
+		case '2': num = GetUniqueByName(value);
 			if (0 >= num) {
 				SendMsgToChar(ch, "Такого персонажа не существует.\r\n");
 				return false;
@@ -226,20 +226,20 @@ bool parse_nedit_menu(CharData *ch, char *arg) {
 			break;
 
 		case '3':
-			if (*buf2 && a_isdigit(*buf2) && sscanf(buf2, "%d", &num)) {
+			if (*value && a_isdigit(*value) && sscanf(value, "%d", &num)) {
 				ch->desc->named_obj->can_clan = 0 == num ? 0 : 1;
 			}
 			break;
 
 		case '4':
-			if (*buf2 && a_isdigit(*buf2) && sscanf(buf2, "%d", &num)) {
+			if (*value && a_isdigit(*value) && sscanf(value, "%d", &num)) {
 				ch->desc->named_obj->can_alli = 0 == num ? 0 : 1;
 			}
 			break;
 
 		case '5':
-			if (*buf2) {
-				ch->desc->named_obj->wear_msg_v = delete_doubledollar(buf2);
+			if (*value) {
+				ch->desc->named_obj->wear_msg_v = delete_doubledollar(value);
 				/* TODO: review me
 				if(!strcmp(ch->desc->named_obj->wear_msg_v.c_str(), "_"))
 					ch->desc->named_obj->wear_msg_v == "";
@@ -248,8 +248,8 @@ bool parse_nedit_menu(CharData *ch, char *arg) {
 			break;
 
 		case '6':
-			if (*buf2) {
-				ch->desc->named_obj->wear_msg_a = delete_doubledollar(buf2);
+			if (*value) {
+				ch->desc->named_obj->wear_msg_a = delete_doubledollar(value);
 				/* TODO: review me
 				if(!strcmp(ch->desc->named_obj->wear_msg_a.c_str(), "_"))
 					ch->desc->named_obj->wear_msg_a == "";
@@ -258,8 +258,8 @@ bool parse_nedit_menu(CharData *ch, char *arg) {
 			break;
 
 		case '7':
-			if (*buf2) {
-				ch->desc->named_obj->cant_msg_v = delete_doubledollar(buf2);
+			if (*value) {
+				ch->desc->named_obj->cant_msg_v = delete_doubledollar(value);
 				/* TODO: review me
 				if(!strcmp(ch->desc->named_obj->cant_msg_v.c_str(), "_"))
 					ch->desc->named_obj->cant_msg_v == "";
@@ -268,8 +268,8 @@ bool parse_nedit_menu(CharData *ch, char *arg) {
 			break;
 
 		case '8':
-			if (*buf2) {
-				ch->desc->named_obj->cant_msg_a = delete_doubledollar(buf2);
+			if (*value) {
+				ch->desc->named_obj->cant_msg_a = delete_doubledollar(value);
 				/* TODO: review me
 				if(!strcmp(ch->desc->named_obj->cant_msg_a.c_str(), "_"))
 					ch->desc->named_obj->cant_msg_a == "";
@@ -345,88 +345,92 @@ void do_named(CharData *ch, char *argument, int cmd, int subcmd) {
 	bool have_missed_items = false;
 	int first = 0, last = 0, found = 0, uid = -1;
 
-	two_arguments(argument, buf, buf2);
+	char arg_first[kMaxInputLength], arg_second[kMaxInputLength];
+	two_arguments(argument, arg_first, arg_second);
+	// Фильтр по владельцу: либо почта найденного персонажа, либо то, что ввели,
+	// -- тогда ищем подстроку в почте. При поиске по номерам фильтр пустой.
+	std::string mail_filter;
 
-	if (*buf) {
-		if (is_number(buf)) {
-			first = atoi(buf);
-			if (*buf2)
-				last = atoi(buf2);
-			else
-				last = first;
-			*buf = '\0';
+	if (*arg_first) {
+		if (is_number(arg_first)) {
+			first = atoi(arg_first);
+			last = *arg_second ? atoi(arg_second) : first;
 		} else {
 			last = 1;
 			first = 0x7fffffff;
-			uid = GetUniqueByName(buf);
-			//*buf = '\0';
+			uid = GetUniqueByName(arg_first);
+			mail_filter = arg_first;
 			if (uid > 0) {
-				strcpy(buf, player_table[GetPtableByUnique(uid)].mail.c_str());
+				mail_filter = player_table[GetPtableByUnique(uid)].mail;
 			}
 		}
 	}
 
 	switch (subcmd) {
-		case SCMD_NAMED_LIST: sprintf(buf1, "Список именных предметов:\r\n");
-			if (stuff_list.size() == 0) {
-				out += buf1;
+		case SCMD_NAMED_LIST: {
+			const std::string header = "Список именных предметов:\r\n";
+			if (stuff_list.empty()) {
+				out += header;
 				out += " Пока что пусто.\r\n";
 			} else {
 				for (StuffListType::iterator it = stuff_list.begin(), iend = stuff_list.end(); it != iend; ++it) {
+					const bool by_mail = !mail_filter.empty()
+						&& it->second->mail.find(mail_filter) != std::string::npos;
 					if ((r_num = GetObjRnum(it->first)) < 0) {
-						if ((*buf && strstr(it->second->mail.c_str(), buf))
+						if (by_mail
 							|| (uid != -1
 								&& uid == it->second->uid)
 							|| (uid == -1
 								&& it->first >= first
 								&& it->first <= last)) {
 							if (found == 0) {
-								out += buf1;
+								out += header;
 							}
 							found++;
-							strcpy(buf2, fmt::format("{:6}) &R*&n{:<31} Владелец:{:<16} e-mail:&S{}&s\r\n",
-									it->first + 1,
-									"Несуществующий предмет",
-									GetNameByUnique(it->second->uid, false),
-									it->second->mail
-							).c_str());
-							out += buf2;
+							out += fmt::format("{:6}) &R*&n{:<31} Владелец:{:<16} e-mail:&S{}&s\r\n",
+											   it->first + 1,
+											   "Несуществующий предмет",
+											   GetNameByUnique(it->second->uid, false),
+											   it->second->mail);
 						}
 					} else {
-						if ((*buf && strstr(it->second->mail.c_str(), buf))
+						if (by_mail
 							|| (uid != -1
 								&& uid == it->second->uid)
 							|| (uid == -1
 								&& obj_proto[r_num]->get_vnum() >= first
 								&& obj_proto[r_num]->get_vnum() <= last)) {
-							sprintf(buf1, "%6d) %s",
-									obj_proto[r_num]->get_vnum(),
-									colored_name(obj_proto[r_num]->get_short_description().c_str(), -32));
-							if (privilege::IsGrGod(ch) || ch->IsFlagged(EPrf::kCoderinfo)) {
-								strcpy(buf2, fmt::format("{} Игра:{} Пост:{} Владелец:{:<16} e-mail:&S{}&s\r\n", buf1,
-										 obj_proto.total_online(r_num), obj_proto.stored(r_num),
-										 GetNameByUnique(it->second->uid, false), it->second->mail).c_str());
-							} else {
-								snprintf(buf2, kMaxStringLength, "%s\r\n", buf1);
-							}
+							// Колонка с названием -- 32 символа влево, как и в ветке выше:
+							// раньше сюда передавали -32, и ширина превращалась в 255 пробелов.
+							const std::string line =
+								fmt::format("{:6}) {}",
+											obj_proto[r_num]->get_vnum(),
+											colored_name(obj_proto[r_num]->get_short_description().c_str(), 32, true));
 							if (found == 0) {
-								out += buf1;
+								out += header;
 							}
 							found++;
-							out += buf2;
+							if (privilege::IsGrGod(ch) || ch->IsFlagged(EPrf::kCoderinfo)) {
+								out += fmt::format("{} Игра:{} Пост:{} Владелец:{:<16} e-mail:&S{}&s\r\n",
+												   line,
+												   obj_proto.total_online(r_num), obj_proto.stored(r_num),
+												   GetNameByUnique(it->second->uid, false), it->second->mail);
+							} else {
+								out += line + "\r\n";
+							}
 						}
 					}
 				}
 			}
 			if (!found) {
-				sprintf(buf, "Нет таких именных вещей.\r\nСинтаксис %s [vnum [vnum] | имя | email]\r\n",
-						cmd_info[cmd].command);
-				out += buf;
+				out += fmt::format("Нет таких именных вещей.\r\nСинтаксис {} [vnum [vnum] | имя | email]\r\n",
+								   cmd_info[cmd].command);
 			}
 			SendMsgToChar(out.c_str(), ch);
 			break;
+		}
 		case SCMD_NAMED_EDIT: int found = 0;
-			if ((first > 0 && first < 0x7fffffff) || uid != -1 || *buf) {
+			if ((first > 0 && first < 0x7fffffff) || uid != -1 || !mail_filter.empty()) {
 				if (first > 0 && first < 0x7fffffff && GetObjRnum(first) < 0) {
 					SendMsgToChar(ch, "Такого объекта не существует.\r\n");
 					return;
@@ -438,18 +442,16 @@ void do_named(CharData *ch, char *argument, int cmd, int subcmd) {
 					it != iend;
 					++it) {
 					if ((uid == -1 && it->first == first) || it->second->uid == uid
-						|| !str_cmp(it->second->mail.c_str(), buf)) {
+						|| !str_cmp(it->second->mail.c_str(), mail_filter.c_str())) {
 						if (GetObjRnum(it->first) < 0) {
 							if (!have_missed_items) {
 								out += "&RВнимание!!!&n\r\nНесуществующие объекты в списке именых вещей:\r\n";
 								have_missed_items = true;
 							}
-							sprintf(buf2, "vnum:%9ld uid:%9d mail:%s\r\n",
-									it->first,
-									it->second->uid,
-									str_dup(it->second->mail.c_str())
-							);
-							out += buf2;
+							out += fmt::format("vnum:{:9} uid:{:9} mail:{}\r\n",
+											   it->first,
+											   it->second->uid,
+											   it->second->mail);
 							continue;
 						}
 						ch->desc->old_vnum = it->first;
@@ -457,11 +459,11 @@ void do_named(CharData *ch, char *argument, int cmd, int subcmd) {
 						tmp_node->uid = it->second->uid;
 						tmp_node->can_clan = it->second->can_clan;
 						tmp_node->can_alli = it->second->can_alli;
-						tmp_node->mail = str_dup(it->second->mail.c_str());
-						tmp_node->wear_msg_v = str_dup(it->second->wear_msg_v.c_str());
-						tmp_node->wear_msg_a = str_dup(it->second->wear_msg_a.c_str());
-						tmp_node->cant_msg_v = str_dup(it->second->cant_msg_v.c_str());
-						tmp_node->cant_msg_a = str_dup(it->second->cant_msg_a.c_str());
+						tmp_node->mail = it->second->mail;
+						tmp_node->wear_msg_v = it->second->wear_msg_v;
+						tmp_node->wear_msg_a = it->second->wear_msg_a;
+						tmp_node->cant_msg_v = it->second->cant_msg_v;
+						tmp_node->cant_msg_a = it->second->cant_msg_a;
 						found++;
 						break;
 					}
@@ -472,11 +474,11 @@ void do_named(CharData *ch, char *argument, int cmd, int subcmd) {
 					tmp_node->uid = 0;
 					tmp_node->can_clan = 0;
 					tmp_node->can_alli = 0;
-					tmp_node->mail = str_dup("");
-					tmp_node->wear_msg_v = str_dup("");
-					tmp_node->wear_msg_a = str_dup("");
-					tmp_node->cant_msg_v = str_dup("");
-					tmp_node->cant_msg_a = str_dup("");
+					tmp_node->mail.clear();
+					tmp_node->wear_msg_v.clear();
+					tmp_node->wear_msg_a.clear();
+					tmp_node->cant_msg_v.clear();
+					tmp_node->cant_msg_a.clear();
 					found++;
 				}
 				if (have_missed_items) {
@@ -510,22 +512,22 @@ void receive_items(CharData *ch, CharData *mailman) {
 	MobRnum r_num;
 	int found = 0;
 	int in_world = 0;
-	snprintf(buf1, kMaxStringLength, "не найден именной предмет");
+	std::string reason = "не найден именной предмет";
 	for (StuffListType::const_iterator it = stuff_list.begin(), iend = stuff_list.end(); it != iend; ++it) {
 		if ((it->second->uid == ch->get_uid()) || (!strcmp(GET_EMAIL(ch), it->second->mail.c_str()))) {
 			if ((r_num = GetObjRnum(it->first)) < 0) {
 				SendMsgToChar("Странно, но такого объекта не существует.\r\n", ch);
-				snprintf(buf1, kMaxStringLength, "объект не существует!!!");
+				reason = "объект не существует!!!";
 				continue;
 			}
 			if ((GetObjMIW(r_num) > obj_proto.actual_count(r_num))    //Проверка на макс в мире
 				|| (obj_proto.actual_count(r_num) < 1))//Пока что если в мире нету то тоже загрузить
 			{
 				found++;
-				snprintf(buf1, kMaxStringLength, "выдаем именной предмет %s Max:%d > Current:%d",
-						 obj_proto[r_num]->get_short_description().c_str(),
-						 GetObjMIW(r_num),
-						 obj_proto.actual_count(r_num));
+				reason = fmt::format("выдаем именной предмет {} Max:{} > Current:{}",
+									 obj_proto[r_num]->get_short_description(),
+									 GetObjMIW(r_num),
+									 obj_proto.actual_count(r_num));
 				const auto obj = world_objects.create_from_prototype_by_rnum(r_num);
 				obj->set_extra_flag(EObjFlag::kNamed);
 				PlaceObjToInventory(obj.get(), ch);
@@ -535,14 +537,14 @@ void receive_items(CharData *ch, CharData *mailman) {
 				act("$n дал$g вам $o3.", false, mailman, obj.get(), ch, kToVict);
 				act("$N дал$G $n2 $o3.", false, ch, obj.get(), mailman, kToRoom);
 			} else {
-				snprintf(buf1, kMaxStringLength, "не выдаем именной предмет %s Max:%d <= Current:%d",
-						 obj_proto[r_num]->get_short_description().c_str(),
-						 GetObjMIW(r_num),
-						 obj_proto.actual_count(r_num));
+				reason = fmt::format("не выдаем именной предмет {} Max:{} <= Current:{}",
+									 obj_proto[r_num]->get_short_description(),
+									 GetObjMIW(r_num),
+									 obj_proto.actual_count(r_num));
 				in_world++;
 			}
-			snprintf(buf, kMaxStringLength, "NamedStuff: %s vnum:%ld %s", GET_PAD(ch, 0), it->first, buf1);
-			mudlog(buf, LGH, kLvlImmortal, SYSLOG, true);
+			mudlog(fmt::format("NamedStuff: {} vnum:{} {}", GET_PAD(ch, 0), it->first, reason),
+				   LGH, kLvlImmortal, SYSLOG, true);
 		}
 	}
 
@@ -573,26 +575,22 @@ void load() {
 			long vnum = std::stol(node.attribute("vnum").value(), nullptr, 10);
 			std::string name;
 			if (stuff_list.find(vnum) != stuff_list.end()) {
-				snprintf(buf, kMaxStringLength, "NamedStuff: дубликат записи vnum=%ld пропущен", vnum);
-				mudlog(buf, NRM, kLvlBuilder, SYSLOG, true);
+				mudlog(fmt::format("NamedStuff: дубликат записи vnum={} пропущен", vnum),
+					   NRM, kLvlBuilder, SYSLOG, true);
 				continue;
 			}
 
 			if (GetObjRnum(vnum) < 0) {
-				snprintf(buf, kMaxStringLength,
-						 "NamedStuff: предмет vnum=%ld не существует.", vnum);
-				mudlog(buf, NRM, kLvlBuilder, SYSLOG, true);
+				mudlog(fmt::format("NamedStuff: предмет vnum={} не существует.", vnum),
+					   NRM, kLvlBuilder, SYSLOG, true);
 			}
 			if (node.attribute("uid")) {
 				tmp_node->uid = std::stol(node.attribute("uid").value(), nullptr, 10);
 				name = GetNameByUnique(tmp_node->uid, false);// Ищем персонажа с указанным уид(богов игнорируем)
 				if (name.empty()) {
-					snprintf(buf,
-							 kMaxStringLength,
-							 "NamedStuff: Unique=%d - персонажа не существует(владелец предмета vnum=%ld).",
-							 tmp_node->uid,
-							 vnum);
-					mudlog(buf, NRM, kLvlBuilder, SYSLOG, true);
+					mudlog(fmt::format("NamedStuff: Unique={} - персонажа не существует(владелец предмета vnum={}).",
+									   tmp_node->uid, vnum),
+						   NRM, kLvlBuilder, SYSLOG, true);
 				}
 			}
 			if (node.attribute("mail")) {
@@ -618,13 +616,11 @@ void load() {
 			}
 			if (!IsValidEmail(tmp_node->mail.c_str())) {
 				std::string name = GetNameByUnique(tmp_node->uid, false);
-				snprintf(buf,
-						 kMaxStringLength,
-						 "NamedStuff: указан не корректный e-mail=&S%s&s для предмета vnum=%ld (владелец=%s).",
-						 tmp_node->mail.c_str(),
-						 vnum,
-						 (name.empty() ? "неизвестен" : name.c_str()));
-				mudlog(buf, NRM, kLvlBuilder, SYSLOG, true);
+				mudlog(fmt::format("NamedStuff: указан не корректный e-mail=&S{}&s для предмета vnum={} (владелец={}).",
+								   tmp_node->mail,
+								   vnum,
+								   name.empty() ? std::string("неизвестен") : name),
+					   NRM, kLvlBuilder, SYSLOG, true);
 			}
 			if (node.attribute("can_clan"))
 				tmp_node->can_clan = std::stoi(node.attribute("can_clan").value(), nullptr, 10);
@@ -640,10 +636,8 @@ void load() {
 			log("NamedStuff : exception %s (%s %s %d)", e.what(), __FILE__, __func__, __LINE__);
 		}
 	}
-	snprintf(buf, kMaxStringLength,
-			 "NamedStuff: список именных вещей загружен, всего объектов: %lu.",
-			 static_cast<unsigned long>(stuff_list.size()));
-	mudlog(buf, CMP, kLvlBuilder, SYSLOG, true);
+	mudlog(fmt::format("NamedStuff: список именных вещей загружен, всего объектов: {}.", stuff_list.size()),
+		   CMP, kLvlBuilder, SYSLOG, true);
 }
 
 } // namespace NamedStuff


### PR DESCRIPTION
Часть #3814: `src/gameplay/mechanics/named_stuff.cpp` (84 обращения к `buf`/`buf1`/`buf2`) и `src/engine/ui/cmd_god/do_reload.cpp` (62 к `arg`) — оба по нулям.

## Что сделано

- `parse_nedit_menu` разбирает ввод в собственные `param`/`value` вместо общих `buf1`/`buf2`; показ текущего сообщения собирается через `fmt::format`, локальный `char i[256]` убран.
- `do_named` пишет список прямо в `out`, а фильтр по владельцу стал `std::string` вместо затираемого по ходу дела глобального `buf`.
- `do_reload` разбирает цель перезагрузки в локальный `target`.

## Найденные по дороге баги

Все три — давние, и все три видны в живом сравнении с master.

**1. Заголовок списка терялся.** `buf1` сначала держал «Список именных предметов:», а потом в него же печаталась строка предмета — поэтому первая строка списка выводилась дважды, а заголовка не было. Было/стало:

```
master:  201)              ...   201) ... Игра:0 Пост:0 Владелец: ...
ветка:   Список именных предметов:
            201) руна хляби     Игра:0 Пост:0 Владелец: ...
```

**2. Колонка с названием — 255 пробелов.** Название печаталось через `colored_name(..., -32)`. Отрицательная ширина превращалась в `size_t` в астрономическую величину, ограничитель внутри `colored_name` резал её до 255 — колонка становилась строкой из 255 пробелов, а само название обрезалось посреди UTF-8 буквы (`руна тв`, `руна <мусор>`). Теперь 32 символа влево — ровно как в соседней ветке с несуществующим предметом, где стоит `{:<31}`.

**3. Утечка `str_dup`.** `tmp_node->mail = str_dup(it->second->mail.c_str())` и ещё восемь таких присваиваний в `std::string`, плюс `str_dup` в аргументе `%s` — каждая правка через `nedit` подтекала. Заменено на прямое присваивание.

## Проверка

- Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.
- Живое сравнение с master на тестовом мире: `nlist` (пусто / по номерам / по почте / по имени / по несуществующему предмету), `nedit` (меню, неверный числовой и буквенный параметр, показ сообщения, отсутствие второго параметра, смена внума, флаг клана, выход без сохранения, несуществующий внум), `reload` (без аргумента, spells, named, depot без имени, неизвестная цель). Вывод и syslog совпадают с master везде, кроме двух пунктов выше.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr