### PR TITLE
refactor(cmd): drop global buffers from the food and drink commands (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_drink.cpp
+++ b/src/engine/ui/cmd/do_drink.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/core/target_resolver.h"
 #include "do_drink.h"
 #include "gameplay/mechanics/condition.h"
@@ -29,19 +31,20 @@ void TryDrinkAlcohol(CharData *ch, ObjData *jar, int amount);
 void DoDrink(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	ObjData *jar;
 	int amount;
+	char name[kMaxInputLength];
 
 	if (ch->IsNpc()) {
 		return;
 	}
 
-	one_argument(argument, arg);
+	one_argument(argument, name);
 
-	if (!*arg) {
+	if (!*name) {
 		SendMsgToChar("Пить из чего?\r\n", ch);
 		return;
 	}
 
-	if (!(jar = GetDrinkingJar(ch, arg))) {
+	if (!(jar = GetDrinkingJar(ch, name))) {
 		return;
 	}
 
@@ -59,14 +62,12 @@ void DoDrink(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	}
 
 	if (subcmd == kScmdDrink) {
-		sprintf(buf, "$n выпил$g %s из $o1.", drinks[GET_OBJ_VAL(jar, 2)]);
-		act(buf, true, ch, jar, nullptr, kToRoom);
-		sprintf(buf, "Вы выпили %s из %s.\r\n", drinks[GET_OBJ_VAL(jar, 2)], OBJN(jar, ch, grammar::ECase::kGen));
-		SendMsgToChar(buf, ch);
+		act(fmt::format("$n выпил$g {} из $o1.", drinks[GET_OBJ_VAL(jar, 2)]), true, ch, jar, nullptr, kToRoom);
+		SendMsgToChar(fmt::format("Вы выпили {} из {}.\r\n",
+								  drinks[GET_OBJ_VAL(jar, 2)], OBJN(jar, ch, grammar::ECase::kGen)), ch);
 	} else {
 		act("$n отхлебнул$g из $o1.", true, ch, jar, nullptr, kToRoom);
-		sprintf(buf, "Вы узнали вкус %s.\r\n", drinks[GET_OBJ_VAL(jar, 2)]);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Вы узнали вкус {}.\r\n", drinks[GET_OBJ_VAL(jar, 2)]), ch);
 	}
 
 	if (jar->get_type() != EObjType::kFountain) {
@@ -117,7 +118,7 @@ void DoDrink(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 ObjData *GetDrinkingJar(CharData *ch, char *jar_name) {
 	ObjData *jar = nullptr;
 	if (!(jar = get_obj_in_list_vis(ch, jar_name, ch->carrying))) {
-		if (!(jar = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents))) {
+		if (!(jar = get_obj_in_list_vis(ch, jar_name, world[ch->in_room]->contents))) {
 			SendMsgToChar("Вы не смогли это найти!\r\n", ch);
 			return jar;
 		}

--- a/src/engine/ui/cmd/do_drunkoff.cpp
+++ b/src/engine/ui/cmd/do_drunkoff.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/obj_data.h"
 #include "gameplay/mechanics/condition.h"
 #include "engine/entities/char_data.h"
@@ -47,9 +49,10 @@ void do_drunkoff(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	one_argument(argument, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
 
-	if (!*arg) {
+	if (!*name) {
 		for (obj = ch->carrying; obj; obj = obj->get_next_content()) {
 			if (obj->get_type() == EObjType::kLiquidContainer) {
 				break;
@@ -59,8 +62,8 @@ void do_drunkoff(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			SendMsgToChar("У вас нет подходящего напитка для похмелья.\r\n", ch);
 			return;
 		}
-	} else if (!(obj = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-		if (!(obj = get_obj_in_list_vis(ch, arg, world[ch->in_room]->contents))) {
+	} else if (!(obj = get_obj_in_list_vis(ch, name, ch->carrying))) {
+		if (!(obj = get_obj_in_list_vis(ch, name, world[ch->in_room]->contents))) {
 			SendMsgToChar("Вы не смогли это найти!\r\n", ch);
 			return;
 		} else {
@@ -121,8 +124,8 @@ void do_drunkoff(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	}
 
 	if (percent > prob) {
-		sprintf(buf, "Вы отхлебнули %s из $o1, но ваша голова стала еще тяжелее...", drinks[GET_OBJ_VAL(obj, 2)]);
-		act(buf, false, ch, obj, 0, kToChar);
+		act(fmt::format("Вы отхлебнули {} из $o1, но ваша голова стала еще тяжелее...",
+						drinks[GET_OBJ_VAL(obj, 2)]), false, ch, obj, 0, kToChar);
 		duration = std::max(1, amount / 3);
 		Affect<EApply> af[3];
 		af[0].duration = CalcDuration(ch, ch, ESkill::kHangovering, duration, 15, 0, 0);
@@ -159,9 +162,8 @@ void do_drunkoff(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		gain_condition(ch, condition::kDrunk, amount);
 		EmitAffectImpose(ch, nullptr, EAffect::kAbstinent, false);
 	} else {
-		sprintf(buf, "Вы отхлебнули %s из $o1 и почувствовали приятную легкость во всем теле...",
-				drinks[GET_OBJ_VAL(obj, 2)]);
-		act(buf, false, ch, obj, 0, kToChar);
+		act(fmt::format("Вы отхлебнули {} из $o1 и почувствовали приятную легкость во всем теле...",
+						drinks[GET_OBJ_VAL(obj, 2)]), false, ch, obj, 0, kToChar);
 		act("$n похмелил$u и расцвел$g прям на глазах.", false, ch, nullptr, nullptr, kToRoom);
 		RemoveAffectFromCharAndRecalculate(ch, EAffect::kAbstinent);
 	}

--- a/src/engine/ui/cmd/do_eat.cpp
+++ b/src/engine/ui/cmd/do_eat.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include "do_eat.h"
 #include "gameplay/mechanics/condition.h"
 #include "administration/privilege.h"
@@ -90,15 +92,16 @@ void feed_charmice(CharData *ch, char *local_arg) {
 void do_eat(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	ObjData *food;
 	int amount;
+	char name[kMaxInputLength];
 
-	one_argument(argument, arg);
+	one_argument(argument, name);
 
 	if (subcmd == kScmdDevour) {
 		// kUndead покрывает и умертвий (animate dead), и оживлённых (kResurrection):
 		// раньше тут было kResurrected, но animate dead его больше не ставит (issue #3482)
 		if (ch->IsFlagged(EMobFlag::kUndead)
 			&& CanUseFeat(ch->get_master(), EFeat::kZombieDrover)) {
-			feed_charmice(ch, arg);
+			feed_charmice(ch, name);
 			return;
 		}
 	}
@@ -111,7 +114,7 @@ void do_eat(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	if (ch->IsNpc())        // Cannot use GET_COND() on mobs.
 		return;
 
-	if (!*arg) {
+	if (!*name) {
 		SendMsgToChar("Чем вы собрались закусить?\r\n", ch);
 		return;
 	}
@@ -120,9 +123,8 @@ void do_eat(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		return;
 	}
 
-	if (!(food = get_obj_in_list_vis(ch, arg, ch->carrying))) {
-		snprintf(buf, kMaxInputLength, "У вас нет '%s'.\r\n", arg);
-		SendMsgToChar(buf, ch);
+	if (!(food = get_obj_in_list_vis(ch, name, ch->carrying))) {
+		SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", name), ch);
 		return;
 	}
 	if (subcmd == kScmdTaste

--- a/src/engine/ui/cmd/do_pour.cpp
+++ b/src/engine/ui/cmd/do_pour.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "do_pour.h"
 #include "engine/core/target_resolver.h"
 
@@ -60,8 +62,7 @@ void do_pour(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 			return;
 		}
 		if (!(from_obj = get_obj_in_list_vis(ch, arg2, world[ch->in_room]->contents))) {
-			sprintf(buf, "Вы не видите здесь '%s'.\r\n", arg2);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Вы не видите здесь '{}'.\r\n", arg2), ch);
 			return;
 		}
 		if (from_obj->get_type() != EObjType::kFountain) {


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Четыре команды переведены на `fmt::format` и локальные строки: `есть`, `пить`, `наполнить`, `похмелиться`. Глобальные `buf` и `arg` из них ушли.

Сообщения о напитках собирались в `buf` через `sprintf` и тут же уходили в `act`/`SendMsgToChar` — теперь строка собирается прямо на месте вызова. В `do_eat` `snprintf` в `buf` с ограничением `kMaxInputLength` заменён на `fmt::format`, так что имя предмета в ответе «У вас нет '...'» больше не обрезается.

Правок смысла нет, ни один текст сообщения не изменён.

Сборка без предупреждений, 712 тестов проходят.
