### PR TITLE
refactor(cmd): drop global buffers from seven small player commands (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_diagnose.cpp
+++ b/src/engine/ui/cmd/do_diagnose.cpp
@@ -13,10 +13,11 @@
 void do_diagnose(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	CharData *vict;
 
-	one_argument(argument, buf);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
 
-	if (*buf) {
-		vict = target_resolver::FindCharInRoom(ch, buf);
+	if (*name) {
+		vict = target_resolver::FindCharInRoom(ch, name);
 		if (!vict)
 			SendMsgToChar(CommonMsg(ECommonMsg::kNoPerson) + "\r\n", ch);
 		else

--- a/src/engine/ui/cmd/do_flee.cpp
+++ b/src/engine/ui/cmd/do_flee.cpp
@@ -117,9 +117,10 @@ void DoFlee(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 	if (CanUseFeat(ch, EFeat::kCalmness) || GET_GOD_FLAG(ch, EGf::kGodsLike)) {
-		one_argument(argument, arg);
-		if ((direction = search_block(arg, dirs, false)) >= 0 ||
-			(direction = search_block(arg, dirs_rus, false)) >= 0) {
+		char dir_arg[kMaxInputLength];
+		one_argument(argument, dir_arg);
+		if ((direction = search_block(dir_arg, dirs, false)) >= 0 ||
+			(direction = search_block(dir_arg, dirs_rus, false)) >= 0) {
 			GoDirectFlee(ch, direction);
 			return;
 		}

--- a/src/engine/ui/cmd/do_follow.cpp
+++ b/src/engine/ui/cmd/do_follow.cpp
@@ -16,12 +16,13 @@ void PerformDropGold(CharData *ch, int amount);
 
 void do_follow(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	CharData *leader;
-	one_argument(argument, smallBuf);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
 
 	if (ch->IsNpc() && AFF_FLAGGED(ch, EAffect::kCharmed) && ch->GetEnemy())
 		return;
-	if (*smallBuf) {
-		if (!str_cmp(smallBuf, "я") || !str_cmp(smallBuf, "self") || !str_cmp(smallBuf, "me")) {
+	if (*name) {
+		if (!str_cmp(name, "я") || !str_cmp(name, "self") || !str_cmp(name, "me")) {
 			if (!ch->has_master()) {
 				SendMsgToChar("Но вы ведь ни за кем не следуете...\r\n", ch);
 			} else {
@@ -29,7 +30,7 @@ void do_follow(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			}
 			return;
 		}
-		leader = target_resolver::FindCharInRoom(ch, smallBuf);
+		leader = target_resolver::FindCharInRoom(ch, name);
 		if (!leader) {
 			SendMsgToChar(CommonMsg(ECommonMsg::kNoPerson) + "\r\n", ch);
 			return;

--- a/src/engine/ui/cmd/do_listen.cpp
+++ b/src/engine/ui/cmd/do_listen.cpp
@@ -5,6 +5,8 @@
 \brief description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "engine/ui/color.h"
@@ -55,9 +57,9 @@ void hear_in_direction(CharData *ch, int dir, int info_is) {
 		|| (EXIT(ch, dir)
 			&& EXIT(ch, dir)->to_room() != kNowhere)) {
 		rdata = EXIT(ch, dir);
-		count += sprintf(buf, "%s%s:%s ", kColorYel, dirs_rus[dir], kColorNrm);
-		count += sprintf(buf + count, "\r\n%s", kColorGrn);
-		SendMsgToChar(buf, ch);
+		// Цвет кодами, а не константами kColor*: их раскрывает proc_color на выходе,
+		// и настройка цвета игрока перестаёт игнорироваться.
+		SendMsgToChar(fmt::format("&Y{}:&n \r\n&G", dirs_rus[dir]), ch);
 		count = 0;
 		for (const auto tch : world[rdata->to_room()]->people) {
 			percent = number(1, MUD::Skill(ESkill::kHearing).difficulty);
@@ -121,7 +123,8 @@ void hear_in_direction(CharData *ch, int dir, int info_is) {
 			SendMsgToChar(tmpstr.c_str(), ch);
 		}
 
-		SendMsgToChar(kColorNrm, ch);
+		// Закрывающая половина той же пары: открывали &G, закрываем &n.
+		SendMsgToChar("&n", ch);
 	} else {
 		if (info_is & sight::EXIT_SHOW_WALL) {
 			SendMsgToChar("И что вы там хотите услышать?\r\n", ch);

--- a/src/engine/ui/cmd/do_mode.cpp
+++ b/src/engine/ui/cmd/do_mode.cpp
@@ -237,16 +237,16 @@ void DoMode(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	argument = one_argument(argument, arg);
-//	skip_spaces(&argument);
+	char mode_arg[kMaxInputLength];
+	argument = one_argument(argument, mode_arg);
 	int i{0};
 	bool showhelp{false};
-	if (!*arg) {
+	if (!*mode_arg) {
 		do_toggle(ch, argument, 0, 0);
 		return;
-	} else if (*arg == '?') {
+	} else if (*mode_arg == '?') {
 		showhelp = true;
-	} else if ((i = search_block(arg, gen_tog_type, false)) < 0) {
+	} else if ((i = search_block(mode_arg, gen_tog_type, false)) < 0) {
 		showhelp = true;
 	} else if ((GetRealLevel(ch) < gen_tog_param[i >> 1].level)
 		|| (!GET_GOD_FLAG(ch, EGf::kAllowTesterMode) && gen_tog_param[i >> 1].tester)) {

--- a/src/engine/ui/cmd/do_style.cpp
+++ b/src/engine/ui/cmd/do_style.cpp
@@ -24,9 +24,10 @@ void DoStyle(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	};
 	int tp;
-	one_argument(argument, arg);
+	char style_arg[kMaxInputLength];
+	one_argument(argument, style_arg);
 
-	if (!*arg) {
+	if (!*style_arg) {
 		SendMsgToChar(ch, "Вы сражаетесь %s стилем.\r\n",
 					  ch->IsFlagged(EPrf::kPunctual) ? "точным" : ch->IsFlagged(EPrf::kAwake) ? "осторожным"
 																									  : "обычным");
@@ -35,7 +36,7 @@ void DoStyle(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (TryFlipActivatedFeature(ch, argument)) {
 		return;
 	}
-	if ((tp = search_block(arg, cstyles, false)) == -1) {
+	if ((tp = search_block(style_arg, cstyles, false)) == -1) {
 		SendMsgToChar("Формат: стиль { название стиля }\r\n", ch);
 		return;
 	}

--- a/src/engine/ui/cmd/do_wake.cpp
+++ b/src/engine/ui/cmd/do_wake.cpp
@@ -10,21 +10,22 @@ void do_wake(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	CharData *vict;
 	int self = 0;
 
-	one_argument(argument, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
 
 	if (subcmd == kScmdWakeUp) {
-		if (!(*arg)) {
+		if (!(*name)) {
 			SendMsgToChar("Кого будить то будем???\r\n", ch);
 			return;
 		}
 	} else {
-		*arg = 0;
+		*name = 0;
 	}
 
-	if (*arg) {
+	if (*name) {
 		if (ch->GetPosition() == EPosition::kSleep)
 			SendMsgToChar("Может быть вам лучше проснуться?\r\n", ch);
-		else if ((vict = target_resolver::FindCharInRoom(ch, arg)) == nullptr)
+		else if ((vict = target_resolver::FindCharInRoom(ch, name)) == nullptr)
 			SendMsgToChar(CommonMsg(ECommonMsg::kNoPerson) + "\r\n", ch);
 		else if (vict == ch)
 			self = 1;


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Семь мелких команд игрока переведены на локальные строки: `следовать`, `будить`, `бежать`, `слушать`, `оценить`, `стиль`, `режим`. Из `do_follow` ушёл `smallBuf` — это было его последнее место в подсистеме команд.

Отдельно про `do_listen`: заголовок направления собирался в `buf` двумя `sprintf` подряд (второй писал по `buf + count`), причём возвращаемые значения тут же выбрасывались обнулением `count`. Теперь строка собирается через `fmt::format`, а цвет проставлен кодами `&Y`/`&n`/`&G` вместо констант `kColor*` — их раскрывает `proc_color` на выходе, так что настройка цвета у игрока перестаёт игнорироваться. Закрывающая половина той же пары приведена к `&n`.

Тексты сообщений не менялись.

Сборка без предупреждений, 712 тестов проходят.
