### PR TITLE
refactor(users): drop global buffers from users and vnum (#3814)

### DIFF
--- a/src/engine/ui/cmd_god/do_tabulate.cpp
+++ b/src/engine/ui/cmd_god/do_tabulate.cpp
@@ -30,51 +30,52 @@ static bool IsFilterKey(const char *str) {
 }
 
 void DoTabulate(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-	half_chop(argument, buf, buf2);
+	char what[kMaxInputLength], name[kMaxInputLength];
+	half_chop(argument, what, name);
 
-	if (!*buf || !*buf2
-		|| (!utils::IsAbbr(buf, "mob")
-			&& !utils::IsAbbr(buf, "obj")
-			&& !utils::IsAbbr(buf, "room")
-			&& !utils::IsAbbr(buf, "flag")
-			&& !IsFilterKey(buf)
-			&& !utils::IsAbbr(buf, "существо")
-			&& !utils::IsAbbr(buf, "предмет")
-			&& !utils::IsAbbr(buf, "флаг")
-			&& !utils::IsAbbr(buf, "комната")
-			&& !utils::IsAbbr(buf, "trig")
-			&& !utils::IsAbbr(buf, "триггер")
-			&& !utils::IsAbbr(buf, "load"))) {
+	if (!*what || !*name
+		|| (!utils::IsAbbr(what, "mob")
+			&& !utils::IsAbbr(what, "obj")
+			&& !utils::IsAbbr(what, "room")
+			&& !utils::IsAbbr(what, "flag")
+			&& !IsFilterKey(what)
+			&& !utils::IsAbbr(what, "существо")
+			&& !utils::IsAbbr(what, "предмет")
+			&& !utils::IsAbbr(what, "флаг")
+			&& !utils::IsAbbr(what, "комната")
+			&& !utils::IsAbbr(what, "trig")
+			&& !utils::IsAbbr(what, "триггер")
+			&& !utils::IsAbbr(what, "load"))) {
 		SendMsgToChar("Usage: vnum { obj | mob | flag | f | room | trig | load} <name>\r\n"
 					  "  f <фильтр> -- поиск предметов по фильтру (как в хранилище клана),\r\n"
 					  "                например: vnum f Адлительность\r\n", ch);
 		return;
 	}
 
-	if ((utils::IsAbbr(buf, "mob")) || (utils::IsAbbr(buf, "существо"))) {
-		if (!TabulateMobsByName(buf2, ch)) {
+	if ((utils::IsAbbr(what, "mob")) || (utils::IsAbbr(what, "существо"))) {
+		if (!TabulateMobsByName(name, ch)) {
 			SendMsgToChar("Нет существа с таким именем.\r\n", ch);
 		}
-	} else if ((utils::IsAbbr(buf, "obj")) || (utils::IsAbbr(buf, "предмет"))) {
-		if (!TabulateObjsByAliases(buf2, ch)) {
+	} else if ((utils::IsAbbr(what, "obj")) || (utils::IsAbbr(what, "предмет"))) {
+		if (!TabulateObjsByAliases(name, ch)) {
 			SendMsgToChar("Нет предмета с таким названием.\r\n", ch);
 		}
-	} else if (IsFilterKey(buf)) {
-		TabulateObjsByFilter(buf2, ch);
-	} else if ((utils::IsAbbr(buf, "flag")) || (utils::IsAbbr(buf, "флаг"))) {
-		if (!TabulateObjsByFlagName(buf2, ch)) {
+	} else if (IsFilterKey(what)) {
+		TabulateObjsByFilter(name, ch);
+	} else if ((utils::IsAbbr(what, "flag")) || (utils::IsAbbr(what, "флаг"))) {
+		if (!TabulateObjsByFlagName(name, ch)) {
 			SendMsgToChar("Нет объектов с таким флагом.\r\n", ch);
 		}
-	} else if ((utils::IsAbbr(buf, "room")) || (utils::IsAbbr(buf, "комната"))) {
-		if (!TabulateRoomsByName(buf2, ch)) {
+	} else if ((utils::IsAbbr(what, "room")) || (utils::IsAbbr(what, "комната"))) {
+		if (!TabulateRoomsByName(name, ch)) {
 			SendMsgToChar("Нет объектов с таким флагом.\r\n", ch);
 		}
-	} else if (utils::IsAbbr(buf, "trig") || utils::IsAbbr(buf, "триггер")) {
-		if (!TabulateTrigsByObjLoad(buf2, ch)) {
+	} else if (utils::IsAbbr(what, "trig") || utils::IsAbbr(what, "триггер")) {
+		if (!TabulateTrigsByObjLoad(name, ch)) {
 			SendMsgToChar("Нет триггеров, загружающих такой объект.\r\n", ch);
 		}
-	} else if (utils::IsAbbr(buf, "load") || utils::IsAbbr(buf, "загрузка")) {
-		if (!TabulateMobsByDeadLoad(buf2, ch)) {
+	} else if (utils::IsAbbr(what, "load") || utils::IsAbbr(what, "загрузка")) {
+		if (!TabulateMobsByDeadLoad(name, ch)) {
 			SendMsgToChar("Нет мобов, загружаюющих такой объект по списку dead load.\r\n", ch);
 		}
 	}
@@ -117,10 +118,9 @@ int TabulateMobsByName(char *searchname, CharData *ch) {
 
 	for (nr = 0; nr <= top_of_mobt; nr++) {
 		if (isname(searchname, mob_proto[nr].GetCharAliases())) {
-			strcpy(buf, fmt::format("{:3}. [{:5}] {:<30} ({})\r\n", ++found, mob_index[nr].vnum,
-					mob_proto[nr].get_npc_name(),
-					npc_race_types[mob_proto[nr].player_data.Race - ENpcRace::kBasic]).c_str());
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("{:3}. [{:5}] {:<30} ({})\r\n", ++found, mob_index[nr].vnum,
+									  mob_proto[nr].get_npc_name(),
+									  npc_race_types[mob_proto[nr].player_data.Race - ENpcRace::kBasic]), ch);
 		}
 	}
 	return (found);
@@ -132,10 +132,8 @@ int TabulateObjsByAliases(char *searchname, CharData *ch) {
 	for (const auto &nr : obj_proto) {
 		if (isname(searchname, nr->get_aliases())) {
 			++found;
-			sprintf(buf, "%3d. [%7d] %s\r\n",
-					found, nr->get_vnum(),
-					nr->get_short_description().c_str());
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("{:3}. [{:7}] {}\r\n",
+									  found, nr->get_vnum(), nr->get_short_description()), ch);
 		}
 	}
 	return (found);

--- a/src/engine/ui/cmd_god/do_users.cpp
+++ b/src/engine/ui/cmd_god/do_users.cpp
@@ -17,8 +17,7 @@
 "Формат: users [-l minlevel[-maxlevel]] [-n name] [-h host] [-c classlist] [-o] [-p]\r\n"
 const int kMaxListLen = 200;
 void do_users(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-	char idletime[10], classname[128];
-	char state[30] = "\0", *timeptr, mode;
+	char mode;
 	char name_search[kMaxInputLength] = "\0", host_search[kMaxInputLength];
 	char host_by_name[kMaxInputLength] = "\0";
 	DescriptorData *list_players[kMaxListLen];
@@ -176,6 +175,7 @@ void do_users(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	for (cycle_i = 0; cycle_i < count_pl; cycle_i++) {
 		d = list_players[cycle_i];
 
+		std::string classname;
 		if (d->state != EConState::kPlaying && playing)
 			continue;
 		if (d->state == EConState::kPlaying && deadweight)
@@ -205,66 +205,45 @@ void do_users(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				continue;
 			}
 
-			if (d->original) {
-				if (showremorts) {
-					sprintf(classname,
-							"[%2d %2d %s]",
-							GetRealLevel(d->original),
-							remort::GetRealRemort(d->original),
-							MUD::Class(d->original->GetClass()).GetAbbr().c_str());
-				} else {
-					sprintf(classname,
-							"[%2d %s]   ",
-							GetRealLevel(d->original),
-							MUD::Class(d->original->GetClass()).GetAbbr().c_str());
-				}
-			} else if (showremorts) {
-				sprintf(classname,
-						"[%2d %2d %s]",
-						GetRealLevel(d->character),
-						remort::GetRealRemort(d->character),
-						MUD::Class(d->character->GetClass()).GetAbbr().c_str());
-			} else {
-				sprintf(classname,
-						"[%2d %s]   ",
-						GetRealLevel(d->character),
-						MUD::Class(d->character->GetClass()).GetAbbr().c_str());
-			}
+			// В switched-состоянии показываем того, кем игрок был до вселения.
+			const CharData *shown = d->original ? d->original.get() : d->character.get();
+			classname = showremorts
+						? fmt::format("[{:2} {:2} {}]",
+									  GetRealLevel(shown), remort::GetRealRemort(shown),
+									  MUD::Class(shown->GetClass()).GetAbbr())
+						: fmt::format("[{:2} {}]   ",
+									  GetRealLevel(shown), MUD::Class(shown->GetClass()).GetAbbr());
 		} else {
-			strcpy(classname, "      -      ");
+			classname = "      -      ";
 		}
 
 		if (GetRealLevel(ch) < kLvlImplementator && !ch->IsFlagged(EPrf::kCoderinfo)) {
-			strcpy(classname, "      -      ");
+			classname = "      -      ";
 		}
 
-		timeptr = asctime(localtime(&d->login_time));
-		timeptr += 11;
-		*(timeptr + 8) = '\0';
+		// asctime отдаёт "Www Mmm dd hh:mm:ss yyyy"; берём часы-минуты-секунды, не затирая
+		// нулём статический буфер библиотеки, как делал прежний код.
+		const std::string login_time = std::string(asctime(localtime(&d->login_time))).substr(11, 8);
 
-		if (d->state == EConState::kPlaying && d->original) {
-			strcpy(state, "Switched");
-		} else {
-			strcpy(state, GetConDescription(d->state));
-		}
+		const std::string state = (d->state == EConState::kPlaying && d->original)
+								  ? "Switched"
+								  : GetConDescription(d->state);
 
-		if (d->character
-			&& d->state == EConState::kPlaying
-			&& !privilege::IsGod(d->character.get())) {
-			sprintf(idletime, "%-3d", d->character->char_specials.timer *
-				kSecsPerMudHour / kSecsPerRealMin);
-		} else {
-			strcpy(idletime, "   ");
-		}
+		const std::string idletime = (d->character
+									  && d->state == EConState::kPlaying
+									  && !privilege::IsGod(d->character.get()))
+									 ? fmt::format("{:<3}", d->character->char_specials.timer
+												   * kSecsPerMudHour / kSecsPerRealMin)
+									 : "   ";
 
 		std::string line;
 		if (d->character) {
 			line = fmt::format(fmt::runtime(format), d->desc_num, classname,
 							   d->original ? d->original->GetCharAliases() : d->character->GetCharAliases(),
-							   state, idletime, timeptr);
+							   state, idletime, login_time);
 		} else {
 			line = fmt::format(fmt::runtime(format), d->desc_num, "   -   ", "UNDEFINED",
-							   state, idletime, timeptr);
+							   state, idletime, login_time);
 		}
 
 		if (*d->host) {

--- a/src/engine/ui/cmd_god/do_users.cpp
+++ b/src/engine/ui/cmd_god/do_users.cpp
@@ -17,7 +17,7 @@
 "Формат: users [-l minlevel[-maxlevel]] [-n name] [-h host] [-c classlist] [-o] [-p]\r\n"
 const int kMaxListLen = 200;
 void do_users(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
-	char line[256], line2[220], idletime[10], classname[128];
+	char idletime[10], classname[128];
 	char state[30] = "\0", *timeptr, mode;
 	char name_search[kMaxInputLength] = "\0", host_search[kMaxInputLength];
 	char host_by_name[kMaxInputLength] = "\0";
@@ -35,89 +35,86 @@ void do_users(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 	host_search[0] = name_search[0] = '\0';
 
-	strcpy(buf, argument);
-	while (*buf) {
-		half_chop(buf, arg, buf1);
-		if (*arg == '-') {
-			mode = *(arg + 1);    // just in case; we destroy arg in the switch
+	char rest[kMaxInputLength], option[kMaxInputLength], tail[kMaxInputLength];
+	strl_cpy(rest, argument, sizeof(rest));
+	while (*rest) {
+		half_chop(rest, option, tail);
+		if (*option == '-') {
+			mode = *(option + 1);    // just in case; we destroy option in the switch
 			switch (mode) {
 				case 'o':
 				case 'k': outlaws = 1;
 					playing = 1;
-					strcpy(buf, buf1);
+					strl_cpy(rest, tail, sizeof(rest));
 					break;
 				case 'p': playing = 1;
-					strcpy(buf, buf1);
+					strl_cpy(rest, tail, sizeof(rest));
 					break;
 				case 'd': deadweight = 1;
-					strcpy(buf, buf1);
+					strl_cpy(rest, tail, sizeof(rest));
 					break;
 				case 'l':
 					if (!privilege::IsGod(ch))
 						return;
 					playing = 1;
-					half_chop(buf1, arg, buf);
-					sscanf(arg, "%d-%d", &low, &high);
+					half_chop(tail, option, rest);
+					sscanf(option, "%d-%d", &low, &high);
 					break;
 				case 'n': playing = 1;
-					half_chop(buf1, name_search, buf);
+					half_chop(tail, name_search, rest);
 					break;
 				case 'h': playing = 1;
-					half_chop(buf1, host_search, buf);
+					half_chop(tail, host_search, rest);
 					break;
 				case 'u': playing = 1;
-					half_chop(buf1, host_by_name, buf);
+					half_chop(tail, host_by_name, rest);
 					break;
 				case 'w':
 					if (!privilege::IsGrGod(ch))
 						return;
 					playing = 1;
 					locating = 1;
-					strcpy(buf, buf1);
+					strl_cpy(rest, tail, sizeof(rest));
 					break;
 				case 'c': {
 					playing = 1;
-					half_chop(buf1, arg, buf);
+					half_chop(tail, option, rest);
 /*					const size_t len = strlen(arg);
 					for (size_t i = 0; i < len; i++) {
 						showclass |= FindCharClassMask(arg[i]);
 					}*/
-					showclass = FindAvailableCharClassId(arg);
+					showclass = FindAvailableCharClassId(option);
 					break;
 				}
 				case 'e': showemail = 1;
-					strcpy(buf, buf1);
+					strl_cpy(rest, tail, sizeof(rest));
 					break;
 				case 'r': showremorts = 1;
-					strcpy(buf, buf1);
+					strl_cpy(rest, tail, sizeof(rest));
 					break;
 
 				case 's':
-					sorting = *(arg + 2);
-					strcpy(buf, buf1);
+					sorting = *(option + 2);
+					strl_cpy(rest, tail, sizeof(rest));
 					break;
 				default: SendMsgToChar(USERS_FORMAT, ch);
 					return;
 			}    // end of switch
 
 		} else {
-			strcpy(name_search, arg);
-			strcpy(buf, buf1);
+			strl_cpy(name_search, option, sizeof(name_search));
+			strl_cpy(rest, tail, sizeof(rest));
 		}
 	}            // end while (parser)
 
 	// Ширина колонок - в символах, а не в байтах (issue #3681): поля ниже паддятся
 // через native_text, поэтому формат содержит голые "%s".
 	const char *format = "{:3} {:<7} {:<20} {:<17} {:<3} {:<8} ";
-	if (showemail) {
-		strcpy(line, "Ном Професс    Имя                  Состояние         Idl Логин    Сайт       E-mail\r\n");
-	} else {
-		strcpy(line, "Ном Професс    Имя                  Состояние         Idl Логин    Сайт\r\n");
-	}
-	strcat(line, "--- ---------- -------------------- ----------------- --- -------- ----------------------------\r\n");
-	SendMsgToChar(line, ch);
-
-	one_argument(argument, arg);
+	std::string header = showemail
+		? "Ном Професс    Имя                  Состояние         Idl Логин    Сайт       E-mail\r\n"
+		: "Ном Професс    Имя                  Состояние         Idl Логин    Сайт\r\n";
+	header += "--- ---------- -------------------- ----------------- --- -------- ----------------------------\r\n";
+	SendMsgToChar(header, ch);
 
 	if (strlen(host_by_name) != 0) {
 		strcpy(host_search, "!");
@@ -260,59 +257,46 @@ void do_users(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			strcpy(idletime, "   ");
 		}
 
-		if (d->character
-			&& d->character->GetCharAliases().c_str()) {
-			if (d->original) {
-				strcpy(line, fmt::format(fmt::runtime(format),
-						d->desc_num, classname, d->original->GetCharAliases().c_str(),
-						state, idletime, timeptr).c_str());
-			} else {
-				strcpy(line, fmt::format(fmt::runtime(format),
-						d->desc_num, classname, d->character->GetCharAliases().c_str(),
-						state, idletime, timeptr).c_str());
-			}
+		std::string line;
+		if (d->character) {
+			line = fmt::format(fmt::runtime(format), d->desc_num, classname,
+							   d->original ? d->original->GetCharAliases() : d->character->GetCharAliases(),
+							   state, idletime, timeptr);
 		} else {
-			strcpy(line, fmt::format(fmt::runtime(format), d->desc_num, "   -   ",
-					"UNDEFINED", state, idletime, timeptr).c_str());
+			line = fmt::format(fmt::runtime(format), d->desc_num, "   -   ", "UNDEFINED",
+							   state, idletime, timeptr);
 		}
 
-		if (d && *d->host) {
-			sprintf(line2, "[%s]", d->host);
-			strcat(line, line2);
+		if (*d->host) {
+			line += fmt::format("[{}]", d->host);
 		} else {
-			strcat(line, "[Неизвестный хост]");
+			line += "[Неизвестный хост]";
 		}
 
 		if (showemail) {
-			sprintf(line2, "[&S%s&s]",
-					d->original ? GET_EMAIL(d->original) : d->character ? GET_EMAIL(d->character) : "");
-			strcat(line, line2);
+			line += fmt::format("[&S{}&s]",
+								d->original ? GET_EMAIL(d->original) : d->character ? GET_EMAIL(d->character) : "");
 		}
 
-		if (locating && (*name_search || *host_by_name)) {
-			if (d->state == EConState::kPlaying) {
-				const auto ci = d->get_character();
-				if (ci
-					&& sight::CanSee(ch, ci)
-					&& ci->in_room != kNowhere) {
-					if (d->original && d->character) {
-						sprintf(line2, " [%7d] %s (in %s)",
-								GET_ROOM_VNUM(d->character->in_room),
-								world[d->character->in_room]->name, GET_NAME(d->character));
-					} else {
-						sprintf(line2, " [%7d] %s",
-								GET_ROOM_VNUM(ci->in_room), world[ci->in_room]->name);
-					}
+		// Комната ищется только по ключу -w с именем или хостом. Раньше строка с комнатой
+		// приклеивалась и тогда, когда её не собрали, -- в вывод попадал прошлый кусок буфера.
+		if (locating && (*name_search || *host_by_name) && d->state == EConState::kPlaying) {
+			const auto ci = d->get_character();
+			if (ci && sight::CanSee(ch, ci) && ci->in_room != kNowhere) {
+				// имя комнаты бывает нулевым (конструктор RoomData), а fmt на нуле бросает исключение
+				const char *room_name = world[ci->in_room]->name ? world[ci->in_room]->name : "";
+				if (d->original && d->character) {
+					line += fmt::format(" [{:7}] {} (in {})",
+										GET_ROOM_VNUM(d->character->in_room), room_name, GET_NAME(d->character));
+				} else {
+					line += fmt::format(" [{:7}] {}", GET_ROOM_VNUM(ci->in_room), room_name);
 				}
-
-				strcat(line, line2);
 			}
 		}
 
-		strcat(line, "\r\n");
+		line += "\r\n";
 		if (d->state != EConState::kPlaying) {
-			snprintf(line2, sizeof(line2), "%s%s%s", kColorGrn, line, kColorNrm);
-			strcpy(line, line2);
+			line = fmt::format("&g{}&n", line);
 		}
 
 		if (d->state != EConState::kPlaying || (d->state == EConState::kPlaying && d->character && sight::CanSee(ch, d->character))) {
@@ -321,6 +305,5 @@ void do_users(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 	}
 
-	sprintf(line, "\r\n%d видимых соединений.\r\n", num_can_see);
-	page_string(ch->desc, line, true);
+	page_string(ch->desc, fmt::format("\r\n{} видимых соединений.\r\n", num_can_see));
 }


### PR DESCRIPTION
Часть #3814: `do_users.cpp` (40 обращений) и `do_tabulate.cpp` (40) — оба по нулям.

## Что сделано

- Разбор ключей `users` идёт через собственные `rest`/`option`/`tail` вместо `buf`/`arg`/`buf1`.
- Строка таблицы собирается в `std::string`, а не склеивается `strcat` в `line[256]` — имя комнаты в ключе `-w` эту строку могло и переполнить.
- Разбор `vnum <что> <имя>` — тоже в локальные буферы.

## Найденное по дороге

- **`users -w` приклеивал чужой кусок буфера.** `strcat(line, line2)` стоял снаружи проверки, собралась ли строка с комнатой. Если персонаж невидим или `in_room == kNowhere`, в вывод уезжало прошлое содержимое `line2` — хост или почта предыдущей записи. Теперь пишется только то, что действительно собрали.
- Там же нулевое имя комнаты (`RoomData` ставит `nullptr`): `fmt` на нулевом `char*` бросает исключение, `printf` печатал `(null)`. Добавлена проверка.
- Убран мёртвый `one_argument(argument, arg)` — результат нигде не использовался, разбор уже сделан циклом выше.
- Цвет строки неигровых соединений переведён с `kColorGrn`/`kColorNrm` на `&g`/`&n`.

## Проверка

- Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.
- Живое сравнение с master на чистом тестовом мире (одинаковый снимок для обоих прогонов), с сохранением escape-последовательностей: `users` без ключей и с `-p`, `-n <имя>`, `-n <нет такого>`, `-l 1-34`, `-e`, `-r`, `-w`, `-u`, неизвестный ключ; `vnum` без аргументов, `vnum mob`, `vnum существо`, `vnum obj`, `vnum предмет`, `vnum room`, `vnum flag`. Вывод совпадает посимвольно (расходится только значение жизней в промпте — персонаж регенерировал между прогонами).
- Ветки `vnum trig|load|f` в прогоне доехали до пейджера и дальше не листались; сами эти функции правка не трогает — в них изменилось только имя переменной на стороне вызова.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr