### PR TITLE
refactor(cmd): drop global buffers from equip, employ, create, enchant and liblist (#3814)

### DIFF
--- a/src/engine/structs/bitset_flags.h
+++ b/src/engine/structs/bitset_flags.h
@@ -250,6 +250,16 @@ class BitsetFlags {
 									num_planes, ascii, ascii_size);
 	}
 
+	// Строковая форма: без буфера у вызывающего (#3814). Буферный tascii дописывает в конец,
+	// поэтому строку начинаем с пустой -- иначе вызывающему пришлось бы помнить про *buf = '\0'.
+	// На плоскость приходится не больше 30 бит по два символа, так что 512 с запасом.
+	[[nodiscard]] std::string tascii(int num_planes) const {
+		char ascii[512];
+		ascii[0] = '\0';
+		tascii(num_planes, ascii, sizeof(ascii));
+		return ascii;
+	}
+
 	bool sprintbits(const char *names[], char *result, std::size_t result_size, const char *div,
 					int print_flag = 0) const {
 		return bitset_flags_detail::sprintbits(extract_planes(kLegacyPlanes), names, result,
@@ -258,6 +268,9 @@ class BitsetFlags {
 
 	// Строковая форма: список флагов без буфера у вызывающего (#3814). Размер задан здесь же,
 	// чтобы заголовок не тянул за собой structs.h ради одной константы.
+	// ВНИМАНИЕ: пустой не бывает -- на пустом наборе флагов вернёт слово "ничего". Если надо
+	// печатать строку только при наличии флагов, берите форму с буфером: она отдаёт признак
+	// "флаги были" отдельно от текста.
 	[[nodiscard]] std::string sprintbits(const char *names[], const char *div,
 										 int print_flag = 0) const {
 		char result[8192];

--- a/src/engine/ui/cmd/do_create.cpp
+++ b/src/engine/ui/cmd/do_create.cpp
@@ -1,4 +1,6 @@
 #include "do_create.h"
+
+#include <fmt/format.h>
 #include "administration/privilege.h"
 #include "gameplay/mechanics/magic_item.h"
 
@@ -13,10 +15,11 @@ void do_create(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		return;
 
 	// get: blank, spell name, target name
-	argument = one_argument(argument, arg);
+	char item_kind[kMaxInputLength];
+	argument = one_argument(argument, item_kind);
 	skip_spaces(&argument);
 
-	if (!*arg) {
+	if (!*item_kind) {
 		if (subcmd == SCMD_RECIPE)
 			SendMsgToChar("Состав ЧЕГО вы хотите узнать?\r\n", ch);
 		else
@@ -25,14 +28,14 @@ void do_create(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	}
 
 	ESpellType itemnum;
-	if (utils::IsAbbr(arg, "potion") || utils::IsAbbr(arg, "напиток"))
+	if (utils::IsAbbr(item_kind, "potion") || utils::IsAbbr(item_kind, "напиток"))
 		itemnum = ESpellType::kPotionCast;
-	else if (utils::IsAbbr(arg, "wand") || utils::IsAbbr(arg, "палочка"))
+	else if (utils::IsAbbr(item_kind, "wand") || utils::IsAbbr(item_kind, "палочка"))
 		itemnum = ESpellType::kWandCast;
-	else if (utils::IsAbbr(arg, "scroll") || utils::IsAbbr(arg, "свиток"))
+	else if (utils::IsAbbr(item_kind, "scroll") || utils::IsAbbr(item_kind, "свиток"))
 		itemnum = ESpellType::kScrollCast;
-	else if (utils::IsAbbr(arg, "recipe") || utils::IsAbbr(arg, "рецепт") ||
-		utils::IsAbbr(arg, "отвар")) {
+	else if (utils::IsAbbr(item_kind, "recipe") || utils::IsAbbr(item_kind, "рецепт") ||
+		utils::IsAbbr(item_kind, "отвар")) {
 		if (subcmd != SCMD_RECIPE) {
 			SendMsgToChar("Магическую смесь необходимо СМЕШАТЬ.\r\n", ch);
 			return;
@@ -40,7 +43,7 @@ void do_create(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 //		itemnum = SPELL_ITEMS;
 		compose_recipe(ch, argument, 0);
 		return;
-	} else if (utils::IsAbbr(arg, "runes") || utils::IsAbbr(arg, "руны")) {
+	} else if (utils::IsAbbr(item_kind, "runes") || utils::IsAbbr(item_kind, "руны")) {
 		if (subcmd != SCMD_RECIPE) {
 			SendMsgToChar("Руны требуется сложить.\r\n", ch);
 			return;
@@ -48,15 +51,13 @@ void do_create(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		itemnum = ESpellType::kRunes;
 	} else {
 		if (subcmd == SCMD_RECIPE)
-			snprintf(buf, kMaxInputLength, "Состав '%s' уже давно утерян.\r\n", arg);
+			SendMsgToChar(fmt::format("Состав '{}' уже давно утерян.\r\n", item_kind), ch);
 		else
-			snprintf(buf, kMaxInputLength, "Создание '%s' доступно только Великим Богам.\r\n", arg);
-		SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Создание '{}' доступно только Великим Богам.\r\n", item_kind), ch);
 		return;
 	}
 	if (!*argument) {
-		sprintf(buf, "Уточните тип состава!\r\n");
-		SendMsgToChar(buf, ch);
+		SendMsgToChar("Уточните тип состава!\r\n", ch);
 		return;
 	}
 	std::string arg_str(argument);

--- a/src/engine/ui/cmd/do_employ.cpp
+++ b/src/engine/ui/cmd/do_employ.cpp
@@ -1,5 +1,7 @@
 #include "do_employ.h"
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "engine/core/char_equip_flags.h"
 #include "engine/core/obj_handler.h"
@@ -13,11 +15,11 @@ void apply_enchant(CharData *ch, ObjData *obj, std::string text);
 void do_employ(CharData *ch, char *argument, int cmd, int subcmd) {
 	ObjData *mag_item;
 	int do_hold = 0;
-	two_arguments(argument, arg, buf);
-	char *buf_temp = str_dup(buf);
-	if (!*arg) {
-		snprintf(buf2, sizeof(buf2), "Что вы хотите %s?\r\n", cmd_info[cmd].command);
-		SendMsgToChar(buf2, ch);
+	char name[kMaxInputLength];
+	char rest[kMaxInputLength];
+	two_arguments(argument, name, rest);
+	if (!*name) {
+		SendMsgToChar(fmt::format("Что вы хотите {}?\r\n", cmd_info[cmd].command), ch);
 		return;
 	}
 
@@ -28,21 +30,19 @@ void do_employ(CharData *ch, char *argument, int cmd, int subcmd) {
 
 	mag_item = GET_EQ(ch, kHold);
 	if (!mag_item
-		|| !isname(arg, mag_item->get_aliases())) {
+		|| !isname(name, mag_item->get_aliases())) {
 		switch (subcmd) {
 			case SCMD_RECITE:
 			case SCMD_QUAFF:
-				if (!(mag_item = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-					snprintf(buf2, kMaxStringLength, "Окститесь, нет у вас %s.\r\n", arg);
-					SendMsgToChar(buf2, ch);
+				if (!(mag_item = get_obj_in_list_vis(ch, name, ch->carrying))) {
+					SendMsgToChar(fmt::format("Окститесь, нет у вас {}.\r\n", name), ch);
 					return;
 				}
 				break;
-			case SCMD_USE: mag_item = get_obj_in_list_vis(ch, arg, ch->carrying);
+			case SCMD_USE: mag_item = get_obj_in_list_vis(ch, name, ch->carrying);
 				if (!mag_item
 					|| mag_item->get_type() != EObjType::kEnchant) {
-					snprintf(buf2, kMaxStringLength, "Возьмите в руку '%s' перед применением!\r\n", arg);
-					SendMsgToChar(buf2, ch);
+					SendMsgToChar(fmt::format("Возьмите в руку '{}' перед применением!\r\n", name), ch);
 					return;
 				}
 				break;
@@ -71,7 +71,7 @@ void do_employ(CharData *ch, char *argument, int cmd, int subcmd) {
 			break;
 		case SCMD_USE:
 			if (mag_item->get_type() == EObjType::kEnchant) {
-				apply_enchant(ch, mag_item, buf);
+				apply_enchant(ch, mag_item, rest);
 				return;
 			}
 			if (mag_item->get_type() != EObjType::kWand
@@ -110,9 +110,7 @@ void do_employ(CharData *ch, char *argument, int cmd, int subcmd) {
 		EquipObj(ch, mag_item, EEquipPos::kHold, CharEquipFlags());
 	}
 	if ((do_hold && GET_EQ(ch, EEquipPos::kHold) == mag_item) || (!do_hold))
-		EmployMagicItem(ch, mag_item, buf_temp);
-	free(buf_temp);
-
+		EmployMagicItem(ch, mag_item, rest);
 }
 
 void apply_enchant(CharData *ch, ObjData *obj, std::string text) {
@@ -159,8 +157,10 @@ void apply_enchant(CharData *ch, ObjData *obj, std::string text) {
 	} else {
 		int slots = obj->get_wear_flags();
 		REMOVE_BIT(slots, EWearFlag::kTake);
-		if (sprintbit(slots, wear_bits, buf2, sizeof(buf2))) {
-			SendMsgToChar(ch, "Это зачарование применяется к предметам со слотами надевания: %s\r\n", buf2);
+		const std::string slot_names = sprintbit(slots, wear_bits);
+		if (!slot_names.empty()) {
+			SendMsgToChar(fmt::format("Это зачарование применяется к предметам со слотами надевания: {}\r\n",
+									  slot_names), ch);
 		} else {
 			SendMsgToChar(ch, "Некорретное зачарование, не проставлены слоты надевания.\r\n");
 		}

--- a/src/engine/ui/cmd/do_equip.cpp
+++ b/src/engine/ui/cmd/do_equip.cpp
@@ -7,6 +7,9 @@
 */
 
 #include "engine/ui/cmd/do_equip.h"
+
+#include <fmt/format.h>
+
 #include "administration/privilege.h"
 #include "gameplay/mechanics/sight.h"
 #include "utils/grammar/declensions.h"
@@ -170,8 +173,7 @@ int find_eq_pos(CharData *ch, ObjData *obj, char *local_arg) {
 		equip_pos = search_block(local_arg, keywords, false);
 		if (equip_pos < 0
 			|| *local_arg == '!') {
-			sprintf(buf, "'%s'? Странная анатомия у этих русских!\r\n", local_arg);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("'{}'? Странная анатомия у этих русских!\r\n", local_arg), ch);
 			return -1;
 		}
 	}
@@ -209,7 +211,11 @@ void perform_wear(CharData *ch, ObjData *obj, int equip_pos, bool skip_total = f
 		EWearFlag::kQuiver
 	};
 
-	const std::array<const char *, sizeof(wear_bitvectors)> already_wearing =
+	// Массив задавался размером sizeof(wear_bitvectors) -- это байты, а не число
+	// элементов, -- а перед сообщением про колчан не хватало запятой, так что оно
+	// склеивалось с предыдущим. В итоге already_wearing[kQuiver] был nullptr, и
+	// попытка надеть второй колчан уезжала в SendMsgToChar(nullptr).
+	const std::array<const char *, EEquipPos::kNumEquipPos> already_wearing =
 		{
 			"Вы уже используете свет.\r\n",
 			"YOU SHOULD NEVER SEE THIS MESSAGE.  PLEASE REPORT.\r\n",
@@ -229,7 +235,7 @@ void perform_wear(CharData *ch, ObjData *obj, int equip_pos, bool skip_total = f
 			"У вас уже что-то надето на запястья.\r\n",
 			"Вы уже что-то держите в правой руке.\r\n",
 			"Вы уже что-то держите в левой руке.\r\n",
-			"Вы уже держите оружие в обеих руках.\r\n"
+			"Вы уже держите оружие в обеих руках.\r\n",
 			"Вы уже используете колчан.\r\n"
 		};
 
@@ -341,8 +347,7 @@ void do_wear(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			return;
 		}
 		if (!(obj = get_obj_in_list_vis(ch, arg1, ch->carrying))) {
-			sprintf(buf, "У вас нет ничего похожего на '%s'.\r\n", arg1);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("У вас нет ничего похожего на '{}'.\r\n", arg1), ch);
 		} else {
 			while (obj && !AFF_FLAGGED(ch, EAffect::kHold) && ch->GetPosition() > EPosition::kSleep) {
 				next_obj = get_obj_in_list_vis(ch, arg1, obj->get_next_content());
@@ -361,8 +366,7 @@ void do_wear(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 	} else {
 		if (!(obj = get_obj_in_list_vis(ch, arg1, ch->carrying))) {
-			sprintf(buf, "У вас нет ничего похожего на '%s'.\r\n", arg1);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("У вас нет ничего похожего на '{}'.\r\n", arg1), ch);
 		} else {
 			if ((equip_pos = find_eq_pos(ch, obj, arg2)) >= 0)
 				perform_wear(ch, obj, equip_pos);
@@ -375,18 +379,18 @@ void do_wear(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 void do_wield(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	ObjData *obj;
 	int wear;
+	char name[kMaxInputLength];
 
 	if (ch->IsNpc() && (AFF_FLAGGED(ch, EAffect::kCharmed)
 		&& (!NPC_FLAGGED(ch, ENpcFlag::kWielding) || ch->IsFlagged(EMobFlag::kResurrected))))
 		return;
 
-	argument = one_argument(argument, arg);
+	argument = one_argument(argument, name);
 
-	if (!*arg)
+	if (!*name)
 		SendMsgToChar("Вооружиться чем?\r\n", ch);
-	else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-		snprintf(buf, kMaxInputLength, "Вы не видите ничего похожего на \'%s\'.\r\n", arg);
-		SendMsgToChar(buf, ch);
+	else if (!(obj = get_obj_in_list_vis(ch, name, ch->carrying))) {
+		SendMsgToChar(fmt::format("Вы не видите ничего похожего на '{}'.\r\n", name), ch);
 	} else {
 		if (!CAN_WEAR(obj, EWearFlag::kWield)
 			&& !CAN_WEAR(obj, EWearFlag::kBoth)) {
@@ -398,8 +402,9 @@ void do_wield(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			&& ch->IsFlagged(EMobFlag::kCorpse)) {
 			SendMsgToChar("Ожившие трупы не могут вооружаться.\r\n", ch);
 		} else {
-			one_argument(argument, arg);
-			if (!str_cmp(arg, "обе")
+			char both_arg[kMaxInputLength];
+			one_argument(argument, both_arg);
+			if (!str_cmp(both_arg, "обе")
 				&& CAN_WEAR(obj, EWearFlag::kBoth)) {
 				// иногда бывает надо
 				if (!privilege::IsImmortal(ch) && !CanBeTakenInBothHands(ch, obj)) {
@@ -444,16 +449,16 @@ void do_wield(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 void do_grab(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	auto equip_pos{EEquipPos::kHold};
 	ObjData *obj;
-	one_argument(argument, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
 
 	if (ch->IsNpc() && !NPC_FLAGGED(ch, ENpcFlag::kWielding))
 		return;
 
-	if (!*arg)
+	if (!*name)
 		SendMsgToChar("Вы заорали : 'Держи его!!! Хватай его!!!'\r\n", ch);
-	else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-		snprintf(buf, kMaxInputLength, "У вас нет ничего похожего на '%s'.\r\n", arg);
-		SendMsgToChar(buf, ch);
+	else if (!(obj = get_obj_in_list_vis(ch, name, ch->carrying))) {
+		SendMsgToChar(fmt::format("У вас нет ничего похожего на '{}'.\r\n", name), ch);
 	} else {
 		if (obj->get_type() == EObjType::kLightSource) {
 			perform_wear(ch, obj, EEquipPos::kLight);

--- a/src/engine/ui/cmd_god/do_liblist.cpp
+++ b/src/engine/ui/cmd_god/do_liblist.cpp
@@ -31,13 +31,15 @@ namespace mob_list {
 void do_liblist(CharData *ch, char *argument, int cmd, int subcmd) {
 	int first, last, nr, found = 0;
 
-	argument = two_arguments(argument, buf, buf2);
-	first = atoi(buf);
+	char arg_first[kMaxInputLength];
+	char arg_last[kMaxInputLength];
+	argument = two_arguments(argument, arg_first, arg_last);
+	first = atoi(arg_first);
 	if (!(privilege::HasPrivilege(ch, std::string(cmd_info[cmd].command), 0, 0, false)) && (GET_OLC_ZONE(ch) != first)) {
 		SendMsgToChar("Чаво?\r\n", ch);
 		return;
 	}
-	if (!*buf || (!*buf2 && (subcmd == kScmdZlist))) {
+	if (!*arg_first || (!*arg_last && (subcmd == kScmdZlist))) {
 		switch (subcmd) {
 			case kScmdRlist:
 				SendMsgToChar("Использование: ксписок <начальный номер или номер зоны> [<конечный номер>]\r\n",
@@ -57,23 +59,21 @@ void do_liblist(CharData *ch, char *argument, int cmd, int subcmd) {
 				SendMsgToChar("Использование: ксписок <начальный номер или номер зоны> [<конечный номер>]\r\n",
 							  ch);
 				break;
-			default: sprintf(buf, "SYSERR:: invalid SCMD passed to ACMDdo_build_list!");
-				mudlog(buf, BRF, kLvlGod, SYSLOG, true);
+			default: mudlog("SYSERR:: invalid SCMD passed to ACMDdo_build_list!", BRF, kLvlGod, SYSLOG, true);
 				break;
 		}
 		return;
 	}
 
-	if (*buf2 && a_isdigit(buf2[0])) {
-		last = atoi(buf2);
+	if (*arg_last && a_isdigit(arg_last[0])) {
+		last = atoi(arg_last);
 	} else {
 		first *= 100;
 		last = first + 99;
 	}
 
 	if ((first < 0) || (first > kMaxProtoNumber) || (last < 0) || (last > kMaxProtoNumber)) {
-		sprintf(buf, "Значения должны быть между 0 и %d.\n\r", kMaxProtoNumber);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Значения должны быть между 0 и {}.\n\r", kMaxProtoNumber), ch);
 		return;
 	}
 
@@ -86,24 +86,20 @@ void do_liblist(CharData *ch, char *argument, int cmd, int subcmd) {
 		return;
 	}
 
-	char buf_[256];
 	std::string out;
 
 	switch (subcmd) {
 		case kScmdRlist:
-			snprintf(buf_, sizeof(buf_),
-					 "Список комнат от Vnum %d до %d\r\n", first, last);
-			out += buf_;
+			out += fmt::format("Список комнат от Vnum {} до {}\r\n", first, last);
 			for (nr = kFirstRoom; nr <= top_of_world && (world[nr]->vnum <= last); nr++) {
 				if (world[nr]->vnum >= first) {
-					snprintf(buf_, sizeof(buf_), "%5d. [%7d] (%3d) %s",
-							 ++found, world[nr]->vnum, nr, world[nr]->name);
-					out += buf_;
+					// Имя комнаты бывает пустым: printf печатал "(null)", fmt на этом бросает.
+					const char *room_name = world[nr]->name ? world[nr]->name : "";
+					out += fmt::format("{:5}. [{:7}] ({:3}) {}", ++found, world[nr]->vnum, nr, room_name);
 					if (!world[nr]->proto_script->empty()) {
 						out += " - есть скрипты -";
 						for (const auto trigger_vnum : *world[nr]->proto_script) {
-							sprintf(buf1, " [%d]", trigger_vnum);
-							out += buf1;
+							out += fmt::format(" [{}]", trigger_vnum);
 						}
 						out += "\r\n";
 					} else {
@@ -117,8 +113,8 @@ void do_liblist(CharData *ch, char *argument, int cmd, int subcmd) {
 
 		case kScmdMlist: {
 			std::string option;
-			if (*buf2 && !a_isdigit(buf2[0])) {
-				option = buf2;
+			if (*arg_last && !a_isdigit(arg_last[0])) {
+				option = arg_last;
 			}
 			option += " ";
 			option += argument;
@@ -126,26 +122,22 @@ void do_liblist(CharData *ch, char *argument, int cmd, int subcmd) {
 			return;
 		}
 		case kScmdZlist:
-			snprintf(buf_, sizeof(buf_),
-					 "Список зон от %d до %d\r\n"
-					 "(флаги, номер, резет, уровень/средний уровень мобов, группа, имя)\r\n",
-					 first, last);
-			out += buf_;
+			out += fmt::format("Список зон от {} до {}\r\n"
+							   "(флаги, номер, резет, уровень/средний уровень мобов, группа, имя)\r\n",
+							   first, last);
 
 			for (nr = 0; nr < static_cast<ZoneRnum>(zone_table.size()) && (zone_table[nr].vnum <= last); nr++) {
 				if (zone_table[nr].vnum >= first) {
-					snprintf(buf_, sizeof(buf_),
-							 "%5d. [%s%s] [%5d] (%3d) (%2d/%2d) (%2d) %s\r\n",
-							 ++found,
-							 zone_table[nr].locked ? "L" : " ",
-							 zone_table[nr].under_construction ? "T" : " ",
-							 zone_table[nr].vnum,
-							 zone_table[nr].lifespan,
-							 zone_table[nr].level,
-							 zone_table[nr].mob_level,
-							 zone_table[nr].group,
-							 zone_table[nr].name.c_str());
-					out += buf_;
+					out += fmt::format("{:5}. [{}{}] [{:5}] ({:3}) ({:2}/{:2}) ({:2}) {}\r\n",
+									   ++found,
+									   zone_table[nr].locked ? "L" : " ",
+									   zone_table[nr].under_construction ? "T" : " ",
+									   zone_table[nr].vnum,
+									   zone_table[nr].lifespan,
+									   zone_table[nr].level,
+									   zone_table[nr].mob_level,
+									   zone_table[nr].group,
+									   zone_table[nr].name);
 				}
 			}
 			break;
@@ -153,8 +145,7 @@ void do_liblist(CharData *ch, char *argument, int cmd, int subcmd) {
 		case kScmdClist: out = "Заглушка. Возможно, будет использоваться в будущем\r\n";
 			break;
 
-		default: sprintf(buf, "SYSERR:: invalid SCMD passed to ACMDdo_build_list!");
-			mudlog(buf, BRF, kLvlGod, SYSLOG, true);
+		default: mudlog("SYSERR:: invalid SCMD passed to ACMDdo_build_list!", BRF, kLvlGod, SYSLOG, true);
 			return;
 	}
 
@@ -166,8 +157,7 @@ void do_liblist(CharData *ch, char *argument, int cmd, int subcmd) {
 				break;
 			case kScmdZlist: SendMsgToChar("Нет зон в этом промежутке.\r\n", ch);
 				break;
-			default: sprintf(buf, "SYSERR:: invalid SCMD passed to do_build_list!");
-				mudlog(buf, BRF, kLvlGod, SYSLOG, true);
+			default: mudlog("SYSERR:: invalid SCMD passed to do_build_list!", BRF, kLvlGod, SYSLOG, true);
 				break;
 		}
 		return;

--- a/src/gameplay/mechanics/obj_enchant.cpp
+++ b/src/gameplay/mechanics/obj_enchant.cpp
@@ -2,6 +2,8 @@
 // Part of Bylins http://www.mud.ru
 
 #include "obj_enchant.h"
+
+#include <fmt/format.h>
 #include "engine/entities/obj_data.h"
 #include "engine/ui/color.h"
 #include "engine/entities/char_data.h"
@@ -43,19 +45,19 @@ void enchant::print(CharData *ch) const {
 		print_obj_affects(ch, *i);
 	}
 
-	if (affects_flags_.sprintbits(equipment_affects, buf2, sizeof(buf2), ",")) {
-		SendMsgToChar(ch, "%s   аффекты: %s%s\r\n",
-					  kColorCyn, buf2, kColorNrm);
+	// Буфер здесь нужен: строковая форма sprintbits подставляет "ничего" и пустой не бывает,
+	// а печатать строку надо только когда флаги есть -- это знает только bool-форма.
+	char flags[kMaxStringLength];
+	if (affects_flags_.sprintbits(equipment_affects, flags, sizeof(flags), ",")) {
+		SendMsgToChar(fmt::format("&c   аффекты: {}&n\r\n", flags), ch);
 	}
 
-	if (extra_flags_.sprintbits(extra_bits, buf2, sizeof(buf2), ",")) {
-		SendMsgToChar(ch, "%s   экстрафлаги: %s%s\r\n",
-					  kColorCyn, buf2, kColorNrm);
+	if (extra_flags_.sprintbits(extra_bits, flags, sizeof(flags), ",")) {
+		SendMsgToChar(fmt::format("&c   экстрафлаги: {}&n\r\n", flags), ch);
 	}
 
-	if (no_flags_.sprintbits(no_bits, buf2, sizeof(buf2), ",")) {
-		SendMsgToChar(ch, "%s   неудобен: %s%s\r\n",
-					  kColorCyn, buf2, kColorNrm);
+	if (no_flags_.sprintbits(no_bits, flags, sizeof(flags), ",")) {
+		SendMsgToChar(fmt::format("&c   неудобен: {}&n\r\n", flags), ch);
 	}
 
 	if (weight_ != 0) {
@@ -87,17 +89,9 @@ std::string enchant::print_to_file() const {
 		out << " A " << i->location << " " << i->modifier << "\n";
 	}
 
-	*buf = '\0';
-	affects_flags_.tascii(kFlagPlanes, buf, sizeof(buf));
-	out << " F " << buf << "\n";
-
-	*buf = '\0';
-	extra_flags_.tascii(kFlagPlanes, buf, sizeof(buf));
-	out << " E " << buf << "\n";
-
-	*buf = '\0';
-	no_flags_.tascii(kFlagPlanes, buf, sizeof(buf));
-	out << " N " << buf << "\n";
+	out << " F " << affects_flags_.tascii(kFlagPlanes) << "\n";
+	out << " E " << extra_flags_.tascii(kFlagPlanes) << "\n";
+	out << " N " << no_flags_.tascii(kFlagPlanes) << "\n";
 
 	out << " W " << weight_ << "\n";
 	out << " B " << ndice_ << "\n";


### PR DESCRIPTION
Восьмой батч по #3814: `do_equip.cpp`, `do_employ.cpp`, `do_create.cpp`, `obj_enchant.cpp`, `do_liblist.cpp`. Глобальных `buf/buf1/buf2/arg` в них не осталось; локальные `char[]` убраны там, где их не требовала сигнатура вызываемой функции.

## Баги, вылезшие по дороге

**`already_wearing[kQuiver]` был `nullptr`.** В `perform_wear` массив сообщений «у вас уже что-то надето» объявлен как `std::array<const char *, sizeof(wear_bitvectors)>` — `sizeof` в **байтах**, а не число элементов, — и перед последней строкой не хватало запятой:

```cpp
"Вы уже держите оружие в обеих руках.\r\n"     // <-- нет запятой
"Вы уже используете колчан.\r\n"
```

Два литерала склеились в один, инициализаторов стало 19 на 80 элементов, и `already_wearing[EEquipPos::kQuiver]` (индекс 19) оказался `nullptr`. Попытка надеть второй колчан уходила в `SendMsgToChar(nullptr, ch)`. Запятая на месте, размер задан через `EEquipPos::kNumEquipPos`.

**`ксписок` — имя комнаты могло быть nullptr.** `printf` печатал `(null)`, `fmt` на этом бросает `std::logic_error`. Добавлена проверка (как в `выходы` из #3865).

**`do_employ` — лишняя копия аргумента.** Аргумент дублировался через `str_dup` в отдельный буфер только потому, что оригинал лежал в глобальном `buf`, который мог перетереться по дороге. Буфер, копия и `free` ушли.

## Своя ошибка, пойманная на A/B

Строковая форма `BitsetFlags::sprintbits` на пустом наборе флагов подставляет слово «ничего» и пустой **не бывает** — в отличие от `utils::sprintbit`, которая оставляет строку пустой. Я заменил bool-форму на строковую с проверкой `!empty()`, и в описании зачарования появилась лишняя строка «аффекты: ничего». A/B это показал. В `obj_enchant` вернул форму с буфером (только она отдаёт признак «флаги были» отдельно от текста), а к строковой форме в `bitset_flags.h` добавил предупреждение, чтобы следующий не наступил.

## Прочее

- В `BitsetFlags` добавлена строковая форма `tascii(num_planes)` — буферная дописывает в конец, поэтому строковая начинает с пустой, и вызывающему больше не надо помнить про `*buf = '\0'`.
- Цвета в описании зачарования переведены на короткие коды. Следствие: `kColorNrm` это `\x1B[0;37m`, а `&n` — `\x1B[0;0m`.

## Проверка

Сборка `-Dbuild_profile=release -Dbuild_tests=true` без предупреждений, 712 тестов проходят.

A/B на тестовом мире против master (один и тот же чистый снимок, `RAW=1`): `ксписок`, `зсписок`, `осписок`, `мсписок` и их ошибочные варианты (без аргументов, вне диапазона), `надеть` / `надеть все` / `надеть <предмет> <часть тела>` / несуществующая часть тела, `вооружиться`, `держать`, `создать`, `состав`, `применить`, `осушить`, `зачитать` — **побайтово идентично**. Отдельным прогоном: зачарование предмета руническим знаком и последующее `опознать` — отличается только код сброса цвета.

Закрывает часть #3814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0149Vshdnhpowc9M4JxmUtcr
