### PR TITLE
refactor(core): drop global buffers from comm, login, crafting and auction (#3814)

### DIFF
--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -988,18 +988,14 @@ void stop_game(ush_int port) {
 		for (entry = olc_save_list; entry; entry = next_entry) {
 			next_entry = entry->next;
 			if (entry->type < 0 || entry->type > 4) {
-				sprintf(buf, "OLC: Illegal save type %d!", entry->type);
-				log("%s", buf);
+				log("OLC: Illegal save type %d!", entry->type);
 			} else if ((rznum = GetZoneRnum(entry->zone)) == -1) {
-				sprintf(buf, "OLC: Illegal save zone %d!", entry->zone);
-				log("%s", buf);
+				log("OLC: Illegal save zone %d!", entry->zone);
 			} else if (rznum < 0 || rznum >= static_cast<int>(zone_table.size())) {
-				sprintf(buf, "OLC: Invalid real zone number %d!", rznum);
-				log("%s", buf);
+				log("OLC: Invalid real zone number %d!", rznum);
 			} else {
-				sprintf(buf, "OLC: Reboot saving %s for zone %d.",
-						save_info_msg[(int) entry->type], zone_table[rznum].vnum);
-				log("%s", buf);
+				log("OLC: Reboot saving %s for zone %d.",
+					save_info_msg[(int) entry->type], zone_table[rznum].vnum);
 				auto* data_source = world_loader::WorldDataSourceManager::Instance().GetDataSource();
 				switch (entry->type) {
 					case OLC_SAVE_ROOM: data_source->SaveRooms(rznum);
@@ -1257,18 +1253,12 @@ int shutting_down(void) {
 	wait = shutdown_parameters.get_shutdown_timeout() - time(nullptr);
 
 	if (wait == 10 || wait == 30 || wait == 60 || wait == 120 || wait % 300 == 0) {
-		if (shutdown_parameters.reboot_after_shutdown()) {
-			remove("../.crash");
-			sprintf(buf, "ПЕРЕЗАГРУЗКА через ");
-		} else {
-			remove("../.crash");
-			sprintf(buf, "ОСТАНОВКА через ");
-		}
-		if (wait < 60)
-			sprintf(buf + strlen(buf), "%d %s.\r\n", wait, grammar::GetDeclensionInNumber(wait, grammar::EWhat::kSec));
-		else
-			sprintf(buf + strlen(buf), "%d %s.\r\n", wait / 60, grammar::GetDeclensionInNumber(wait / 60, grammar::EWhat::kMinU));
-		SendMsgToAll(buf);
+		remove("../.crash");
+		const char *what = shutdown_parameters.reboot_after_shutdown() ? "ПЕРЕЗАГРУЗКА" : "ОСТАНОВКА";
+		const std::string left = wait < 60
+			? fmt::format("{} {}", wait, grammar::GetDeclensionInNumber(wait, grammar::EWhat::kSec))
+			: fmt::format("{} {}", wait / 60, grammar::GetDeclensionInNumber(wait / 60, grammar::EWhat::kMinU));
+		SendMsgToAll(fmt::format("{} через {}.\r\n", what, left).c_str());
 		lastmessage = time(nullptr);
 		// на десятой секунде засейвим нужное нам в сислог
 		if (wait == 10)
@@ -1279,8 +1269,7 @@ int shutting_down(void) {
 
 void log_zone_count_reset() {
 	for (auto & i : zone_table) {
-		sprintf(buf, "Zone: %d, count_reset: %d", i.vnum, i.count_reset);
-		log("%s", buf);
+		log("Zone: %d, count_reset: %d", i.vnum, i.count_reset);
 	}
 }
 
@@ -1906,17 +1895,15 @@ int new_descriptor(socket_t s)
 	 * Note that your immortals may wonder if they see a connection from
 	 * your site, but you are wizinvis upon login.
 	 */
-	sprintf(buf2, "New connection from [%s]", newd->host);
-	mudlog(buf2, CMP, kLevelGod, SYSLOG, false);
+	mudlog(fmt::format("New connection from [{}]", newd->host), CMP, kLevelGod, SYSLOG, false);
 #endif
 	if (ban->IsBanned(newd->host) == BanList::BAN_ALL) {
 		time_t bantime = ban->GetBanDate(newd->host);
-		sprintf(buf, "Sorry, your IP is banned till %s",
-				bantime == -1 ? "Infinite duration\r\n" : asctime(localtime(&bantime)));
-		iosystem::write_to_descriptor(desc, buf, strlen(buf));
+		const std::string reject = fmt::format("Sorry, your IP is banned till {}",
+											   bantime == -1 ? "Infinite duration\r\n"
+															 : asctime(localtime(&bantime)));
+		iosystem::write_to_descriptor(desc, reject.c_str(), reject.length());
 		CLOSE_SOCKET(desc);
-		// sprintf(buf2, "Connection attempt denied from [%s]", newd->host);
-		// mudlog(buf2, CMP, kLevelGod, SYSLOG, true);
 		delete newd;
 		return (-3);
 	}
@@ -2110,16 +2097,16 @@ void close_socket(DescriptorData * d, int direct)
 		if (d->state == EConState::kPlaying || d->state == EConState::kDisconnect) {
 			act("$n потерял$g связь.", true, d->character.get(), 0, 0, kToRoom | kToArenaListen);
 			if (d->character->GetEnemy() && d->character->IsFlagged(EPrf::kAntiDcMode)) {
-				snprintf(buf2, sizeof(buf2), "зачитать свиток.возврата");
-				command_interpreter(d->character.get(), buf2);
+				char recall[] = "зачитать свиток.возврата";
+				command_interpreter(d->character.get(), recall);
 			}
 			if (!d->character->IsNpc()) {
 				d->character->save_char();
 				CheckLight(d->character.get(), kLightNo, kLightNo, kLightNo, kLightNo, -1);
 				Crash_ldsave(d->character.get());
 
-				sprintf(buf, "Closing link to: %s.", GET_NAME(d->character));
-				mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(d->character)), SYSLOG, true);
+				mudlog(fmt::format("Closing link to: {}.", GET_NAME(d->character)),
+					   NRM, std::max(kLvlGod, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			}
 			d->character->desc = nullptr;
 		} else {
@@ -2127,8 +2114,7 @@ void close_socket(DescriptorData * d, int direct)
 				Depot::exit_char(d->character.get());
 			}
 			if (character_list.get_character_by_address(d->character.get())) {
-				sprintf(buf, "Remove from character list to: %s.", GET_NAME(d->character));
-				log("%s", buf);
+				log("Remove from character list to: %s.", GET_NAME(d->character));
 				character_list.remove(d->character);
 			}
 		}
@@ -2486,14 +2472,14 @@ void perform_act(const char *orig,
 				 const std::string &kick_type) {
 	const char *i = nullptr;
 	char nbuf[256];
-	char lbuf[kMaxStringLength], *buf;
+	char lbuf[kMaxStringLength], *out;
 	ubyte padis;
 	int stopbyte, cap = 0;
 	CharData *dg_victim = nullptr;
 	ObjData *dg_target = nullptr;
 	char *dg_arg = nullptr;
 
-	buf = lbuf;
+	out = lbuf;
 
 	if (orig == nullptr)
 		return mudlog("perform_act: NULL *orig string", BRF, -1, ERRLOG, true);
@@ -2723,10 +2709,10 @@ void perform_act(const char *orig,
 			}
 			if (cap) {
 				if (*i == '&') {
-					*buf = *(i++);
-					buf++;
-					*buf = *(i++);
-					buf++;
+					*out = *(i++);
+					out++;
+					*out = *(i++);
+					out++;
 				}
 				// Заглавной делаем букву целиком, а не первый байт: в UTF-8 русская буква
 				// двухбайтовая, и a_ucc(*i) портил ведущий байт -- "Волчица" приезжала как
@@ -2735,35 +2721,35 @@ void perform_act(const char *orig,
 				std::string first(i, letter_bytes);
 				native_text::capitalize_first(first);
 				for (const char symbol : first) {
-					*buf = symbol;
-					++buf;
+					*out = symbol;
+					++out;
 				}
 				i += letter_bytes;
 				cap = 0;
 			}
-			while ((*buf = *(i++)))
-				buf++;
+			while ((*out = *(i++)))
+				out++;
 			orig++;
 		} else if (*orig == '\\') {
 			if (*(orig + 1) == 'r') {
-				*(buf++) = '\r';
+				*(out++) = '\r';
 				orig += 2;
 			} else if (*(orig + 1) == 'n') {
-				*(buf++) = '\n';
+				*(out++) = '\n';
 				orig += 2;
 			} else if (*(orig + 1) == 'u')//Следующая подстановка $... будет с большой буквы
 			{
 				cap = 1;
 				orig += 2;
 			} else
-				*(buf++) = *(orig++);
-		} else if (!(*(buf++) = *(orig++)))
+				*(out++) = *(orig++);
+		} else if (!(*(out++) = *(orig++)))
 			break;
 	}
 
-	*(--buf) = '\r';
-	*(++buf) = '\n';
-	*(++buf) = '\0';
+	*(--out) = '\r';
+	*(++out) = '\n';
+	*(++out) = '\0';
 
 	if (to->desc) {
 		// Делаем первый символ большим, учитывая &X

--- a/src/engine/scripting/dg_domination_helper.cpp
+++ b/src/engine/scripting/dg_domination_helper.cpp
@@ -1,6 +1,8 @@
 #include "dg_domination_helper.h"
 #include "dg_scripts.h"
 
+#include <fmt/format.h>
+
 #include "engine/ui/interpreter.h"
 #include "engine/db/db.h"
 #include "engine/core/char_handler.h"
@@ -62,27 +64,23 @@ static bool read_local_variables(DominationData &dd, Trigger *trig, char *cmd)
 
 	dd.current_round = atoi(arg);
 	if (dd.current_round < 1 || dd.current_round > expected_round_count) {
-		snprintf(buf2, kMaxStringLength, "Неверное значение переменной round: %d", dd.current_round);
-		trig_log(trig, buf2);
+		trig_log(trig, fmt::format("Неверное значение переменной round: {}", dd.current_round));
 		return false;
 	}
 	if (dd.debug_mode) {
-		snprintf(buf2, kMaxStringLength, "номер раунда: %d", atoi(arg));
-		trig_log(trig, buf2);
+		trig_log(trig, fmt::format("номер раунда: {}", atoi(arg)));
 	}
 
 	// количество мобов
 	auto vd_mob_count = find_var_cntx(trig->var_list, var_name_counter.c_str(), trig->context);
 	if (vd_mob_count.name.empty()) {
-		snprintf(buf2, kMaxStringLength, "local var '%s' not found", var_name_counter.c_str());
-		trig_log(trig, buf2);
+		trig_log(trig, fmt::format("local var '{}' not found", var_name_counter));
 		return false;
 	}
 	// вычитываем список количества мобов по раундам
 	SplitArgument(vd_mob_count.value.c_str(), dd.mob_counter_per_round);
 	if (dd.mob_counter_per_round.size() != expected_round_count) {
-		snprintf(buf2, kMaxStringLength, "Неверное количество элементов в переменной mobs_count: %zu", dd.mob_counter_per_round.size());
-		trig_log(trig, buf2);
+		trig_log(trig, fmt::format("Неверное количество элементов в переменной mobs_count: {}", dd.mob_counter_per_round.size()));
 		return false;
 	}
 	// валидация количества мобов по раундам
@@ -90,8 +88,7 @@ static bool read_local_variables(DominationData &dd, Trigger *trig, char *cmd)
 	const int mob_count_mamimum = 3200;
 	for (const auto &counter : dd.mob_counter_per_round) {
 		if (counter < mob_count_minimum || counter > mob_count_mamimum) {
-			snprintf(buf2, kMaxStringLength, "Неверный счетчик мобов в переменной mobs_count: %d", counter);
-			trig_log(trig, buf2);
+			trig_log(trig, fmt::format("Неверный счетчик мобов в переменной mobs_count: {}", counter));
 			return false;
 		}
 	}
@@ -99,23 +96,20 @@ static bool read_local_variables(DominationData &dd, Trigger *trig, char *cmd)
 	for (const auto &var_name_mob : var_name_mob_list) {
 		auto vd_mob = find_var_cntx(trig->var_list, var_name_mob.first.c_str(), trig->context);
 		if (vd_mob.name.empty()) {
-			snprintf(buf2, kMaxStringLength, "local var '%s' not found", var_name_mob.first.c_str());
-			trig_log(trig, buf2);
+			trig_log(trig, fmt::format("local var '{}' not found", var_name_mob.first));
 			return false;
 		}
 		std::vector<MobVnum> mob_vnum_list;
 		SplitArgument(vd_mob.value.c_str(), mob_vnum_list);
 		// т.к. мобы грузятся по раундам - количество мобов >= количествj раундов
 		if (mob_vnum_list.size() < expected_round_count) {
-			snprintf(buf2, kMaxStringLength, "Неверное количество мобов в группе %s: %zu", var_name_mob.first.c_str(), mob_vnum_list.size());
-			trig_log(trig, buf2);
+			trig_log(trig, fmt::format("Неверное количество мобов в группе {}: {}", var_name_mob.first, mob_vnum_list.size()));
 			return false;
 		}
 
 		auto vd_room = find_var_cntx(trig->var_list, var_name_mob.second.c_str(), trig->context);
 		if (vd_room.name.empty()) {
-			snprintf(buf2, kMaxStringLength, "local var '%s' not found", var_name_mob.second.c_str());
-			trig_log(trig, buf2);
+			trig_log(trig, fmt::format("local var '{}' not found", var_name_mob.second));
 			return false;
 		}
 		std::vector<MobVnum> vnumum_list;
@@ -131,21 +125,18 @@ static bool load_arena_mob(Trigger *trig, MobVnum mob_vn, RoomVnum vnum, bool de
 {
 	const RoomRnum room_rn = GetRoomRnum(vnum);
 	if (room_rn <= 0) {
-		snprintf(buf2, kMaxStringLength, "Не могу найти комнату: %d", vnum);
-		trig_log(trig, buf2);
+		trig_log(trig, fmt::format("Не могу найти комнату: {}", vnum));
 		return false;
 	}
 
 	CharData *mob_rn = ReadMobile(mob_vn, kVirtual);
 	if (!mob_rn) {
-		snprintf(buf2, kMaxStringLength, "Не могу найти моба: %d", mob_vn);
-		trig_log(trig, buf2);
+		trig_log(trig, fmt::format("Не могу найти моба: {}", mob_vn));
 		return false;
 	}
 
 	if (debug_mode) {
-		snprintf(buf2, kMaxStringLength, "load mob: %d to room: %d", mob_vn, vnum);
-		trig_log(trig, buf2);
+		trig_log(trig, fmt::format("load mob: {} to room: {}", mob_vn, vnum));
 	}
 	PlaceCharToRoom(mob_rn, room_rn);
 	load_mtrigger(mob_rn);
@@ -166,9 +157,8 @@ void process_arena_round(Trigger *trig, char *cmd)
 	const int amount_mob_each_type = total_mob_counter / var_name_mob_list.size();
 	const int amount_mob_random = total_mob_counter % var_name_mob_list.size();
 	if (dd.debug_mode) {
-		snprintf(buf2, kMaxStringLength, "Общее количество загружаемых мобов: %d, каждого вида: %d(x%zu), случайных мобов: %d",
-				 total_mob_counter, amount_mob_each_type, var_name_mob_list.size(), amount_mob_random);
-		trig_log(trig, buf2);
+		trig_log(trig, fmt::format("Общее количество загружаемых мобов: {}, каждого вида: {}(x{}), случайных мобов: {}",
+				 total_mob_counter, amount_mob_each_type, var_name_mob_list.size(), amount_mob_random));
 	}
 
 	// загрузка мобов каждого вида в количестве amount_mob_each_type

--- a/src/engine/ui/login.cpp
+++ b/src/engine/ui/login.cpp
@@ -292,10 +292,9 @@ int perform_dupe_check(DescriptorData *d) {
 		if (k->original && (k->original->get_uid() == id))    // switched char
 		{
 			if (str_cmp(d->host, k->host)) {
-				sprintf(buf, "ПОВТОРНЫЙ ВХОД! Id = %ld Персонаж = %s Хост = %s(был %s)",
-						d->character->get_uid(), GET_NAME(d->character), k->host, d->host);
-				mudlog(buf, BRF, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
-				//send_to_gods(buf);
+				mudlog(fmt::format("ПОВТОРНЫЙ ВХОД! Id = {} Персонаж = {} Хост = {}(был {})",
+								   d->character->get_uid(), GET_NAME(d->character), k->host, d->host),
+					   BRF, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			}
 
 			iosystem::write_to_output("\r\nПопытка второго входа - отключаемся.\r\n", k);
@@ -314,10 +313,9 @@ int perform_dupe_check(DescriptorData *d) {
 			k->original = nullptr;
 		} else if (k->character && (k->character->get_uid() == id)) {
 			if (str_cmp(d->host, k->host)) {
-				sprintf(buf, "ПОВТОРНЫЙ ВХОД! Id = %ld Name = %s Host = %s(был %s)",
-						d->character->get_uid(), GET_NAME(d->character), k->host, d->host);
-				mudlog(buf, BRF, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
-				//send_to_gods(buf);
+				mudlog(fmt::format("ПОВТОРНЫЙ ВХОД! Id = {} Name = {} Host = {}(был {})",
+								   d->character->get_uid(), GET_NAME(d->character), k->host, d->host),
+					   BRF, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			}
 
 			if (!target &&  k->state == EConState::kPlaying) {
@@ -395,8 +393,8 @@ int perform_dupe_check(DescriptorData *d) {
 			CheckLight(d->character.get(), kLightNo, kLightNo, kLightNo, kLightNo, 1);
 			act("$n восстановил$g связь.",
 				true, d->character.get(), nullptr, nullptr, kToRoom);
-			sprintf(buf, "%s [%s] has reconnected.", GET_NAME(d->character), d->host);
-			mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+			mudlog(fmt::format("{} [{}] has reconnected.", GET_NAME(d->character), d->host),
+				   NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			login_change_invoice(d->character.get());
 			break;
 
@@ -404,13 +402,13 @@ int perform_dupe_check(DescriptorData *d) {
 			act("$n надломил$u от боли, окруженн$w белой аурой...\r\n"
 				"Тело $s было захвачено новым духом!",
 				true, d->character.get(), nullptr, nullptr, kToRoom);
-			sprintf(buf, "%s has re-logged in ... disconnecting old socket.", GET_NAME(d->character));
-			mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+			mudlog(fmt::format("{} has re-logged in ... disconnecting old socket.", GET_NAME(d->character)),
+				   NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			break;
 
 		case UNSWITCH: iosystem::write_to_output("Пересоединяемся для перевключения игрока.", d);
-			sprintf(buf, "%s [%s] has reconnected (UNSWITCH).", GET_NAME(d->character), d->host);
-			mudlog(buf, NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+			mudlog(fmt::format("{} [{}] has reconnected (UNSWITCH).", GET_NAME(d->character), d->host),
+				   NRM, MAX(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 			break;
 
 		default:
@@ -729,18 +727,20 @@ void do_entergame(DescriptorData *d) {
 		REMOVE_BIT(d->character->player_specials->saved.GodsLike, EGf::kDemigod);
 	}
 
+	const char *entered = "вошло";
 	switch (d->character->get_sex()) {
 		case EGender::kLast: [[fallthrough]];
-		case EGender::kNeutral: sprintf(buf, "%s вошло в игру.", GET_NAME(d->character));
+		case EGender::kNeutral: entered = "вошло";
 			break;
-		case EGender::kMale: sprintf(buf, "%s вошел в игру.", GET_NAME(d->character));
+		case EGender::kMale: entered = "вошел";
 			break;
-		case EGender::kFemale: sprintf(buf, "%s вошла в игру.", GET_NAME(d->character));
+		case EGender::kFemale: entered = "вошла";
 			break;
-		case EGender::kPoly: sprintf(buf, "%s вошли в игру.", GET_NAME(d->character));
+		case EGender::kPoly: entered = "вошли";
 			break;
 	}
-	mudlog(buf, NRM, std::max(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
+	mudlog(fmt::format("{} {} в игру.", GET_NAME(d->character), entered),
+		   NRM, std::max(kLvlImmortal, GET_INVIS_LEV(d->character)), SYSLOG, true);
 	d->has_prompt = 0;
 	login_change_invoice(d->character.get());
 	log("Player %s enter at room %d", GET_NAME(d->character), GET_ROOM_VNUM(load_room));
@@ -807,15 +807,15 @@ void DoAfterPassword(DescriptorData *d) {
 	if (ban->IsBanned(d->host) == BanList::BAN_SELECT && !d->character->IsFlagged(EPlrFlag::kSiteOk)) {
 		iosystem::write_to_output("Извините, вы не можете выбрать этого игрока с данного IP!\r\n", d);
 		d->state = EConState::kClose;
-		sprintf(buf, "Connection attempt for %s denied from %s", GET_NAME(d->character), d->host);
-		mudlog(buf, NRM, kLvlGod, SYSLOG, true);
+		mudlog(fmt::format("Connection attempt for {} denied from {}", GET_NAME(d->character), d->host),
+			   NRM, kLvlGod, SYSLOG, true);
 		return;
 	}
 	if (GetRealLevel(d->character) < circle_restrict) {
 		iosystem::write_to_output("Игра временно приостановлена.. Ждем вас немного позже.\r\n", d);
 		d->state = EConState::kClose;
-		sprintf(buf, "Request for login denied for %s [%s] (wizlock)", GET_NAME(d->character), d->host);
-		mudlog(buf, NRM, kLvlGod, SYSLOG, true);
+		mudlog(fmt::format("Request for login denied for {} [{}] (wizlock)", GET_NAME(d->character), d->host),
+			   NRM, kLvlGod, SYSLOG, true);
 		return;
 	}
 	if (new_loc_codes.count(GET_EMAIL(d->character)) != 0) {
@@ -834,8 +834,8 @@ void DoAfterPassword(DescriptorData *d) {
 
 	if (!subnets.empty()) {
 		if (subnets.count(inet_addr(d->host) & MASK) == 0) {
-			sprintf(buf, "Персонаж %s вошел с необычного места!", GET_NAME(d->character));
-			mudlog(buf, CMP, kLvlGod, SYSLOG, true);
+			mudlog(fmt::format("Персонаж {} вошел с необычного места!", GET_NAME(d->character)),
+				   CMP, kLvlGod, SYSLOG, true);
 			if (d->character->IsFlagged(EPrf::kIpControl)) {
 				int random_number = number(1000000, 9999999);
 				new_loc_codes[GET_EMAIL(d->character)] = random_number;
@@ -861,16 +861,15 @@ void DoAfterPassword(DescriptorData *d) {
 	log("%s [%s] has connected.", GET_NAME(d->character), d->host);
 
 	if (load_result) {
-		sprintf(buf, "\r\n\r\n\007\007\007"
-					 "%s%d LOGIN FAILURE%s SINCE LAST SUCCESSFUL LOGIN.%s\r\n",
-				kColorRed, load_result, (load_result > 1) ? "S" : "", kColorNrm);
-		iosystem::write_to_output(buf, d);
+		iosystem::write_to_output(fmt::format("\r\n\r\n\007\007\007"
+											  "&r{} LOGIN FAILURE{} SINCE LAST SUCCESSFUL LOGIN.&n\r\n",
+											  load_result, load_result > 1 ? "S" : "").c_str(), d);
 		GET_BAD_PWS(d->character) = 0;
 	}
 	time_t tmp_time = d->character->get_last_logon();
-	sprintf(buf, "\r\nПоследний раз вы заходили к нам в %s с адреса (%s).\r\n",
-			rustime(localtime(&tmp_time)), d->character->player_specials->saved.LastIP);
-	iosystem::write_to_output(buf, d);
+	iosystem::write_to_output(fmt::format("\r\nПоследний раз вы заходили к нам в {} с адреса ({}).\r\n",
+										  rustime(localtime(&tmp_time)),
+										  d->character->player_specials->saved.LastIP).c_str(), d);
 
 	//if (!GloryMisc::check_stats(d->character))
 	if (!ValidateStats(d)) {
@@ -1009,14 +1008,10 @@ void DoAfterEmailConfirm(DescriptorData *d) {
 	d->character->get_account()->add_player(d->character->get_uid());
 
 	// добавляем в список ждущих одобрения
+	// Здесь собиралась строка "<имя> - новый игрок ... ждет одобрения имени" -- по
+	// оформлению (". ]\r\n[ ") она писалась под mudlog, но её никто никуда не отправлял
+	// за всю видимую историю. Мёртвую сборку убрали, сообщение так и не заведено.
 	if (!(int) NAME_FINE(d->character)) {
-		sprintf(buf, "%s - новый игрок. Падежи: %s/%s/%s/%s/%s/%s Email: %s Пол: %s. ]\r\n"
-					 "[ %s ждет одобрения имени.",
-				GET_NAME(d->character), GET_PAD(d->character, 0),
-				GET_PAD(d->character, 1), GET_PAD(d->character, 2),
-				GET_PAD(d->character, 3), GET_PAD(d->character, 4),
-				GET_PAD(d->character, 5), GET_EMAIL(d->character),
-				genders[(int) d->character->get_sex()], GET_NAME(d->character));
 		NewNames::add(d->character.get());
 	}
 

--- a/src/gameplay/crafting/im.cpp
+++ b/src/gameplay/crafting/im.cpp
@@ -229,64 +229,64 @@ char *get_im_alias(im_memb *s, const char *name) {
 }
 
 // Функция заменяет alias в названиях ингредиентов
-const char *replace_alias(const char *ptr, im_memb *sample, int rnum, const char *std) {
-	char *dst, *al;
+std::string replace_alias(const char *ptr, im_memb *sample, int rnum, const char *std) {
+	char *al;
 	char aname[16];
 
 	if (!sample && rnum == -1)
 		return ptr;
 
-	// Строю соответствуюжую строку в buf
+	std::string out;
 	if (sample) {
 		// поиск в образце
 		if (std && (al = get_im_alias(sample, std)) != nullptr) {
-			ptr = al;
-		} else {
-			// Посимвольный разбор строки
-			dst = buf;
-			do {
-				if (*ptr == VAR_CHAR) {
-					int k;
-					++ptr;
-					// One whole character per step (issue #3681), with a bounds check: the
-					// previous loop had none, and multibyte text fills aname[] twice as fast.
-					for (k = 0; *ptr && native_text::is_alnum_char(ptr);) {
-						const size_t bytes = native_text::char_bytes(ptr);
-						if (static_cast<size_t>(k) + bytes >= sizeof(aname)) {
-							break;
-						}
-						for (size_t i = 0; i < bytes; ++i) {
-							aname[k++] = *ptr++;
-						}
+			return al;
+		}
+		// Посимвольный разбор строки
+		for (;;) {
+			if (*ptr == VAR_CHAR) {
+				int k;
+				++ptr;
+				// One whole character per step (issue #3681), with a bounds check: the
+				// previous loop had none, and multibyte text fills aname[] twice as fast.
+				for (k = 0; *ptr && native_text::is_alnum_char(ptr);) {
+					const size_t bytes = native_text::char_bytes(ptr);
+					if (static_cast<size_t>(k) + bytes >= sizeof(aname)) {
+						break;
 					}
-					aname[k] = 0;
-					al = get_im_alias(sample, aname);
-					strcpy(dst, al ? al : aname);
-					while (*dst != 0)
-						++dst;
+					for (size_t i = 0; i < bytes; ++i) {
+						aname[k++] = *ptr++;
+					}
 				}
-			} while ((*dst++ = *ptr++) != 0);
-			ptr = buf;
+				aname[k] = 0;
+				al = get_im_alias(sample, aname);
+				out += al ? al : aname;
+			}
+			if (*ptr == '\0') {
+				break;
+			}
+			out += *ptr++;
 		}
 	} else {
 		// поиск в мобе (только p0-p5)
 		// Посимвольный разбор строки
-		for (dst = buf; (*dst++ = *ptr++) != 0;) {
-			int k;
+		while (*ptr != '\0') {
+			out += *ptr++;
+			// k раньше не инициализировался: если sscanf ничего не разобрал, ветка
+			// выбиралась по мусору на стеке.
+			int k = -1;
 			if (*ptr != VAR_CHAR)
 				continue;
-			sscanf(ptr + 1, "p%d", &k);
+			if (sscanf(ptr + 1, "p%d", &k) != 1)
+				continue;
 			if (k < 0 || k > 5)
 				continue;
 			ptr += 3;
-			strcpy(dst, GET_PAD(mob_proto + rnum, k));
-			while (*dst != 0)
-				++dst;
+			out += GET_PAD(mob_proto + rnum, k);
 		}
-		ptr = buf;
 	}
 
-	return ptr;
+	return out;
 }
 
 int im_type_rnum(int vnum) {
@@ -376,15 +376,16 @@ ObjData *load_ingredient(int index, int power, int rnum)
 {
 	int err;
 
+	std::string error;
 	while (1) {
 		if (imtypes[index].proto_vnum < 0) {
-			sprintf(buf, "IM METATYPE ingredient loading %d", imtypes[index].id);
+			error = fmt::format("IM METATYPE ingredient loading {}", imtypes[index].id);
 			break;
 		}
 
 		const auto ing = world_objects.create_from_prototype_by_vnum(imtypes[index].proto_vnum);
 		if (!ing) {
-			sprintf(buf, "IM ingredient prototype %d not found", imtypes[index].proto_vnum);
+			error = fmt::format("IM ingredient prototype {} not found", imtypes[index].proto_vnum);
 			break;
 		}
 
@@ -395,14 +396,14 @@ ObjData *load_ingredient(int index, int power, int rnum)
 		err = im_assign_power(ing.get());
 		if (err != 0) {
 			ExtractObjFromWorld(ing.get());
-			sprintf(buf, "IM power assignment error %d", err);
+			error = fmt::format("IM power assignment error {}", err);
 			break;
 		}
 
 		return ing.get();
 	}
 
-	imlog(CMP, buf);
+	imlog(CMP, error.c_str());
 	return nullptr;
 }
 
@@ -923,22 +924,23 @@ void list_recipes(CharData *ch, bool all_recipes) {
 	int i = 0, sortpos;
 	im_rskill *rs;
 
+	std::string out;
+
 	if (all_recipes) {
 		if (!ch->IsFlagged(EPrf::kBlindMode)) {
-			sprintf(buf, " Список доступных рецептов.\r\n"
-						 " Зеленым цветом выделены уже изученные рецепты.\r\n"
-						 " Красным цветом выделены рецепты, недоступные вам в настоящий момент.\r\n"
-						 "\r\n     Рецепт                Уровень (реморт)\r\n"
-						 "------------------------------------------------\r\n");
+			out = " Список доступных рецептов.\r\n"
+				  " Зеленым цветом выделены уже изученные рецепты.\r\n"
+				  " Красным цветом выделены рецепты, недоступные вам в настоящий момент.\r\n"
+				  "\r\n     Рецепт                Уровень (реморт)\r\n"
+				  "------------------------------------------------\r\n";
 		} else {
-			sprintf(buf, " Список доступных рецептов.\r\n"
-						 " Пометкой [И] выделены уже изученные рецепты.\r\n"
-						 " Пометкой [Д] выделены доступные для изучения рецепты.\r\n"
-						 " Пометкой [Н] выделены рецепты, недоступные вам в настоящий момент.\r\n"
-						 "\r\n     Рецепт                Уровень (реморт)\r\n"
-						 "------------------------------------------------\r\n");
+			out = " Список доступных рецептов.\r\n"
+				  " Пометкой [И] выделены уже изученные рецепты.\r\n"
+				  " Пометкой [Д] выделены доступные для изучения рецепты.\r\n"
+				  " Пометкой [Н] выделены рецепты, недоступные вам в настоящий момент.\r\n"
+				  "\r\n     Рецепт                Уровень (реморт)\r\n"
+				  "------------------------------------------------\r\n";
 		}
-		strcpy(buf1, buf);
 		// issue.class-recipes: доступность рецепта классу спрашиваем у самого класса.
 		const auto &char_class = MUD::Class(ch->GetClass());
 		for (sortpos = 0, i = 0; sortpos <= top_imrecipes; sortpos++) {
@@ -947,51 +949,38 @@ void list_recipes(CharData *ch, bool all_recipes) {
 				continue;
 			}
 
-			if (strlen(buf1) >= kMaxStringLength - 60) {
-				strcat(buf1, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-				break;
-			}
 			rs = im_get_char_rskill(ch, sortpos);
 			const bool unavailable = req->level > GetRealLevel(ch) || req->remort > remort::GetRealRemort(ch);
 			if (!ch->IsFlagged(EPrf::kBlindMode)) {
-				strcpy(buf, fmt::format("     {}{:<30}{} {:2} ({:2}){}\r\n",
-						unavailable ? kColorRed : rs ? kColorGrn : kColorNrm,
-						imrecipes[sortpos].name, kColorCyn,
-						req->level, req->remort, kColorNrm).c_str());
+				out += fmt::format("     {}{:<30}&c {:2} ({:2})&n\r\n",
+						unavailable ? "&r" : rs ? "&g" : "&n",
+						imrecipes[sortpos].name, req->level, req->remort);
 			} else {
-				strcpy(buf, fmt::format(" {} {:<30} {:2} ({:2})\r\n",
+				out += fmt::format(" {} {:<30} {:2} ({:2})\r\n",
 						unavailable ? "[Н]" : rs ? "[И]" : "[Д]", imrecipes[sortpos].name,
-						req->level, req->remort).c_str());
+						req->level, req->remort);
 			}
-			strcat(buf1, buf);
 			++i;
 		}
 		if (!i)
-			sprintf(buf1 + strlen(buf1), "Нет рецептов.\r\n");
-		page_string(ch->desc, buf1, 1);
+			out += "Нет рецептов.\r\n";
+		page_string(ch->desc, out);
 		return;
 	}
 
-	sprintf(buf, "Вы владеете следующими рецептами :\r\n");
-
-	strcpy(buf2, buf);
+	out = "Вы владеете следующими рецептами :\r\n";
 
 	for (rs = GET_RSKILL(ch), i = 0; rs; rs = rs->link) {
-		if (strlen(buf2) >= kMaxStringLength - 60) {
-			strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-			break;
-		}
 		if (rs->perc <= 0)
 			continue;
-		strcpy(buf, fmt::format("{:<30} {}{}\r\n", imrecipes[rs->rid].name, how_good(rs->perc, kMaxRecipeLevel), kColorBoldBlk).c_str());
-		strcat(buf2, buf);
+		out += fmt::format("{:<30} {}&K\r\n", imrecipes[rs->rid].name, how_good(rs->perc, kMaxRecipeLevel));
 		++i;
 	}
 
 	if (!i)
-		sprintf(buf2 + strlen(buf2), "Нет рецептов.\r\n");
+		out += "Нет рецептов.\r\n";
 
-	page_string(ch->desc, buf2, 1);
+	page_string(ch->desc, out);
 }
 
 void do_recipes(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
@@ -1006,8 +995,7 @@ void do_recipes(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 void do_rset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	CharData *vict;
-	char name[kMaxInputLength], buf2[128];
-	char buf[kMaxInputLength], help[kMaxStringLength];
+	char name[kMaxInputLength], help[kMaxStringLength];
 	int rcpt = -1, value, i, qend;
 	im_rskill *rs;
 
@@ -1072,13 +1060,14 @@ void do_rset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 	argument += qend + 1;    // skip to next parameter
-	argument = one_argument(argument, buf);
+	char value_arg[kMaxInputLength];
+	argument = one_argument(argument, value_arg);
 
-	if (!*buf) {
+	if (!*value_arg) {
 		SendMsgToChar("Пропущен уровень рецепта.\r\n", ch);
 		return;
 	}
-	value = atoi(buf);
+	value = atoi(value_arg);
 	if (value < 0) {
 		SendMsgToChar("Минимальное значение рецепта 0.\r\n", ch);
 		return;
@@ -1101,10 +1090,11 @@ void do_rset(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	}
 	rs->perc = value;
 
-	sprintf(buf2, "%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict), imrecipes[rcpt].name, value);
-	mudlog(buf2, BRF, -1, SYSLOG, true);
-	imm_log("%s changed %s's %s to %d.", GET_NAME(ch), GET_NAME(vict), imrecipes[rcpt].name, value);
-	SendMsgToChar(buf2, ch);
+	const std::string log_line = fmt::format("{} changed {}'s {} to {}.",
+											 GET_NAME(ch), GET_NAME(vict), imrecipes[rcpt].name, value);
+	mudlog(log_line, BRF, -1, SYSLOG, true);
+	imm_log("%s", log_line.c_str());
+	SendMsgToChar(log_line, ch);
 }
 
 void im_improve_recipe(CharData *ch, im_rskill *rs, int success) {
@@ -1129,14 +1119,11 @@ void im_improve_recipe(CharData *ch, im_rskill *rs, int success) {
 		prob += number(1, rs->perc * 5);
 		if (number(1, MAX(1, prob)) <= GetRealInt(ch)) {
 			if (success)
-				sprintf(buf,
-						"%sВы постигли тонкости приготовления рецепта \"%s\".%s\r\n",
-						kColorBoldCyn, imrecipes[rs->rid].name, kColorNrm);
+				SendMsgToChar(fmt::format("&CВы постигли тонкости приготовления рецепта \"{}\".&n\r\n",
+										  imrecipes[rs->rid].name), ch);
 			else
-				sprintf(buf,
-						"%sНеудача позволила вам осознать тонкости приготовления рецепта \"%s\".%s\r\n",
-						kColorBoldCyn, imrecipes[rs->rid].name, kColorNrm);
-			SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("&CНеудача позволила вам осознать тонкости приготовления "
+										  "рецепта \"{}\".&n\r\n", imrecipes[rs->rid].name), ch);
 			rs->perc += number(1, 2);
 			if (!privilege::IsImmortal(ch))
 				rs->perc = MIN(CalcSkillRemortCap(ch), rs->perc);
@@ -1145,7 +1132,8 @@ void im_improve_recipe(CharData *ch, im_rskill *rs, int success) {
 }
 
 ObjData **im_obtain_ingredients(CharData *ch, char *argument, int *count) {
-	char name[kMaxInputLength], buf[kMaxInputLength];
+	char name[kMaxInputLength];
+	std::string error;
 	ObjData **array = nullptr;
 	ObjData *o;
 	int i, n = 0;
@@ -1161,21 +1149,22 @@ ObjData **im_obtain_ingredients(CharData *ch, char *argument, int *count) {
 		}
 		o = get_obj_in_list_vis(ch, name, ch->carrying);
 		if (!o) {
-			snprintf(buf, kMaxInputLength, "У вас нет %s.\r\n", name);
+			error = fmt::format("У вас нет {}.\r\n", name);
 			break;
 		}
 		if (o->get_type() != EObjType::kMagicComponent) {
-			sprintf(buf, "Вы должны использовать только магические ингредиенты.\r\n");
+			error = "Вы должны использовать только магические ингредиенты.\r\n";
 			break;
 		}
 		if (im_type_rnum(GET_OBJ_VAL(o, IM_TYPE_SLOT)) < 0) {
-			sprintf(buf, "Магическая сила %s утеряна, похоже, безвозвратно.\r\n", o->get_PName(grammar::ECase::kGen).c_str());
+			error = fmt::format("Магическая сила {} утеряна, похоже, безвозвратно.\r\n",
+								o->get_PName(grammar::ECase::kGen));
 			break;
 		}
 		for (i = 0; i < n; ++i) {
 			if (array[i] != o)
 				continue;
-			sprintf(buf, "Один и тот же ингредиент нельзя использовать дважды.\r\n");
+			error = "Один и тот же ингредиент нельзя использовать дважды.\r\n";
 			break;
 		}
 		if (i != n) {
@@ -1190,8 +1179,8 @@ ObjData **im_obtain_ingredients(CharData *ch, char *argument, int *count) {
 	}
 	if (array)
 		free(array);
-	imlog(NRM, buf);
-	SendMsgToChar(buf, ch);
+	imlog(NRM, error.c_str());
+	SendMsgToChar(error, ch);
 	return nullptr;
 }
 
@@ -1593,7 +1582,8 @@ void forget_recipe(CharData *ch, char *argument, int/* subcmd*/) {
 	int qend, rcpt = -1;
 	im_rskill *rs;
 
-	argument = one_argument(argument, arg);
+	char skip_word[kMaxInputLength];
+	argument = one_argument(argument, skip_word);
 
 	skip_spaces(&argument);
 	if (!*argument) {
@@ -1635,8 +1625,7 @@ void forget_recipe(CharData *ch, char *argument, int/* subcmd*/) {
 		return;
 	}
 	rs->perc = 0;
-	sprintf(buf, "Вы забыли рецепт отвара '%s'.\r\n", imrecipes[rcpt].name);
-	SendMsgToChar(buf, ch);
+	SendMsgToChar(fmt::format("Вы забыли рецепт отвара '{}'.\r\n", imrecipes[rcpt].name), ch);
 }
 
 int im_ing_dump(int *ping, char *s) {
@@ -1700,8 +1689,7 @@ void trg_recipeturn(CharData *ch, int rid, int recipediff) {
 	if (rs) {
 		if (recipediff)
 			return;
-		sprintf(buf, "Вас лишили рецепта '%s'.\r\n", imrecipes[rid].name);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Вас лишили рецепта '{}'.\r\n", imrecipes[rid].name), ch);
 		rs->perc = 0;
 	} else {
 		if (!recipediff)
@@ -1713,10 +1701,8 @@ void trg_recipeturn(CharData *ch, int rid, int recipediff) {
 			GET_RSKILL(ch) = rs;
 			rs->perc = 5;
 		}
-		sprintf(buf, "Вы изучили рецепт '%s'.\r\n", imrecipes[rid].name);
-		SendMsgToChar(buf, ch);
-		sprintf(buf, "RECIPE: игроку %s добавлен рецепт %s", GET_NAME(ch), imrecipes[rid].name);
-		log("%s", buf);
+		SendMsgToChar(fmt::format("Вы изучили рецепт '{}'.\r\n", imrecipes[rid].name), ch);
+		log("RECIPE: игроку %s добавлен рецепт %s", GET_NAME(ch), imrecipes[rid].name);
 	}
 }
 
@@ -1731,13 +1717,15 @@ void AddRecipe(CharData *ch, int rid, int recipediff) {
 	skill = rs->perc;
 	rs->perc = MAX(1, MIN(skill + recipediff, kMaxRecipeLevel));
 
-	if (skill > rs->perc)
-		sprintf(buf, "Ваше знание рецепта '%s' понизилось.\r\n", imrecipes[rid].name);
-	else if (skill < rs->perc)
-		sprintf(buf, "Вы повысили знание рецепта '%s'.\r\n", imrecipes[rid].name);
-	else
-		sprintf(buf, "Ваше знание рецепта '%s' осталось неизменным.\r\n", imrecipes[rid].name);
-	SendMsgToChar(buf, ch);
+	std::string msg;
+	if (skill > rs->perc) {
+		msg = fmt::format("Ваше знание рецепта '{}' понизилось.\r\n", imrecipes[rid].name);
+	} else if (skill < rs->perc) {
+		msg = fmt::format("Вы повысили знание рецепта '{}'.\r\n", imrecipes[rid].name);
+	} else {
+		msg = fmt::format("Ваше знание рецепта '{}' осталось неизменным.\r\n", imrecipes[rid].name);
+	}
+	SendMsgToChar(msg, ch);
 }
 
 void do_imlist(CharData *ch, char /**argument*/, int/* cmd*/, int/* subcmd*/) {

--- a/src/gameplay/economics/auction.cpp
+++ b/src/gameplay/economics/auction.cpp
@@ -9,6 +9,9 @@
 ************************************************************************ */
 
 #include "auction.h"
+
+#include <fmt/format.h>
+
 #include "administration/privilege.h"
 #include "engine/db/global_objects.h"
 #include "gameplay/economics/currencies.h"
@@ -424,39 +427,40 @@ bool auction_drive(CharData *ch, char *argument) {
 				return false;
 			}
 			obj = GET_LOT(lot)->item;
-			sprintf(buf, "Предмет \"%s\", ", obj->get_short_description().c_str());
-			if ((obj->get_type() == EObjType::kWand)
-				|| (obj->get_type() == EObjType::kStaff)) {
-				if (obj->GetPotionValueKey(ObjVal::EValueKey::kCurCharges)
-					< obj->GetPotionValueKey(ObjVal::EValueKey::kMaxCharges)) {
-					strcat(buf, "(б/у), ");
+			{
+				std::string out = fmt::format("Предмет \"{}\", ", obj->get_short_description());
+				if ((obj->get_type() == EObjType::kWand)
+					|| (obj->get_type() == EObjType::kStaff)) {
+					if (obj->GetPotionValueKey(ObjVal::EValueKey::kCurCharges)
+						< obj->GetPotionValueKey(ObjVal::EValueKey::kMaxCharges)) {
+						out += "(б/у), ";
+					}
 				}
+				out += " тип ";
+				const char *type_name = GetTypeName(to_underlying(obj->get_type()), item_types);
+				if (*type_name) {
+					out += type_name;
+					out += "\n";
+				}
+				out += sight::diag_weapon_to_char(obj, true);
+				out += sight::diag_timer_to_char(obj);
+				out += "\r\n";
+				// obj_info дописывает в конец переданного буфера, поэтому даём ей свой.
+				char info[kMaxStringLength];
+				info[0] = '\0';
+				sight::obj_info(ch, obj, info);
+				out += info;
+				out += "\n";
+				if (invalid_anti_class(ch, obj) || invalid_unique(ch, obj) || NamedStuff::check_named(ch, obj, 0)) {
+					out += "Эта вещь вам недоступна!\n";
+				}
+				if ((!ch->IsNpc() && HaveIncompatibleAlign(ch, obj))
+					|| invalid_no_class(ch, obj)) {
+					out += "Вы не сможете пользоваться этой вещью.\n";
+				}
+				SendMsgToChar(out, ch);
 			}
-			strcat(buf, " тип ");
-			sprinttype(obj->get_type(), item_types, buf2);
-			if (*buf2) {
-				strcat(buf, buf2);
-				strcat(buf, "\n");
-			};
-			strcat(buf, sight::diag_weapon_to_char(obj, true));
-			strcat(buf, sight::diag_timer_to_char(obj));
-			strcat(buf, "\r\n");
-			sight::obj_info(ch, obj, buf);
-			strcat(buf, "\n");
-			if (invalid_anti_class(ch, obj) || invalid_unique(ch, obj) || NamedStuff::check_named(ch, obj, 0)) {
-				sprintf(buf2, "Эта вещь вам недоступна!");
-				strcat(buf, buf2);
-				strcat(buf, "\n");
-			}
-			if ((!ch->IsNpc() && HaveIncompatibleAlign(ch, obj))
-				|| invalid_no_class(ch, obj)) {
-				sprintf(buf2, "Вы не сможете пользоваться этой вещью.");
-				strcat(buf, buf2);
-				strcat(buf, "\n");
-			}
-			SendMsgToChar(buf, ch);
 			return true;
-			break;
 		case 6:        //Identify
 			ObjData *iobj;
 			if (!sscanf(argument, "%d", &lot)) {


### PR DESCRIPTION
Седьмой батч по #3814: `comm.cpp`, `login.cpp`, `im.cpp`, `auction.cpp`, `dg_domination_helper.cpp`. Глобальных `buf/buf1/buf2/arg` в них не осталось; локальные `char[]` убраны там, где их не требовала сигнатура вызываемой функции.

## Баги, вылезшие по дороге

**`replace_alias` отдавала наружу общий буфер.** Функция подставляет алиасы в падежи и описания свежесозданного магического ингредиента и возвращала `const char *`, указывающий в глобальный `buf`. Вызывается она четыре раза подряд — на падежи, описание, короткое описание и алиасы — и каждый следующий вызов перетирал результат предыдущего. Держалось это только на том, что `set_*` копирует строку сразу же. Теперь функция возвращает `std::string`.

**Там же — неинициализированная переменная.** В ветке подстановки падежей моба (`$p0`…`$p5`) `int k;` не инициализировалась, а результат `sscanf` не проверялся: если разбор не удался, ветка выбиралась по мусору на стеке и `k` могла попасть в диапазон 0..5. Теперь `k = -1` и проверяется, что `sscanf` прочитал ровно одно поле.

**Список рецептов обрезался.** `рецепты` и `рецепты все` собирались в `buf1`/`buf2` с проверкой на `kMaxStringLength` и дописыванием `***ПЕРЕПОЛНЕНИЕ***`. Буфера больше нет — ограничение снято.

**Мёртвая сборка сообщения в login.cpp.** Строка «`<имя>` - новый игрок. Падежи: … ждет одобрения имени» собиралась в `buf` — по оформлению (`". ]\r\n[ "`) она писалась под `mudlog`, — но её никто никуда не отправлял. Мертва уже в `432f2cfb8`, так что боги этого сообщения никогда не видели. Мёртвую сборку убрал; заводить сообщение не стал — это твоё решение.

## Цвета

Переведены на короткие коды (#3862 по касательной): список рецептов, сообщение об осознании рецепта, счётчик неудачных входов на логине. Побочно это чинит вывод для игроков с выключенным цветом — раньше им уезжали сырые ANSI-последовательности, которые `proc_color` не убирает.

**Одно заметное следствие:** `kColorNrm` — это `\x1B[0;37m`, а `&n` — `\x1B[0;0m`. В A/B-диффе ниже расходятся ровно эти байты и ничего больше.

## Проверка

Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.

A/B на тестовом мире против master (один и тот же чистый снимок, `RAW=1` — сравниваются и escape-последовательности): `рецепты`, `рецепты все`, `rset` (список и установка/снятие), `варить`, `забыть`, `исписок`, `аукцион`, `whoami`, `смотреть`, эмоции (act-форматирование), вход в игру. Диff — ровно 50 строк списка рецептов, и в них отличаются только `[0;37m` → `[0;0m`.

Отдельно проверено:
- `Новик вошел в игру.` в syslog — байт в байт как на master;
- обратный отсчёт: `shutdown reboot 65` → `ПЕРЕЗАГРУЗКА через 1 минуту.`;
- множества строковых литералов сверены с master по всем пяти файлам.

Закрывает часть #3814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
