### PR TITLE
fix(stat): count the line width without ANSI colour constants

### DIFF
--- a/src/engine/ui/cmd_god/do_stat.cpp
+++ b/src/engine/ui/cmd_god/do_stat.cpp
@@ -245,7 +245,10 @@ void do_stat_character(CharData *ch, CharData *k, const int virt) {
 				}
 			}
 			if (GetRealLevel(ch) >= kLvlImmortal) {
-				parts.push_back(fmt::sprintf("%sOLC[%d]%s", kColorGrn, GET_OLC_ZONE(k), kColorNrm));
+				// Цвет короткими кодами: ширину строки OutWordsList меряет через
+				// GetStringWithoutColors, а она снимает только "&X". ANSI-константы
+				// попадали в счёт как 14 видимых символов, и строка переносилась раньше.
+				parts.push_back(fmt::sprintf("&gOLC[%d]&n", GET_OLC_ZONE(k)));
 			}
 			const size_t width = (!ch->IsNpc() && ch->player_specials->saved.stringLength > 0)
 					? ch->player_specials->saved.stringLength : 120;
@@ -817,11 +820,11 @@ void do_stat_object(CharData *ch, ObjData *j, const int virt = 0) {
 
 		case EObjType::kScroll: {
 			// issue.magic-items: заклинания свитка лежат в extra_values, сила -- умение мастера
-			line = fmt::format("{}", utils::OutWordsList(SpellItemSpellsWithPotency(j), ch->player_specials->saved.stringLength, ", ", std::string(kColorGrn) + "Заклинания:" + kColorNrm + " "));
+			line = fmt::format("{}", utils::OutWordsList(SpellItemSpellsWithPotency(j), ch->player_specials->saved.stringLength, ", ", "&gЗаклинания:&n "));
 			break;
 		}
 		case EObjType::kPotion: {
-			line = fmt::format("{}", utils::OutWordsList(SpellItemSpellsWithPotency(j), ch->player_specials->saved.stringLength, ", ", std::string(kColorGrn) + "Заклинания:" + kColorNrm + " "));
+			line = fmt::format("{}", utils::OutWordsList(SpellItemSpellsWithPotency(j), ch->player_specials->saved.stringLength, ", ", "&gЗаклинания:&n "));
 			break;
 		}
 		case EObjType::kWand:


### PR DESCRIPTION
По сообщению с боевого: в `stat <имя>` строка с рентой разрывается перед `OLC[...]`.

```
Рента: [12510], Денег: [   774675], В банке: [694943754] (Всего: 695718429), очко славы: 1471, медная гривна: 97, осколок волшебного льда: 5,
OLC[125]
```

## Почему

Строка собирается из кусков и переносится по ширине экрана игрока через `OutWordsList`. Ширину та считает по **видимой** длине — `native_text::char_count(GetStringWithoutColors(word))`. А `GetStringWithoutColors` снимает только короткие коды вида `&X` (`remove_colors_template` умеет ровно это) и ничего не знает про ANSI-последовательности.

Кусок с OLC собирался константами:

```cpp
parts.push_back(fmt::sprintf("%sOLC[%d]%s", kColorGrn, GET_OLC_ZONE(k), kColorNrm));
```

`kColorGrn` — это `"\x1B[0;32m"`, `kColorNrm` — `"\x1B[0;37m"`, по 7 символов каждая. В счёт ширины они шли как видимые: кусок «весил» 22 символа вместо 8. На строке в 141 видимый символ получалось 141 + 2 + 22 = 165 вместо 151 — и перенос срабатывал там, где места на самом деле хватало.

Тот же счёт был у префикса `Заклинания:` при осмотре свитков и напитков.

## Что сделано

Цвет в обоих местах переведён на короткие коды (`&g`/`&n`). На экране ровно то же самое — `&g` разворачивается в `\x1B[0;32m`, — но ширина теперь меряется по видимым символам.

Правка не связана с переносом `do_stat` на строки (#3814): блок с валютами и OLC в этом виде существует с июня, менялся только под UTF-8 в августе.

## Проверка

- Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.
- На тестовом мире `stat` печатает кусок OLC тем же зелёным, escape-последовательности в выводе прежние.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr