### PR TITLE
refactor(weather): drop global buffers from weather, time and glory (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_time.cpp
+++ b/src/engine/ui/cmd/do_time.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "gameplay/mechanics/weather.h"
@@ -14,15 +16,15 @@ void do_time(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	int day, month, days_go;
 	if (ch->IsNpc())
 		return;
-	sprintf(buf, "Сейчас ");
+	std::string out = "Сейчас ";
 	switch (time_info.hours % 24) {
-		case 0: sprintf(buf + strlen(buf), "полночь, ");
+		case 0: out += "полночь, ";
 			break;
-		case 1: sprintf(buf + strlen(buf), "1 час ночи, ");
+		case 1: out += "1 час ночи, ";
 			break;
 		case 2:
 		case 3:
-		case 4: sprintf(buf + strlen(buf), "%d часа ночи, ", time_info.hours);
+		case 4: out += fmt::format("{} часа ночи, ", time_info.hours);
 			break;
 		case 5:
 		case 6:
@@ -30,15 +32,15 @@ void do_time(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 		case 8:
 		case 9:
 		case 10:
-		case 11: sprintf(buf + strlen(buf), "%d часов утра, ", time_info.hours);
+		case 11: out += fmt::format("{} часов утра, ", time_info.hours);
 			break;
-		case 12: sprintf(buf + strlen(buf), "полдень, ");
+		case 12: out += "полдень, ";
 			break;
-		case 13: sprintf(buf + strlen(buf), "1 час пополудни, ");
+		case 13: out += "1 час пополудни, ";
 			break;
 		case 14:
 		case 15:
-		case 16: sprintf(buf + strlen(buf), "%d часа пополудни, ", time_info.hours - 12);
+		case 16: out += fmt::format("{} часа пополудни, ", time_info.hours - 12);
 			break;
 		case 17:
 		case 18:
@@ -46,58 +48,57 @@ void do_time(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 		case 20:
 		case 21:
 		case 22:
-		case 23: sprintf(buf + strlen(buf), "%d часов вечера, ", time_info.hours - 12);
+		case 23: out += fmt::format("{} часов вечера, ", time_info.hours - 12);
 			break;
 	}
 
-	if (GET_RELIGION(ch) == kReligionPoly)
-		strcat(buf, weekdays_poly[weather_info.week_day_poly]);
-	else
-		strcat(buf, weekdays[weather_info.week_day_mono]);
+	if (GET_RELIGION(ch) == kReligionPoly) {
+		out += weekdays_poly[weather_info.week_day_poly];
+	} else {
+		out += weekdays[weather_info.week_day_mono];
+	}
 	switch (weather_info.sunlight) {
-		case kSunDark: strcat(buf, ", ночь");
+		case kSunDark: out += ", ночь";
 			break;
-		case kSunSet: strcat(buf, ", закат");
+		case kSunSet: out += ", закат";
 			break;
-		case kSunLight: strcat(buf, ", день");
+		case kSunLight: out += ", день";
 			break;
-		case kSunRise: strcat(buf, ", рассвет");
+		case kSunRise: out += ", рассвет";
 			break;
 	}
-	strcat(buf, ".\r\n");
-	SendMsgToChar(buf, ch);
+	out += ".\r\n";
+	SendMsgToChar(out, ch);
 
 	day = time_info.day + 1;    // day in [1..30]
-	*buf = '\0';
+	out.clear();
 	if (GET_RELIGION(ch) == kReligionPoly || privilege::IsImmortal(ch)) {
 		days_go = time_info.month * kDaysPerMonth + time_info.day;
 		month = days_go / 40;
 		days_go = (days_go % 40) + 1;
-		sprintf(buf + strlen(buf), "%s, %dй День, Год %d%s",
-				month_name_poly[month], days_go, time_info.year, privilege::IsImmortal(ch) ? ".\r\n" : "");
+		out += fmt::format("{}, {}й День, Год {}{}",
+						   month_name_poly[month], days_go, time_info.year, privilege::IsImmortal(ch) ? ".\r\n" : "");
 	}
-	if (GET_RELIGION(ch) == kReligionMono || privilege::IsImmortal(ch))
-		sprintf(buf + strlen(buf), "%s, %dй День, Год %d",
-				month_name[static_cast<int>(time_info.month)], day, time_info.year);
-	if (privilege::IsImmortal(ch))
-		sprintf(buf + strlen(buf),
-				"\r\n%d.%d.%d, дней с начала года: %d",
-				day,
-				time_info.month + 1,
-				time_info.year,
-				(time_info.month * kDaysPerMonth) + day);
+	if (GET_RELIGION(ch) == kReligionMono || privilege::IsImmortal(ch)) {
+		out += fmt::format("{}, {}й День, Год {}",
+						   month_name[static_cast<int>(time_info.month)], day, time_info.year);
+	}
+	if (privilege::IsImmortal(ch)) {
+		out += fmt::format("\r\n{}.{}.{}, дней с начала года: {}",
+						   day, time_info.month + 1, time_info.year, (time_info.month * kDaysPerMonth) + day);
+	}
 	switch (weather_info.season) {
-		case ESeason::kWinter: strcat(buf, ", зима");
+		case ESeason::kWinter: out += ", зима";
 			break;
-		case ESeason::kSpring: strcat(buf, ", весна");
+		case ESeason::kSpring: out += ", весна";
 			break;
-		case ESeason::kSummer: strcat(buf, ", лето");
+		case ESeason::kSummer: out += ", лето";
 			break;
-		case ESeason::kAutumn: strcat(buf, ", осень");
+		case ESeason::kAutumn: out += ", осень";
 			break;
 	}
-	strcat(buf, ".\r\n");
-	SendMsgToChar(buf, ch);
+	out += ".\r\n";
+	SendMsgToChar(out, ch);
 	gods_day_now(ch);
 }
 

--- a/src/gameplay/mechanics/glory_const.cpp
+++ b/src/gameplay/mechanics/glory_const.cpp
@@ -126,11 +126,9 @@ void glory_hide(CharData *ch,
 		 ++t_it) {
 		if (ch->get_uid() == t_it->get()->uid) {
 			if (mode == true) {
-				sprintf(buf, "Проставляю hide славы для %s", GET_NAME(ch));
-				mudlog(buf, CMP, kLvlGreatGod, SYSLOG, true);
+				mudlog(fmt::format("Проставляю hide славы для {}", GET_NAME(ch)), CMP, kLvlGreatGod, SYSLOG, true);
 			} else {
-				sprintf(buf, "Убираю hide славы для %s", GET_NAME(ch));
-				mudlog(buf, CMP, kLvlGreatGod, SYSLOG, true);
+				mudlog(fmt::format("Убираю hide славы для {}", GET_NAME(ch)), CMP, kLvlGreatGod, SYSLOG, true);
 			}
 			t_it->get()->hide = mode;
 		}
@@ -226,21 +224,21 @@ int calculate_glory_in_stats(GloryListType::const_iterator &i) {
 // * Распечатка 'слава информация'.
 void print_glory(CharData *ch, GloryListType::iterator &it) {
 	int spent = 0;
-	*buf = '\0';
+	std::string out;
 	for (auto i = it->second->stats.begin(), iend = it->second->stats.end(); i != iend; ++i) {
 		if ((i->first >= 0) && (i->first < (int) sizeof(olc_stat_name))) {
-			strcat(buf, fmt::format("{:<16}: +{}", olc_stat_name[i->first],
-					i->second * stat_multi(i->first)).c_str());
-			if (stat_multi(i->first) > 1)
-				sprintf(buf + strlen(buf), "(%d)", i->second);
-			strcat(buf, "\r\n");
+			out += fmt::format("{:<16}: +{}", olc_stat_name[i->first], i->second * stat_multi(i->first));
+			if (stat_multi(i->first) > 1) {
+				out += fmt::format("({})", i->second);
+			}
+			out += "\r\n";
 		} else {
 			log("Glory: некорректный номер стата %d (uid: %ld)", i->first, it->first);
 		}
 		spent = spent + 1000 * i->second + 200 * (i->second - 1);
 	}
-	sprintf(buf + strlen(buf), "Свободных очков: %d. Вложено: %d\r\n", it->second->free_glory, spent);
-	SendMsgToChar(buf, ch);
+	out += fmt::format("Свободных очков: {}. Вложено: {}\r\n", it->second->free_glory, spent);
+	SendMsgToChar(out, ch);
 }
 
 // * Показ свободной и вложенной славы у чара (glory имя).
@@ -649,12 +647,8 @@ void do_spend_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		remove_glory(ch->get_uid(), amount);
 		add_glory(vict->get_uid(), total_amount);
 
-		snprintf(buf, kMaxStringLength,
-				 "Transfer %d const glory from %s", total_amount, GET_NAME(ch));
-		AddKarma(vict, buf, "командой");
-
-		snprintf(buf, kMaxStringLength, "Transfer %d const glory to %s", amount, GET_NAME(vict));
-		AddKarma(ch, buf, "командой");
+		AddKarma(vict, fmt::format("Transfer {} const glory from {}", total_amount, GET_NAME(ch)).c_str(), "командой");
+		AddKarma(ch, fmt::format("Transfer {} const glory to {}", amount, GET_NAME(vict)).c_str(), "командой");
 
 		total_charge += tax;
 		transfer_log("%s -> %s transfered %d (%d tax)", GET_NAME(ch), GET_NAME(vict), total_amount, tax);
@@ -769,10 +763,10 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 	enum { SHOW_GLORY, ADD_GLORY, SUB_GLORY, RESET_GLORY };
 
-	char num[kMaxInputLength];
+	char name[kMaxInputLength], num[kMaxInputLength];
 	int mode = 0;
 
-	char *reason = two_arguments(argument, arg, num);
+	char *reason = two_arguments(argument, name, num);
 	skip_spaces(&reason);
 
 	if (!*num) {
@@ -792,14 +786,14 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	CharData *vict = target_resolver::FindPlayerVis(ch, arg);
+	CharData *vict = target_resolver::FindPlayerVis(ch, name);
 	if (vict && vict->desc && vict->desc->state == EConState::kGloryConst) {
 		SendMsgToChar("Персонаж в данный момент редактирует свою славу.\r\n", ch);
 		return;
 	}
 	Player t_vict; // TODO: мутно
 	if (!vict) {
-		if (LoadPlayerCharacter(arg, &t_vict, ELoadCharFlags::kFindId) < 0) {
+		if (LoadPlayerCharacter(name, &t_vict, ELoadCharFlags::kFindId) < 0) {
 			SendMsgToChar("Такого персонажа не существует.\r\n", ch);
 			return;
 		}
@@ -813,12 +807,13 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			SendMsgToChar(ch, "%s добавлено %d у.е. постоянной славы (Всего: %d у.е.).\r\n",
 						  GET_PAD(vict, 2), amount, get_glory(vict->get_uid()));
 			// запись в карму, логи
-			sprintf(buf, "(GC) %s sets +%d const glory to %s.", GET_NAME(ch), amount, GET_NAME(vict));
-			mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
-			imm_log("%s", buf);
-			sprintf(buf, "Change const glory +%d by %s", amount, GET_NAME(ch));
-			AddKarma(vict, buf, reason);
-			GloryMisc::add_log(mode, amount, std::string(buf), std::string(reason), vict);
+			const std::string log_line =
+				fmt::format("(GC) {} sets +{} const glory to {}.", GET_NAME(ch), amount, GET_NAME(vict));
+			mudlog(log_line, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+			imm_log("%s", log_line.c_str());
+			const std::string karma_line = fmt::format("Change const glory +{} by {}", amount, GET_NAME(ch));
+			AddKarma(vict, karma_line.c_str(), reason);
+			GloryMisc::add_log(mode, amount, karma_line, std::string(reason), vict);
 			break;
 		}
 		case SUB_GLORY: {
@@ -830,24 +825,26 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			SendMsgToChar(ch, "У %s вычтено %d у.е. постоянной славы (Всего: %d у.е.).\r\n",
 						  GET_PAD(vict, 1), amount, get_glory(vict->get_uid()));
 			// запись в карму, логи
-			sprintf(buf, "(GC) %s sets -%d const glory to %s.", GET_NAME(ch), amount, GET_NAME(vict));
-			mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
-			imm_log("%s", buf);
-			sprintf(buf, "Change const glory -%d by %s", amount, GET_NAME(ch));
-			AddKarma(vict, buf, reason);
-			GloryMisc::add_log(mode, amount, std::string(buf), std::string(reason), vict);
+			const std::string log_line =
+				fmt::format("(GC) {} sets -{} const glory to {}.", GET_NAME(ch), amount, GET_NAME(vict));
+			mudlog(log_line, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+			imm_log("%s", log_line.c_str());
+			const std::string karma_line = fmt::format("Change const glory -{} by {}", amount, GET_NAME(ch));
+			AddKarma(vict, karma_line.c_str(), reason);
+			GloryMisc::add_log(mode, amount, karma_line, std::string(reason), vict);
 			break;
 		}
 		case RESET_GLORY: {
 			if (reset_glory(vict)) {
 				SendMsgToChar(ch, "%s - очищена запись постоянной славы.\r\n", vict->get_name().c_str());
 				// запись в карму, логи
-				sprintf(buf, "(GC) %s reset const glory to %s.", GET_NAME(ch), GET_NAME(vict));
-				mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
-				imm_log("%s", buf);
-				sprintf(buf, "Reset stats and const glory by %s", GET_NAME(ch));
-				AddKarma(vict, buf, reason);
-				GloryMisc::add_log(mode, 0, std::string(buf), std::string(reason), vict);
+				const std::string log_line =
+					fmt::format("(GC) {} reset const glory to {}.", GET_NAME(ch), GET_NAME(vict));
+				mudlog(log_line, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+				imm_log("%s", log_line.c_str());
+				const std::string karma_line = fmt::format("Reset stats and const glory by {}", GET_NAME(ch));
+				AddKarma(vict, karma_line.c_str(), reason);
+				GloryMisc::add_log(mode, 0, karma_line, std::string(reason), vict);
 			} else {
 				SendMsgToChar(ch, "%s - запись постоянной славы и так пустая.\r\n", vict->get_name().c_str());
 			}
@@ -910,20 +907,16 @@ void load() {
 	const std::string xml_glory_const = native_text::read_data_file(LIB_USERDATA"glory_const.xml");
 	pugi::xml_parse_result result = doc.load_buffer(xml_glory_const.data(), xml_glory_const.size());
 	if (!result) {
-		snprintf(buf, kMaxStringLength, "WARNING: glory_const.xml not found or unreadable (%s), skipping (non-fatal)", result.description());
-		perror(buf);
+		perror(fmt::format("WARNING: glory_const.xml not found or unreadable ({}), skipping (non-fatal)",
+						   result.description()).c_str());
 		return;
 	}
 	pugi::xml_node char_list = doc.child("glory_list");
 	if (char_list.attribute("version")) {
 		ver = std::stoi(char_list.attribute("version").value(), nullptr, 10);
 		if (ver > cur_ver) {
-			snprintf(buf,
-					 kMaxStringLength,
-					 "SYSERR: error reading glory_const.xml: unsupported version: %d, current version: %d",
-					 ver,
-					 cur_ver);
-			perror(buf);
+			perror(fmt::format("SYSERR: error reading glory_const.xml: unsupported version: {}, current version: {}",
+							   ver, cur_ver).c_str());
 			return;
 		}
 	}

--- a/src/gameplay/mechanics/weather.cpp
+++ b/src/gameplay/mechanics/weather.cpp
@@ -572,27 +572,27 @@ void weather_change() {
 
 	temp += temp_change;
 	cweather_type = 0;
-	*buf = '\0';
+	std::string message;
 	if (weather_info.temperature - temp > 6) {
-		strcat(buf, "Резкое похолодание.\r\n");
+		message += "Резкое похолодание.\r\n";
 		SET_BIT(cweather_type, kWeatherQuickcool);
 	} else if (weather_info.temperature - temp < -6) {
-		strcat(buf, "Резкое потепление.\r\n");
+		message += "Резкое потепление.\r\n";
 		SET_BIT(cweather_type, kWeatherQuickhot);
 	}
 	weather_info.temperature = MIN(year_temp[time_info.month].max, MAX(year_temp[time_info.month].min, temp));
 
 	if (weather_info.change >= 10 || weather_info.change <= -10) {
-		strcat(buf, "Сильный ветер.\r\n");
+		message += "Сильный ветер.\r\n";
 		SET_BIT(cweather_type, kWeatherBigwind);
 	} else if (weather_info.change >= 6 || weather_info.change <= -6) {
-		strcat(buf, "Умеренный ветер.\r\n");
+		message += "Умеренный ветер.\r\n";
 		SET_BIT(cweather_type, kWeatherMediumwind);
 	} else if (weather_info.change >= 2 || weather_info.change <= -2) {
-		strcat(buf, "Слабый ветер.\r\n");
+		message += "Слабый ветер.\r\n";
 		SET_BIT(cweather_type, kWeatherLightwind);
 	} else if (IS_SET(weather_info.weather_type, kWeatherBigwind | kWeatherMediumwind | kWeatherLightwind)) {
-		strcat(buf, "Ветер утих.\r\n");
+		message += "Ветер утих.\r\n";
 		if (IS_SET(weather_info.weather_type, kWeatherBigwind))
 			SET_BIT(cweather_type, kWeatherMediumwind);
 		else if (IS_SET(weather_info.weather_type, kWeatherMediumwind))
@@ -601,7 +601,7 @@ void weather_change() {
 
 	switch (sky_change) {
 		case 1:        // CLOUDLESS -> CLOUDY
-			strcat(buf, "Небо затянуло тучами.\r\n");
+			message += "Небо затянуло тучами.\r\n";
 			weather_info.sky = kSkyCloudy;
 			break;
 		case 2:        // CLOUDY -> RAINING
@@ -610,40 +610,40 @@ void weather_change() {
 				case EMonth::kJune:
 				case EMonth::kJuly:
 				case EMonth::kAugust:
-				case EMonth::kSeptember: strcat(buf, "Начался дождь.\r\n");
+				case EMonth::kSeptember: message += "Начался дождь.\r\n";
 					SetPrecipitations(&cweather_type, kWeatherLightrain, 30, 40, 30);
 					break;
 				case EMonth::kDecember:
 				case EMonth::kJanuary:
-				case EMonth::kFebruary: strcat(buf, "Пошел снег.\r\n");
+				case EMonth::kFebruary: message += "Пошел снег.\r\n";
 					SetPrecipitations(&cweather_type, kWeatherLightsnow, 30, 40, 30);
 					break;
 				case EMonth::kOctober:
 				case EMonth::kApril:
 					if (IS_SET(cweather_type, kWeatherQuickcool)
 						&& weather_info.temperature <= 5) {
-						strcat(buf, "Пошел снег.\r\n");
+						message += "Пошел снег.\r\n";
 						SET_BIT(cweather_type, kWeatherLightsnow);
 					} else {
-						strcat(buf, "Начался дождь.\r\n");
+						message += "Начался дождь.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightrain, 40, 60, 0);
 					}
 					break;
 				case EMonth::kNovember:
 					if (avg_day_temp <= 3 || IS_SET(cweather_type, kWeatherQuickcool)) {
-						strcat(buf, "Пошел снег.\r\n");
+						message += "Пошел снег.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightsnow, 40, 60, 0);
 					} else {
-						strcat(buf, "Начался дождь.\r\n");
+						message += "Начался дождь.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightrain, 40, 60, 0);
 					}
 					break;
 				case EMonth::kMarch:
 					if (avg_day_temp >= 3 || IS_SET(cweather_type, kWeatherQuickhot)) {
-						strcat(buf, "Начался дождь.\r\n");
+						message += "Начался дождь.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightrain, 80, 20, 0);
 					} else {
-						strcat(buf, "Пошел снег.\r\n");
+						message += "Пошел снег.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightsnow, 60, 30, 10);
 					}
 					break;
@@ -651,20 +651,20 @@ void weather_change() {
 			weather_info.sky = kSkyRaining;
 			break;
 		case 3:        // CLOUDY -> CLOUDLESS
-			strcat(buf, "Начало проясняться.\r\n");
+			message += "Начало проясняться.\r\n";
 			weather_info.sky = kSkyCloudless;
 			break;
 		case 4:        // RAINING -> LIGHTNING
-			strcat(buf, "Налетевший ветер разогнал тучи.\r\n");
+			message += "Налетевший ветер разогнал тучи.\r\n";
 			weather_info.sky = kSkyLightning;
 			break;
 		case 5:        // RAINING -> CLOUDY
 			if (IS_SET(weather_info.weather_type, kWeatherLightrain | kWeatherMediumrain | kWeatherBigrain))
-				strcat(buf, "Дождь прекратился.\r\n");
+				message += "Дождь прекратился.\r\n";
 			else if (IS_SET(weather_info.weather_type, kWeatherLightsnow | kWeatherMediumsnow | kWeatherBigsnow))
-				strcat(buf, "Снегопад прекратился.\r\n");
+				message += "Снегопад прекратился.\r\n";
 			else if (IS_SET(weather_info.weather_type, kWeatherHail))
-				strcat(buf, "Град прекратился.\r\n");
+				message += "Град прекратился.\r\n";
 			weather_info.sky = kSkyCloudy;
 			break;
 		case 6:        // LIGHTNING -> RAINING
@@ -675,44 +675,44 @@ void weather_change() {
 				case EMonth::kAugust:
 				case EMonth::kSeptember:
 					if (IS_SET(cweather_type, kWeatherQuickcool)) {
-						strcat(buf, "Начался град.\r\n");
+						message += "Начался град.\r\n";
 						SET_BIT(cweather_type, kWeatherHail);
 					} else {
-						strcat(buf, "Полил дождь.\r\n");
+						message += "Полил дождь.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightrain, 10, 40, 50);
 					}
 					break;
 				case EMonth::kDecember:
 				case EMonth::kJanuary:
-				case EMonth::kFebruary: strcat(buf, "Повалил снег.\r\n");
+				case EMonth::kFebruary: message += "Повалил снег.\r\n";
 					SetPrecipitations(&cweather_type, kWeatherLightsnow, 10, 40, 50);
 					break;
 				case EMonth::kOctober:
 				case EMonth::kApril:
 					if (IS_SET(cweather_type, kWeatherQuickcool)
 						&& weather_info.temperature <= 5) {
-						strcat(buf, "Повалил снег.\r\n");
+						message += "Повалил снег.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightsnow, 40, 60, 0);
 					} else {
-						strcat(buf, "Начался дождь.\r\n");
+						message += "Начался дождь.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightrain, 40, 60, 0);
 					}
 					break;
 				case EMonth::kNovember:
 					if (avg_day_temp <= 3 || IS_SET(cweather_type, kWeatherQuickcool)) {
-						strcat(buf, "Повалил снег.\r\n");
+						message += "Повалил снег.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightsnow, 40, 60, 0);
 					} else {
-						strcat(buf, "Начался дождь.\r\n");
+						message += "Начался дождь.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightrain, 40, 60, 0);
 					}
 					break;
 				case EMonth::kMarch:
 					if (avg_day_temp >= 3 || IS_SET(cweather_type, kWeatherQuickhot)) {
-						strcat(buf, "Начался дождь.\r\n");
+						message += "Начался дождь.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightrain, 80, 20, 0);
 					} else {
-						strcat(buf, "Пошел снег.\r\n");
+						message += "Пошел снег.\r\n";
 						SetPrecipitations(&cweather_type, kWeatherLightsnow, 60, 30, 10);
 					}
 					break;
@@ -722,47 +722,47 @@ void weather_change() {
 		case 0:
 		default:
 			if (IS_SET(weather_info.weather_type, kWeatherHail)) {
-				strcat(buf, "Град прекратился.\r\n");
+				message += "Град прекратился.\r\n";
 				SetPrecipitations(&cweather_type, kWeatherLightrain, 10, 40, 50);
 			} else if (IS_SET(weather_info.weather_type, kWeatherBigrain)) {
 				if (weather_info.change >= 5) {
-					strcat(buf, "Дождь утих.\r\n");
+					message += "Дождь утих.\r\n";
 					SetPrecipitations(&cweather_type, kWeatherLightrain, 20, 80, 0);
 				} else
 					SET_BIT(cweather_type, kWeatherBigrain);
 			} else if (IS_SET(weather_info.weather_type, kWeatherMediumrain)) {
 				if (weather_info.change <= -5) {
-					strcat(buf, "Дождь усилился.\r\n");
+					message += "Дождь усилился.\r\n";
 					SET_BIT(cweather_type, kWeatherBigrain);
 				} else if (weather_info.change >= 5) {
-					strcat(buf, "Дождь утих.\r\n");
+					message += "Дождь утих.\r\n";
 					SET_BIT(cweather_type, kWeatherLightrain);
 				} else
 					SET_BIT(cweather_type, kWeatherMediumrain);
 			} else if (IS_SET(weather_info.weather_type, kWeatherLightrain)) {
 				if (weather_info.change <= -5) {
-					strcat(buf, "Дождь усилился.\r\n");
+					message += "Дождь усилился.\r\n";
 					SetPrecipitations(&cweather_type, kWeatherLightrain, 0, 70, 30);
 				} else
 					SET_BIT(cweather_type, kWeatherLightrain);
 			} else if (IS_SET(weather_info.weather_type, kWeatherBigsnow)) {
 				if (weather_info.change >= 5) {
-					strcat(buf, "Снегопад утих.\r\n");
+					message += "Снегопад утих.\r\n";
 					SetPrecipitations(&cweather_type, kWeatherLightsnow, 20, 80, 0);
 				} else
 					SET_BIT(cweather_type, kWeatherBigsnow);
 			} else if (IS_SET(weather_info.weather_type, kWeatherMediumsnow)) {
 				if (weather_info.change <= -5) {
-					strcat(buf, "Снегопад усилился.\r\n");
+					message += "Снегопад усилился.\r\n";
 					SET_BIT(cweather_type, kWeatherBigsnow);
 				} else if (weather_info.change >= 5) {
-					strcat(buf, "Снегопад утих.\r\n");
+					message += "Снегопад утих.\r\n";
 					SET_BIT(cweather_type, kWeatherLightsnow);
 				} else
 					SET_BIT(cweather_type, kWeatherMediumsnow);
 			} else if (IS_SET(weather_info.weather_type, kWeatherLightsnow)) {
 				if (weather_info.change <= -5) {
-					strcat(buf, "Снегопад усилился.\r\n");
+					message += "Снегопад усилился.\r\n";
 					SetPrecipitations(&cweather_type, kWeatherLightsnow, 0, 70, 30);
 				} else
 					SET_BIT(cweather_type, kWeatherLightsnow);
@@ -770,8 +770,8 @@ void weather_change() {
 			break;
 	}
 
-	if (*buf)
-		SendMsgToOutdoor(buf, WEATHER_CONTROL);
+	if (!message.empty())
+		SendMsgToOutdoor(message.c_str(), WEATHER_CONTROL);
 	weather_info.weather_type = cweather_type;
 }
 


### PR DESCRIPTION
Часть #3814: `weather.cpp` (41 обращение), `glory_const.cpp` (41) и `do_time.cpp` (38) — все три по нулям.

## Что сделано

- Сообщение о смене погоды собирается в локальную строку — 38 `strcat` в общий буфер.
- `время` собирает обе даты и сезон в одну строку.
- Постоянная слава: список вложений, записи в карму и в лог, разбор аргументов `glory` (имя уехало в локальный буфер вместо глобального `arg`).

## Проверка

- Набор строковых литералов в `weather.cpp` до и после совпадает — 69 из 69, так что ни одна ветка погоды не потерялась и не подменилась (погода меняется по случайному числу, и сравнить два прогона построчно нельзя).
- Живое сравнение с master на тестовом мире, с сохранением escape-последовательностей: `время` и вся команда `glory` (показ, `+N`, `-N`, `reset`, несуществующий игрок, без причины). Вывод игроку и строки syslog совпадают посимвольно.
- Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr