### PR TITLE
refactor(core): drop global buffers from boot, editor, trigedit, pk and crafting (#3814)

### DIFF
--- a/src/engine/boot/boot_data_files.cpp
+++ b/src/engine/boot/boot_data_files.cpp
@@ -284,7 +284,6 @@ void TriggersFile::parse_trigger(int vnum) {
 	}
 	zone_table[zrn].RnumTrigsLocation.second = top_of_trigt;
 
-	snprintf(buf2, sizeof(buf2), "trig vnum %d", vnum);
 	std::string name(fread_string());
 	get_line(file(), line);
 
@@ -451,11 +450,13 @@ void WorldFile::parse_room(int virtual_nr) {
 
 	world[room_realnum]->ex_description.clear();
 
-	snprintf(buf, sizeof(buf), "SYSERR: Format error in room #%d (expecting D/E/S)", virtual_nr);
+	// Сообщение лежало в общем буфере и затиралось ошибкой про extradesc ниже: после
+	// первого битого E-блока комната падала с чужим текстом.
+	const std::string format_error = fmt::format("SYSERR: Format error in room #{} (expecting D/E/S)", virtual_nr);
 
 	for (;;) {
 		if (!get_line(file(), line)) {
-			fatal_log("%s", buf);
+			fatal_log("%s", format_error.c_str());
 		}
 		switch (*line) {
 			case 'D': setup_dir(room_realnum, atoi(line + 1));
@@ -468,8 +469,7 @@ void WorldFile::parse_room(int virtual_nr) {
 				if (!new_descr.keyword.empty() && !new_descr.description.empty()) {
 					world[room_realnum]->ex_description.push_back(std::move(new_descr));
 				} else {
-					snprintf(buf, sizeof(buf), "SYSERR: Format error in room #%d (Corrupt extradesc)", virtual_nr);
-					log("%s", buf);
+					log("SYSERR: Format error in room #%d (Corrupt extradesc)", virtual_nr);
 				}
 			}
 				break;
@@ -493,7 +493,7 @@ void WorldFile::parse_room(int virtual_nr) {
 				} while (letter != 0);
 				return;
 
-			default: fatal_log("%s", buf);
+			default: fatal_log("%s", format_error.c_str());
 		}
 	}
 }
@@ -507,7 +507,7 @@ void WorldFile::setup_dir(int room, unsigned dir) {
 	int t[5];
 	char line[256];
 
-	snprintf(buf2, sizeof(buf2), "room #%d, direction D%u", GET_ROOM_VNUM(room), dir);
+	const std::string where = fmt::format("room #{}, direction D{}", GET_ROOM_VNUM(room), dir);
 
 	world[room]->dir_option_proto[dir] = std::make_shared<ExitData>();
 	world[room]->dir_option_proto[dir]->general_description = fread_string();
@@ -534,7 +534,7 @@ void WorldFile::setup_dir(int room, unsigned dir) {
 		world[room]->dir_option_proto[dir]->exit_info.set_plane(0, t[0]);
 		world[room]->dir_option_proto[dir]->lock_complexity = t[3];
 	} else {
-		fatal_log("SYSERR: Format error, %s", buf2);
+		fatal_log("SYSERR: Format error, %s", where.c_str());
 	}
 
 	world[room]->dir_option_proto[dir]->key = t[1];
@@ -614,8 +614,9 @@ void ObjectFile::parse_object(const int nr) {
 	tobj->set_aliases(aliases);
 	tobj->set_short_description(utils::colorLOW(fread_string()));
 
-	snprintf(buf, sizeof(buf), "%s", tobj->get_short_description().c_str());
-	tobj->set_PName(grammar::ECase::kNom, utils::colorLOW(buf)); //именительный падеж равен короткому описанию
+	//именительный падеж равен короткому описанию
+	std::string nominative(tobj->get_short_description());
+	tobj->set_PName(grammar::ECase::kNom, utils::colorLOW(nominative));
 
 	for (j = grammar::ECase::kGen; j <= grammar::ECase::kLastCase; j++) {
 		tobj->set_PName(static_cast<grammar::ECase>(j), utils::colorLOW(fread_string()));
@@ -750,11 +751,7 @@ void ObjectFile::parse_object(const int nr) {
 				if (!new_descr.keyword.empty() && !new_descr.description.empty()) {
 					tobj->ex_descriptions().push_back(std::move(new_descr));
 				} else {
-					const auto written =
-						snprintf(buf, sizeof(buf), "SYSERR: Format error in %s (Corrupt extradesc)", m_buffer);
-					buf[written] = '\0';
-
-					log("%s", buf);
+					log("SYSERR: Format error in %s (Corrupt extradesc)", m_buffer);
 				}
 			}
 				break;
@@ -836,23 +833,24 @@ bool ObjectFile::check_object(ObjData *obj) {
 			GET_OBJ_VNUM(obj), obj->get_short_description().c_str(), obj->get_rent_off());
 	}
 */
-	sprintbit(obj->get_wear_flags(), wear_bits, buf, sizeof(buf));
-	if (strstr(buf, "UNDEFINED")) {
+	char flags[kMaxStringLength];
+	sprintbit(obj->get_wear_flags(), wear_bits, flags, sizeof(flags));
+	if (strstr(flags, "UNDEFINED")) {
 		error = true;
 		log("SYSERR: Object #%d (%s) has unknown wear flags.", GET_OBJ_VNUM(obj), obj->get_short_description().c_str());
 	}
 
-	obj->get_extra_flags().sprintbits(extra_bits, buf, sizeof(buf), ",", 4);
-	if (strstr(buf, "UNDEFINED")) {
+	obj->get_extra_flags().sprintbits(extra_bits, flags, sizeof(flags), ",", 4);
+	if (strstr(flags, "UNDEFINED")) {
 		error = true;
 		log("SYSERR: Object #%d (%s) has unknown extra flags.",
 			GET_OBJ_VNUM(obj),
 			obj->get_short_description().c_str());
 	}
 
-	obj->get_affect_flags().sprintbits(equipment_affects, buf, sizeof(buf), ",", 4);
+	obj->get_affect_flags().sprintbits(equipment_affects, flags, sizeof(flags), ",", 4);
 
-	if (strstr(buf, "UNDEFINED")) {
+	if (strstr(flags, "UNDEFINED")) {
 		error = true;
 		log("SYSERR: Object #%d (%s) has unknown affection flags.",
 			GET_OBJ_VNUM(obj),
@@ -1509,13 +1507,13 @@ bool ZoneFile::load_zone() {
 bool ZoneFile::load_regular_zone() {
 	auto &zone = zone_table[s_zone_number];
 
-	snprintf(buf2, sizeof(buf2), "beginning of zone #%d", zone.vnum);
+	char line[kMaxStringLength];
 
 	rewind(file());
 	char *ptr;
 	auto num_of_cmds = 0;
-	while (get_line(file(), buf)) {
-		ptr = buf;
+	while (get_line(file(), line)) {
+		ptr = line;
 		skip_spaces(&ptr);
 
 		if (*ptr == 'A') {
@@ -1550,67 +1548,67 @@ bool ZoneFile::load_regular_zone() {
 		CREATE(zone.cmd, num_of_cmds);
 	}
 
-	auto line_num = get_line(file(), buf);    // skip already processed "#<zone number> [<zone type>]" line
+	auto line_num = get_line(file(), line);    // skip already processed "#<zone number> [<zone type>]" line
 
-	line_num += get_line(file(), buf);
-	if ((ptr = strchr(buf, '~')) != nullptr)    // take off the '~' if it's there
+	line_num += get_line(file(), line);
+	if ((ptr = strchr(line, '~')) != nullptr)    // take off the '~' if it's there
 	{
 		*ptr = '\0';
 	}
-	zone.name = buf;
+	zone.name = line;
 
 	log("Читаем zon файл: %s", full_file_name().c_str());
-	while (*buf != 'S' && !feof(file())) {
-		line_num += get_line(file(), buf);
+	while (*line != 'S' && !feof(file())) {
+		line_num += get_line(file(), line);
 
-		if (*buf == '#') {
+		if (*line == '#') {
 			break;
 		}
 
-		if (*buf == '^') {
-			std::string comment = buf;
+		if (*line == '^') {
+			std::string comment = line;
 			utils::TrimIf(comment, "^~");
 			zone.comment = comment;
 		}
 
-		if (*buf == '&') {
-			std::string location = buf;
+		if (*line == '&') {
+			std::string location = line;
 			utils::TrimIf(location, "&~");
 			zone.location = location;
 		}
 
-		if (*buf == '!') {
-			std::string autor = buf;
+		if (*line == '!') {
+			std::string autor = line;
 			utils::TrimIf(autor, "!~");
 			zone.author = autor;
 		}
 
-		if (*buf == '$') {
-			std::string description = buf ;
+		if (*line == '$') {
+			std::string description = line ;
 			utils::TrimIf(description, "$~");
 			zone.description = description;
 		}
 	}
 
-	if (*buf != '#') {
+	if (*line != '#') {
 		fatal_log("SYSERR: ERROR!!! not # in file %s", full_file_name().c_str());
 	}
 	auto group = 0;
-	const auto count = sscanf(buf, "#%d %d %d %d", &zone.level, &zone.type, &group, &zone.entrance);
+	const auto count = sscanf(line, "#%d %d %d %d", &zone.level, &zone.type, &group, &zone.entrance);
 	if (count < 2) {
-		fatal_log("SYSERR: ошибка чтения z.level, z.type, z.group, z.entrance: %s", buf);
+		fatal_log("SYSERR: ошибка чтения z.level, z.type, z.group, z.entrance: %s", line);
 	}
 	zone.group = (group == 0) ? 1 : group; //группы в 0 рыл не бывает
-	line_num += get_line(file(), buf);
+	line_num += get_line(file(), line);
 
 	char t1[80];
 	char t2[80];
 	*t1 = 0;
 	*t2 = 0;
 	auto tmp_reset_idle = 0;
-	if (sscanf(buf, " %d %d %d %d %s %s", &zone.top, &zone.lifespan, &zone.reset_mode, &tmp_reset_idle, t1, t2) < 4) {
+	if (sscanf(line, " %d %d %d %d %s %s", &zone.top, &zone.lifespan, &zone.reset_mode, &tmp_reset_idle, t1, t2) < 4) {
 		// если нет четырех констант, то, возможно, это старый формат -- попробуем прочитать три
-		const auto count = sscanf(buf, " %d %d %d %s %s",
+		const auto count = sscanf(line, " %d %d %d %s %s",
 								  &zone.top,
 								  &zone.lifespan,
 								  &zone.reset_mode,
@@ -1628,14 +1626,14 @@ bool ZoneFile::load_regular_zone() {
 	auto cmd_no = 0;
 
 	for (;;) {
-		const auto lines_read = get_line(file(), buf);
+		const auto lines_read = get_line(file(), line);
 
 		if (lines_read == 0) {
 			fatal_log("SYSERR: Format error in %s - premature end of file", full_file_name().c_str());
 		}
 
 		line_num += lines_read;
-		ptr = buf;
+		ptr = line;
 		skip_spaces(&ptr);
 
 		if ((zone.cmd[cmd_no].command = *ptr) == '*') {
@@ -1713,7 +1711,7 @@ bool ZoneFile::load_regular_zone() {
 		zone.cmd[cmd_no].if_flag = if_flag;
 
 		if (error) {
-			fatal_log("SYSERR: Format error in %s, line %d: '%s'", full_file_name().c_str(), line_num, buf);
+			fatal_log("SYSERR: Format error in %s, line %d: '%s'", full_file_name().c_str(), line_num, line);
 		}
 		zone.cmd[cmd_no].line = line_num;
 		cmd_no++;
@@ -1723,10 +1721,6 @@ bool ZoneFile::load_regular_zone() {
 }
 
 bool ZoneFile::load_generated_zone() const {
-	auto &zone = zone_table[s_zone_number];
-
-	snprintf(buf2, sizeof(buf2), "beginning of generated zone #%d", zone.vnum);
-
 	return true;
 }
 

--- a/src/engine/core/iosystem.h
+++ b/src/engine/core/iosystem.h
@@ -40,6 +40,7 @@ void flush_queues(DescriptorData *d);
 int write_to_descriptor(socket_t desc, const char *txt, size_t total);
 bool write_to_descriptor_with_options(DescriptorData *t, const char *buffer, size_t byffer_size, int &written);
 void write_to_output(const char *txt, DescriptorData *d);
+inline void write_to_output(const std::string &txt, DescriptorData *d) { write_to_output(txt.c_str(), d); }
 void string_add(DescriptorData *d, char *str);
 int toggle_compression(DescriptorData *d);
 int process_input(DescriptorData *t);

--- a/src/engine/scripting/dg_olc.cpp
+++ b/src/engine/scripting/dg_olc.cpp
@@ -228,9 +228,9 @@ void TrigeditFprintEscapedBody(FILE *fp, const std::string &body)
 void TrigeditCommitSave(DescriptorData *d)
 {
 	trigedit_save(d);
-	snprintf(buf, sizeof(buf), "OLC: %s edits trigger %d", GET_NAME(d->character), OLC_NUM(d));
 	olc_log("%s end trig %d", GET_NAME(d->character), OLC_NUM(d));
-	mudlog(buf, NRM, MAX(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
+	mudlog(fmt::format("OLC: {} edits trigger {}", GET_NAME(d->character), OLC_NUM(d)),
+		   NRM, MAX(kLvlBuilder, GET_INVIS_LEV(d->character)), SYSLOG, true);
 }
 
 void TrigeditSaveAndExit(DescriptorData *d)
@@ -407,9 +407,8 @@ void trigedit_disp_types(DescriptorData *d) {
 					  d->character.get());
 	}
 
-	sprintbit(GET_TRIG_TYPE(OLC_TRIG(d)), types, buf1, sizeof(buf1), 2);
 	SendMsgToChar(fmt::format("\r\nCurrent types : {}{}{}\r\nEnter type (0 to quit) : ",
-								  cyn, buf1, nrm),
+								  cyn, sprintbit(GET_TRIG_TYPE(OLC_TRIG(d)), types, 2), nrm),
 				  d->character.get());
 }
 
@@ -821,7 +820,6 @@ bool trigedit_save_to_disk(int zone_rnum, int notify_level) {
 	int trig_rnum, i;
 	Trigger *trig;
 	int zone, top;
-	char buf[kMaxStringLength];
 	char bitBuf[kMaxInputLength];
 	char fname[kMaxInputLength];
 	char logbuf[kMaxInputLength];
@@ -835,8 +833,7 @@ bool trigedit_save_to_disk(int zone_rnum, int notify_level) {
 	top = zone_table[zone_rnum].top;
 
 	if (zone >= dungeons::kZoneStartDungeons) {
-		snprintf(buf, sizeof(buf), "Отказ сохранения зоны %d на диск.", zone);
-		mudlog(buf, CMP, kLvlGreatGod, SYSLOG, true);
+		mudlog(fmt::format("Отказ сохранения зоны {} на диск.", zone), CMP, kLvlGreatGod, SYSLOG, true);
 		return false;
 	}
 
@@ -892,9 +889,9 @@ bool trigedit_save_to_disk(int zone_rnum, int notify_level) {
 	fprintf(trig_file, "$\n$\n");
 	fclose(trig_file);
 
-	snprintf(buf, sizeof(buf), "%s/%d.trg", TRG_PREFIX, zone);
-	remove(buf);
-	rename(fname, buf);
+	const std::string trg_name = fmt::format("{}/{}.trg", TRG_PREFIX, zone);
+	remove(trg_name.c_str());
+	rename(fname, trg_name.c_str());
 	trigedit_create_index(zone, "trg");
 	return true;
 }
@@ -909,33 +906,37 @@ void trigedit_create_index(int znum, const char *type) {
 	snprintf(old_name, sizeof(old_name), "%s/index", prefix);
 	snprintf(new_name, sizeof(new_name), "%s/newindex", prefix);
 
+	// В сообщении об ошибке стоял общий буфер buf -- в него писал кто угодно до нас,
+	// так что имя нераскрывшегося файла в лог не попадало ни разу. Печатаем его.
 	if (!(oldfile = fopen(old_name, "r"))) {
-		snprintf(buf1, kMaxStringLength, "SYSERR: TRIGEDIT: Failed to open %s", buf);
-		mudlog(buf1, BRF, kLvlImplementator, SYSLOG, true);
+		mudlog(fmt::format("SYSERR: TRIGEDIT: Failed to open {}", old_name),
+			   BRF, kLvlImplementator, SYSLOG, true);
 		return;
 	} else if (!(newfile = fopen(new_name, "w"))) {
-		snprintf(buf1, kMaxStringLength, "SYSERR: TRIGEDIT: Failed to open %s", buf);
-		mudlog(buf1, BRF, kLvlImplementator, SYSLOG, true);
+		mudlog(fmt::format("SYSERR: TRIGEDIT: Failed to open {}", new_name),
+			   BRF, kLvlImplementator, SYSLOG, true);
+		fclose(oldfile);
 		return;
 	}
 
 	// Index contents must be in order: search through the old file for the
 	// right place, insert the new file, then copy the rest over.
-	snprintf(buf1, sizeof(buf1), "%d.%s", znum, type);
-	while (get_line(oldfile, buf)) {
-		if (*buf == '$') {
-			fprintf(newfile, "%s\n$\n", (!found ? buf1 : "$"));
+	const std::string entry = fmt::format("{}.{}", znum, type);
+	char line[kMaxStringLength];
+	while (get_line(oldfile, line)) {
+		if (*line == '$') {
+			fprintf(newfile, "%s\n$\n", (!found ? entry.c_str() : "$"));
 			break;
 		} else if (!found) {
-			sscanf(buf, "%d", &num);
+			sscanf(line, "%d", &num);
 			if (num == znum)
 				found = true;
 			else if (num > znum) {
 				found = true;
-				fprintf(newfile, "%s\n", buf1);
+				fprintf(newfile, "%s\n", entry.c_str());
 			}
 		}
-		fprintf(newfile, "%s\n", buf);
+		fprintf(newfile, "%s\n", line);
 	}
 
 	fclose(newfile);
@@ -997,24 +998,24 @@ void dg_script_menu(DescriptorData *d) {
 									  ++i, cyn, trigger_vnum, nrm, cyn, trig_index[GetTriggerRnum(trigger_vnum)]->proto->get_name().c_str(), nrm),
 					  d->character.get());
 		if (trig_index[GetTriggerRnum(trigger_vnum)]->proto->get_attach_type() != OLC_ITEM_TYPE(d)) {
-			snprintf(buf, sizeof(buf), "   %s** Mis-matched Trigger Type **%s\r\n", grn, nrm);
+			SendMsgToChar(fmt::format("   {}** Mis-matched Trigger Type **{}\r\n", grn, nrm),
+						  d->character.get());
 		} else {
-			snprintf(buf, sizeof(buf), "\r\n");
+			SendMsgToChar("\r\n", d->character.get());
 		}
-		SendMsgToChar(buf, d->character.get());
 	}
 
 	if (i == 0) {
 		SendMsgToChar("     <none>\r\n", d->character.get());
 	}
 
-	snprintf(buf, sizeof(buf), "\r\n"
-				 " %sN%s)  Новый триггер для этого скрипта\r\n"
-				 " %sD%s)  Удалить триггер в этом скрипте\r\n"
-				 " %sX%s)  Выйти из редактора скрипта\r\n"
-				 " %sQ%s)  Выйти из редактора скрипта (без сохранения) \r\n\r\n"
-				 "     Введите выбранное :", grn, nrm, grn, nrm, grn, nrm, grn, nrm);
-	SendMsgToChar(buf, d->character.get());
+	SendMsgToChar(fmt::format("\r\n"
+							  " {0}N{1})  Новый триггер для этого скрипта\r\n"
+							  " {0}D{1})  Удалить триггер в этом скрипте\r\n"
+							  " {0}X{1})  Выйти из редактора скрипта\r\n"
+							  " {0}Q{1})  Выйти из редактора скрипта (без сохранения) \r\n\r\n"
+							  "     Введите выбранное :", grn, nrm),
+				  d->character.get());
 }
 
 int dg_script_edit_parse(DescriptorData *d, char *arg) {

--- a/src/engine/ui/modify.cpp
+++ b/src/engine/ui/modify.cpp
@@ -142,7 +142,7 @@ void parse_action(int command, char *string, DescriptorData *d) {
 	//log("[PA] Start %d(%s)", command, string);
 	switch (command) {
 		case PARSE_HELP:
-			sprintf(buf,
+			iosystem::write_to_output(
 					"Формат команд редактора: /<letter>\r\n\r\n"
 					"/a         -  прекратить редактирование\r\n"
 					"/c         -  очистить буфер\r\n"
@@ -156,8 +156,7 @@ void parse_action(int command, char *string, DescriptorData *d) {
 					"/n         -  пролистать буфер с номерами строк\r\n"
 					"/r 'a' 'b' -  заменить первое вхождение текста <a> в буфере на текст <b>\r\n"
 					"/ra 'a' 'b'-  заменить все вхождения текста <a> в буфере на текст <b>\r\n"
-					"              Формат: /r[a] 'шаблон' 'на_что_меняем'\r\n" "/s         -  сохранить текст\r\n");
-			iosystem::write_to_output(buf, d);
+					"              Формат: /r[a] 'шаблон' 'на_что_меняем'\r\n" "/s         -  сохранить текст\r\n", d);
 			break;
 
 		case PARSE_FORMAT:
@@ -176,8 +175,8 @@ void parse_action(int command, char *string, DescriptorData *d) {
 
 			format_text(d->writer, flags, d, d->max_str);
 
-			sprintf(buf, "Текст отформатирован %s\r\n", (indent ? "WITH INDENT." : "."));
-			iosystem::write_to_output(buf, d);
+			iosystem::write_to_output(indent ? "Текст отформатирован WITH INDENT.\r\n"
+										    : "Текст отформатирован .\r\n", d);
 			break;
 
 		case PARSE_REPLACE:
@@ -220,11 +219,10 @@ void parse_action(int command, char *string, DescriptorData *d) {
 				if (total_len <= d->max_str) {
 					replaced = replace_str(d->writer, old_text.c_str(), new_text.c_str(), rep_all, static_cast<int>(d->max_str));
 					if (replaced > 0) {
-						sprintf(buf, "Заменено вхождений '%s' на '%s' - %d.\r\n", old_text.c_str(), new_text.c_str(), replaced);
-						iosystem::write_to_output(buf, d);
+						iosystem::write_to_output(fmt::format("Заменено вхождений '{}' на '{}' - {}.\r\n",
+															  old_text, new_text, replaced), d);
 					} else if (replaced == 0) {
-						sprintf(buf, "Шаблон '%s' не найден.\r\n", old_text.c_str());
-						iosystem::write_to_output(buf, d);
+						iosystem::write_to_output(fmt::format("Шаблон '{}' не найден.\r\n", old_text), d);
 					} else {
 						iosystem::write_to_output("ОШИБКА: При попытке замены буфер переполнен - прервано.\r\n", d);
 					}
@@ -287,8 +285,8 @@ void parse_action(int command, char *string, DescriptorData *d) {
 					*t = '\0';
 					d->writer->set_string(buffer);
 
-					sprintf(buf, "%u line%sdeleted.\r\n", total_len, ((total_len != 1) ? "s " : " "));
-					iosystem::write_to_output(buf, d);
+					iosystem::write_to_output(fmt::format("{} line{}deleted.\r\n",
+														  total_len, total_len != 1 ? "s " : " "), d);
 				} else {
 					iosystem::write_to_output("Отрицательный или нулевой номер строки для удаления.\r\n", d);
 					return;
@@ -297,9 +295,6 @@ void parse_action(int command, char *string, DescriptorData *d) {
 			break;
 
 		case PARSE_LIST_NORM:
-			// * Note: Rv's buf, buf1, buf2, and arg variables are defined to 32k so
-			// * they are probly ok for what to do here.
-			*buf = '\0';
 			if (*string != '\0')
 				switch (sscanf(string, " %d - %d ", &line_low, &line_high)) {
 					case 0: line_low = 1;
@@ -320,11 +315,12 @@ void parse_action(int command, char *string, DescriptorData *d) {
 				iosystem::write_to_output("Неверный диапазон.\r\n", d);
 				return;
 			}
-			*buf = '\0';
-			if ((line_high < 999999) || (line_low > 1))
-				sprintf(buf, "Текущий диапазон [%d - %d]:\r\n", line_low, line_high);
 			i = 1;
 			{
+				std::string out;
+				if ((line_high < 999999) || (line_low > 1)) {
+					out = fmt::format("Текущий диапазон [{} - {}]:\r\n", line_low, line_high);
+				}
 				const char *pos = d->writer->get_string();
 
 				unsigned int total_len = 0;
@@ -350,20 +346,17 @@ void parse_action(int command, char *string, DescriptorData *d) {
 				}
 
 				if (pos) {
-					strncat(buf, beginning, pos - beginning);
+					out.append(beginning, pos - beginning);
 				} else {
-					strcat(buf, beginning);
+					out += beginning;
 				}
 
-				page_string(d, buf, true);
+				page_string(d, out);
 			}
 
 			break;
 
 		case PARSE_LIST_NUM:
-			// * Note: Rv's buf, buf1, buf2, and arg variables are defined to 32k so
-			// * they are probly ok for what to do here.
-			*buf = '\0';
 			if (*string != '\0') {
 				switch (sscanf(string, " %d - %d ", &line_low, &line_high)) {
 					case 0: line_low = 1;
@@ -398,9 +391,9 @@ void parse_action(int command, char *string, DescriptorData *d) {
 				page_string(d, numbered);
 				break;
 			}
-			*buf = '\0';
 			i = 1;
 			{
+				std::string out;
 				const char *pos = d->writer->get_string();
 				unsigned int total_len = 0;
 
@@ -422,34 +415,35 @@ void parse_action(int command, char *string, DescriptorData *d) {
 						i++;
 						total_len++;
 						pos++;
-						sprintf(buf1, "%s", buf);
-						snprintf(buf, kMaxStringLength, "%s%4d:\r\n", buf1, (i - 1));
-						strncat(buf, beginning, pos - beginning);
+						out += fmt::format("{:4}:\r\n", i - 1);
+						out.append(beginning, pos - beginning);
 						beginning = pos;
 					}
 				}
 
 				if (pos && beginning) {
-					strncat(buf, beginning, pos - beginning);
+					out.append(beginning, pos - beginning);
 				} else if (beginning) {
-					strcat(buf, beginning);
+					out += beginning;
 				}
-			}
 
-			page_string(d, buf, true);
+				page_string(d, out);
+			}
 			break;
 
-		case PARSE_INSERT: half_chop(string, buf, buf2);
-			if (*buf == '\0') {
+		case PARSE_INSERT: {
+			std::string new_line;
+			const std::string line_arg = utils::ExtractFirstArgumentLower(string ? string : "", new_line);
+			if (line_arg.empty()) {
 				iosystem::write_to_output("Вы должны указать номер строки, после которой вставить текст.\r\n", d);
 				return;
 			}
-			line_low = atoi(buf);
-			strcat(buf2, "\r\n");
+			line_low = atoi(line_arg.c_str());
+			new_line += "\r\n";
 
 			i = 1;
-			*buf = '\0';
 			{
+				std::string out;
 				const char *pos = d->writer->get_string();
 				const char *beginning = pos;
 				if (pos == nullptr) {
@@ -467,18 +461,18 @@ void parse_action(int command, char *string, DescriptorData *d) {
 						iosystem::write_to_output("Номер строки вне диапазона - прервано.\r\n", d);
 						return;
 					}
-					if ((pos - beginning + strlen(buf2) + strlen(pos) + 3) > d->max_str) {
+					if ((pos - beginning + new_line.size() + strlen(pos) + 3) > d->max_str) {
 						iosystem::write_to_output("Превышение размеров буфера - прервано.\r\n", d);
 						return;
 					}
 					if (beginning && (*beginning != '\0')) {
-						strncat(buf, beginning, pos - beginning);
+						out.append(beginning, pos - beginning);
 					}
-					strcat(buf, buf2);
+					out += new_line;
 					if (*pos != '\0') {
-						strcat(buf, pos);
+						out += pos;
 					}
-					d->writer->set_string(buf);
+					d->writer->set_string(out.c_str());
 					iosystem::write_to_output("Строка вставлена.\r\n", d);
 				} else {
 					iosystem::write_to_output("Номер строки должен быть больше 0.\r\n", d);
@@ -486,18 +480,21 @@ void parse_action(int command, char *string, DescriptorData *d) {
 				}
 			}
 			break;
+		}
 
-		case PARSE_EDIT: half_chop(string, buf, buf2);
-			if (*buf == '\0') {
+		case PARSE_EDIT: {
+			std::string new_line;
+			const std::string line_arg = utils::ExtractFirstArgumentLower(string ? string : "", new_line);
+			if (line_arg.empty()) {
 				iosystem::write_to_output("Вы должны указать номер строки изменяемого текста.\r\n", d);
 				return;
 			}
-			line_low = atoi(buf);
-			strcat(buf2, "\r\n");
+			line_low = atoi(line_arg.c_str());
+			new_line += "\r\n";
 
 			i = 1;
-			*buf = '\0';
 			{
+				std::string out;
 				const char *s = d->writer->get_string();
 				const char *beginning = s;
 				if (s == nullptr) {
@@ -523,10 +520,10 @@ void parse_action(int command, char *string, DescriptorData *d) {
 					// message text and I don't need to put that into the changed buffer.
 					if (s != beginning) {    // First things first .. we get this part into the buffer.
 						// Put the first 'good' half of the text into storage.
-						strncat(buf, beginning, s - beginning);
+						out.append(beginning, s - beginning);
 					}
 					// Put the new 'good' line into place.
-					strcat(buf, buf2);
+					out += new_line;
 					if ((s = strchr(s, '\n')) != nullptr) {
 						/*
 						* This means that we are at the END of the line, we want out of
@@ -535,17 +532,17 @@ void parse_action(int command, char *string, DescriptorData *d) {
 						*/
 						s++;
 						// * Now put the last 'good' half of buffer into storage.
-						strcat(buf, s);
+						out += s;
 					}
 
 					// * Check for buffer overflow.
-					if (strlen(buf) > d->max_str) {
+					if (out.size() > d->max_str) {
 						iosystem::write_to_output("Превышение максимального размера буфера - прервано.\r\n", d);
 						return;
 					}
 
 					// * Change the size of the REAL buffer to fit the new text.
-					d->writer->set_string(buf);
+					d->writer->set_string(out.c_str());
 					iosystem::write_to_output("Строка изменена.\r\n", d);
 				} else {
 					iosystem::write_to_output("Номер строки должен быть больше 0.\r\n", d);
@@ -553,6 +550,7 @@ void parse_action(int command, char *string, DescriptorData *d) {
 				}
 			}
 			break;
+		}
 
 		default: iosystem::write_to_output("Неверная опция.\r\n", d);
 			mudlog("SYSERR: invalid command passed to parse_action", BRF, kLvlImplementator, SYSLOG, true);
@@ -882,8 +880,8 @@ void string_add(DescriptorData *d, char *str) {
 
 void do_featset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	CharData *vict;
-	char name[kMaxInputLength], buf2[128];
-	char buf[kMaxInputLength], help[kMaxStringLength];
+	char name[kMaxInputLength];
+	char value_arg[kMaxInputLength], help[kMaxStringLength];
 	int value, qend;
 
 	argument = one_argument(argument, name);
@@ -954,13 +952,13 @@ void do_featset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	}
 
 	argument += qend + 1;    // skip to next parameter //
-	argument = one_argument(argument, buf);
+	argument = one_argument(argument, value_arg);
 
-	if (!*buf) {
+	if (!*value_arg) {
 		SendMsgToChar("Не указан числовой параметр (0 или 1).\r\n", ch);
 		return;
 	}
-	value = atoi(buf);
+	value = atoi(value_arg);
 	if (value < 0 || value > 1) {
 		SendMsgToChar("Допустимые значения: 0 (снять), 1 (установить).\r\n", ch);
 		return;
@@ -971,23 +969,25 @@ void do_featset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	sprintf(buf2, "%s changed %s's %s to '%s'.", GET_NAME(ch), GET_NAME(vict),
-			MUD::Feat(feat_id).GetCName(), value ? "enabled" : "disabled");
-	mudlog(buf2, BRF, -1, SYSLOG, true);
-	imm_log("%s", buf2);
+	// Лог собирался в 128-байтный буфер: два длинных имени и название способности
+	// в него не помещались.
+	const std::string log_line = fmt::format("{} changed {}'s {} to '{}'.", GET_NAME(ch), GET_NAME(vict),
+											 MUD::Feat(feat_id).GetName(), value ? "enabled" : "disabled");
+	mudlog(log_line, BRF, -1, SYSLOG, true);
+	imm_log("%s", log_line.c_str());
 	if (value) {
 		vict->SetFeat(feat_id);
 	} else {
 		vict->UnsetFeat(feat_id);
 	}
 
-	sprintf(buf2, "Вы изменили для %s '%s' на '%s'.\r\n", GET_PAD(vict, 1),
-			MUD::Feat(feat_id).GetCName(), value ? "доступно" : "недоступно");
+	const std::string report = fmt::format("Вы изменили для {} '{}' на '{}'.\r\n", GET_PAD(vict, 1),
+										   MUD::Feat(feat_id).GetName(), value ? "доступно" : "недоступно");
 	if (!CanGetFeat(vict, feat_id) && value == 1) {
 		SendMsgToChar("Эта способность недоступна персонажу и будет удалена при повторном входе в игру.\r\n",
 					 ch);
 	}
-	SendMsgToChar(buf2, ch);
+	SendMsgToChar(report, ch);
 }
 
 // **********************************************************************
@@ -996,8 +996,8 @@ void do_featset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 void do_skillset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	CharData *vict;
-	char name[kMaxInputLength], buf2[128];
-	char buf[kMaxInputLength], help[kMaxStringLength];
+	char name[kMaxInputLength];
+	char value_arg[kMaxInputLength], help[kMaxStringLength];
 	int value;
 
 	argument = one_argument(argument, name);
@@ -1069,13 +1069,13 @@ void do_skillset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 	argument += qend + 1;    // skip to next parameter
-	argument = one_argument(argument, buf);
+	argument = one_argument(argument, value_arg);
 
-	if (!*buf) {
+	if (!*value_arg) {
 		SendMsgToChar("Пропущен уровень умения.\r\n", ch);
 		return;
 	}
-	value = atoi(buf);
+	value = atoi(value_arg);
 	if (value < 0) {
 		SendMsgToChar("Минимальное значение умения 0.\r\n", ch);
 		return;
@@ -1089,9 +1089,12 @@ void do_skillset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		value = MUD::Skill(skill_id).cap;
 	}
 
-	sprintf(buf2, "%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict),
-			spell_id >= ESpell::kFirst ? MUD::Spell(spell_id).GetCName() : MUD::Skill(skill_id).GetName(), value);
-	mudlog(buf2, BRF, kLvlImmortal, SYSLOG, true);
+	// Лог собирался в 128-байтный буфер: два длинных имени и название умения в него не влезали.
+	const std::string ability_name = spell_id >= ESpell::kFirst
+									 ? MUD::Spell(spell_id).GetName()
+									 : MUD::Skill(skill_id).GetName();
+	mudlog(fmt::format("{} changed {}'s {} to {}.", GET_NAME(ch), GET_NAME(vict), ability_name, value),
+		   BRF, kLvlImmortal, SYSLOG, true);
 	if (spell_id >= ESpell::kFirst && spell_id <= ESpell::kLast) {
 		if (value == 0 && IS_SET(GET_SPELL_TYPE(vict, spell_id), ESpellType::kTemp)) {
 			for (auto it = vict->temp_spells.begin(); it != vict->temp_spells.end();) {
@@ -1108,9 +1111,9 @@ void do_skillset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	} else if (ESkill::kUndefined != skill_id && skill_id <= ESkill::kLast) {
 		SetSkill(vict, skill_id, value);
 	}
-	sprintf(buf2, "Вы изменили для %s '%s' на %d.\r\n", GET_PAD(vict, 1),
-			spell_id > ESpell::kUndefined ? MUD::Spell(spell_id).GetCName() : MUD::Skill(skill_id).GetName(), value);
-	SendMsgToChar(buf2, ch);
+	SendMsgToChar(fmt::format("Вы изменили для {} '{}' на {}.\r\n", GET_PAD(vict, 1),
+							  spell_id > ESpell::kUndefined ? MUD::Spell(spell_id).GetName()
+														    : MUD::Skill(skill_id).GetName(), value), ch);
 }
 
 
@@ -1255,16 +1258,16 @@ void page_string(DescriptorData *d, char *str, int keep_internal) {
 		paginate_string(str, d);
 	}
 
-	buf2[0] = '\0';
-	show_string(d, buf2);
+	char no_input[1] = {'\0'};
+	show_string(d, no_input);
 }
 
 // TODO типа временно для стрингов
-void page_string(DescriptorData *d, const std::string &buf) {
+void page_string(DescriptorData *d, const std::string &text) {
 	// TODO: при keep_internal == true (а в 99% случаев так оно есть)
 	// получаем дальше в page_string повторный str_dup.
 	// как бы собраться с силами и переписать все это :/
-	char *str = str_dup(buf.c_str());
+	char *str = str_dup(text.c_str());
 	page_string(d, str, true);
 	free(str);
 }
@@ -1272,13 +1275,14 @@ void page_string(DescriptorData *d, const std::string &buf) {
 // The call that displays the next page.
 void show_string(DescriptorData *d, char *input) {
 	char buffer[kMaxStringLength];
+	char key[kMaxInputLength];
 	int diff;
 
-	one_argument(input, buf);
+	one_argument(input, key);
 
 	//* Q is for quit. :)
-	if (native_text::first_char_code_lower(buf) == 'q'
-		|| native_text::first_char_code_lower(buf) == rus::kKa) {
+	if (native_text::first_char_code_lower(key) == 'q'
+		|| native_text::first_char_code_lower(key) == rus::kKa) {
 		free(d->showstr_vector);
 		d->showstr_count = 0;
 		if (d->showstr_head) {
@@ -1290,21 +1294,21 @@ void show_string(DescriptorData *d, char *input) {
 	}
 		// R is for refresh, so back up one page internally so we can display
 		// it again.
-	else if (native_text::first_char_code_lower(buf) == 'r'
-		|| native_text::first_char_code_lower(buf) == rus::kPe) {
+	else if (native_text::first_char_code_lower(key) == 'r'
+		|| native_text::first_char_code_lower(key) == rus::kPe) {
 		d->showstr_page = MAX(0, d->showstr_page - 1);
 	}
 		// B is for back, so back up two pages internally so we can display the
 		// correct page here.
-	else if (native_text::first_char_code_lower(buf) == 'b'
-		|| native_text::first_char_code_lower(buf) == rus::kEn) {
+	else if (native_text::first_char_code_lower(key) == 'b'
+		|| native_text::first_char_code_lower(key) == rus::kEn) {
 		d->showstr_page = MAX(0, d->showstr_page - 2);
 	}
 		// Feature to 'goto' a page.  Just type the number of the page and you
 		// are there!
-	else if (a_isdigit(*buf)) {
-		d->showstr_page = MAX(0, MIN(atoi(buf) - 1, d->showstr_count - 1));
-	} else if (*buf) {
+	else if (a_isdigit(*key)) {
+		d->showstr_page = MAX(0, MIN(atoi(key) - 1, d->showstr_count - 1));
+	} else if (*key) {
 		SendMsgToChar("Листать : <RETURN>, Q<К>онец, R<П>овтор, B<Н>азад, или номер страницы.\r\n", d->character.get());
 		return;
 	}

--- a/src/gameplay/crafting/item_creation.cpp
+++ b/src/gameplay/crafting/item_creation.cpp
@@ -502,8 +502,8 @@ void go_create_weapon(CharData *ch, ObjData *obj, int obj_type, ESkill skill) {
 						tobj->get_timer() / 100 * GetSkill(ch, skill) - number(0, tobj->get_timer() / 100 * 25);
 					const int timer = MAX(ObjData::ONE_DAY, timer_value);
 					tobj->set_timer(timer);
-					sprintf(buf, "Ваше изделие продержится примерно %d дней\n", tobj->get_timer() / 24 / 60);
-					act(buf, false, ch, tobj.get(), 0, kToChar);
+					act(fmt::format("Ваше изделие продержится примерно {} дней\n", tobj->get_timer() / 24 / 60),
+						false, ch, tobj.get(), 0, kToChar);
 					tobj->set_material(obj->get_material());
 					// Карачун. Так логичнее.
 					// было tobj->get_maximum_durability() = MAX(50, MIN(300, 300 * prob / percent));
@@ -572,8 +572,8 @@ void go_create_weapon(CharData *ch, ObjData *obj, int obj_type, ESkill skill) {
 						tobj->get_timer() / 100 * GetSkill(ch, skill) - number(0, tobj->get_timer() / 100 * 25);
 					const int timer = MAX(ObjData::ONE_DAY, timer_value);
 					tobj->set_timer(timer);
-					sprintf(buf, "Ваше изделие продержится примерно %d дней\n", tobj->get_timer() / 24 / 60);
-					act(buf, false, ch, tobj.get(), 0, kToChar);
+					act(fmt::format("Ваше изделие продержится примерно {} дней\n", tobj->get_timer() / 24 / 60),
+						false, ch, tobj.get(), 0, kToChar);
 					tobj->set_material(obj->get_material());
 					// Карачун. Так логичнее.
 					// было tobj->get_maximum_durability() = MAX(50, MIN(300, 300 * prob / percent));
@@ -666,8 +666,7 @@ void do_transform_weapon(CharData *ch, char *argument, int/* cmd*/, int subcmd) 
 		}
 		for (obj_type = 0; *create_item_name[obj_type] != '\n'; obj_type++) {
 			if (created_item[obj_type].skill == skill_id) {
-				sprintf(buf, "- %s\r\n", create_item_name[obj_type]);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("- {}\r\n", create_item_name[obj_type]), ch);
 			}
 		}
 		return;
@@ -689,8 +688,7 @@ void do_transform_weapon(CharData *ch, char *argument, int/* cmd*/, int subcmd) 
 		return;
 	}
 	if (!(obj = get_obj_in_list_vis(ch, arg2, ch->carrying))) {
-		sprintf(buf, "У Вас нет '%s'.\r\n", arg2);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", arg2), ch);
 		return;
 	}
 	if (obj->get_contains()) {
@@ -1223,34 +1221,35 @@ float MakeRecept::count_affect_weight(int num, int mod) {
 void MakeRecept::make_object(CharData *ch, ObjData *obj, ObjData *ingrs[MAX_PARTS], int ingr_cnt) {
 	int i, j;
 	//ставим именительные именительные падежи в алиасы
-	sprintf(buf, "%s %s %s %s",
-			obj->get_PName(grammar::ECase::kNom).c_str(),
-			ingrs[0]->get_PName(grammar::ECase::kGen).c_str(),
-			ingrs[1]->get_PName(grammar::ECase::kIns).c_str(),
-			ingrs[2]->get_PName(grammar::ECase::kIns).c_str());
-	obj->set_aliases(buf);
+	obj->set_aliases(fmt::format("{} {} {} {}",
+								 obj->get_PName(grammar::ECase::kNom),
+								 ingrs[0]->get_PName(grammar::ECase::kGen),
+								 ingrs[1]->get_PName(grammar::ECase::kIns),
+								 ingrs[2]->get_PName(grammar::ECase::kIns)));
 	for (i = grammar::ECase::kFirstCase; i <= grammar::ECase::kLastCase; i++) // ставим падежи в имя с учетов ингров
 	{
 		auto name_case = static_cast<grammar::ECase>(i);
-		sprintf(buf, "%s", obj->get_PName(name_case).c_str());
-		strcat(buf, " из ");
-		strcat(buf, ingrs[0]->get_PName(grammar::ECase::kGen).c_str());
-		strcat(buf, " с ");
-		strcat(buf, ingrs[1]->get_PName(grammar::ECase::kIns).c_str());
-		strcat(buf, " и ");
-		strcat(buf, ingrs[2]->get_PName(grammar::ECase::kIns).c_str());
-		obj->set_PName(name_case, buf);
+		const std::string name = fmt::format("{} из {} с {} и {}",
+											 obj->get_PName(name_case),
+											 ingrs[0]->get_PName(grammar::ECase::kGen),
+											 ingrs[1]->get_PName(grammar::ECase::kIns),
+											 ingrs[2]->get_PName(grammar::ECase::kIns));
+		obj->set_PName(name_case, name);
 		if (i == 0) // именительный падеж
 		{
-			obj->set_short_description(buf);
-			if (GET_OBJ_SEX(obj) == EGender::kMale) {
-				snprintf(buf2, kMaxStringLength, "Брошенный %s лежит тут.", buf);
-			} else if (GET_OBJ_SEX(obj) == EGender::kFemale) {
-				snprintf(buf2, kMaxStringLength, "Брошенная %s лежит тут.", buf);
-			} else if (GET_OBJ_SEX(obj) == EGender::kPoly) {
-				snprintf(buf2, kMaxStringLength, "Брошенные %s лежат тут.", buf);
+			obj->set_short_description(name);
+			// Средний род раньше не разбирался, и на землю уезжало описание от прошлого
+			// изделия -- то, что осталось в общем буфере.
+			std::string on_ground;
+			switch (GET_OBJ_SEX(obj)) {
+				case EGender::kFemale: on_ground = fmt::format("Брошенная {} лежит тут.", name);
+					break;
+				case EGender::kPoly: on_ground = fmt::format("Брошенные {} лежат тут.", name);
+					break;
+				default: on_ground = fmt::format("Брошенный {} лежит тут.", name);
+					break;
 			}
-			obj->set_description(buf2); // описание на земле
+			obj->set_description(on_ground); // описание на земле
 		}
 	}
 	obj->set_is_rename(true); // ставим флаг что объект переименован
@@ -1961,13 +1960,13 @@ int MakeRecept::add_affects(CharData *ch,
 // output act format//
 char *format_act(const char *orig, CharData *ch, ObjData *obj, const void *vict_obj) {
 	const char *i = nullptr;
-	char *buf, *lbuf;
+	char *out, *lbuf;
 	ubyte padis;
 	int stopbyte;
 //	CharacterData *dg_victim = nullptr;
 
-	buf = (char *) malloc(kMaxStringLength);
-	lbuf = buf;
+	out = (char *) malloc(kMaxStringLength);
+	lbuf = out;
 
 	for (stopbyte = 0; stopbyte < kMaxStringLength; stopbyte++) {
 		if (*orig == '$') {
@@ -2116,25 +2115,25 @@ char *format_act(const char *orig, CharData *ch, ObjData *obj, const void *vict_
 					i = "";
 					break;
 			}
-			while ((*buf = *(i++)))
-				buf++;
+			while ((*out = *(i++)))
+				out++;
 			orig++;
 		} else if (*orig == '\\') {
 			if (*(orig + 1) == 'r') {
-				*(buf++) = '\r';
+				*(out++) = '\r';
 				orig += 2;
 			} else if (*(orig + 1) == 'n') {
-				*(buf++) = '\n';
+				*(out++) = '\n';
 				orig += 2;
 			} else
-				*(buf++) = *(orig++);
-		} else if (!(*(buf++) = *(orig++)))
+				*(out++) = *(orig++);
+		} else if (!(*(out++) = *(orig++)))
 			break;
 	}
 
-	*(--buf) = '\r';
-	*(++buf) = '\n';
-	*(++buf) = '\0';
+	*(--out) = '\r';
+	*(++out) = '\n';
+	*(++out) = '\0';
 	return (lbuf);
 }
 

--- a/src/gameplay/fight/pk.cpp
+++ b/src/gameplay/fight/pk.cpp
@@ -615,26 +615,29 @@ std::string pk_list_sprintf(CharData *ch) {
 
 void do_revenge(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	int found = false;
-	char arg2[kMaxInputLength];
 	bool bOnlineOnly;
 
 	if (ch->IsNpc())
 		return;
 
-	*buf = '\0';
+	char arg1[kMaxInputLength];
+	char arg2[kMaxInputLength];
+	*arg1 = '\0';
 	*arg2 = '\0';
-	two_arguments(argument, arg, arg2);
+	two_arguments(argument, arg1, arg2);
 
 	// отображать только находящихся онлайн
 	bOnlineOnly = !(utils::IsAbbr(arg2, "все") || utils::IsAbbr(arg2, "all"));
 
+	std::string out;
+
 	// "месть мне [все]"
 	// кто может мне отомстить
-	if (utils::IsAbbr(arg, "мне") || utils::IsAbbr(arg, "me")) {
+	if (utils::IsAbbr(arg1, "мне") || utils::IsAbbr(arg1, "me")) {
 		if (bOnlineOnly) {
-			strcat(buf, "Вам имеют право отомстить (находятся сейчас онлайн):\r\n");
+			out += "Вам имеют право отомстить (находятся сейчас онлайн):\r\n";
 		} else {
-			strcat(buf, "Вам имеют право отомстить (полный список):\r\n");
+			out += "Вам имеют право отомстить (полный список):\r\n";
 		}
 		for (const auto &[uid, pk] : ch->pk_map) {
 			// если местей нет, проверяем на БД
@@ -658,9 +661,9 @@ void do_revenge(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					if (tch->get_uid() == uid) {
 						found = true;
 						if (pk.battle_exp > time(nullptr)) {
-							strcat(buf, fmt::format("  {:<40} <БОЕВЫЕ ДЕЙСТВИЯ>\r\n", temp).c_str());
+							out += fmt::format("  {:<40} <БОЕВЫЕ ДЕЙСТВИЯ>\r\n", temp);
 						} else {
-							strcat(buf, fmt::format("  {:<40} {:3} {:3}\r\n", temp, pk.kill_num, pk.revenge_num).c_str());
+							out += fmt::format("  {:<40} {:3} {:3}\r\n", temp, pk.kill_num, pk.revenge_num);
 						}
 						break;
 					}
@@ -668,15 +671,15 @@ void do_revenge(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			} else {
 				found = true;
 				if (pk.battle_exp > time(nullptr)) {
-					strcat(buf, fmt::format("  {:<40} <БОЕВЫЕ ДЕЙСТВИЯ>\r\n", temp).c_str());
+					out += fmt::format("  {:<40} <БОЕВЫЕ ДЕЙСТВИЯ>\r\n", temp);
 				} else {
-					strcat(buf, fmt::format("  {:<40} {:3} {:3}\r\n", temp, pk.kill_num, pk.revenge_num).c_str());
+					out += fmt::format("  {:<40} {:3} {:3}\r\n", temp, pk.kill_num, pk.revenge_num);
 				}
 			}
 		}
 
 		if (found) {
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(out, ch);
 		} else {
 			SendMsgToChar("Ни у кого нет права мести вам.\r\n", ch);
 		}
@@ -685,12 +688,12 @@ void do_revenge(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	}
 
 	found = false;
-	*buf = '\0';
+	out.clear();
 	for (const auto &tch : character_list) {
 		if (tch->IsNpc()) {
 			continue;
 		}
-		if (*arg && !isname(GET_NAME(tch), arg)) {
+		if (*arg1 && !isname(GET_NAME(tch), arg1)) {
 			continue;
 		}
 
@@ -703,24 +706,26 @@ void do_revenge(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 			// Сначала проверка клан флага
 			if (CLAN(ch) && pk.clan_exp > time(nullptr)) {
-				strcat(buf, fmt::format("  {:<40} <ВОЙНА>\r\n", GET_NAME(tch)).c_str());
+				out += fmt::format("  {:<40} <ВОЙНА>\r\n", GET_NAME(tch));
 			} else if (pk.clan_exp > time(nullptr)) {
-				strcat(buf, fmt::format("  {:<40} <ВРЕМЕННЫЙ ФЛАГ>\r\n", GET_NAME(tch)).c_str());
+				out += fmt::format("  {:<40} <ВРЕМЕННЫЙ ФЛАГ>\r\n", GET_NAME(tch));
 			} else if (pk.kill_num + pk.revenge_num > 0) {
-				strcat(buf, fmt::format("  {:<40} {:3} {:3}\r\n",
-						GET_NAME(tch), pk.kill_num, pk.revenge_num).c_str());
+				out += fmt::format("  {:<40} {:3} {:3}\r\n",
+						GET_NAME(tch), pk.kill_num, pk.revenge_num);
 			} else {
 				continue;
 			}
 
-			if (!found)
-				SendMsgToChar("Вы имеете право отомстить :\r\n", ch);
-			SendMsgToChar(buf, ch);
 			found = true;
 		}
 	}
 
-	if (!found) {
+	// Раньше строка списка дописывалась в общий буфер и он отправлялся прямо в цикле:
+	// второй враг приезжал вместе с первым, третий -- вместе с первыми двумя. Шлём один раз.
+	if (found) {
+		SendMsgToChar("Вы имеете право отомстить :\r\n", ch);
+		SendMsgToChar(out, ch);
+	} else {
 		SendMsgToChar("Вам некому мстить.\r\n", ch);
 	}
 }
@@ -736,19 +741,18 @@ void do_forgive(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	one_argument(argument, arg);
-	if (!*arg) {
+	char name[kMaxInputLength];
+	one_argument(argument, name);
+	if (!*name) {
 		SendMsgToChar("Кого вы хотите простить?\r\n", ch);
 		return;
 	}
-
-	*buf = '\0';
 
 	CharData *found = nullptr;
 	for (const auto &tch : character_list) {
 		if (tch->IsNpc()
 			|| !sight::CanSeeIgnoringLight(ch, tch)
-			|| !isname(GET_NAME(tch), arg)) {
+			|| !isname(GET_NAME(tch), name)) {
 			continue;
 		}
 
@@ -1170,22 +1174,27 @@ bool bloody::CatchBloodyCorpse(ObjData *l) {
 
 void UpdatePkLogs(CharData *ch, CharData *victim) {
 	ClanPkLog::check(ch, victim);
-	sprintf(buf2, "%s killed by %s at %s [%d] ", GET_NAME(victim), GET_NAME(ch),
-			victim->in_room != kNowhere ? world[victim->in_room]->name : "kNowhere", GET_ROOM_VNUM(victim->in_room));
-	mudlog(buf2, CMP, kLvlImmortal, SYSLOG, true);
+	const char *room_name = "kNowhere";
+	if (victim->in_room != kNowhere && world[victim->in_room]->name) {
+		room_name = world[victim->in_room]->name;
+	}
+	const std::string kill_log = fmt::format("{} killed by {} at {} [{}] ",
+											 GET_NAME(victim), GET_NAME(ch), room_name,
+											 GET_ROOM_VNUM(victim->in_room));
+	mudlog(kill_log, CMP, kLvlImmortal, SYSLOG, true);
 
 	if ((!ch->IsNpc()
 		|| (ch->has_master()
 			&& !ch->get_master()->IsNpc()))
 		&& NORENTABLE(victim)
 		&& !ROOM_FLAGGED(victim->in_room, ERoomFlag::kArena)) {
-		mudlog(buf2, BRF, kLvlImplementator, SYSLOG, false);
+		mudlog(kill_log, BRF, kLvlImplementator, SYSLOG, false);
 		if (ch->IsNpc()
 			&& (AFF_FLAGGED(ch, EAffect::kCharmed) || mount::IsHorse(ch))
 			&& ch->has_master()
 			&& !ch->get_master()->IsNpc()) {
-			sprintf(buf2, "%s is following %s.", GET_NAME(ch), GET_PAD(ch->get_master(), 2));
-			mudlog(buf2, BRF, kLvlImplementator, SYSLOG, true);
+			mudlog(fmt::format("{} is following {}.", GET_NAME(ch), GET_PAD(ch->get_master(), 2)),
+				   BRF, kLvlImplementator, SYSLOG, true);
 		}
 	}
 }


### PR DESCRIPTION
Шестой батч по #3814: `boot_data_files.cpp`, `modify.cpp`, `dg_olc.cpp`, `pk.cpp`, `item_creation.cpp`. Глобальных `buf/buf1/buf2/arg` в них не осталось; локальные `char[]` убраны там, где их не требовала сигнатура вызываемой функции. В `iosystem.h` добавлена перегрузка `write_to_output` для `std::string`.

## Баги, вылезшие по дороге

**месть — список врагов приезжал нарастающим итогом.** Во втором списке строка дописывалась в общий буфер, а `SendMsgToChar(buf, ch)` стоял **внутри** цикла: первого врага игрок видел один раз, второго — вместе с первым, третьего — вместе с двумя первыми. Собираем строку целиком и шлём один раз.

**trigedit_create_index — в логе никогда не было имени файла.** Сообщение `"SYSERR: TRIGEDIT: Failed to open %s"` подставляло общий `buf`, в который писал кто угодно до нас; настоящее имя (`old_name`/`new_name`) в лог не попадало ни разу. Заодно на второй ветке отказа теперь закрывается уже открытый `oldfile`.

**Загрузка комнаты — падение с чужим текстом.** Строка `"Format error in room #N (expecting D/E/S)"` лежала в общем буфере и затиралась сообщением про битый extradesc. После первого кривого `E`-блока следующее падение печатало «Corrupt extradesc» вместо «expecting D/E/S».

**Ковка — описание «на земле» для среднего рода.** Ветки были только для мужского, женского и множественного; при `kNeutral` `buf2` не переписывался, и предмету доставалось описание предыдущего изделия, оставшееся в буфере. Средний род теперь идёт по мужской ветке.

**featset/skillset — лог в 128-байтном буфере.** `sprintf(buf2, "%s changed %s's %s to ...")` при двух длинных именах и длинном названии умения в `char buf2[128]` не помещался.

**ПК-лог — имя комнаты могло быть nullptr.** `printf` печатал `(null)`, `fmt` на этом бросает исключение; добавлена проверка.

**Мёртвые записи в общий буфер.** `"trig vnum %d"`, `"beginning of zone #%d"` и `"beginning of generated zone #%d"` писались и никем не читались — убраны.

## Прочее

- Редактор строк (`/l /n /i /e /r /d /f /h`) переписан на `std::string`. Раньше он полагался на то, что общие буферы 32k (об этом прямо говорил комментарий в коде), и при `/n` на каждой строке копировал всё накопленное в `buf1` и обратно — квадратичная работа на длинном тексте.
- `sprintbit` в trigedit переведён на строковую перегрузку.
- `format_act` в ковке: локальный `char *buf` переименован, чтобы не путаться с глобальным.
- Цветовые переменные `grn`/`cyn`/`nrm` в OLC оставлены как есть — это #3862.

## Проверка

Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.

A/B на тестовом мире против master (один и тот же чистый снимок): `featset` (установка и снятие), `skillset`, `месть`, `месть мне`, `простить`, полная сессия редактора на доске — `/l`, `/n`, `/i`, `/e`, `/r`, `/d`, `/f`, `/h`, `/a` — вывод **побайтово идентичен**. Загрузочный лог совпадает по составу строк; расходятся только две строки `[objlife] RemoveObjFromChar` — случайность ресета зоны. Множества строковых литералов сверены с master.

Закрывает часть #3814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
