### PR TITLE
refactor(feats): drop global buffers from feats and player files (#3814)

### DIFF
--- a/src/engine/entities/char_player.cpp
+++ b/src/engine/entities/char_player.cpp
@@ -396,9 +396,10 @@ void Player::save_char(bool update_save_time) {
 	saved.printf("Exp : %ld\n", this->get_exp());
 	saved.printf("Rmrt: %d\n", this->get_remort());
 	// флаги
-	*buf = '\0';
-	char_specials.saved.plr_flags.tascii(4, buf, sizeof(buf));
-	saved.printf("Act : %s\n", buf);
+	char flags[kMaxInputLength];
+	flags[0] = '\0';
+	char_specials.saved.plr_flags.tascii(4, flags, sizeof(flags));
+	saved.printf("Act : %s\n", flags);
 	if (GET_EMAIL(this))//edited WorM 2010.08.27 перенесено чтоб грузилось для сохранения в индексе игроков
 	{
 		saved.printf("EMal: %s\n", GET_EMAIL(this));
@@ -421,9 +422,9 @@ void Player::save_char(bool update_save_time) {
 	if (!this->player_data.title.empty())
 		saved.printf("Titl: %s\n", this->player_data.title.c_str());
 	if (!this->player_data.description.empty()) {
-		snprintf(buf, sizeof(buf), "%s", this->player_data.description.c_str());
-		kill_ems(buf);
-		saved.printf("Desc:\n%s~\n", buf);
+		std::string description = this->player_data.description;
+		kill_ems(description);
+		saved.printf("Desc:\n%s~\n", description.c_str());
 	}
 	if (POOFIN(this))
 		saved.printf("PfIn: %s\n", POOFIN(this));
@@ -443,9 +444,9 @@ void Player::save_char(bool update_save_time) {
 	saved.printf("Size: %d\n", GET_SIZE(this));
 	// структуры
 	saved.printf("Alin: %d\n", alignment::GetAlignment(this));
-	*buf = '\0';
-	AFF_FLAGS(this).tascii(kFlagPlanes, buf, sizeof(buf));
-	saved.printf("Aff : %s\n", buf);
+	flags[0] = '\0';
+	AFF_FLAGS(this).tascii(kFlagPlanes, flags, sizeof(flags));
+	saved.printf("Aff : %s\n", flags);
 
 	// дальше не по порядку
 	// статсы
@@ -601,9 +602,9 @@ void Player::save_char(bool update_save_time) {
 			MUD::RaceMessages().GetMessage(GET_RACE(this), this->get_sex()).c_str());
 	saved.printf("DrSt: %d\n", GET_DRUNK_STATE(this));
 	saved.printf("Olc : %d\n", GET_OLC_ZONE(this));
-	*buf = '\0';
-	this->player_specials->saved.pref.tascii(kFlagPlanes, buf, sizeof(buf));
-	saved.printf("Pref: %s\n", buf);
+	flags[0] = '\0';
+	this->player_specials->saved.pref.tascii(kFlagPlanes, flags, sizeof(flags));
+	saved.printf("Pref: %s\n", flags);
 	saved.printf("MgSh: %d\n", static_cast<int>(GetBriefShieldsMode()));
 
 	if (punishments::Get(this, punishments::EType::kMute).duration > 0 && this->IsFlagged(EPlrFlag::kMuted))
@@ -657,9 +658,9 @@ void Player::save_char(bool update_save_time) {
 				punishments::Get(this, punishments::EType::kUnreg).reason.c_str());
 
 	if (KARMA(this)) {
-		snprintf(buf, sizeof(buf), "%s", KARMA(this));
-		kill_ems(buf);
-		saved.printf("Karm:\n%s~\n", buf);
+		std::string karma = KARMA(this);
+		kill_ems(karma);
+		saved.printf("Karm:\n%s~\n", karma.c_str());
 	}
 	if (!LOGON_LIST(this).empty()) {
 		log("Saving logon list.");
@@ -902,6 +903,8 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 	FBFILE *fl = nullptr;
 	char filename[40];
 	char line[kMaxStringLength], tag[6];
+	// сюда разбираются текстовые хвосты строк пфайла (причины наказаний, квесты, логоны)
+	char text[kMaxStringLength];
 	char line1[kMaxStringLength];
 	TimedFeat timed_feat;
 	*filename = '\0';
@@ -1013,7 +1016,9 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 					set_remort(num);
 				}
 				break;
-			default: sprintf(buf, "SYSERR: Unknown tag %s in pfile %s", tag, name);
+			// Неизвестный тег молча пропускаем. Раньше здесь собиралась строка
+			// "SYSERR: Unknown tag ... in pfile ...", но её никто не печатал.
+			default: break;
 		}
 	} while (!skip_file);
 
@@ -1458,9 +1463,9 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 					long lnum, lnum2;
 					do {
 						fbgetline(fl, line);
-						sscanf(line, "%s %ld %ld", &buf[0], &lnum, &lnum2);
-						if (buf[0] != '~') {
-							const network::Logon cur_log = {buf, lnum, lnum2, false};
+						sscanf(line, "%s %ld %ld", &text[0], &lnum, &lnum2);
+						if (text[0] != '~') {
+							const network::Logon cur_log = {text, lnum, lnum2, false};
 							LOGON_LIST(this).push_back(cur_log);
 						} else break;
 					} while (true);
@@ -1587,56 +1592,56 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 					}
 					// Loads Here new punishment strings
 				} else if (!strcmp(tag, "PMut")) {
-					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &buf[0]);
+					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &text[0]);
 					punishments::Get(this, punishments::EType::kMute).duration = lnum;
 					punishments::Get(this, punishments::EType::kMute).level = num2;
 					punishments::Get(this, punishments::EType::kMute).godid = lnum3;
-					punishments::Get(this, punishments::EType::kMute).reason = buf;
+					punishments::Get(this, punishments::EType::kMute).reason = text;
 				} else if (!strcmp(tag, "PHel")) {
-					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &buf[0]);
+					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &text[0]);
 					punishments::Get(this, punishments::EType::kHell).duration = lnum;
 					punishments::Get(this, punishments::EType::kHell).level = num2;
 					punishments::Get(this, punishments::EType::kHell).godid = lnum3;
