### PR TITLE
refactor(cmd_god): drop global buffers from zone, glory and karma commands (#3814)

### DIFF
--- a/src/administration/karma.cpp
+++ b/src/administration/karma.cpp
@@ -6,17 +6,25 @@
 \detail Detail description.
 */
 
+#include "karma.h"
+
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 
 // Adds karma string to KARMA
 // \TODO Move everything related to karma to this module.
-void AddKarma(CharData *ch, const char *punish, const char *reason) {
-	if (reason && (reason[0] != '.')) {
-		char smallbuf[kMaxInputLength];
-		time_t nt = time(nullptr);
-		snprintf(smallbuf, kMaxInputLength, "%s :: %s [%s]\r\n", rustime(localtime(&nt)), punish, reason);
-		KARMA(ch) = str_add(KARMA(ch), smallbuf);
+void AddKarma(CharData *ch, const std::string &punish, const std::string &reason) {
+	// Причина с ведущей точкой -- признак "записывать не надо".
+	if (!reason.empty() && reason[0] == '.') {
+		return;
 	}
+
+	const time_t nt = time(nullptr);
+	// Раньше строка собиралась в буфер длиной kMaxInputLength и молча обрезалась:
+	// длинное название наказания вместе с причиной туда не влезало.
+	const std::string line = fmt::format("{} :: {} [{}]\r\n", rustime(localtime(&nt)), punish, reason);
+	KARMA(ch) = str_add(KARMA(ch), line.c_str());
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/administration/karma.h
+++ b/src/administration/karma.h
@@ -9,8 +9,15 @@
 #ifndef BYLINS_SRC_ADMINISTRATION_KARMA_H_
 #define BYLINS_SRC_ADMINISTRATION_KARMA_H_
 
+#include <string>
+
 class CharData;
-void AddKarma(CharData *ch, const char *punish, const char *reason);
+
+/**
+ * Дописать строку в карму персонажа.
+ * Причина, начинающаяся с точки, означает "не писать" -- так команды богов гасят запись.
+ */
+void AddKarma(CharData *ch, const std::string &punish, const std::string &reason);
 
 #endif //BYLINS_SRC_ADMINISTRATION_KARMA_H_
 

--- a/src/administration/punishments.cpp
+++ b/src/administration/punishments.cpp
@@ -55,7 +55,7 @@ bool SetMute(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Mute OFF by {}", GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		to_vict = fmt::format("&G{} разрешил$G вам кричать.&n", GET_NAME(ch));
 		to_room = "$n2 вернулся голос.";
 	} else {
@@ -65,7 +65,7 @@ bool SetMute(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Mute ON ({}h) by {}", times, GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		to_vict = fmt::format("&R{} запретил$G вам кричать.&n", GET_NAME(ch));
 		to_room = "$n подавился своим криком.";
 		SetPunisherParamsToPundata(ch, pundata, reason);
@@ -91,7 +91,7 @@ bool SetDumb(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Dumb OFF by {}", GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		to_vict = fmt::format("&G{} разрешил$G вам издавать звуки.&n", GET_NAME(ch));
 		to_room = "$n нарушил$g обет молчания.";
 	} else {
@@ -101,7 +101,7 @@ bool SetDumb(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Dumb ON ({}m) by {}", times, GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		to_vict = fmt::format("&R{} запретил$G вам издавать звуки.&n", GET_NAME(ch));
 		to_room = "$n дал$g обет молчания.";
 		SetPunisherParamsToPundata(ch, pundata, reason);
@@ -127,7 +127,7 @@ bool SetHell(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Removed FROM hell by {}", GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		if (vict->in_room != kNowhere) {
 			act("$n выпущен$a из темницы!", false, vict, nullptr, nullptr, kToRoom);
 			MoveToStartRoom(vict);
@@ -148,7 +148,7 @@ bool SetHell(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Moved TO hell ({}h) by {}", times, GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		to_vict = fmt::format("&R{} поместил$G вас в темницу.&n", GET_NAME(ch));
 		to_room = "$n водворен$a в темницу!";
 		SetPunisherParamsToPundata(ch, pundata, reason);
@@ -178,7 +178,7 @@ bool SetFreeze(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Freeze OFF by {}", GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		if (vict->in_room != kNowhere) {
 			act("$n выпущен$a из темницы!", false, vict, nullptr, nullptr, kToRoom);
 			MoveToStartRoom(vict);
@@ -195,7 +195,7 @@ bool SetFreeze(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Freeze ON ({}h) by {}", times, GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		to_vict = "&BАдский холод сковал ваше тело ледяным панцирем.\r\n&n";
 		to_room = "Ледяной панцирь покрыл тело $n1! Стало очень тихо и холодно.";
 		if (vict->in_room != kNowhere) {
@@ -227,7 +227,7 @@ bool SetNameRoom(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Removed FROM name room by {}", GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		if (vict->in_room != kNowhere) {
 			MoveToStartRoom(vict);
 			act("$n выпущен$a из комнаты имени!", false, vict, nullptr, nullptr, kToRoom);
@@ -248,7 +248,7 @@ bool SetNameRoom(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Removed TO nameroom ({}h) by {}", times, GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		to_vict = fmt::format("&R{} поместил$G вас в комнату имени.&n", GET_NAME(ch));
 		to_room = "$n помещен$a в комнату имени!";
 		SetPunisherParamsToPundata(ch, pundata, reason);
@@ -272,7 +272,7 @@ bool SetRegister(CharData *ch, CharData *vict, char *reason) {
 	imm_log("%s", log_line.c_str());
 	const std::string karma = fmt::format("Registered by {}", GET_NAME(ch));
 	RegisterSystem::add(vict, karma.c_str(), reason);
-	AddKarma(vict, karma.c_str(), reason);
+	AddKarma(vict, karma, reason);
 	if (vict->in_room != kNowhere) {
 		act("$n зарегистрирован$a!", false, vict, nullptr, nullptr, kToRoom);
 		MoveToStartRoom(vict);
@@ -300,7 +300,7 @@ bool SetUnregister(CharData *ch, CharData *vict, char *reason, long times) {
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Unregistered by {}", GET_NAME(ch));
 		RegisterSystem::remove(vict);
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		if (vict->in_room != kNowhere) {
 			act("C $n1 снята метка регистрации!", false, vict, nullptr, nullptr, kToRoom);
 		}
@@ -323,7 +323,7 @@ bool SetUnregister(CharData *ch, CharData *vict, char *reason, long times) {
 		mudlog(log_line, DEF, std::max(kLvlImmortal, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s", log_line.c_str());
 		const std::string karma = fmt::format("Unregistered ({}h) by {}", times, GET_NAME(ch));
-		AddKarma(vict, karma.c_str(), reason);
+		AddKarma(vict, karma, reason);
 		to_vict = fmt::format("&R{} снял$G с вас... регистрацию :).&n", GET_NAME(ch));
 		to_room = "$n лишен$a регистрации!";
 		SetPunisherParamsToPundata(ch, pundata, reason);

--- a/src/engine/ui/cmd_god/do_delete_obj.cpp
+++ b/src/engine/ui/cmd_god/do_delete_obj.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "engine/db/world_objects.h"
 #include "gameplay/mechanics/depot.h"
@@ -15,13 +17,14 @@
 
 void DoDeleteObj(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	int vnum;
-	one_argument(argument, buf);
+	char arg_vnum[kMaxInputLength];
+	one_argument(argument, arg_vnum);
 	int num = 0;
-	if (!*buf || !a_isdigit(*buf)) {
+	if (!*arg_vnum || !a_isdigit(*arg_vnum)) {
 		SendMsgToChar("Usage: delete <number>\r\n", ch);
 		return;
 	}
-	if ((vnum = atoi(buf)) < 0) {
+	if ((vnum = atoi(arg_vnum)) < 0) {
 		SendMsgToChar("Указан неверный VNUM объекта !\r\n", ch);
 		return;
 	}
@@ -34,8 +37,7 @@ void DoDeleteObj(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 //	num += Clan::delete_obj(vnum);
 	num += Depot::delete_obj(vnum);
 	num += Parcel::delete_obj(vnum);
-	sprintf(buf2, "Удалено всего предметов: %d, смотрим ренту.\r\n", num);
-	SendMsgToChar(buf2, ch);
+	SendMsgToChar(fmt::format("Удалено всего предметов: {}, смотрим ренту.\r\n", num), ch);
 	num = 0;
 	for (std::size_t pt_num = 0; pt_num< player_table.size(); pt_num++) {
 		bool need_save = false;
@@ -45,8 +47,8 @@ void DoDeleteObj(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					 iend = player_table[pt_num].timer->time.end(); i != iend; ++i) {
 				if (i->vnum == vnum && i->timer > 0) {
 					num++;
-					sprintf(buf2, "Player %s : item [%d] deleted\r\n", player_table[pt_num].name().c_str(), i->vnum);;
-					SendMsgToChar(buf2, ch);
+					SendMsgToChar(fmt::format("Player {} : item [{}] deleted\r\n",
+											  player_table[pt_num].name(), i->vnum), ch);
 					i->timer = -1;
 					int rnum = GetObjRnum(i->vnum);
 					if (rnum >= 0) {
@@ -58,13 +60,14 @@ void DoDeleteObj(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 		if (need_save) {
 			if (!Crash_write_timer(pt_num)) {
-				sprintf(buf, "SYSERROR: [TO] Error writing timer file for %s", player_table[pt_num].name().c_str());
-				SendMsgToChar(buf2, ch);
+				// Сообщение собиралось в buf, а богу уходил buf2 -- то есть предыдущая
+				// строка "item deleted" вместо ошибки записи файла таймеров.
+				SendMsgToChar(fmt::format("SYSERROR: [TO] Error writing timer file for {}\r\n",
+										  player_table[pt_num].name()), ch);
 			}
 		}
 	}
-	sprintf(buf2, "Удалено еще предметов: %d.\r\n", num);
-	SendMsgToChar(buf2, ch);
+	SendMsgToChar(fmt::format("Удалено еще предметов: {}.\r\n", num), ch);
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/ui/cmd_god/do_glory.cpp
+++ b/src/engine/ui/cmd_god/do_glory.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "utils/utils_string.h"
 #include "gameplay/mechanics/glory.h"
@@ -28,6 +30,7 @@ void DoGlory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	// Без параметров выводит славу у игрока
 	// + cлава прибавляет славу
 	// - cлава убавляет славу
+	char name[kMaxInputLength];
 	char num[kMaxInputLength];
 	char arg1[kMaxInputLength];
 	int mode = 0;
@@ -41,7 +44,7 @@ void DoGlory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					  "   glory <имя> hide on|off причина (показывать или нет чара в топе славы)\r\n", ch);
 		return;
 	}
-	reason = two_arguments(argument, arg, num);
+	reason = two_arguments(argument, name, num);
 	skip_spaces(&reason);
 
 	if (!*num)
@@ -77,10 +80,10 @@ void DoGlory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 	}
 
-	CharData *vict = target_resolver::FindPlayerVis(ch, arg);
+	CharData *vict = target_resolver::FindPlayerVis(ch, name);
 	Player t_vict; // TODO: надо выносить во вторую функцию, чтобы зря не создавать
 	if (!vict) {
-		if (LoadPlayerCharacter(arg, &t_vict, ELoadCharFlags::kFindId) < 0) {
+		if (LoadPlayerCharacter(name, &t_vict, ELoadCharFlags::kFindId) < 0) {
 			SendMsgToChar("Такого персонажа не существует.\r\n", ch);
 			return;
 		}
@@ -105,16 +108,16 @@ void DoGlory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 						  GET_PAD(vict, 1), amount, Glory::get_glory(vict->get_uid()));
 			imm_log("(GC) %s sets -%d glory to %s.", GET_NAME(ch), amount, GET_NAME(vict));
 			// запись в карму
-			sprintf(buf, "Change glory -%d by %s", amount, GET_NAME(ch));
-			AddKarma(vict, buf, reason);
-			GloryMisc::add_log(mode, amount, std::string(buf), std::string(reason), vict);
+			const std::string punish = fmt::format("Change glory -{} by {}", amount, GET_NAME(ch));
+			AddKarma(vict, punish, reason);
+			GloryMisc::add_log(mode, amount, punish, reason, vict);
 			break;
 		}
 		case kSubStats: {
 			if (Glory::remove_stats(vict, ch, atoi(arg1))) {
-				sprintf(buf, "Remove stats %s by %s", arg1, GET_NAME(ch));
-				AddKarma(vict, buf, reason);
-				GloryMisc::add_log(mode, 0, std::string(buf), std::string(reason), vict);
+				const std::string punish = fmt::format("Remove stats {} by {}", arg1, GET_NAME(ch));
+				AddKarma(vict, punish, reason);
+				GloryMisc::add_log(mode, 0, punish, reason, vict);
 			}
 			break;
 		}
@@ -124,9 +127,9 @@ void DoGlory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 		case kSubHide: {
 			Glory::hide_char(vict, ch, arg1);
-			sprintf(buf, "Hide %s by %s", arg1, GET_NAME(ch));
-			AddKarma(vict, buf, reason);
-			GloryMisc::add_log(mode, 0, std::string(buf), std::string(reason), vict);
+			const std::string punish = fmt::format("Hide {} by {}", arg1, GET_NAME(ch));
+			AddKarma(vict, punish, reason);
+			GloryMisc::add_log(mode, 0, punish, reason, vict);
 			break;
 		}
 		default: Glory::show_glory(vict, ch);

--- a/src/engine/ui/cmd_god/do_set.cpp
+++ b/src/engine/ui/cmd_god/do_set.cpp
@@ -535,7 +535,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			}
 			Password::set_password(vict, val_arg);
 			Password::send_password(GET_EMAIL(vict), val_arg, std::string(GET_NAME(vict)));
-			AddKarma(vict, fmt::format("{} заменен пароль богом.", GET_PAD(vict, 2)).c_str(), GET_NAME(ch));
+			AddKarma(vict, fmt::format("{} заменен пароль богом.", GET_PAD(vict, 2)), GET_NAME(ch));
 			sprintf(output, "Пароль изменен на '%s'.", val_arg);
 			break;
 		case 37: on_off_mode ? vict->SetFlag(EPlrFlag::kNoDelete) : vict->UnsetFlag(EPlrFlag::kNoDelete);
@@ -661,7 +661,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 				}
 				const std::string rename_note = fmt::format("Name changed from {} to {}", GET_NAME(vict), npad[0]);
 				vict->set_name(npad[0]);
-				AddKarma(vict, rename_note.c_str(), GET_NAME(ch));
+				AddKarma(vict, rename_note, GET_NAME(ch));
 
 				if (!vict->IsFlagged(EPlrFlag::kFrozen)
 					&& !vict->IsFlagged(EPlrFlag::kDeleted)
@@ -746,7 +746,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 		case 50:
 			if (IsValidEmail(val_arg)) {
 				utils::ConvertToLow(val_arg);
-				AddKarma(vict, fmt::format("Email changed from {} to {}", GET_EMAIL(vict), val_arg).c_str(), GET_NAME(ch));
+				AddKarma(vict, fmt::format("Email changed from {} to {}", GET_EMAIL(vict), val_arg), GET_NAME(ch));
 				strncpy(GET_EMAIL(vict), val_arg, 127);
 				*(GET_EMAIL(vict) + 127) = '\0';
 			} else {
@@ -834,7 +834,7 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 					act("Вы отпустили $N2 все грехи.", false, ch, nullptr, vict, kToChar);
 					AddKarma(vict, "Очистка грехов", GET_NAME(ch));
 
-				} else AddKarma(vict, karma_source.c_str(), reason);
+				} else AddKarma(vict, karma_source, reason);
 			} else {
 				SendMsgToChar("Формат команды: set [ file | player ] <character> karma <reason>\r\n", ch);
 				return (0);
@@ -864,8 +864,8 @@ int PerformSet(CharData *ch, CharData *vict, int mode, char *val_arg) {
 			if (value > 1 && value < 75) {
 				const std::string remort_note =
 					fmt::format("Иммортал {} установил реморт {}  для игрока {} ", GET_NAME(ch), value, GET_NAME(vict));
-				AddKarma(vict, remort_note.c_str(), GET_NAME(ch));
-				AddKarma(ch, remort_note.c_str(), GET_NAME(vict));
+				AddKarma(vict, remort_note, GET_NAME(ch));
+				AddKarma(ch, remort_note, GET_NAME(vict));
 				vict->set_remort(value);
 				SendMsgToGods(remort_note.c_str());
 			} else {

--- a/src/engine/ui/cmd_god/do_set_all.cpp
+++ b/src/engine/ui/cmd_god/do_set_all.cpp
@@ -111,7 +111,7 @@ void setall_inspect() {
 										player_table[it->second->pos].name(),
 										player_table[it->second->pos].mail,
 										it->second->newmail);
-						AddKarma(d_vict->character.get(), mail_note.c_str(), GET_NAME(imm_d->character));
+						AddKarma(d_vict->character.get(), mail_note, GET_NAME(imm_d->character));
 						it->second->out += mail_note;
 
 					} else {
@@ -138,7 +138,7 @@ void setall_inspect() {
 											player_table[it->second->pos].mail,
 											it->second->newmail);
 							it->second->out += mail_note;
-							AddKarma(vict, mail_note.c_str(), GET_NAME(imm_d->character));
+							AddKarma(vict, mail_note, GET_NAME(imm_d->character));
 							vict->save_char();
 						}
 					}
@@ -155,7 +155,7 @@ void setall_inspect() {
 							fmt::format("У персонажа {} изменен пароль (setall).", player_table[it->second->pos].name());
 						it->second->out += pwd_note;
 						it->second->out += "\r\n";
-						AddKarma(d_vict->character.get(), pwd_note.c_str(), GET_NAME(imm_d->character));
+						AddKarma(d_vict->character.get(), pwd_note, GET_NAME(imm_d->character));
 					} else {
 						if (LoadPlayerCharacter(player_table[it->second->pos].name().c_str(), vict,
 												ELoadCharFlags::kFindId | ELoadCharFlags::kNoCrcCheck) < 0) {
@@ -175,7 +175,7 @@ void setall_inspect() {
 							fmt::format("У персонажа {} изменен пароль (setall).", player_table[it->second->pos].name());
 						it->second->out += pwd_note;
 						it->second->out += "\r\n";
-						AddKarma(vict, pwd_note.c_str(), GET_NAME(imm_d->character));
+						AddKarma(vict, pwd_note, GET_NAME(imm_d->character));
 						vict->save_char();
 					}
 				} else if (it->second->type_req == kSetallHell) {

--- a/src/engine/ui/cmd_god/do_vstat.cpp
+++ b/src/engine/ui/cmd_god/do_vstat.cpp
@@ -19,15 +19,17 @@ void DoVstat(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 	MobVnum number;    // or ObjVnum ...
 	MobRnum r_num;        // or ObjRnum ...
 
-	two_arguments(argument, buf, buf2);
-	int first = atoi(buf2) / 100;
+	char kind[kMaxInputLength];
+	char arg_vnum[kMaxInputLength];
+	two_arguments(argument, kind, arg_vnum);
+	int first = atoi(arg_vnum) / 100;
 
 	if (!(privilege::HasPrivilege(ch, std::string(cmd_info[cmd].command), 0, 0, false)) && (GET_OLC_ZONE(ch) <= 0)) {
 		SendMsgToChar("Чаво?\r\n", ch);
 		return;
 	}
 
-	if (!*buf || !*buf2 || !a_isdigit(*buf2)) {
+	if (!*kind || !*arg_vnum || !a_isdigit(*arg_vnum)) {
 		SendMsgToChar("Usage: vstat { obj | mob } <number>\r\n", ch);
 		return;
 	}
@@ -38,11 +40,11 @@ void DoVstat(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 		return;
 	}
 
-	if ((number = atoi(buf2)) < 0) {
+	if ((number = atoi(arg_vnum)) < 0) {
 		SendMsgToChar("Отрицательный номер? Оригинально!\r\n", ch);
 		return;
 	}
-	if (utils::IsAbbr(buf, "mob")) {
+	if (utils::IsAbbr(kind, "mob")) {
 		if ((r_num = GetMobRnum(number)) < 0) {
 			SendMsgToChar("Обратитесь в Арктику - там ОН живет.\r\n", ch);
 			return;
@@ -51,7 +53,7 @@ void DoVstat(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 		PlaceCharToRoom(mob, 1);
 		do_stat_character(ch, mob, 1);
 		ExtractCharFromWorld(mob, false);
-	} else if (utils::IsAbbr(buf, "obj")) {
+	} else if (utils::IsAbbr(kind, "obj")) {
 		if ((r_num = GetObjRnum(number)) < 0) {
 			SendMsgToChar("Этот предмет явно перенесли в РМУД.\r\n", ch);
 			return;

--- a/src/engine/ui/cmd_god/do_wizutil.cpp
+++ b/src/engine/ui/cmd_god/do_wizutil.cpp
@@ -8,6 +8,8 @@
 
 #include "do_wizutil.h"
 
+#include <fmt/format.h>
+
 #include "administration/punishments.h"
 #include "engine/entities/char_data.h"
 #include "engine/core/target_resolver.h"
@@ -19,14 +21,14 @@ void DoWizutil(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	long result;
 	int times = 0;
 	char *reason;
+	char name[kMaxInputLength];
 	char num[kMaxInputLength];
 
-	//  one_argument(argument, arg);
-	reason = two_arguments(argument, arg, num);
+	reason = two_arguments(argument, name, num);
 
-	if (!*arg)
+	if (!*name)
 		SendMsgToChar("Для кого?\r\n", ch);
-	else if (!(vict = target_resolver::FindPlayer(ch, arg)))
+	else if (!(vict = target_resolver::FindPlayer(ch, name)))
 		SendMsgToChar("Нет такого игрока.\r\n", ch);
 	else if (GetRealLevel(vict) > GetRealLevel(ch) && !GET_GOD_FLAG(ch, EGf::kDemigod)
 		&& !ch->IsFlagged(EPrf::kCoderinfo))
@@ -52,11 +54,13 @@ void DoWizutil(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 				vict->IsFlagged(EPlrFlag::kNoTitle) ? vict->UnsetFlag(EPlrFlag::kNoTitle)
 													: vict->SetFlag(EPlrFlag::kNoTitle);
 				result = vict->IsFlagged(EPlrFlag::kNoTitle);
-				sprintf(buf, "(GC) Notitle %s for %s by %s.", (result ? "ON" : "OFF"), GET_NAME(vict), GET_NAME(ch));
-				mudlog(buf, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
-				imm_log("Notitle %s for %s by %s.", (result ? "ON" : "OFF"), GET_NAME(vict), GET_NAME(ch));
-				strcat(buf, "\r\n");
-				SendMsgToChar(buf, ch);
+				{
+					const std::string log_line = fmt::format("(GC) Notitle {} for {} by {}.",
+															 result ? "ON" : "OFF", GET_NAME(vict), GET_NAME(ch));
+					mudlog(log_line, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+					imm_log("Notitle %s for %s by %s.", (result ? "ON" : "OFF"), GET_NAME(vict), GET_NAME(ch));
+					SendMsgToChar(log_line + "\r\n", ch);
+				}
 				break;
 			case kScmdSquelch: break;
 			case kScmdMute: if (*num) times = atol(num);

--- a/src/engine/ui/cmd_god/do_zclear.cpp
+++ b/src/engine/ui/cmd_god/do_zclear.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "utils/utils_time.h"
 #include "administration/privilege.h"
@@ -16,25 +18,30 @@ void DoClearZone(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 	UniqueList<ZoneRnum> zone_repop_list;
 	ZoneRnum zrn;
 
-	one_argument(argument, arg);
+	char zone_arg[kMaxInputLength];
+	one_argument(argument, zone_arg);
 	if (!(privilege::HasPrivilege(ch, std::string(cmd_info[cmd].command), 0, 0, false))) {
 		SendMsgToChar("Чаво?\r\n", ch);
 		return;
 	}
-	if (!*arg) {
+	if (!*zone_arg) {
 		SendMsgToChar("Укажите зону.\r\n", ch);
 		return;
 	}
-	if (*arg == '.') {
+	if (*zone_arg == '.') {
 		zrn = world[ch->in_room]->zone_rn;
 	} else {
-		zrn = GetZoneRnum(atoi(arg));
+		zrn = GetZoneRnum(atoi(zone_arg));
 	}
-	if (zrn > 0 || *arg == '.' || *arg == '1') {
+	// Было "zrn > 0 || *arg == '.' || *arg == '1'": первая зона имеет rnum 0, и её
+	// пропускали через проверку на ведущую единицу в номере. Но тогда и любая
+	// несуществующая зона, номер которой начинается с единицы (17, 150), проходила
+	// с zrn == -1 -- и команда лезла в zone_table[-1]. Проверяем сам rnum, как в zreset.
+	if (zrn >= 0) {
 		utils::CExecutionTimer timer;
 
-		sprintf(buf, "Очищаю и перегружаю зону #%d: %s\r\n", zone_table[zrn].vnum, zone_table[zrn].name.c_str());
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Очищаю и перегружаю зону #{}: {}\r\n",
+								  zone_table[zrn].vnum, zone_table[zrn].name), ch);
 		for (auto rrn = zone_table[zrn].RnumRoomsLocation.first; rrn <= zone_table[zrn].RnumRoomsLocation.second; rrn++) {
 			dungeons::ClearRoom(world[rrn]);
 		}
@@ -42,8 +49,9 @@ void DoClearZone(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 		zone_repop_list.push_back(zrn);
 		DecayObjectsOnRepop(zone_repop_list);
 		ResetZone(zrn);
-		sprintf(buf, "(GC) %s clear and reset zone %d (%s), delta %f", GET_NAME(ch), zrn, zone_table[zrn].name.c_str(), timer.delta().count());
-		mudlog(buf, NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(fmt::format("(GC) {} clear and reset zone {} ({}), delta {:f}",
+						   GET_NAME(ch), zrn, zone_table[zrn].name, timer.delta().count()),
+			   NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s clear and reset zone %d (%s)", GET_NAME(ch), zrn, zone_table[zrn].name.c_str());
 	} else {
 		SendMsgToChar("Нет такой зоны.\r\n", ch);

--- a/src/engine/ui/cmd_god/do_zreset.cpp
+++ b/src/engine/ui/cmd_god/do_zreset.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "utils/utils_time.h"
 #include "administration/privilege.h"
@@ -15,25 +17,26 @@
 void DoZreset(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 	ZoneRnum i;
 	UniqueList<ZoneRnum> zone_repop_list;
-	one_argument(argument, arg);
+	char zone_arg[kMaxInputLength];
+	one_argument(argument, zone_arg);
 
 	if (!(privilege::HasPrivilege(ch, std::string(cmd_info[cmd].command), 0, 0, false)) && (GET_OLC_ZONE(ch) <= 0)) {
 		SendMsgToChar("Чаво?\r\n", ch);
 		return;
 	}
 
-	if (!*arg) {
+	if (!*zone_arg) {
 		SendMsgToChar("Укажите зону.\r\n", ch);
 		return;
 	}
 	// zreset *<номер> -- сброс всего комплекса: головная зона и её зоны typeA
 	// (зоны, которые сбрасываются одновременно с головной).
-	if (*arg == '*') {
-		if (!*(arg + 1)) {
+	if (*zone_arg == '*') {
+		if (!*(zone_arg + 1)) {
 			SendMsgToChar("Укажите головную зону комплекса: zreset *<номер>.\r\n", ch);
 			return;
 		}
-		const int zone_vnum = atoi(arg + 1);
+		const int zone_vnum = atoi(zone_arg + 1);
 		if (!privilege::IsImmortal(ch) && GET_OLC_ZONE(ch) != zone_vnum) {
 			SendMsgToChar("Доступ к данной зоне запрещен!\r\n", ch);
 			return;
@@ -55,37 +58,37 @@ void DoZreset(CharData *ch, char *argument, int cmd, int/* subcmd*/) {
 				zone_repop_list.push_back(rn);
 			}
 		}
-		sprintf(buf, "Перегружаю комплекс зоны #%d: %s\r\n", zone_table[head].vnum, zone_table[head].name.c_str());
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Перегружаю комплекс зоны #{}: {}\r\n",
+								  zone_table[head].vnum, zone_table[head].name), ch);
 		DecayObjectsOnRepop(zone_repop_list);
 		for (const auto rn : zone_repop_list) {
 			ResetZone(rn);
 		}
-		sprintf(buf, "(GC) %s reset complex %d (%s), delta %f",
-				GET_NAME(ch), zone_table[head].vnum, zone_table[head].name.c_str(), timer.delta().count());
-		mudlog(buf, NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(fmt::format("(GC) {} reset complex {} ({}), delta {:f}",
+						   GET_NAME(ch), zone_table[head].vnum, zone_table[head].name, timer.delta().count()),
+			   NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s reset complex %d (%s)", GET_NAME(ch), zone_table[head].vnum, zone_table[head].name.c_str());
 		return;
 	}
-	if (!privilege::IsImmortal(ch) && GET_OLC_ZONE(ch) != atoi(arg)) {
+	if (!privilege::IsImmortal(ch) && GET_OLC_ZONE(ch) != atoi(zone_arg)) {
 		SendMsgToChar("Доступ к данной зоне запрещен!\r\n", ch);
 		return;
 	}
-	if (*arg == '.') {
+	if (*zone_arg == '.') {
 		i = world[ch->in_room]->zone_rn;
 	} else {
-		i = GetZoneRnum(atoi(arg));
+		i = GetZoneRnum(atoi(zone_arg));
 	}
-	if (i >= 0 || *arg == '.') {
+	if (i >= 0 || *zone_arg == '.') {
 		utils::CExecutionTimer timer;
 
-		sprintf(buf, "Перегружаю зону #%d: %s\r\n", zone_table[i].vnum, zone_table[i].name.c_str());
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Перегружаю зону #{}: {}\r\n", zone_table[i].vnum, zone_table[i].name), ch);
 		zone_repop_list.push_back(i);
 		DecayObjectsOnRepop(zone_repop_list);
 		ResetZone(i);
-		sprintf(buf, "(GC) %s reset zone %d (%s), delta %f", GET_NAME(ch), i, zone_table[i].name.c_str(), timer.delta().count());
-		mudlog(buf, NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(fmt::format("(GC) {} reset zone {} ({}), delta {:f}",
+						   GET_NAME(ch), i, zone_table[i].name, timer.delta().count()),
+			   NRM, MAX(kLvlGreatGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		imm_log("%s reset zone %d (%s)", GET_NAME(ch), i, zone_table[i].name.c_str());
 	} else {
 		SendMsgToChar("Нет такой зоны.\r\n", ch);

--- a/src/gameplay/clans/house.cpp
+++ b/src/gameplay/clans/house.cpp
@@ -1183,8 +1183,8 @@ void Clan::HouseAdd(CharData *ch, std::string &buffer) {
 								  (*it).c_str(),
 								  kColorNrm);
 					AddKarma(d->character.get(),
-							 fmt::format("Звание в дружине изменено на {}", *it).c_str(),
-							 ch->get_name().c_str());
+							 fmt::format("Звание в дружине изменено на {}", *it),
+							 ch->get_name());
 				}
 
 				// оповещение соклановцев о изменении звания
@@ -1304,7 +1304,7 @@ void Clan::remove_member(const ClanMembersList::key_type &key, char *reason) {
 	if (k && k->character) {
 		Clan::SetClanData(k->character.get());
 		SendMsgToChar(k->character.get(), "Вас исключили из дружины '%s'!\r\n", this->name.c_str());
-		AddKarma(k->character.get(), fmt::format("Исключен(а) из дружины '{}'", this->name).c_str(), reason);
+		AddKarma(k->character.get(), fmt::format("Исключен(а) из дружины '{}'", this->name), reason);
 		const auto clan = Clan::GetClanByRoom(k->character->in_room);
 		if (clan) {
 			char_from_room(k->character);
@@ -1323,7 +1323,7 @@ void Clan::remove_member(const ClanMembersList::key_type &key, char *reason) {
 		Player p_vict;
 		CharData *vict = &p_vict;
 		if (LoadPlayerCharacter(name.c_str(), vict, ELoadCharFlags::kFindId) > -1) {
-			AddKarma(vict, fmt::format("Исключен(а) из дружины '{}'", this->name).c_str(), reason);
+			AddKarma(vict, fmt::format("Исключен(а) из дружины '{}'", this->name), reason);
 			vict->save_char();
 		}
 	}
@@ -3481,8 +3481,8 @@ void Clan::ClanAddMember(CharData *ch, int rank, std::string invite_name) {
 	SendMsgToChar(ch, "%sВас приписали к дружине '%s', статус - '%s'.%s\r\n",
 				  kColorWht, this->name.c_str(), (this->ranks[rank]).c_str(), kColorNrm);
 	AddKarma(ch,
-			 fmt::format("Принят в дружину '{}', статус - '{}'", this->name, this->ranks[rank]).c_str(),
-			 invite_name.c_str());
+			 fmt::format("Принят в дружину '{}', статус - '{}'", this->name, this->ranks[rank]),
+			 invite_name);
 	return;
 }
 

--- a/src/gameplay/mechanics/glory_const.cpp
+++ b/src/gameplay/mechanics/glory_const.cpp
@@ -647,8 +647,8 @@ void do_spend_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		remove_glory(ch->get_uid(), amount);
 		add_glory(vict->get_uid(), total_amount);
 
-		AddKarma(vict, fmt::format("Transfer {} const glory from {}", total_amount, GET_NAME(ch)).c_str(), "командой");
-		AddKarma(ch, fmt::format("Transfer {} const glory to {}", amount, GET_NAME(vict)).c_str(), "командой");
+		AddKarma(vict, fmt::format("Transfer {} const glory from {}", total_amount, GET_NAME(ch)), "командой");
+		AddKarma(ch, fmt::format("Transfer {} const glory to {}", amount, GET_NAME(vict)), "командой");
 
 		total_charge += tax;
 		transfer_log("%s -> %s transfered %d (%d tax)", GET_NAME(ch), GET_NAME(vict), total_amount, tax);
@@ -812,7 +812,7 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			mudlog(log_line, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 			imm_log("%s", log_line.c_str());
 			const std::string karma_line = fmt::format("Change const glory +{} by {}", amount, GET_NAME(ch));
-			AddKarma(vict, karma_line.c_str(), reason);
+			AddKarma(vict, karma_line, reason);
 			GloryMisc::add_log(mode, amount, karma_line, std::string(reason), vict);
 			break;
 		}
@@ -830,7 +830,7 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			mudlog(log_line, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 			imm_log("%s", log_line.c_str());
 			const std::string karma_line = fmt::format("Change const glory -{} by {}", amount, GET_NAME(ch));
-			AddKarma(vict, karma_line.c_str(), reason);
+			AddKarma(vict, karma_line, reason);
 			GloryMisc::add_log(mode, amount, karma_line, std::string(reason), vict);
 			break;
 		}
@@ -843,7 +843,7 @@ void do_glory(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				mudlog(log_line, NRM, MAX(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 				imm_log("%s", log_line.c_str());
 				const std::string karma_line = fmt::format("Reset stats and const glory by {}", GET_NAME(ch));
-				AddKarma(vict, karma_line.c_str(), reason);
+				AddKarma(vict, karma_line, reason);
 				GloryMisc::add_log(mode, 0, karma_line, std::string(reason), vict);
 			} else {
 				SendMsgToChar(ch, "%s - запись постоянной славы и так пустая.\r\n", vict->get_name().c_str());


### PR DESCRIPTION
Слой 1 из #3807, продолжение #3814.

Шесть команд богов переведены на `fmt::format` и `std::string`: `zreset`, `zclear`, `glory`, `delete`, `vstat`, `wizutil`. Заодно `AddKarma` переписана на `std::string` — в неё всё равно передавали то `c_str()` от только что собранной строки, то глобальный буфер. Обновлены все вызовы: карма, наказания, дружины, `set`, `setall`, слава и постоянная слава.

## Найденные ошибки

* **`zclear` мог уронить сервер.** Проверка зоны была `zrn > 0 || *arg == '.' || *arg == '1'`: первая зона имеет rnum 0, и её пропускали по ведущей единице в номере — но так же проходила и любая **несуществующая** зона, номер которой начинается с единицы (17, 150). С `zrn == -1` команда лезла в `zone_table[-1]`. Теперь проверяется сам rnum, как это давно сделано в соседнем `zreset`.
* **`delete` показывал богу не ту строку.** Сообщение об ошибке записи файла таймеров собиралось в `buf`, а отправлялся `buf2` — то есть предыдущая строка `item deleted` вместо ошибки.

## `AddKarma`

```c
-void AddKarma(CharData *ch, const char *punish, const char *reason);
+void AddKarma(CharData *ch, const std::string &punish, const std::string &reason);
```

Запись больше не обрезается: строка собиралась в буфер длиной `kMaxInputLength`, куда длинное наказание вместе с причиной не влезало. Прежний признак «не писать карму» — причина с ведущей точкой — сохранён. Проверка на `nullptr` убрана: причина всюду приходит из разбора аргументов команды (`one_argument`/`two_arguments`), где указатель не бывает нулевым; проверил все 45 мест вызова.

## Мимо

`do_inspect` из пачки выпал: его десять «вхождений» по счётчику из #3814 — это `fmt::arg`, глобальных буферов там нет. Счётчик из задачи их не отличает, так что остаток по слою на самом деле меньше заявленного — отпишусь отдельно в #3814.

## Проверено

Сборка без единого предупреждения (release + tests, и отдельно legacy-вариант `-Dyaml=disabled`), 712 тестов проходят, сервер стартует на малом мире.
