### PR TITLE
refactor(affects): drop global buffers from affects and recipes (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_affects.cpp
+++ b/src/engine/ui/cmd/do_affects.cpp
@@ -56,7 +56,6 @@ struct SquashRow {
 }  // namespace
 
 void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-	char sp_name[kMaxStringLength];
 
 	if (*argument && utils::IsAbbr(argument, "краткий")) {
 		if (!ch->get_master()) {
@@ -79,14 +78,12 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		aff_copy.unset(j);
 	}
 
-	snprintf(buf2, sizeof(buf2), "%s", affects::DescribeActive(aff_copy, ", ").c_str());
-	std::vector<std::string> out_str = utils::Split(buf2, ',');
+	std::vector<std::string> out_str = utils::Split(affects::DescribeActive(aff_copy, ", "), ',');
 	// "Аффекты: " передаём префиксом: учитывается в ширине строки, но не
 	// склеивается через ", " (иначе после метки была бы лишняя запятая).
-	snprintf(buf, kMaxStringLength, "%s%s%s\r\n", kColorYel,
-			 utils::OutWordsList(out_str, ch->player_specials->saved.stringLength, ", ", "Аффекты: ").c_str(),
-			 kColorNrm);
-	SendMsgToChar(buf, ch);
+	SendMsgToChar(fmt::format("&y{}&n\r\n",
+							  utils::OutWordsList(out_str, ch->player_specials->saved.stringLength, ", ", "Аффекты: ")),
+				  ch);
 
 	if (ch->affected.empty()) {
 		return;
@@ -118,10 +115,10 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			// A permanent source wins the label; otherwise show the longest remaining time.
 			// Ширина колонок -- в символах: fmt для корректного UTF-8 меряет её в кодовых
 			// точках, printf мерил бы в байтах (issue #3681).
-			std::string line = fmt::format("{}{}{:<21} {:<12}{}",
+			std::string line = fmt::format("{}&C{:<21} {:<12}&n",
 										   (!r.name.empty() && r.name[0] == '!') ? "Состояние  : " : "Заклинание : ",
-										   kColorBoldCyn, r.name,
-										   FormatAffectDuration(r.permanent ? -1 : r.best_mod), kColorNrm);
+										   r.name,
+										   FormatAffectDuration(r.permanent ? -1 : r.best_mod));
 			if (r.count > 1) {
 				line += fmt::format(" [x{}]", r.count);
 			}
@@ -142,49 +139,41 @@ void do_affects(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	for (auto affect_i = ch->affected.begin(); affect_i != ch->affected.end(); ++affect_i) {
 		const auto aff = *affect_i;
 
-		*buf2 = '\0';
 		// issue.affect-migration: name the affect by its own identity (affect_type kShortDesc);
 		// fall back to the casting spell's name for affects not yet migrated off Affect::type.
-		snprintf(sp_name, sizeof(sp_name), "%s",
-				affects::AffectMsg(aff->affect_type, affects::EAffectMsgType::kShortDesc).c_str());
+		const std::string sp_name = affects::AffectMsg(aff->affect_type, affects::EAffectMsgType::kShortDesc);
 		const std::string duration = FormatAffectDuration(AffectDisplayMod(aff));
 		// Ширина колонок -- в символах: fmt для корректного UTF-8 меряет её в кодовых
 		// точках, printf мерил бы в байтах (issue #3681).
-		strcpy(buf, fmt::format("{}{}{:<21} {:<12}{} ",
-								*sp_name == '!' ? "Состояние  : " : "Заклинание : ",
-								kColorBoldCyn, sp_name, duration, kColorNrm).c_str());
-		*buf2 = '\0';
+		std::string line = fmt::format("{}&C{:<21} {:<12}&n ",
+									   !sp_name.empty() && sp_name[0] == '!' ? "Состояние  : " : "Заклинание : ",
+									   sp_name, duration);
 		if (immortal) {
+			bool has_modifier = false;
 			if (aff->modifier) {
-				sprintf(buf2, "%-3d к параметру: %s", aff->modifier, apply_types[(int) aff->location]);
-				snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%s", buf2);
+				line += fmt::format("{:<3} к параметру: {}", aff->modifier, apply_types[(int) aff->location]);
+				has_modifier = true;
 			}
 			// Show the affect's short-desc; an anonymous affect (kDefault/kUndefined) resolves
 			// via the shared kDefault sheaf fallback to "странное ощущение".
-			if (!affects::AffectMsg(aff->affect_type, affects::EAffectMsgType::kShortDesc).empty()) {
-				if (*buf2) {
-					strncat(buf, ", устанавливает ", sizeof(buf) - strlen(buf) - 1);
-				} else {
-					strncat(buf, "устанавливает ", sizeof(buf) - strlen(buf) - 1);
-				}
-				strncat(buf, kColorBoldRed, sizeof(buf) - strlen(buf) - 1);
-				snprintf(buf2, sizeof(buf2), "%s", affects::AffectMsg(aff->affect_type, affects::EAffectMsgType::kShortDesc).c_str());
-				snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), "%s", buf2);
-				strncat(buf, kColorNrm, sizeof(buf) - strlen(buf) - 1);
+			if (!sp_name.empty()) {
+				line += has_modifier ? ", устанавливает " : "устанавливает ";
+				line += fmt::format("&R{}&n", sp_name);
 			}
 		}
 		// Stack count (issue.affect-stacks): show [xN] for a multi-stack affect.
 		if (aff->stacks > 1) {
-			snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), " [x%d]", aff->stacks);
+			line += fmt::format(" [x{}]", aff->stacks);
 		}
 		// Potency for immortals / testers: the cast-roll strength (dice+skill+stat)
 		// recorded on the affect at impose time; drives the dispel comparison in
 		// CastUnaffects::DispelSucceeds. 0 means "not recorded" (charms, name-tied
 		// affects, etc.).
 		if (immortal || ch->IsFlagged(EPrf::kTester)) {
-			snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf), " [p: %.1f]", aff->potency);
+			line += fmt::format(" [p: {:.1f}]", aff->potency);
 		}