-					punishments::Get(this, punishments::EType::kHell).reason = buf;
+					punishments::Get(this, punishments::EType::kHell).reason = text;
 				} else if (!strcmp(tag, "PDum")) {
-					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &buf[0]);
+					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &text[0]);
 					punishments::Get(this, punishments::EType::kDumb).duration = lnum;
 					punishments::Get(this, punishments::EType::kDumb).level = num2;
 					punishments::Get(this, punishments::EType::kDumb).godid = lnum3;
-					punishments::Get(this, punishments::EType::kDumb).reason = buf;
+					punishments::Get(this, punishments::EType::kDumb).reason = text;
 				} else if (!strcmp(tag, "PNam")) {
-					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &buf[0]);
+					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &text[0]);
 					punishments::Get(this, punishments::EType::kName).duration = lnum;
 					punishments::Get(this, punishments::EType::kName).level = num2;
 					punishments::Get(this, punishments::EType::kName).godid = lnum3;
-					punishments::Get(this, punishments::EType::kName).reason = buf;
+					punishments::Get(this, punishments::EType::kName).reason = text;
 				} else if (!strcmp(tag, "PFrz")) {
-					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &buf[0]);
+					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &text[0]);
 					punishments::Get(this, punishments::EType::kFreeze).duration = lnum;
 					punishments::Get(this, punishments::EType::kFreeze).level = num2;
 					punishments::Get(this, punishments::EType::kFreeze).godid = lnum3;
-					punishments::Get(this, punishments::EType::kFreeze).reason = buf;
+					punishments::Get(this, punishments::EType::kFreeze).reason = text;
 				} else if (!strcmp(tag, "PGcs")) {
-					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &buf[0]);
+					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &text[0]);
 					punishments::Get(this, punishments::EType::kGcurse).duration = lnum;
 					punishments::Get(this, punishments::EType::kGcurse).level = num2;
 					punishments::Get(this, punishments::EType::kGcurse).godid = lnum3;
-					punishments::Get(this, punishments::EType::kGcurse).reason = buf;
+					punishments::Get(this, punishments::EType::kGcurse).reason = text;
 				} else if (!strcmp(tag, "PUnr")) {
-					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &buf[0]);
+					sscanf(line, "%ld %d %ld %[^~]", &lnum, &num2, &lnum3, &text[0]);
 					punishments::Get(this, punishments::EType::kUnreg).duration = lnum;
 					punishments::Get(this, punishments::EType::kUnreg).level = num2;
 					punishments::Get(this, punishments::EType::kUnreg).godid = lnum3;
-					punishments::Get(this, punishments::EType::kUnreg).reason = buf;
+					punishments::Get(this, punishments::EType::kUnreg).reason = text;
 				}
 
 				break;
 
 			case 'Q':
 				if (!strcmp(tag, "Qst ")) {
-					buf[0] = '\0';
-					sscanf(line, "%d %[^~]", &num, &buf[0]);
-					this->quested_add(this, num, buf);
+					text[0] = '\0';
+					sscanf(line, "%d %[^~]", &num, &text[0]);
+					this->quested_add(this, num, text);
 				}
 				break;
 
@@ -1821,7 +1826,9 @@ int Player::load_char_ascii(const char *name, const int load_flags) {
 					this->set_who_mana(num);
 				break;
 
-			default: sprintf(buf, "SYSERR: Unknown tag %s in pfile %s", tag, name);
+			// Неизвестный тег молча пропускаем. Раньше здесь собиралась строка
+			// "SYSERR: Unknown tag ... in pfile ...", но её никто не печатал.
+			default: break;
 		}
 	}
 	this->SetFlag(EPrf::kColor2); //всегда цвет полный

--- a/src/engine/ui/cmd/do_features.cpp
+++ b/src/engine/ui/cmd/do_features.cpp
@@ -6,6 +6,9 @@
 #include "gameplay/mechanics/player_races.h"
 #include "engine/db/global_objects.h"
 
+#include <string>
+#include <vector>
+
 int feat_slot_lvl(int remort, int slot_for_remort, int slot) {
 	int result = 0;
 	for (result = 1; result < kLvlImmortal; result++) {
@@ -35,33 +38,22 @@ int feat_slot_lvl(int remort, int slot_for_remort, int slot) {
 */
 void DisplayFeats(CharData *ch, CharData *vict, bool all_feats) {
 	int i = 0, j = 0, slot, max_slot = 0;
-	char msg[kMaxStringLength];
 	bool sfound;
 
 	//Найдем максимальный слот, который вобще может потребоваться данному персонажу на текущем морте
 	max_slot = CalcFeatSlotsAmountPerRemort(ch);
-	char **names = new char *[max_slot];
-
-	for (int k = 0; k < max_slot; k++) {
-		names[k] = new char[kMaxStringLength];
-	}
+	std::vector<std::string> names(max_slot);
 
 	if (all_feats) {
-		sprintf(names[0], "\r\nКруг 1  (1  уровень):\r\n");
-	} else {
-		*names[0] = '\0';
-	}
-	for (i = 1; i < max_slot; i++) {
-		if (all_feats) {
+		names[0] = "\r\nКруг 1  (1  уровень):\r\n";
+		for (i = 1; i < max_slot; i++) {
 			// на каком уровне будет слот i?
 			j = feat_slot_lvl(ch->get_remort(), MUD::Class(ch->GetClass()).GetRemortsNumForFeatSlot(), i);
-			sprintf(names[i], "\r\nКруг %-2d (%-2d уровень):\r\n", i + 1, j);
-		} else {
-			*names[i] = '\0';
+			names[i] = fmt::format("\r\nКруг {:<2} ({:<2} уровень):\r\n", i + 1, j);
 		}
 	}
 
-	sprintf(buf2, "\r\nВрожденные способности :\r\n");
+	std::string inborn = "\r\nВрожденные способности :\r\n";
 	j = 0;
 	if (all_feats) {
 		if (!ch->IsFlagged(EPrf::kBlindMode)) {
@@ -81,65 +73,50 @@ void DisplayFeats(CharData *ch, CharData *vict, bool all_feats) {
 				!MUD::PcRaces()[GET_RACE(ch)].HasFeature(feat.GetId())) {
 				continue;
 			}
+			const char *mark = ch->HaveFeat(feat.GetId()) ? "[И]"
+							   : CanGetFeat(ch, feat.GetId()) ? "[Д]" : "[Н]";
+			std::string line;
 			if (!ch->IsFlagged(EPrf::kBlindMode)) {
-				strcpy(buf, fmt::format("        {}{} {:<30}{}\r\n",
-						ch->HaveFeat(feat.GetId()) ? kColorGrn :
-						CanGetFeat(ch, feat.GetId()) ? kColorNrm : kColorRed,
-						ch->HaveFeat(feat.GetId()) ? "[И]" :
-						CanGetFeat(ch, feat.GetId()) ? "[Д]" : "[Н]",
-						MUD::Feat(feat.GetId()).GetCName(), kColorNrm).c_str());
+				const char *color = ch->HaveFeat(feat.GetId()) ? "&g"
+									: CanGetFeat(ch, feat.GetId()) ? "&n" : "&r";
+				line = fmt::format("        {}{} {:<30}&n\r\n", color, mark, MUD::Feat(feat.GetId()).GetCName());
 			} else {
-				strcpy(buf, fmt::format("    {} {:<30}\r\n",
-						ch->HaveFeat(feat.GetId()) ? "[И]" :
-						CanGetFeat(ch, feat.GetId()) ? "[Д]" : "[Н]",
-						MUD::Feat(feat.GetId()).GetCName()).c_str());
+				line = fmt::format("    {} {:<30}\r\n", mark, MUD::Feat(feat.GetId()).GetCName());
 			}
 
 			if (feat.IsInborn() ||
 				MUD::PcRaces()[GET_RACE(ch)].HasFeature(feat.GetId())) {
-				strcat(buf2, buf);
+				inborn += line;
 				j++;
 			} else if (feat.GetSlot() < max_slot) {
-				strcat(names[feat.GetSlot()], buf);
+				names[feat.GetSlot()] += line;
 			}
 		}
-		sprintf(buf1, "--------------------------------------");
+
+		std::string out = "--------------------------------------";
 		for (i = 0; i < max_slot; i++) {
-			if (strlen(buf1) >= kMaxStringLength - 60) {
-				strcat(buf1, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-				break;
-			}
-			sprintf(buf1 + strlen(buf1), "%s", names[i]);
+			out += names[i];
 		}
-
-		SendMsgToChar(buf1, vict);
-//		page_string(ch->desc, buf, 1);
-		if (j)
-			SendMsgToChar(buf2, vict);
-
-		for (int k = 0; k < max_slot; k++)
-			delete[] names[k];
-
-		delete[] names;
+		SendMsgToChar(out, vict);
+		if (j) {
+			SendMsgToChar(inborn, vict);
+		}
 
 		return;
 	}
 
 // ======================================================
 
-	sprintf(buf1, "Вы обладаете следующими способностями :\r\n");
+	std::string out = "Вы обладаете следующими способностями :\r\n";
 
 	for (const auto &feat : MUD::Class(ch->GetClass()).feats) {
-		if (strlen(buf2) >= kMaxStringLength - 60) {
-			strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-			break;
-		}
 		if (ch->HaveFeat(feat.GetId())) {
 			if (MUD::Feat(feat.GetId()).IsInvalid()) {
 				ch->UnsetFeat(feat.GetId());
 				continue;
 			}
 
+			std::string line;
 			switch (feat.GetId()) {
 				case EFeat::kBerserker:
 				case EFeat::kLightWalk:
@@ -147,9 +124,9 @@ void DisplayFeats(CharData *ch, CharData *vict, bool all_feats) {
 				case EFeat::kRelocate:
 				case EFeat::kShadowThrower:
 					if (IsTimedByFeat(ch, feat.GetId())) {
-						sprintf(buf, "[%3d] ", IsTimedByFeat(ch, feat.GetId()));
+						line = fmt::format("[{:3}] ", IsTimedByFeat(ch, feat.GetId()));
 					} else {
-						sprintf(buf, "[-!-] ");
+						line = "[-!-] ";
 					}
 					break;
 				case EFeat::kPowerAttack:
@@ -161,33 +138,31 @@ void DisplayFeats(CharData *ch, CharData *vict, bool all_feats) {
 				case EFeat::kTripleThrower:
 				case EFeat::kSerratedBlade:
 					if (ch->IsFlagged(GetPrfWithFeatNumber(feat.GetId()))) {
-						sprintf(buf, "[-%s*%s-] ", kColorBoldGrn, kColorNrm);
+						line = "[-&G*&n-] ";
 					} else {
-						sprintf(buf, "[-:-] ");
+						line = "[-:-] ";
 					}
 					break;
-				default: sprintf(buf, "      ");
+				default: line = "      ";
 			}
 			if (CanUseFeat(ch, feat.GetId())) {
-				sprintf(buf + strlen(buf), "%s%s%s\r\n",
-						kColorBoldYel, MUD::Feat(feat.GetId()).GetCName(), kColorNrm);
+				line += fmt::format("&Y{}&n\r\n", MUD::Feat(feat.GetId()).GetCName());
 			} else if (!ch->IsFlagged(EPrf::kBlindMode)) {
-				sprintf(buf + strlen(buf), "%s\r\n", MUD::Feat(feat.GetId()).GetCName());
+				line += fmt::format("{}\r\n", MUD::Feat(feat.GetId()).GetCName());
 			} else {
-				sprintf(buf, "[-Н-] %s\r\n", MUD::Feat(feat.GetId()).GetCName());
+				line = fmt::format("[-Н-] {}\r\n", MUD::Feat(feat.GetId()).GetCName());
 			}
 			if (feat.IsInborn() ||
 				MUD::PcRaces()[GET_RACE(ch)].HasFeature(feat.GetId())) {
-				sprintf(buf2 + strlen(buf2), "    ");
-				strcat(buf2, buf);
+				inborn += "    ";
+				inborn += line;
 				j++;
 			} else {
 				slot = feat.GetSlot();
 				sfound = false;
 				while (slot < max_slot) {
-					if (*names[slot] == '\0') {
-						sprintf(names[slot], " %s%-2d%s) ", kColorGrn, slot + 1, kColorNrm);
-						strcat(names[slot], buf);
+					if (names[slot].empty()) {
+						names[slot] = fmt::format(" &g{:<2}&n) ", slot + 1) + line;
 						sfound = true;
 						break;
 					} else {
@@ -197,9 +172,9 @@ void DisplayFeats(CharData *ch, CharData *vict, bool all_feats) {
 				if (!sfound) {
 					// Если способность не врожденная и под нее нет слота - удаляем
 					//	чтобы можно было менять слоты на лету и чтобы не читерили
-					sprintf(msg, "WARNING: Unset out of slots feature '%s' for character '%s'!",
-							MUD::Feat(feat.GetId()).GetCName(), GET_NAME(ch));
-					mudlog(msg, BRF, kLvlImplementator, SYSLOG, true);
+					mudlog(fmt::format("WARNING: Unset out of slots feature '{}' for character '{}'!",
+									   MUD::Feat(feat.GetId()).GetCName(), GET_NAME(ch)),
+						   BRF, kLvlImplementator, SYSLOG, true);
 					ch->UnsetFeat(feat.GetId());
 				}
 			}
@@ -208,16 +183,18 @@ void DisplayFeats(CharData *ch, CharData *vict, bool all_feats) {
 
 	auto max_slot_per_lvl = CalcMaxFeatSlotPerLvl(ch);
 	for (i = 0; i < max_slot; i++) {
-		if (*names[i] == '\0')
-			sprintf(names[i], " %s%-2d%s)       %s[пусто]%s\r\n", kColorGrn, i + 1, kColorNrm, kColorBoldBlk, kColorNrm);
+		if (names[i].empty()) {
+			names[i] = fmt::format(" &g{:<2}&n)       &K[пусто]&n\r\n", i + 1);
+		}
 		if (i >= max_slot_per_lvl)
 			break;
-		sprintf(buf1 + strlen(buf1), "%s", names[i]);
+		out += names[i];
 	}
-	SendMsgToChar(buf1, vict);
+	SendMsgToChar(out, vict);
 
-	if (j)
-		SendMsgToChar(buf2, vict);
+	if (j) {
+		SendMsgToChar(inborn, vict);
+	}
 	const auto &race_features = MUD::PcRaces()[GET_RACE(ch)].GetFeatures();
 	if (race_features.size() > 0) {
 		SendMsgToChar(vict,  "Родовые способности :\r\n");
@@ -225,10 +202,6 @@ void DisplayFeats(CharData *ch, CharData *vict, bool all_feats) {
 			SendMsgToChar(vict, "          %s\r\n", MUD::Feat(feat_id).GetCName());
 		}
 	}
-	for (int k = 0; k < max_slot; k++)
-		delete[] names[k];
-
-	delete[] names;
 }
 
 void DoFeatures(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {


### PR DESCRIPTION
Часть #3814: `do_features.cpp` (35 обращений) и `char_player.cpp` (42) — оба по нулям.

## Что сделано

- Список способностей собирается в `std::string`; массив имён кругов стал `std::vector<std::string>` вместо ручного `new char*[]` / `delete[]`.
- Проверки `***ПЕРЕПОЛНЕНИЕ***` убраны — у строки нет того предела, ради которого они стояли.
- В пфайле флаги (`Act`/`Aff`/`Pref`) пишутся через локальный буфер, описание и карма — через `std::string` (у `kill_ems` есть строковая перегрузка), разбор причин наказаний и квестов читает в локальный `text`.
- Цвета в переписанных строках переведены на короткие коды (`&g`, `&r`, `&n`, `&G`, `&Y`, `&K`).

## Мёртвый код

В `load_char_ascii` ветка `default` собирала строку `"SYSERR: Unknown tag %s in pfile %s"`, но её никто не печатал — буфер заполнялся и забывался. Строку убрал, вывод включать не стал: на старых пфайлах это дало бы новый поток сообщений в syslog, и решать тут не мне.

## Проверка

- Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.
- Живое сравнение с master на чистом тестовом мире: `способности`, `способности все` (обе ветки — с цветом и в слепом режиме недоступна), `умения`, `счет`, `осмотреть`, запись пфайла по `сохранить`. Текст совпадает посимвольно; пфайл — с точностью до отметок времени и текущих жизней.
- Единственное отличие в цвете — код сброса: `kColorNrm` это `\x1B[0;37m`, а `&n` даёт `\x1B[0;0m`, как и весь остальной игровой текст. Остальные цвета (`0;32`, `1;33`, `0;31`, `1;30`) совпали байт в байт.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr