### PR TITLE
refactor(cmd): drop global buffers from five commands (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_exits.cpp
+++ b/src/engine/ui/cmd/do_exits.cpp
@@ -7,6 +7,8 @@
 
 #include "engine/entities/char_data.h"
 #include <fmt/format.h>
+
+#include <string>
 #include "administration/privilege.h"
 #include "gameplay/mechanics/sight.h"
 #include "gameplay/mechanics/illumination.h"
@@ -16,9 +18,6 @@ void do_blind_exits(CharData *ch);
 void DoExits(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	int door;
 
-	*buf = '\0';
-	*buf2 = '\0';
-
 	if (ch->IsFlagged(EPrf::kBlindMode)) {
 		do_blind_exits(ch);
 		return;
@@ -27,31 +26,37 @@ void DoExits(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 		SendMsgToChar("Вы слепы, как котенок!\r\n", ch);
 		return;
 	}
+
+	std::string out;
 	for (door = 0; door < EDirection::kMaxDirNum; door++)
 		if (EXIT(ch, door) && EXIT(ch, door)->to_room() != kNowhere && !EXIT_FLAGGED(EXIT(ch, door), EExitFlag::kClosed)) {
-			if (privilege::IsGod(ch))
-				strcpy(buf2, fmt::format("{:<6} - [{:5}] {}\r\n", dirs_rus[door],
-						GET_ROOM_VNUM(EXIT(ch, door)->to_room()), world[EXIT(ch, door)->to_room()]->name).c_str());
-			else {
-				strcpy(buf2, fmt::format("{:<6} - ", dirs_rus[door]).c_str());
-				if (is_dark(EXIT(ch, door)->to_room()) && !sight::CanSeeInDark(ch))
-					strcat(buf2, "слишком темно\r\n");
-				else {
-					const RoomRnum rnum_exit_room = EXIT(ch, door)->to_room();
+			const RoomRnum rnum_exit_room = EXIT(ch, door)->to_room();
+			// имя комнаты бывает нулевым (конструктор RoomData), а fmt на нуле бросает исключение
+			const char *room_name = world[rnum_exit_room]->name ? world[rnum_exit_room]->name : "";
+			std::string line;
+			if (privilege::IsGod(ch)) {
+				line = fmt::format("{:<6} - [{:5}] {}\r\n", dirs_rus[door],
+								   GET_ROOM_VNUM(rnum_exit_room), room_name);
+			} else {
+				line = fmt::format("{:<6} - ", dirs_rus[door]);
+				if (is_dark(rnum_exit_room) && !sight::CanSeeInDark(ch)) {
+					line += "слишком темно\r\n";
+				} else {
 					if (ch->IsFlagged(EPrf::kMapper) && !ch->IsFlagged(EPlrFlag::kScriptWriter)
 						&& !ROOM_FLAGGED(rnum_exit_room, ERoomFlag::kMoMapper)) {
-						sprintf(buf2 + strlen(buf2), "[%7d] %s", GET_ROOM_VNUM(rnum_exit_room), world[rnum_exit_room]->name);
+						line += fmt::format("[{:7}] {}", GET_ROOM_VNUM(rnum_exit_room), room_name);
 					} else {
-						strcat(buf2, world[rnum_exit_room]->name);
+						line += room_name;
 					}
-					strcat(buf2, "\r\n");
+					line += "\r\n";
 				}
 			}
-			strcat(buf, utils::CAP(buf2));
+			// CAP(std::string) возвращает копию, а не правит на месте
+			out += utils::CAP(line);
 		}
 	SendMsgToChar("Видимые выходы:\r\n", ch);
-	if (*buf)
-		SendMsgToChar(buf, ch);
+	if (!out.empty())
+		SendMsgToChar(out, ch);
 	else
 		SendMsgToChar(" Замуровали, ДЕМОНЫ!\r\n", ch);
 }
@@ -59,38 +64,38 @@ void DoExits(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 void do_blind_exits(CharData *ch) {
 	int door;
 
-	*buf = '\0';
-	*buf2 = '\0';
-
 	if (AFF_FLAGGED(ch, EAffect::kBlind)) {
 		SendMsgToChar("Вы слепы, как котенок!\r\n", ch);
 		return;
 	}
+
+	std::string out;
 	for (door = 0; door < EDirection::kMaxDirNum; door++)
 		if (EXIT(ch, door) && EXIT(ch, door)->to_room() != kNowhere && !EXIT_FLAGGED(EXIT(ch, door), EExitFlag::kClosed)) {
-			if (privilege::IsGod(ch))
-				sprintf(buf2, "&W%s - [%d] %s ", dirs_rus[door],
-						GET_ROOM_VNUM(EXIT(ch, door)->to_room()), world[EXIT(ch, door)->to_room()]->name);
-			else {
-				sprintf(buf2, "&W%s - ", dirs_rus[door]);
-				if (is_dark(EXIT(ch, door)->to_room()) && !sight::CanSeeInDark(ch))
-					strcat(buf2, "слишком темно");
-				else {
-					const RoomRnum rnum_exit_room = EXIT(ch, door)->to_room();
+			const RoomRnum rnum_exit_room = EXIT(ch, door)->to_room();
+			const char *room_name = world[rnum_exit_room]->name ? world[rnum_exit_room]->name : "";
+			std::string line;
+			if (privilege::IsGod(ch)) {
+				line = fmt::format("&W{} - [{}] {} ", dirs_rus[door],
+								   GET_ROOM_VNUM(rnum_exit_room), room_name);
+			} else {
+				line = fmt::format("&W{} - ", dirs_rus[door]);
+				if (is_dark(rnum_exit_room) && !sight::CanSeeInDark(ch)) {
+					line += "слишком темно";
+				} else {
 					if (ch->IsFlagged(EPrf::kMapper) && !ch->IsFlagged(EPlrFlag::kScriptWriter)
 						&& !ROOM_FLAGGED(rnum_exit_room, ERoomFlag::kMoMapper)) {
-						sprintf(buf2 + strlen(buf2), "[%d] %s", GET_ROOM_VNUM(rnum_exit_room), world[rnum_exit_room]->name);
+						line += fmt::format("[{}] {}", GET_ROOM_VNUM(rnum_exit_room), room_name);
 					} else {
-						strcat(buf2, world[rnum_exit_room]->name);
+						line += room_name;
 					}
-					strcat(buf2, "");
 				}
 			}
-			strcat(buf, utils::CAP(buf2));
+			out += utils::CAP(line);
 		}
 	SendMsgToChar("Видимые выходы:\r\n", ch);
-	if (*buf)
-		SendMsgToChar(ch, "%s&n\r\n", buf);
+	if (!out.empty())
+		SendMsgToChar(out + "&n\r\n", ch);
 	else
 		SendMsgToChar("&W Замуровали, ДЕМОНЫ!&n\r\n", ch);
 }

--- a/src/engine/ui/cmd/do_get.cpp
+++ b/src/engine/ui/cmd/do_get.cpp
@@ -36,9 +36,8 @@ int other_pc_in_group(CharData *ch) {
 void split_or_clan_tax(CharData *ch, long amount) {
 	if (AFF_FLAGGED(ch, EAffect::kGroup) && (other_pc_in_group(ch) > 0) &&
 		ch->IsFlagged(EPrf::kAutosplit)) {
-		char buf_[kMaxInputLength];
-		snprintf(buf_, sizeof(buf_), "%ld", amount);
-		group::do_split(ch, buf_, 0, 0);
+		std::string share = std::to_string(amount);
+		group::do_split(ch, share.data(), 0, 0);
 	} else {
 		long tax = ClanSystem::do_gold_tax(ch, amount);
 		currencies::RemoveHand(*ch, currencies::kGold, tax);
@@ -62,20 +61,17 @@ void get_check_money(CharData *ch, ObjData *obj, ObjData *cont) {
 	const auto &money_cur = MUD::Currency(curr_type);
 	if (money_cur.GetId() >= 0 && money_cur.GetTextId() != currencies::kGold) {
 		// Не-золотая валюта (напр. событийная): зачисляем; force_split - делим всегда.
-		sprintf(buf, "Это составило %d %s.\r\n", value, money_cur.GetNameWithAmount(value, grammar::ECase::kAcc).c_str());
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Это составило {} {}.\r\n", value, money_cur.GetNameWithAmount(value, grammar::ECase::kAcc).c_str()), ch);
 		currencies::AddHand(*ch, curr_type, value);
 		if (money_cur.ForceSplit() && AFF_FLAGGED(ch, EAffect::kGroup) && other_pc_in_group(ch) > 0) {
-			char local_buf[256];
-			sprintf(local_buf, "%d", value);
-			group::do_split(ch, local_buf, 0, 0, curr_type);
+			std::string share = std::to_string(value);
+			group::do_split(ch, share.data(), 0, 0, curr_type);
 		}
 		ExtractObjFromWorld(obj);
 		return;
 	}
 
-	sprintf(buf, "Это составило %d %s.\r\n", value, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kAcc).c_str());
-	SendMsgToChar(buf, ch);
+	SendMsgToChar(fmt::format("Это составило {} {}.\r\n", value, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kAcc).c_str()), ch);
 	if (InTestZone(ch)) {
 		ExtractObjFromWorld(obj);
 		return;
@@ -86,39 +82,22 @@ void get_check_money(CharData *ch, ObjData *obj, ObjData *cont) {
 		// добавляем бабло, пишем в лог, клан-налог снимаем
 		// только по факту деления на группу в do_split()
 		currencies::AddHand(*ch, currencies::kGold, value);
-		sprintf(buf,
-				"<%s> {%d} заработал %d %s в группе.",
-				ch->get_name().c_str(),
-				GET_ROOM_VNUM(ch->in_room),
-				value,
-				MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str());
-		mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
-		char local_buf[256];
-		sprintf(local_buf, "%d", value);
-		group::do_split(ch, local_buf, 0, 0);
+		mudlog(fmt::format("<{}> {{{}}} заработал {} {} в группе.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), value, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str()), NRM, kLvlGreatGod, MONEY_LOG, true);
+		std::string share = std::to_string(value);
+		group::do_split(ch, share.data(), 0, 0);
 	} else if (cont && system_obj::is_purse(cont)) {
 		// лут кошелька с баблом
 		// налогом не облагается, т.к. уже все уплочено
 		// на данном этапе cont уже не содержит владельца
-		sprintf(buf, "%s взял деньги из кошелька: %d  %s.", ch->get_name().c_str(), value,
-				MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str());
-		mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
+		mudlog(fmt::format("{} взял деньги из кошелька: {}  {}.", ch->get_name().c_str(), value, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str()), NRM, kLvlGreatGod, MONEY_LOG, true);
 		currencies::AddHand(*ch, currencies::kGold, value);
 	} else if ((cont && IS_MOB_CORPSE(cont)) || GET_OBJ_VNUM(obj) != -1) {
 		// лут из трупа моба или из предметов-денег с внумом
 		// (предметы-награды в зонах) - снимаем клан-налог
-		sprintf(buf, "%s заработал %d  %s.", ch->get_name().c_str(), value,
-				MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str());
-		mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
+		mudlog(fmt::format("{} заработал {}  {}.", ch->get_name().c_str(), value, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str()), NRM, kLvlGreatGod, MONEY_LOG, true);
 		currencies::AddHand(*ch, currencies::kGold, value - ClanSystem::do_gold_tax(ch, value), false, true);
 	} else {
-		sprintf(buf,
-				"<%s> {%d} как-то получил %d  %s.",
-				ch->get_name().c_str(),
-				GET_ROOM_VNUM(ch->in_room),
-				value,
-				MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str());
-		mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
+		mudlog(fmt::format("<{}> {{{}}} как-то получил {}  {}.", ch->get_name().c_str(), GET_ROOM_VNUM(ch->in_room), value, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(value, grammar::ECase::kNom).c_str()), NRM, kLvlGreatGod, MONEY_LOG, true);
 		currencies::AddHand(*ch, currencies::kGold, value);
 	}
 	RemoveObjFromChar(obj);
@@ -177,8 +156,7 @@ void get_from_container(CharData *ch, ObjData *cont, char *local_arg, int mode, 
 		act("$o закрыт$A.", false, ch, cont, nullptr, kToChar);
 	else if (obj_dotmode == kFindIndiv) {
 		if (!(obj = get_obj_in_list_vis(ch, local_arg, cont->get_contains()))) {
-			sprintf(buf, "Вы не видите '%s' в $o5.", local_arg);
-			act(buf, false, ch, cont, nullptr, kToChar);
+			act(fmt::format("Вы не видите '{}' в $o5.", local_arg), false, ch, cont, nullptr, kToChar);
 		} else {
 			ObjData *obj_next;
 			while (obj && amount--) {
@@ -215,8 +193,7 @@ void get_from_container(CharData *ch, ObjData *cont, char *local_arg, int mode, 
 			if (obj_dotmode == kFindAll)
 				act("$o пуст$A.", false, ch, cont, nullptr, kToChar);
 			else {
-				sprintf(buf, "Вы не видите ничего похожего на '%s' в $o5.", local_arg);
-				act(buf, false, ch, cont, nullptr, kToChar);
+				act(fmt::format("Вы не видите ничего похожего на '{}' в $o5.", local_arg), false, ch, cont, nullptr, kToChar);
 			}
 		}
 	}
@@ -262,8 +239,7 @@ void get_from_room(CharData *ch, char *local_arg, int howmany) {
 
 	if (dotmode == kFindIndiv) {
 		if (!(obj = get_obj_in_list_vis(ch, local_arg, world[ch->in_room]->contents))) {
-			sprintf(buf, "Вы не видите здесь '%s'.\r\n", local_arg);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Вы не видите здесь '{}'.\r\n", local_arg), ch);
 		} else {
 			ObjData *obj_next;
 			while (obj && howmany--) {
@@ -292,8 +268,7 @@ void get_from_room(CharData *ch, char *local_arg, int howmany) {
 			if (dotmode == kFindAll) {
 				SendMsgToChar("Похоже, здесь ничего нет.\r\n", ch);
 			} else {
-				sprintf(buf, "Вы не нашли здесь '%s'.\r\n", local_arg);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("Вы не нашли здесь '{}'.\r\n", local_arg), ch);
 			}
 		}
 	}
@@ -348,8 +323,7 @@ void do_get(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		if (cont_dotmode == kFindIndiv) {
 			mode = generic_find(thecont, where_bits, ch, &tmp_char, &cont);
 			if (!cont) {
-				sprintf(buf, "Вы не видите '%s'.\r\n", arg2);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("Вы не видите '{}'.\r\n", arg2), ch);
 			} else if (cont->get_type() != EObjType::kContainer) {
 				act("$o - не контейнер.", false, ch, cont, nullptr, kToChar);
 			} else {
@@ -393,8 +367,7 @@ void do_get(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				if (cont_dotmode == kFindAll) {
 					SendMsgToChar("Вы не смогли найти ни одного контейнера.\r\n", ch);
 				} else {
-					sprintf(buf, "Вы что-то не видите здесь '%s'.\r\n", thecont);
-					SendMsgToChar(buf, ch);
+					SendMsgToChar(fmt::format("Вы что-то не видите здесь '{}'.\r\n", thecont), ch);
 				}
 			}
 		}

--- a/src/engine/ui/cmd/do_who_am_i.cpp
+++ b/src/engine/ui/cmd/do_who_am_i.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "utils/native_text.h"
 #include "gameplay/clans/house.h"
@@ -13,37 +15,37 @@
 #include "gameplay/core/remort.h"
 
 void DoWhoAmI(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
-	sprintf(buf, "Персонаж : %s\r\n", GET_NAME(ch));
-	sprintf(buf + strlen(buf),
-			"Падежи : &W%s&n/&W%s&n/&W%s&n/&W%s&n/&W%s&n/&W%s&n\r\n",
-			ch->get_name().c_str(), GET_PAD(ch, 1), GET_PAD(ch, 2),
-			GET_PAD(ch, 3), GET_PAD(ch, 4), GET_PAD(ch, 5));
-
-	sprintf(buf + strlen(buf), "Ваш e-mail : &S%s&s\r\n", GET_EMAIL(ch));
 	time_t birt = ch->player_data.time.birth;
-	sprintf(buf + strlen(buf), "Дата вашего рождения : %s\r\n", rustime(localtime(&birt)));
-	sprintf(buf + strlen(buf), "Ваш IP-адрес : %s\r\n", ch->desc ? ch->desc->host : "Unknown");
-	SendMsgToChar(buf, ch);
+	SendMsgToChar(fmt::format("Персонаж : {}\r\n"
+							  "Падежи : &W{}&n/&W{}&n/&W{}&n/&W{}&n/&W{}&n/&W{}&n\r\n"
+							  "Ваш e-mail : &S{}&s\r\n"
+							  "Дата вашего рождения : {}\r\n"
+							  "Ваш IP-адрес : {}\r\n",
+							  GET_NAME(ch),
+							  ch->get_name(), GET_PAD(ch, 1), GET_PAD(ch, 2),
+							  GET_PAD(ch, 3), GET_PAD(ch, 4), GET_PAD(ch, 5),
+							  GET_EMAIL(ch),
+							  rustime(localtime(&birt)),
+							  ch->desc ? ch->desc->host : "Unknown"), ch);
 	if (!(ch)->player_specials->saved.NameGod) {
-		sprintf(buf, "Имя никем не одобрено!\r\n");
-		SendMsgToChar(buf, ch);
+		SendMsgToChar("Имя никем не одобрено!\r\n", ch);
 	} else {
 		const int god_level = (ch)->player_specials->saved.NameGod > 1000 ? (ch)->player_specials->saved.NameGod - 1000 : (ch)->player_specials->saved.NameGod;
-		sprintf(buf1, "%s", GetNameById((ch)->player_specials->saved.NameIDGod).c_str());
-		native_text::capitalize_first(buf1);
+		std::string god_name = GetNameById((ch)->player_specials->saved.NameIDGod);
+		native_text::capitalize_first(god_name);
 
 		static const char *by_rank_god = "Богом";
 		static const char *by_rank_privileged = "привилегированным игроком";
 		const char *by_rank = god_level < kLvlImmortal ? by_rank_privileged : by_rank_god;
 
+		// Строка о запрете собиралась в общий буфер и никуда не отправлялась -- игрок
+		// видел одобрение, а про запрет не узнавал вовсе. Печатаем обе ветки.
 		if ((ch)->player_specials->saved.NameGod < 1000)
-			snprintf(buf, kMaxStringLength, "&RИмя запрещено %s %s&n\r\n", by_rank, buf1);
+			SendMsgToChar(fmt::format("&RИмя запрещено {} {}&n\r\n", by_rank, god_name), ch);
 		else
-			snprintf(buf, kMaxStringLength, "&WИмя одобрено %s %s&n\r\n", by_rank, buf1);
-		SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("&WИмя одобрено {} {}&n\r\n", by_rank, god_name), ch);
 	}
-	sprintf(buf, "Перевоплощений: %d\r\n", remort::GetRealRemort(ch));
-	SendMsgToChar(buf, ch);
+	SendMsgToChar(fmt::format("Перевоплощений: {}\r\n", remort::GetRealRemort(ch)), ch);
 	Clan::CheckPkList(ch);
 	if (ch->player_specials->saved.telegram_id != 0) { //тут прямое обращение, ибо базовый класс, а не наследник
 		SendMsgToChar(ch, "Подключен Телеграм, chat_id: %lu\r\n", ch->player_specials->saved.telegram_id);

--- a/src/engine/ui/cmd_god/do_force.cpp
+++ b/src/engine/ui/cmd_god/do_force.cpp
@@ -6,20 +6,31 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "engine/network/descriptor_data.h"
 #include "engine/core/target_resolver.h"
+#include "utils/utils_string.h"
 
 void do_force(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	DescriptorData *i, *next_desc;
-	char to_force[kMaxInputLength + 2];
 
-	half_chop(argument, arg, to_force);
+	std::string to_force;
+	const std::string arg = utils::ExtractFirstArgumentLower(argument ? argument : "", to_force);
 
-	sprintf(buf1, "$n принудил$g вас '%s'.", to_force);
+	const std::string to_vict = fmt::format("$n принудил$g вас '{}'.", to_force);
 
-	if (!*arg || !*to_force) {
+	// command_interpreter правит переданную строку на месте, поэтому каждой жертве
+	// достаётся своя копия -- иначе второй в списке получил бы огрызок команды.
+	const auto force_command = [&to_force](CharData *victim) {
+		char command[kMaxInputLength + 2];
+		strl_cpy(command, to_force.c_str(), sizeof(command));
+		command_interpreter(victim, command);
+	};
+
+	if (arg.empty() || to_force.empty()) {
 		SendMsgToChar("Кого и что вы хотите принудить сделать?\r\n", ch);
 	} else if (!privilege::IsGrGod(ch) || (str_cmp("all", arg) && str_cmp("room", arg) && str_cmp("все", arg)
 		&& str_cmp("здесь", arg))) {
@@ -30,23 +41,19 @@ void do_force(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		} else if (!vict->IsNpc() && GetRealLevel(ch) <= GetRealLevel(vict) && !ch->IsFlagged(EPrf::kCoderinfo)) {
 			SendMsgToChar("Господи, только не это!\r\n", ch);
 		} else {
-			char *pstr;
 			SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);
-			act(buf1, true, ch, nullptr, vict, kToVict);
-			sprintf(buf, "(GC) %s forced %s to %s", GET_NAME(ch), GET_NAME(vict), to_force);
-			while ((pstr = strchr(buf, '%')) != nullptr) {
-				pstr[0] = '*';
-			}
-			mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
-			imm_log("%s forced %s to %s", GET_NAME(ch), GET_NAME(vict), to_force);
-			command_interpreter(vict, to_force);
+			act(to_vict, true, ch, nullptr, vict, kToVict);
+			std::string log_line = fmt::format("(GC) {} forced {} to {}", GET_NAME(ch), GET_NAME(vict), to_force);
+			std::replace(log_line.begin(), log_line.end(), '%', '*');
+			mudlog(log_line, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+			imm_log("%s forced %s to %s", GET_NAME(ch), GET_NAME(vict), to_force.c_str());
+			force_command(vict);
 		}
 	} else if (!str_cmp("room", arg)
 		|| !str_cmp("здесь", arg)) {
 		SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);
-		sprintf(buf, "(GC) %s forced room %d to %s", GET_NAME(ch), GET_ROOM_VNUM(ch->in_room), to_force);
-		mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
-		imm_log("%s forced room %d to %s", GET_NAME(ch), GET_ROOM_VNUM(ch->in_room), to_force);
+		mudlog(fmt::format("(GC) {} forced room {} to {}", GET_NAME(ch), GET_ROOM_VNUM(ch->in_room), to_force), NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		imm_log("%s forced room %d to %s", GET_NAME(ch), GET_ROOM_VNUM(ch->in_room), to_force.c_str());
 
 		const auto people_copy = world[ch->in_room]->people;
 		for (const auto vict : people_copy) {
@@ -56,15 +63,14 @@ void do_force(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				continue;
 			}
 
-			act(buf1, true, ch, nullptr, vict, kToVict);
-			command_interpreter(vict, to_force);
+			act(to_vict, true, ch, nullptr, vict, kToVict);
+			force_command(vict);
 		}
 	} else        // force all
 	{
 		SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);
-		sprintf(buf, "(GC) %s forced all to %s", GET_NAME(ch), to_force);
-		mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
-		imm_log("%s forced all to %s", GET_NAME(ch), to_force);
+		mudlog(fmt::format("(GC) {} forced all to {}", GET_NAME(ch), to_force), NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		imm_log("%s forced all to %s", GET_NAME(ch), to_force.c_str());
 
 		for (i = descriptor_list; i; i = next_desc) {
 			next_desc = i->next;
@@ -77,8 +83,8 @@ void do_force(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				continue;
 			}
 
-			act(buf1, true, ch, nullptr, vict.get(), kToVict);
-			command_interpreter(vict.get(), to_force);
+			act(to_vict, true, ch, nullptr, vict.get(), kToVict);
+			force_command(vict.get());
 		}
 	}
 }

--- a/src/engine/ui/cmd_god/do_wiznet.cpp
+++ b/src/engine/ui/cmd_god/do_wiznet.cpp
@@ -6,12 +6,15 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "engine/network/descriptor_data.h"
 #include "engine/ui/color.h"
 #include "gameplay/communication/remember.h"
 #include "gameplay/mechanics/sight.h"
+#include "utils/utils_string.h"
 
 void do_wiznet(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	DescriptorData *d;
@@ -36,41 +39,44 @@ void do_wiznet(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (GET_GOD_FLAG(ch, EGf::kDemigod))
 		level = kLvlImmortal;
 
+	std::string text = argument;
+
 	// использование доп. аргументов
 	switch (*argument) {
 		case '*': emote = true;
 			break;
-		case '#':
+		case '#': {
 			// Установить уровень имм канала
-			one_argument(argument + 1, buf1);
-			if (is_number(buf1)) {
-				half_chop(argument + 1, buf1, argument);
-				level = std::max(atoi(buf1), kLvlImmortal);
+			std::string tail;
+			const std::string level_arg = utils::ExtractFirstArgumentLower(argument + 1, tail);
+			if (is_number(level_arg)) {
+				level = std::max(atoi(level_arg.c_str()), kLvlImmortal);
 				if (level > GetRealLevel(ch)) {
 					SendMsgToChar("Вы не можете изрекать выше вашего уровня.\r\n", ch);
 					return;
 				}
-			} else if (emote)
-				argument++;
+				text = tail;
+			}
 			break;
-		case '@':
+		}
+		case '@': {
 			// Обнаруживаем всех кто может (теоретически) нас услышать
+			std::string out;
 			for (d = descriptor_list; d; d = d->next) {
 				if (d->state == EConState::kPlaying &&
 					(privilege::IsImmortal(d->character.get()) || GET_GOD_FLAG(d->character, EGf::kDemigod)) &&
 					!d->character->IsFlagged(EPrf::kNoWiz) && (sight::CanSee(ch, d->character) || privilege::IsImpl(ch))) {
 					if (!bookmark1) {
-						strcpy(buf1,
-							   "Боги/привилегированные которые смогут (наверное) вас услышать:\r\n");
+						out += "Боги/привилегированные которые смогут (наверное) вас услышать:\r\n";
 						bookmark1 = true;
 					}
-					sprintf(buf1 + strlen(buf1), "  %s", GET_NAME(d->character));
+					out += fmt::format("  {}", GET_NAME(d->character));
 					if (d->character->IsFlagged(EPlrFlag::kWriting))
-						strcat(buf1, " (пишет)\r\n");
+						out += " (пишет)\r\n";
 					else if (d->character->IsFlagged(EPlrFlag::kMailing))
-						strcat(buf1, " (пишет письмо)\r\n");
+						out += " (пишет письмо)\r\n";
 					else
-						strcat(buf1, "\r\n");
+						out += "\r\n";
 				}
 			}
 			for (d = descriptor_list; d; d = d->next) {
@@ -78,41 +84,33 @@ void do_wiznet(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					(privilege::IsImmortal(d->character.get()) || GET_GOD_FLAG(d->character, EGf::kDemigod)) &&
 					d->character->IsFlagged(EPrf::kNoWiz) && sight::CanSee(ch, d->character)) {
 					if (!bookmark2) {
-						if (!bookmark1)
-							strcpy(buf1,
-								   "Боги/привилегированные которые не смогут вас услышать:\r\n");
-						else
-							strcat(buf1,
-								   "Боги/привилегированные которые не смогут вас услышать:\r\n");
-
+						out += "Боги/привилегированные которые не смогут вас услышать:\r\n";
 						bookmark2 = true;
 					}
-					sprintf(buf1 + strlen(buf1), "  %s\r\n", GET_NAME(d->character));
+					out += fmt::format("  {}\r\n", GET_NAME(d->character));
 				}
 			}
-			SendMsgToChar(buf1, ch);
+			SendMsgToChar(out, ch);
 
 			return;
+		}
 		default: break;
 	}
 	if (ch->IsFlagged(EPrf::kNoWiz)) {
 		SendMsgToChar("Вы вне игры!\r\n", ch);
 		return;
 	}
-	skip_spaces(&argument);
+	utils::TrimLeft(text);
 
-	if (!*argument) {
+	if (text.empty()) {
 		SendMsgToChar("Не думаю, что Боги одобрят это.\r\n", ch);
 		return;
 	}
-	if (level != kLvlGod) {
-		sprintf(buf1, "%s%s: <%d> %s%s\r\n", GET_NAME(ch),
-				emote ? "" : " богам", level, emote ? "<--- " : "", argument);
-	} else {
-		sprintf(buf1, "%s%s: %s%s\r\n", GET_NAME(ch), emote ? "" : " богам", emote ? "<--- " : "", argument);
-	}
-	snprintf(buf2, kMaxStringLength, "&c%s&n", buf1);
-	Remember::add_to_flaged_cont(Remember::wiznet_, buf2, level);
+	const std::string level_tag = level != kLvlGod ? fmt::format("<{}> ", level) : "";
+	const std::string message = fmt::format("&c{}{}: {}{}{}\r\n&n",
+											GET_NAME(ch), emote ? "" : " богам",
+											level_tag, emote ? "<--- " : "", text);
+	Remember::add_to_flaged_cont(Remember::wiznet_, message, level);
 
 	// пробегаемся по списку дескрипторов чаров и кто должен - тот услышит богов
 	for (d = descriptor_list; d; d = d->next) {
@@ -124,13 +122,11 @@ void do_wiznet(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			(!d->character->IsFlagged(EPlrFlag::kMailing)))    // отправляющий письмо не видит имм канала
 		{
 			// отправляем сообщение чару
-			snprintf(buf2, kMaxStringLength, "%s%s%s",
-					 kColorCyn, buf1, kColorNrm);
-			d->character->remember_add(buf2, Remember::ALL);
+			d->character->remember_add(message, Remember::ALL);
 			// не видино своих мессаг если 'режим repeat'
 			if (d != ch->desc
 				|| !(d->character->IsFlagged(EPrf::kNoRepeat))) {
-				SendMsgToChar(buf2, d->character.get());
+				SendMsgToChar(message, d->character.get());
 			}
 		}
 	}


### PR DESCRIPTION
Пятый файл-батч по #3814: `do_exits.cpp`, `do_get.cpp`, `do_who_am_i.cpp`, `do_force.cpp`, `do_wiznet.cpp`. Глобальных `buf/buf1/buf2/arg` в них не осталось; заодно убраны локальные `char[]` там, где они не диктовались сигнатурой вызываемой функции.

## Баги, вылезшие по дороге

**ктоя — сообщение о запрете имени никуда не уходило.** Обе ветки писали в общий `buf`, а `SendMsgToChar(buf, ch)` стоял после них один на двоих. При разделении `act_informative.cpp` на файлы команд общий вызов потерялся, и остался только в ветке одобрения — игрок с запрещённым именем не видел вообще ничего. В `9a718ef2e` (`act_informative.cpp:3453-3456`) вызов ещё был. Теперь печатаются обе ветки.

**wiznet @ — наружу мог уйти чужой буфер.** Если ни один бог не попал ни в один из двух списков, `buf1` не переписывался и `SendMsgToChar(buf1, ch)` показывал остатки от любой предыдущей команды. Теперь это пустая строка.

**wiznet @ — дублированный заголовок.** «Боги/привилегированные которые не смогут вас услышать» лежал двумя литералами (ветки `strcpy`/`strcat`); схлопнут в один.

**wiznet — два разных представления цвета одного и того же сообщения.** В `remember` клалось `&c…&n`, а слушателям отправлялось то же самое, но с ANSI-константами `kColorCyn`/`kColorNrm` напрямую. Теперь везде `&c…&n`: у бога с выключенным цветом в имм-канале больше не будет сырых escape-последовательностей.

**wiznet #<уровень> — недостижимая ветка.** `else if (emote) argument++` внутри `case '#'` не могла сработать: `emote` выставляется только в `case '*'`, который тут же выходит из switch. Убрана.

**force — одна строка команды на всех жертв.** `command_interpreter` правит переданную строку на месте, а `force здесь`/`force all` прогоняли через него один и тот же буфер в цикле. Теперь каждой жертве достаётся своя копия.

**выходы — имя комнаты могло быть nullptr.** `RoomData::name` бывает пустым, `printf` печатал `(null)`, а `fmt` на этом бросает `std::logic_error`. Добавлена проверка.

## Прочее

- Ширины колонок в `exits` переведены с `%-15s`/`%7d` на `{:<15}`/`{:7}` — байтовые ширины врали на кириллице.
- Замена `'%'` на `'*'` в логе `force` сохранена (проверено: `forced Потап Потапыч to скажи 100* готово`).
- Три временных буфера под `group::do_split` в `do_get.cpp` заменены на `std::to_string`.

## Проверка

Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.

На тестовом мире (чистый снимок, Новик 34 уровня): `whoami`, `exits`, `выходы`, `взять все`, `wiznet @`, `wiznet <текст>`, `wiznet #34 <текст>`, `wiznet #99` (отказ по уровню), `wiznet *эмоция`, `wiznet` без аргументов, `force <моб> <команда>`, `force <моб> скажи 100% готово`, `force здесь`, `force all`, `force` без аргументов, `force` на несуществующего. Множества строковых литералов сверены с master — расходятся только переводом `%s/%d` в `{}` и перечисленными выше схлопываниями.

Закрывает часть #3814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