-		SendMsgToChar(strcat(buf, "\r\n"), ch);
+		line += "\r\n";
+		SendMsgToChar(line, ch);
 	}
 }
 

--- a/src/gameplay/mechanics/magic_item.cpp
+++ b/src/gameplay/mechanics/magic_item.cpp
@@ -120,10 +120,9 @@ static void extract_item(CharData *ch, ObjData *obj, int spelltype) {
 			&& GET_OBJ_VAL(obj, 2) > 0
 			&& GET_OBJ_VAL(obj, 2) < kRuneCrackCharge) {
 			// issue #3422: руна на исходе -- предупреждаем волхва
-			snprintf(buf, kMaxStringLength,
-					 "$o%s покрыл$U трещинами и скоро рассыплется в тлен.",
-					 char_get_custom_label(obj, ch).c_str());
-			act(buf, false, ch, obj, nullptr, kToChar);
+			act(fmt::format("$o{} покрыл$U трещинами и скоро рассыплется в тлен.",
+							char_get_custom_label(obj, ch)).c_str(),
+				false, ch, obj, nullptr, kToChar);
 		}
 	} else if (spelltype != ESpellType::kRunes) {
 		extract = true;
@@ -131,9 +130,8 @@ static void extract_item(CharData *ch, ObjData *obj, int spelltype) {
 
 	if (extract) {
 		if (spelltype == ESpellType::kRunes) {
-			snprintf(buf, kMaxStringLength, "$o%s рассыпал$U у вас в руках.",
-					 char_get_custom_label(obj, ch).c_str());
-			act(buf, false, ch, obj, nullptr, kToChar);
+			act(fmt::format("$o{} рассыпал$U у вас в руках.", char_get_custom_label(obj, ch)).c_str(),
+				false, ch, obj, nullptr, kToChar);
 		}
 		RemoveObjFromChar(obj);
 		ExtractObjFromWorld(obj);
@@ -176,38 +174,26 @@ int CheckRecipeValues(CharData *ch, ESpell spell_id, ESpellType spell_type, int 
 	if (!showrecipe)
 		return (true);
 	else {
-		strcpy(buf, "Вам потребуется :\r\n");
+		std::string recipe = "Вам потребуется :\r\n";
 		if (item0 >= 0) {
-			strcat(buf, kColorBoldRed);
-			strcat(buf, obj_proto[item0]->get_PName(grammar::ECase::kNom).c_str());
-			strcat(buf, "\r\n");
+			recipe += fmt::format("&R{}&n\r\n", obj_proto[item0]->get_PName(grammar::ECase::kNom));
 		}
 		if (item1 >= 0) {
-			strcat(buf, kColorBoldYel);
-			strcat(buf, obj_proto[item1]->get_PName(grammar::ECase::kNom).c_str());
-			strcat(buf, "\r\n");
+			recipe += fmt::format("&Y{}&n\r\n", obj_proto[item1]->get_PName(grammar::ECase::kNom));
 		}
 		if (item2 >= 0) {
-			strcat(buf, kColorBoldGrn);
-			strcat(buf, obj_proto[item2]->get_PName(grammar::ECase::kNom).c_str());
-			strcat(buf, "\r\n");
+			recipe += fmt::format("&G{}&n\r\n", obj_proto[item2]->get_PName(grammar::ECase::kNom));
 		}
 		if (obj_num >= 0 && (spell_type == ESpellType::kItemCast || spell_type == ESpellType::kRunes)) {
-			strcat(buf, kColorBoldBlu);
-			strcat(buf, obj_proto[obj_num]->get_PName(grammar::ECase::kNom).c_str());
-			strcat(buf, "\r\n");
+			recipe += fmt::format("&B{}&n\r\n", obj_proto[obj_num]->get_PName(grammar::ECase::kNom));
 		}
 
-		strcat(buf, kColorNrm);
 		if (spell_type == ESpellType::kItemCast || spell_type == ESpellType::kRunes) {
-			strcat(buf, "для создания магии '");
-			strcat(buf, MUD::Spell(spell_id).GetCName());
-			strcat(buf, "'.");
+			recipe += fmt::format("для создания магии '{}'.", MUD::Spell(spell_id).GetCName());
 		} else {
-			strcat(buf, "для создания ");
-			strcat(buf, obj_proto[obj_num]->get_PName(grammar::ECase::kGen).c_str());
+			recipe += fmt::format("для создания {}", obj_proto[obj_num]->get_PName(grammar::ECase::kGen));
 		}
-		act(buf, false, ch, nullptr, nullptr, kToChar);
+		act(recipe.c_str(), false, ch, nullptr, nullptr, kToChar);
 	}
 
 	return (true);
@@ -360,11 +346,7 @@ int CheckRecipeItems(CharData *ch, ESpell spell_id, ESpellType spell_type, int e
 	}
 
 	if (extract) {
-		if (spell_type == ESpellType::kRunes) {
-			strcpy(buf, "Вы сложили ");
-		} else {
-			strcpy(buf, "Вы взяли ");
-		}
+		std::string used = (spell_type == ESpellType::kRunes) ? "Вы сложили " : "Вы взяли ";
 
 		ObjData::shared_ptr obj;
 		if (create) {
@@ -382,65 +364,56 @@ int CheckRecipeItems(CharData *ch, ESpell spell_id, ESpellType spell_type, int e
 		}
 
 		if (item0 == -2) {
-			strcat(buf, kColorWht);
-			strcat(buf, obj0->get_PName(grammar::ECase::kAcc).c_str());
-			strcat(buf, ", ");
+			used += fmt::format("&W{}&n, ", obj0->get_PName(grammar::ECase::kAcc));
 			AddRuneStats(ch, GET_OBJ_VAL(obj0, 1), spell_type);
 		}
 
 		if (item1 == -2) {
-			strcat(buf, kColorWht);
-			strcat(buf, obj1->get_PName(grammar::ECase::kAcc).c_str());
-			strcat(buf, ", ");
+			used += fmt::format("&W{}&n, ", obj1->get_PName(grammar::ECase::kAcc));
 			AddRuneStats(ch, GET_OBJ_VAL(obj1, 1), spell_type);
 		}
 
 		if (item2 == -2) {
-			strcat(buf, kColorWht);
-			strcat(buf, obj2->get_PName(grammar::ECase::kAcc).c_str());
-			strcat(buf, ", ");
+			used += fmt::format("&W{}&n, ", obj2->get_PName(grammar::ECase::kAcc));
 			AddRuneStats(ch, GET_OBJ_VAL(obj2, 1), spell_type);
 		}
 
 		if (item3 == -2) {
-			strcat(buf, kColorWht);
-			strcat(buf, obj3->get_PName(grammar::ECase::kAcc).c_str());
-			strcat(buf, ", ");
+			used += fmt::format("&W{}&n, ", obj3->get_PName(grammar::ECase::kAcc));
 			AddRuneStats(ch, GET_OBJ_VAL(obj3, 1), spell_type);
 		}
 
-		strcat(buf, kColorNrm);
 
 		if (create) {
 			if (percent >= 0) {
-				strcat(buf, " и создали $o3.");
-				act(buf, false, ch, obj.get(), nullptr, kToChar);
+				used += " и создали $o3.";
+				act(used.c_str(), false, ch, obj.get(), nullptr, kToChar);
 				act("$n создал$g $o3.", false, ch, obj.get(), nullptr, kToRoom | kToArenaListen);
 				PlaceObjToInventory(obj.get(), ch);
 			} else {
-				strcat(buf, " и попытались создать $o3.\r\n" "Ничего не вышло.");
-				act(buf, false, ch, obj.get(), nullptr, kToChar);
+				used += " и попытались создать $o3.\r\n" "Ничего не вышло.";
+				act(used.c_str(), false, ch, obj.get(), nullptr, kToChar);
 				ExtractObjFromWorld(obj.get());
 			}
 		} else {
 			if (spell_type == ESpellType::kItemCast) {
-				strcat(buf, "и создали магическую смесь.\r\n");
-				act(buf, false, ch, nullptr, nullptr, kToChar);
+				used += "и создали магическую смесь.\r\n";
+				act(used.c_str(), false, ch, nullptr, nullptr, kToChar);
 				act("$n смешал$g что-то в своей ноше.\r\n"
 					"Вы почувствовали резкий запах.", true, ch, nullptr, nullptr, kToRoom | kToArenaListen);
 			} else if (spell_type == ESpellType::kRunes) {
-				sprintf(buf + strlen(buf),
-						"котор%s вспыхнул%s ярким светом.%s",
-						num > 1 ? "ые" : grammar::ObjSexEnding((objo)->get_sex(), 3), num > 1 ? "и" : grammar::ObjSexEnding((objo)->get_sex(), 1),
-						ch->IsFlagged(EPrf::kCompact) ? "" : "\r\n");
-				act(buf, false, ch, nullptr, nullptr, kToChar);
+				used += fmt::format("котор{} вспыхнул{} ярким светом.{}",
+									num > 1 ? "ые" : grammar::ObjSexEnding((objo)->get_sex(), 3),
+									num > 1 ? "и" : grammar::ObjSexEnding((objo)->get_sex(), 1),
+									ch->IsFlagged(EPrf::kCompact) ? "" : "\r\n");
+				act(used.c_str(), false, ch, nullptr, nullptr, kToChar);
 				act("$n сложил$g руны, которые вспыхнули ярким пламенем.",
 					true, ch, nullptr, nullptr, kToRoom);
-				sprintf(buf, "$n сложил$g руны в заклинание '%s'%s%s.",
-						MUD::Spell(spell_id).GetCName(),
-						(tch && tch != ch ? " на " : ""),
-						(tch && tch != ch ? GET_PAD(tch, 1) : ""));
-				act(buf, true, ch, nullptr, nullptr, kToArenaListen);
+				act(fmt::format("$n сложил$g руны в заклинание '{}'{}{}.",
+								MUD::Spell(spell_id).GetCName(),
+								(tch && tch != ch ? " на " : ""),
+								(tch && tch != ch ? GET_PAD(tch, 1) : "")).c_str(),
+					true, ch, nullptr, nullptr, kToArenaListen);
 				auto magic_skill = MUD::Spell(spell_id).GetSuccessRoll().GetBaseSkill();
 				if (MUD::Skills().IsValid(magic_skill)) {
 					TrainSkill(ch, magic_skill, true, tch);


### PR DESCRIPTION
Часть #3814: `src/engine/ui/cmd/do_affects.cpp` (43 обращения) и `src/gameplay/mechanics/magic_item.cpp` (50) — оба по нулям.

## Что сделано

- Строка аффекта собирается целиком в `std::string`, без `strcat`/`snprintf(buf + strlen(buf), ...)` в глобальный буфер.
- Рецепт (`состав руны 'свет'`) и сообщения о складывании рун — так же.
- Цвета в переписанных строках переведены с констант `kColor*` на короткие коды (`&R`, `&Y`, `&G`, `&B`, `&W`, `&C`, `&y`, `&n`): у `fmt::format` меньше аргументов, и сразу видно, где цвет включается и гаснет.

## Отличие в выводе

Одно, и оно про код сброса цвета: `kColorNrm` — это `\x1B[0;37m`, а `&n` даёт `\x1B[0;0m`, как и весь остальной игровой текст. Сам текст, ширина колонок и расстановка цвета совпадают с master посимвольно:

```
master:  Заклинание : ^[[1;36mволшебный щит         (13 часов)  ^[[0;37m -6  к параметру: стойкость ...
ветка:   Заклинание : ^[[1;36mволшебный щит         (13 часов)  ^[[0;0m  -6  к параметру: стойкость ...
```

## Проверка

- Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.
- Живое сравнение с master на тестовом мире, с сохранением escape-последовательностей: пять заклинаний на себя и `аффекты`, `аффекты все`, `аффекты краткий` (строки с модификатором, без модификатора, несколько строк на одно заклинание, potency); `состав руны` с существующим и несуществующим рецептом, `состав напиток`, `состав свиток`, `состав` без аргументов, `руны`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr