### PR TITLE
refactor(set): drop global buffers from set and clan code (#3814)

### DIFF
--- a/src/engine/ui/cmd_god/do_set.cpp
+++ b/src/engine/ui/cmd_god/do_set.cpp
@@ -138,31 +138,32 @@ void DoSet(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	int mode, player_i = 0, retval;
 	char is_file = 0, is_player = 0;
 
-	half_chop(argument, name, buf);
+	char rest[kMaxInputLength];
+	half_chop(argument, name, rest);
 
 	if (!*name) {
-		strcpy(buf, "Возможные поля для изменения:\r\n");
+		std::string fields = "Возможные поля для изменения:\r\n";
 		for (int i = 0; set_fields[i].level; i++)
 			if (privilege::HasPrivilege(ch, std::string(set_fields[i].cmd), 0, 1))
-				sprintf(buf + strlen(buf), "%-15s%s", set_fields[i].cmd, (!((i + 1) % 5) ? "\r\n" : ""));
-		strcat(buf, "\r\n");
-		SendMsgToChar(buf, ch);
+				fields += fmt::format("{:<15}{}", set_fields[i].cmd, (!((i + 1) % 5) ? "\r\n" : ""));
+		fields += "\r\n";
+		SendMsgToChar(fields, ch);
 		return;
 	}
 
 	if (!strcmp(name, "file")) {
 		is_file = 1;
-		half_chop(buf, name, buf);
+		half_chop(rest, name, rest);
 	} else if (!str_cmp(name, "player")) {
 		is_player = 1;
-		half_chop(buf, name, buf);
+		half_chop(rest, name, rest);
 	} else if (!str_cmp(name, "mob")) {
-		half_chop(buf, name, buf);
+		half_chop(rest, name, rest);
 	} else
 		is_player = 1;
 
-	half_chop(buf, field, buf);
-	strcpy(val_arg, buf);
+	half_chop(rest, field, rest);
+	strcpy(val_arg, rest);
 
 	if (!*name || !*field) {
 		SendMsgToChar("Usage: set [mob|player|file] <victim> <field> <value>\r\n", ch);
@@ -534,8 +535,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			}
 			Password::set_password(vict, val_arg);
 			Password::send_password(GET_EMAIL(vict), val_arg, std::string(GET_NAME(vict)));
-			sprintf(buf, "%s заменен пароль богом.", GET_PAD(vict, 2));
-			AddKarma(vict, buf, GET_NAME(ch));
+			AddKarma(vict, fmt::format("{} заменен пароль богом.", GET_PAD(vict, 2)).c_str(), GET_NAME(ch));
 			sprintf(output, "Пароль изменен на '%s'.", val_arg);
 			break;
 		case 37: on_off_mode ? vict->SetFlag(EPlrFlag::kNoDelete) : vict->UnsetFlag(EPlrFlag::kNoDelete);
@@ -579,8 +579,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 					punishments::Get(vict, punishments::EType::kGcurse).duration = (i > 0) ? time(nullptr) + i * 60 * 60 : MAX_TIME;
 				else
 					punishments::Get(vict, punishments::EType::kGcurse).duration = 0;
-				sprintf(buf, "%s установил GUDSLIKE персонажу %s.", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, BRF, kLvlImplementator, SYSLOG, 0);
+				mudlog(fmt::format("{} установил GUDSLIKE персонажу {}.", GET_NAME(ch), GET_NAME(vict)), BRF, kLvlImplementator, SYSLOG, 0);
 
 			} else {
 				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kGodsLike);
@@ -602,8 +601,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			if (ch->IsFlagged(EPrf::kCoderinfo) || privilege::IsImpl(ch))
 				GET_OLC_ZONE(vict) = value;
 			else {
-				sprintf(buf, "Слишком низкий уровень чтоб раздавать права OLC.\r\n");
-				SendMsgToChar(buf, ch);
+				SendMsgToChar("Слишком низкий уровень чтоб раздавать права OLC.\r\n", ch);
 			}
 			break;
 
@@ -611,8 +609,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			// изменение имени !!!
 
 			if ((i = sscanf(val_arg, "%s %s %s %s %s %s", npad[0], npad[1], npad[2], npad[3], npad[4], npad[5])) != 6) {
-				sprintf(buf, "Требуется указать 6 падежей, найдено %d\r\n", i);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("Требуется указать 6 падежей, найдено {}\r\n", i), ch);
 				return (0);
 			}
 
@@ -622,13 +619,11 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 					if (!_parse_name(npad[i], npad[i])) {
 						vict->player_data.PNames[i] = std::string(npad[i]);
 					}
-				sprintf(buf, "Произведена замена падежей.\r\n");
-				SendMsgToChar(buf, ch);
+				SendMsgToChar("Произведена замена падежей.\r\n", ch);
 			} else {
 				for (i = grammar::ECase::kFirstCase; i <= grammar::ECase::kLastCase; i++) {
 					if (static_cast<int>(native_text::char_count(npad[i])) < kMinNameLength || static_cast<int>(native_text::char_count(npad[i])) > kMaxNameLength) {
-						sprintf(buf, "Падеж номер %d некорректен.\r\n", ++i);
-						SendMsgToChar(buf, ch);
+						SendMsgToChar(fmt::format("Падеж номер {} некорректен.\r\n", ++i), ch);
 						return (0);
 					}
 				}
@@ -664,9 +659,9 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 						vict->player_data.PNames[i] = std::string(npad[i]);
 					}
 				}
-				sprintf(buf, "Name changed from %s to %s", GET_NAME(vict), npad[0]);
+				const std::string rename_note = fmt::format("Name changed from {} to {}", GET_NAME(vict), npad[0]);
 				vict->set_name(npad[0]);
-				AddKarma(vict, buf, GET_NAME(ch));
+				AddKarma(vict, rename_note.c_str(), GET_NAME(ch));
 
 				if (!vict->IsFlagged(EPlrFlag::kFrozen)
 					&& !vict->IsFlagged(EPlrFlag::kDeleted)
@@ -751,8 +746,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 		case 50:
 			if (IsValidEmail(val_arg)) {
 				utils::ConvertToLow(val_arg);
-				sprintf(buf, "Email changed from %s to %s", GET_EMAIL(vict), val_arg);
-				AddKarma(vict, buf, GET_NAME(ch));
+				AddKarma(vict, fmt::format("Email changed from {} to {}", GET_EMAIL(vict), val_arg).c_str(), GET_NAME(ch));
 				strncpy(GET_EMAIL(vict), val_arg, 127);
 				*(GET_EMAIL(vict) + 127) = '\0';
 			} else {
@@ -823,7 +817,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 					return (0);
 			}
 			break;
-		case 55:
+		case 55: {
 			if (GetRealLevel(vict) >= kLvlImmortal && !privilege::IsImpl(ch) && !ch->IsFlagged(EPrf::kCoderinfo)) {
 				SendMsgToChar("Кем вы себя возомнили?\r\n", ch);
 				return 0;
@@ -831,22 +825,22 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			reason = strdup(val_arg);
 			if (reason && *reason) {
 				skip_spaces(&reason);
-				sprintf(buf, "add by %s", GET_NAME(ch));
+				const std::string karma_source = fmt::format("add by {}", GET_NAME(ch));
 				if (!strcmp(reason, "clear")) {
 					if KARMA(vict)
 						free(KARMA(vict));
 
 					KARMA(vict) = nullptr;
 					act("Вы отпустили $N2 все грехи.", false, ch, nullptr, vict, kToChar);
-					sprintf(buf, "%s", GET_NAME(ch));
-					AddKarma(vict, "Очистка грехов", buf);
+					AddKarma(vict, "Очистка грехов", GET_NAME(ch));
 
-				} else AddKarma(vict, buf, reason);
+				} else AddKarma(vict, karma_source.c_str(), reason);
 			} else {
 				SendMsgToChar("Формат команды: set [ file | player ] <character> karma <reason>\r\n", ch);
 				return (0);
 			}
 			break;
+		}
 
 		case 56:      // Разрегистрация персонажа
 			reason = one_argument(val_arg, num);
@@ -856,8 +850,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 		case 57:      // Установка флага палач
 			reason = one_argument(val_arg, num);
 			skip_spaces(&reason);
-			sprintf(buf, "executor %s by %s", (on_off_mode ? "on" : "off"), GET_NAME(ch));
-//			AddKarma(vict, buf, reason);
+//			AddKarma(vict, fmt::format("executor {} by {}", on_off_mode ? "on" : "off", GET_NAME(ch)).c_str(), reason);
 			if (on_off_mode) {
 				vict->SetFlag(EPrf::kExecutor);
 			} else {
@@ -867,27 +860,27 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 
 		case 58: on_off_mode ? vict->SetFlag(EPlrFlag::kKiller) : vict->UnsetFlag(EPlrFlag::kKiller);
 			break;
-		case 59: // флаг реморта
+		case 59: { // флаг реморта
 			if (value > 1 && value < 75) {
-				sprintf(buf, "Иммортал %s установил реморт %d  для игрока %s ", GET_NAME(ch), value, GET_NAME(vict));
-				AddKarma(vict, buf, GET_NAME(ch));
-				AddKarma(ch, buf, GET_NAME(vict));
+				const std::string remort_note =
+					fmt::format("Иммортал {} установил реморт {}  для игрока {} ", GET_NAME(ch), value, GET_NAME(vict));
+				AddKarma(vict, remort_note.c_str(), GET_NAME(ch));
+				AddKarma(ch, remort_note.c_str(), GET_NAME(vict));
 				vict->set_remort(value);
-				SendMsgToGods(buf);
+				SendMsgToGods(remort_note.c_str());
 			} else {
 				SendMsgToChar(ch, "Неправильно указан реморт.\r\n");
 			}
 			break;
+		}
 		case 60: // флаг тестера
 			if (!str_cmp(val_arg, "off") || !str_cmp(val_arg, "выкл")) {
 				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kAllowTesterMode);
 				vict->UnsetFlag(EPrf::kTester); // обнулим реж тестер
-				sprintf(buf, "%s убрал флаг тестера для игрока %s", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
+				mudlog(fmt::format("{} убрал флаг тестера для игрока {}", GET_NAME(ch), GET_NAME(vict)), BRF, kLvlImmortal, SYSLOG, true);
 			} else {
 				SET_BIT(vict->player_specials->saved.GodsLike, EGf::kAllowTesterMode);
-				sprintf(buf, "%s установил флаг тестера для игрока %s", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
+				mudlog(fmt::format("{} установил флаг тестера для игрока {}", GET_NAME(ch), GET_NAME(vict)), BRF, kLvlImmortal, SYSLOG, true);
 				//			send_to_gods(buf);
 			}
 			break;
@@ -903,18 +896,15 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			break;
 		}
 		case 63: // флаг скриптера
-			sprintf(buf, "%s", GET_NAME(ch));
 			if (!str_cmp(val_arg, "off") || !str_cmp(val_arg, "выкл")) {
 				vict->UnsetFlag(EPlrFlag::kScriptWriter);
-				AddKarma(vict, "Снятие флага скриптера", buf);
-				sprintf(buf, "%s убрал флаг скриптера для игрока %s", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
+				AddKarma(vict, "Снятие флага скриптера", GET_NAME(ch));
+				mudlog(fmt::format("{} убрал флаг скриптера для игрока {}", GET_NAME(ch), GET_NAME(vict)), BRF, kLvlImmortal, SYSLOG, true);
 				return (1);
 			} else if (!str_cmp(val_arg, "on") || !str_cmp(val_arg, "вкл")) {
 				vict->SetFlag(EPlrFlag::kScriptWriter);
-				AddKarma(vict, "Установка флага скриптера", buf);
-				sprintf(buf, "%s установил  флаг скриптера для игрока %s", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
+				AddKarma(vict, "Установка флага скриптера", GET_NAME(ch));
+				mudlog(fmt::format("{} установил  флаг скриптера для игрока {}", GET_NAME(ch), GET_NAME(vict)), BRF, kLvlImmortal, SYSLOG, true);
 				return (1);
 			} else {
 				SendMsgToChar(ch, "Значение может быть только on/off или вкл/выкл.\r\n");
@@ -935,8 +925,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 
 			unsigned long int id = strtoul(val_arg, nullptr, 10);
 			if (!ch->IsNpc() && id != 0) {
-				sprintf(buf, "Telegram chat_id изменен с %lu на %lu\r\n", vict->player_specials->saved.telegram_id, id);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("Telegram chat_id изменен с {} на {}\r\n", vict->player_specials->saved.telegram_id, id), ch);
 				vict->setTelegramId(id);
 			} else
 				SendMsgToChar("Ошибка, указано неверное число или персонаж.\r\n", ch);
@@ -954,9 +943,9 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 		case 68: {
 			auto tmpval = (EPosition) value;
 			if (tmpval > EPosition::kDead && tmpval < EPosition::kLast) {
-				sprinttype(value, position_types, smallBuf);
-				sprintf(buf, "Для персонажа %s установлена позиция: %s.\r\n", GET_NAME(vict), smallBuf);
-				SendMsgToChar(buf, ch);
+				char position_name[kMaxInputLength];
+				sprinttype(value, position_types, position_name);
+				SendMsgToChar(fmt::format("Для персонажа {} установлена позиция: {}.\r\n", GET_NAME(vict), position_name), ch);
 				vict->SetPosition(tmpval);
 			} else {
 				const auto msg = fmt::format("Позиция может принимать значения от {} до {}.\r\n",
@@ -969,12 +958,10 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 		case 69: // флаг скилл тестера
 			if (!str_cmp(val_arg, "off") || !str_cmp(val_arg, "выкл")) {
 				REMOVE_BIT(vict->player_specials->saved.GodsLike, EGf::kSkillTester);
-				sprintf(buf, "%s убрал флаг &Rскилл тестера&n для игрока %s", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
+				mudlog(fmt::format("{} убрал флаг &Rскилл тестера&n для игрока {}", GET_NAME(ch), GET_NAME(vict)), BRF, kLvlImmortal, SYSLOG, true);
 			} else {
 				SET_BIT(vict->player_specials->saved.GodsLike, EGf::kSkillTester);
-				sprintf(buf, "%s установил флаг &Rскилл тестера&n для игрока %s", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, BRF, kLvlImmortal, SYSLOG, true);
+				mudlog(fmt::format("{} установил флаг &Rскилл тестера&n для игрока {}", GET_NAME(ch), GET_NAME(vict)), BRF, kLvlImmortal, SYSLOG, true);
 			}
 			break;
 		case 70: //quest

--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -1541,10 +1541,9 @@ void Clan::CharToChannel(CharData *ch, std::string text, int subcmd) {
 	switch (subcmd) {
 		// своей дружине
 		case kScmdChannel: {
+			const std::string clan_text = fmt::format("{} дружине: &R'{}'.&n\r\n", GET_NAME(ch), text);
 			// вспомнить
-			CLAN(ch)->add_remember(fmt::format("{} дружине: &R'{}'.&n\r\n", GET_NAME(ch), text), Remember::CLAN);
-			const std::string clan_text =
-				fmt::format("{} дружине: {}'{}'.{}\r\n", GET_NAME(ch), kColorBoldRed, text, kColorNrm);
+			CLAN(ch)->add_remember(clan_text, Remember::CLAN);
 
 			for (auto d = descriptor_list; d; d = d->next) {
 				if (d->character
@@ -1558,8 +1557,7 @@ void Clan::CharToChannel(CharData *ch, std::string text, int subcmd) {
 				}
 			}
 
-			const std::string clan_self =
-				fmt::format("Вы дружине: {}'{}'.{}\r\n", kColorBoldRed, text, kColorNrm);
+			const std::string clan_self = fmt::format("Вы дружине: &R'{}'.&n\r\n", text);
 			ch->remember_add(clan_self, Remember::ALL);
 			SendMsgToChar(clan_self, ch);
 
@@ -1568,16 +1566,13 @@ void Clan::CharToChannel(CharData *ch, std::string text, int subcmd) {
 
 			// союзникам
 		case kScmdAchannel: {
-			// вспомнить
-			const std::string ally_remember =
-				fmt::format("{} союзникам: &G'{}'.&n\r\n", GET_NAME(ch), text);
-			const std::string ally_text =
-				fmt::format("{} союзникам: {}'{}'.{}\r\n", GET_NAME(ch), kColorBoldGrn, text, kColorNrm);
+			const std::string ally_text = fmt::format("{} союзникам: &G'{}'.&n\r\n", GET_NAME(ch), text);
 			for (auto &clan : Clan::ClanList) {
 				if ((CLAN(ch)->CheckPolitics(clan->GetRent()) == kPoliticsAlliance
 					&& clan->CheckPolitics(CLAN(ch)->GetRent()) == kPoliticsAlliance)
 					|| CLAN(ch) == clan) {
-					clan->add_remember(ally_remember, Remember::ALLY);
+					// вспомнить
+					clan->add_remember(ally_text, Remember::ALLY);
 				}
 			}
 
@@ -1600,8 +1595,7 @@ void Clan::CharToChannel(CharData *ch, std::string text, int subcmd) {
 				}
 			}
 
-			const std::string ally_self =
-				fmt::format("Вы союзникам: {}'{}'.{}\r\n", kColorBoldGrn, text, kColorNrm);
+			const std::string ally_self = fmt::format("Вы союзникам: &G'{}'.&n\r\n", text);
 			ch->remember_add(ally_self, Remember::ALL);
 			SendMsgToChar(ally_self, ch);
 

--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -1182,8 +1182,9 @@ void Clan::HouseAdd(CharData *ch, std::string &buffer) {
 								  kColorWht,
 								  (*it).c_str(),
 								  kColorNrm);
-					sprintf(buf, "Звание в дружине изменено на %s", (*it).c_str());
-					AddKarma(d->character.get(), buf, ch->get_name().c_str());
+					AddKarma(d->character.get(),
+							 fmt::format("Звание в дружине изменено на {}", *it).c_str(),
+							 ch->get_name().c_str());
 				}
 
 				// оповещение соклановцев о изменении звания
@@ -1303,8 +1304,7 @@ void Clan::remove_member(const ClanMembersList::key_type &key, char *reason) {
 	if (k && k->character) {
 		Clan::SetClanData(k->character.get());
 		SendMsgToChar(k->character.get(), "Вас исключили из дружины '%s'!\r\n", this->name.c_str());
-		sprintf(buf, "Исключен(а) из дружины '%s'", this->name.c_str());
-		AddKarma(k->character.get(), buf, reason);
+		AddKarma(k->character.get(), fmt::format("Исключен(а) из дружины '{}'", this->name).c_str(), reason);
 		const auto clan = Clan::GetClanByRoom(k->character->in_room);
 		if (clan) {
 			char_from_room(k->character);
@@ -1323,8 +1323,7 @@ void Clan::remove_member(const ClanMembersList::key_type &key, char *reason) {
 		Player p_vict;
 		CharData *vict = &p_vict;
 		if (LoadPlayerCharacter(name.c_str(), vict, ELoadCharFlags::kFindId) > -1) {
-			sprintf(buf, "Исключен(а) из дружины '%s'", this->name.c_str());
-			AddKarma(vict, buf, reason);
+			AddKarma(vict, fmt::format("Исключен(а) из дружины '{}'", this->name).c_str(), reason);
 			vict->save_char();
 		}
 	}
@@ -1541,10 +1540,11 @@ void Clan::CharToChannel(CharData *ch, std::string text, int subcmd) {
 
 	switch (subcmd) {
 		// своей дружине
-		case kScmdChannel:
+		case kScmdChannel: {
 			// вспомнить
-			snprintf(buf, kMaxStringLength, "%s дружине: &R'%s'.&n\r\n", GET_NAME(ch), text.c_str());
-			CLAN(ch)->add_remember(buf, Remember::CLAN);
+			CLAN(ch)->add_remember(fmt::format("{} дружине: &R'{}'.&n\r\n", GET_NAME(ch), text), Remember::CLAN);
+			const std::string clan_text =
+				fmt::format("{} дружине: {}'{}'.{}\r\n", GET_NAME(ch), kColorBoldRed, text, kColorNrm);
 
 			for (auto d = descriptor_list; d; d = d->next) {
 				if (d->character
@@ -1553,38 +1553,31 @@ void Clan::CharToChannel(CharData *ch, std::string text, int subcmd) {
 					&& CLAN(d->character) == CLAN(ch)
 					&& !AFF_FLAGGED(d->character, EAffect::kDeafness)
 					&& !ignores(d->character.get(), ch, EIgnore::kClan)) {
-					snprintf(buf,
-							 kMaxStringLength,
-							 "%s дружине: %s'%s'.%s\r\n",
-							 GET_NAME(ch),
-							 kColorBoldRed,
-							 text.c_str(),
-							 kColorNrm);
-					d->character->remember_add(buf, Remember::ALL);
-					SendMsgToChar(buf, d->character.get());
+					d->character->remember_add(clan_text, Remember::ALL);
+					SendMsgToChar(clan_text, d->character.get());
 				}
 			}
 
-			snprintf(buf,
-					 kMaxStringLength,
-					 "Вы дружине: %s'%s'.%s\r\n",
-					 kColorBoldRed,
-					 text.c_str(),
-					 kColorNrm);
-			ch->remember_add(buf, Remember::ALL);
-			SendMsgToChar(buf, ch);
+			const std::string clan_self =
+				fmt::format("Вы дружине: {}'{}'.{}\r\n", kColorBoldRed, text, kColorNrm);
+			ch->remember_add(clan_self, Remember::ALL);
+			SendMsgToChar(clan_self, ch);
 
 			break;
+		}
 
 			// союзникам
-		case kScmdAchannel:
+		case kScmdAchannel: {
 			// вспомнить
-			snprintf(buf, kMaxStringLength, "%s союзникам: &G'%s'.&n\r\n", GET_NAME(ch), text.c_str());
+			const std::string ally_remember =
+				fmt::format("{} союзникам: &G'{}'.&n\r\n", GET_NAME(ch), text);
+			const std::string ally_text =
+				fmt::format("{} союзникам: {}'{}'.{}\r\n", GET_NAME(ch), kColorBoldGrn, text, kColorNrm);
 			for (auto &clan : Clan::ClanList) {
 				if ((CLAN(ch)->CheckPolitics(clan->GetRent()) == kPoliticsAlliance
 					&& clan->CheckPolitics(CLAN(ch)->GetRent()) == kPoliticsAlliance)
 					|| CLAN(ch) == clan) {
-					clan->add_remember(buf, Remember::ALLY);
+					clan->add_remember(ally_remember, Remember::ALLY);
 				}
 			}
 
@@ -1600,30 +1593,20 @@ void Clan::CharToChannel(CharData *ch, std::string text, int subcmd) {
 						// проверка на альянс с обеих сторон, шоб не спамили друг другу на зло
 						if ((CLAN(d->character)->CheckPolitics(CLAN(ch)->GetRent()) == kPoliticsAlliance)
 							|| CLAN(ch) == CLAN(d->character)) {
-							snprintf(buf,
-									 kMaxStringLength,
-									 "%s союзникам: %s'%s'.%s\r\n",
-									 GET_NAME(ch),
-									 kColorBoldGrn,
-									 text.c_str(),
-									 kColorNrm);
-							d->character->remember_add(buf, Remember::ALL);
-							SendMsgToChar(buf, d->character.get());
+							d->character->remember_add(ally_text, Remember::ALL);
+							SendMsgToChar(ally_text, d->character.get());
 						}
 					}
 				}
 			}
 
-			snprintf(buf,
-					 kMaxStringLength,
-					 "Вы союзникам: %s'%s'.%s\r\n",
-					 kColorBoldGrn,
-					 text.c_str(),
-					 kColorNrm);
-			ch->remember_add(buf, Remember::ALL);
-			SendMsgToChar(buf, ch);
+			const std::string ally_self =
+				fmt::format("Вы союзникам: {}'{}'.{}\r\n", kColorBoldGrn, text, kColorNrm);
+			ch->remember_add(ally_self, Remember::ALL);
+			SendMsgToChar(ally_self, ch);
 
 			break;
+		}
 	} // switch
 }
 
@@ -2207,8 +2190,7 @@ void Clan::fix_clan_members_load_room(Clan::shared_ptr clan) {
 			delete cbuf;
 		}
 
-		sprintf(buf, "CLAN: Роспуск, удаляю игрока %s [%s]", player_table[i].name().c_str(), clan->name.c_str());
-		log("%s", buf);
+		log(fmt::format("CLAN: Роспуск, удаляю игрока {} [{}]", player_table[i].name().c_str(), clan->name.c_str()));
 	}
 }
 
@@ -2359,8 +2341,8 @@ bool Clan::PutChest(CharData *ch, ObjData *obj, ObjData *chest) {
 		&& obj->get_contains()) {
 		act("В $o5 что-то лежит.", false, ch, obj, nullptr, kToChar);
 	} else if (SetSystem::is_norent_set(ch, obj, true) && obj->has_flag(EObjFlag::kNotOneInClanChest)) {
-		snprintf(buf, kMaxStringLength, "%s - требуется две и более вещи из набора.\r\n", obj->get_PName(grammar::ECase::kNom).c_str());
-		SendMsgToChar(utils::CAP(buf), ch);
+		SendMsgToChar(utils::CAP(fmt::format("{} - требуется две и более вещи из набора.\r\n",
+											 obj->get_PName(grammar::ECase::kNom))), ch);
 		return false;
 	} else {
 		if ((chest->get_weight() + obj->get_weight()) > CLAN(ch)->ChestMaxWeight()
@@ -3504,8 +3486,9 @@ void Clan::ClanAddMember(CharData *ch, int rank, std::string invite_name) {
 
 	SendMsgToChar(ch, "%sВас приписали к дружине '%s', статус - '%s'.%s\r\n",
 				  kColorWht, this->name.c_str(), (this->ranks[rank]).c_str(), kColorNrm);
-	sprintf(buf, "Принят в дружину '%s', статус - '%s'", this->name.c_str(), (this->ranks[rank]).c_str());
-	AddKarma(ch, buf, invite_name.c_str());
+	AddKarma(ch,
+			 fmt::format("Принят в дружину '{}', статус - '{}'", this->name, this->ranks[rank]).c_str(),
+			 invite_name.c_str());
 	return;
 }
 
@@ -3540,19 +3523,14 @@ void Clan::HouseOwner(CharData *ch, std::string &buffer) {
 		}
 		this->owner = buffer2;
 		SendMsgToChar(ch, "Поздравляем, вы передали свои полномочия %s!\r\n", GET_PAD(d->character, 2));
-		if (IsMale(ch))
-			sprintf(buf,
-					"&RВнимание!!!&n %s ушел на пенсию и добровольно передал руководство дружины %s игроку %s.\r\n",
-					GET_NAME(ch),
-					CLAN(d->character)->GetAbbrev(),
-					GET_PAD(d->character, 2));
-		else
-			sprintf(buf,
-					"&RВнимание!!!&n %s ушла на пенсию и добровольно передала руководство дружины %s игроку %s.\r\n",
-					GET_NAME(ch),
-					CLAN(d->character)->GetAbbrev(),
-					GET_PAD(d->character, 2));
-		SendMsgToAll(buf);
+		// Формат строки выбираем целиком: тернарник внутри fmt::format не годится,
+		// формат проверяется на этапе компиляции и должен быть константой.
+		const std::string retirement = IsMale(ch)
+			? fmt::format("&RВнимание!!!&n {} ушел на пенсию и добровольно передал руководство дружины {} игроку {}.\r\n",
+						  GET_NAME(ch), CLAN(d->character)->GetAbbrev(), GET_PAD(d->character, 2))
+			: fmt::format("&RВнимание!!!&n {} ушла на пенсию и добровольно передала руководство дружины {} игроку {}.\r\n",
+						  GET_NAME(ch), CLAN(d->character)->GetAbbrev(), GET_PAD(d->character, 2));
+		SendMsgToAll(retirement.c_str());
 	}
 }
 
@@ -4186,17 +4164,15 @@ int Clan::print_spell_locate_object(CharData *ch, int count, std::string name) {
 						continue;
 					}
 
-					sprintf(buf, "%s наход%sся в хранилище дружины '%s'.",
-							temp->get_short_description().c_str(),
-							grammar::ObjPluralVerbEnding((temp)->get_sex()),
-							(*clan)->GetAbbrev());
-//					CAP(buf);
+					std::string line = fmt::format("{} наход{}ся в хранилище дружины '{}'.",
+												   temp->get_short_description(),
+												   grammar::ObjPluralVerbEnding((temp)->get_sex()),
+												   (*clan)->GetAbbrev());
 					if (privilege::IsGrGod(ch)) {
-						sprintf(buf2, " Vnum предмета: %d", GET_OBJ_VNUM(temp));
-						strcat(buf, buf2);
+						line += fmt::format(" Vnum предмета: {}", GET_OBJ_VNUM(temp));
 					}
-					strcat(buf, "\r\n");
-					SendMsgToChar(buf, ch);
+					line += "\r\n";
+					SendMsgToChar(line, ch);
 					if (--count <= 0) {
 						return count;
 					}
@@ -4705,8 +4681,7 @@ void Clan::house_web_url(CharData *ch, const std::string &buffer) {
 		SendMsgToChar("Адрес сайта вашей дружины установлен.\r\n"
 					  "Обновление справки 'сайтыдружин' состоится в течении минуты.\r\n", ch);
 
-		snprintf(buf, sizeof(buf), "%s sets new clan website: %s", GET_NAME(ch), url.c_str());
-		mudlog(buf, LGH, kLvlImmortal, SYSLOG, true);
+		mudlog(fmt::format("{} sets new clan website: {}", GET_NAME(ch), url.c_str()), LGH, kLvlImmortal, SYSLOG, true);
 	}
 
 	HelpSystem::need_update = true;
@@ -5508,9 +5483,10 @@ void DoStoreHouse(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		SendMsgToChar("Ваш воевода зажал денег и отключил эту возможность! :(\r\n", ch);
 		return;
 	}
-	char *stufina = one_argument(argument, arg);
+	char mode[kMaxInputLength];
+	char *stufina = one_argument(argument, mode);
 
-	if (!str_cmp(arg, "все") || !str_cmp(arg, "all")) {
+	if (!str_cmp(mode, "все") || !str_cmp(mode, "all")) {
 		for (auto chest : world[GetRoomRnum(CLAN(ch)->chest_room)]->contents) {
 			if (Clan::is_clan_chest(chest)) {
 				Clan::ChestShow(chest, ch);
@@ -5518,7 +5494,7 @@ void DoStoreHouse(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			}
 		}
 	}
-	if (utils::IsAbbr(arg, "характеристики") || utils::IsAbbr(arg, "identify") || utils::IsAbbr(arg, "опознать")) {
+	if (utils::IsAbbr(mode, "характеристики") || utils::IsAbbr(mode, "identify") || utils::IsAbbr(mode, "опознать")) {
 		if ((currencies::GetBank(*ch, currencies::kGold) < kChestIdentPay) && (GetRealLevel(ch) < kLvlImplementator)) {
 			SendMsgToChar("У вас недостаточно денег в банке для такого исследования.\r\n", ch);
 			return;
@@ -5541,8 +5517,7 @@ void DoStoreHouse(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				}
 			}
 		}
-		sprintf(buf1, "Ничего похожего на %s в хранилище ненайдено! Будьте внимательнее.\r\n", stufina);
-		SendMsgToChar(buf1, ch);
+		SendMsgToChar(fmt::format("Ничего похожего на {} в хранилище ненайдено! Будьте внимательнее.\r\n", stufina), ch);
 		return;
 	}
 
@@ -5588,7 +5563,8 @@ void do_clanstuff(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 	std::string title = CLAN(ch)->GetClanTitle();
 
-	half_chop(argument, arg, buf);
+	char name_filter[kMaxInputLength], rest[kMaxInputLength];
+	half_chop(argument, name_filter, rest);
 
 	auto it = CLAN(ch)->clanstuff.begin();
 	for (; it != CLAN(ch)->clanstuff.end(); it++) {
@@ -5603,12 +5579,11 @@ void do_clanstuff(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			continue;
 		}
 
-		if (*arg && !strstr(obj_proto[rnum]->get_short_description().c_str(), arg)) {
+		if (*name_filter && !strstr(obj_proto[rnum]->get_short_description().c_str(), name_filter)) {
 			continue;
 		}
 
-		sprintf(buf, "%s %s clan%d!", it->name.c_str(), title.c_str(), CLAN(ch)->GetRent());
-		obj->set_aliases(buf);
+		obj->set_aliases(fmt::format("{} {} clan{}!", it->name, title, CLAN(ch)->GetRent()));
 		obj->set_short_description(it->PNames[0] + " " + title);
 
 		for (int i = grammar::ECase::kFirstCase; i <= grammar::ECase::kLastCase; i++) {
@@ -5642,17 +5617,18 @@ void do_clanstuff(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		PlaceObjToInventory(obj.get(), ch);
 		cnt++;
 
-		sprintf(buf, "$n взял$g %s из сундука", obj->get_PName(grammar::ECase::kNom).c_str());
-		sprintf(buf2, "Вы взяли %s из сундука", obj->get_PName(grammar::ECase::kNom).c_str());
-		act(buf, false, ch, 0, 0, kToRoom);
-		act(buf2, false, ch, 0, 0, kToChar);
+		act(fmt::format("$n взял$g {} из сундука", obj->get_PName(grammar::ECase::kNom)).c_str(),
+			false, ch, 0, 0, kToRoom);
+		act(fmt::format("Вы взяли {} из сундука", obj->get_PName(grammar::ECase::kNom)).c_str(),
+			false, ch, 0, 0, kToChar);
 	}
 
 	if (cnt) {
-		sprintf(buf2, "\r\nЭкипировка обошлась вам в %d %s.", gold_total,
-				MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(gold_total, grammar::ECase::kNom).c_str());
+		const std::string cost = fmt::format("\r\nЭкипировка обошлась вам в {} {}.", gold_total,
+											 MUD::Currency(currencies::kGoldVnum)
+												 .GetNameWithAmount(gold_total, grammar::ECase::kNom));
 		act("\r\n$n закрыл$g крышку сундука", false, ch, 0, 0, kToRoom);
-		act(buf2, false, ch, 0, 0, kToChar);
+		act(cost.c_str(), false, ch, 0, 0, kToChar);
 	} else {
 		act("\r\n$n порыл$u в сундуке со стандартной экипировкой, но ничего не наш$y", false, ch, 0, 0, kToRoom);
 		act("\r\nВы порылись в сундуке со стандартной экипировкой, но не нашли ничего подходящего",


### PR DESCRIPTION
Часть #3814: `src/gameplay/clans/house.cpp` (63 обращения) и `src/engine/ui/cmd_god/do_set.cpp` (61) — оба по нулям.

## Что сделано

- `DoSet` разбирает команду в локальный `rest`, список полей собирается в `std::string`.
- Клановые каналы (`гдругам`/`гсоюзникам`) собирают сообщение один раз перед циклом, а не заново для каждого получателя.
- `do_clanstuff` и `do_clanchest` разбирают аргументы в собственные буферы.
- Сообщение о передаче воеводства выбирается целиком (тернарник), а не собирается по веткам в общий буфер.

## Что нашлось по дороге

**Съезжала колонка в `set` без аргументов.** `printf("%-15s")` считает байты, а единственное русское имя поля — «палач» — занимает 10 байт из 15, поэтому столбец после него уезжал влево на пять знаков. У `fmt` ширина считается в символах:

```
master:  karma          unreg          палач     killer         remort
ветка:   karma          unreg          палач          killer         remort
```

**Два буфера заполнялись впустую:**
- `set ... палач` — строка `executor on by <бог>` собиралась, но её единственный потребитель (`AddKarma`) закомментирован с давних пор;
- `set ... scriptwriter` — в буфер клали просто имя бога, и оно же шло в `AddKarma`.

## Проверка

- Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.
- Живое сравнение с master на тестовом мире (одинаковый снимок мира для обоих прогонов): `set` по всем веткам с сообщениями — olc, position (обе), karma (обе), remort (обе), tester (обе), email (обе), падежи, неизвестное поле, неизвестный игрок, `set mob`; `hcontrol` и `hcontrol show`; клановые каналы `гдругам`/`гсоюзникам`; `кланстаф` с фильтром и без; `клансундук`. Вывод игроку и syslog совпадают с master везде, кроме выравнивания «палач».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr