### PR TITLE
refactor(cmd): drop global buffers from the talk commands (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_mobshout.cpp
+++ b/src/engine/ui/cmd/do_mobshout.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "engine/network/descriptor_data.h"
@@ -21,7 +23,7 @@ void do_mobshout(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 
 	skip_spaces(&argument); //убираем пробел в начале сообщения
-	sprintf(buf, "$n заорал$g : '%s'", argument);
+	const std::string message = fmt::format("$n заорал$g : '{}'", argument);
 
 	// now send all the strings out
 	for (i = descriptor_list; i; i = i->next) {
@@ -30,7 +32,7 @@ void do_mobshout(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			&& !i->character->IsFlagged(EPlrFlag::kWriting)
 			&& i->character->GetPosition() > EPosition::kSleep) {
 			SendMsgToChar(kColorBoldYel, i->character.get());
-			act(buf, false, ch, nullptr, i->character.get(), kToVict | kToSleep | kToNotDeaf);
+			act(message, false, ch, nullptr, i->character.get(), kToVict | kToSleep | kToNotDeaf);
 			SendMsgToChar(kColorNrm, i->character.get());
 		}
 	}

--- a/src/engine/ui/cmd/do_offtop.cpp
+++ b/src/engine/ui/cmd/do_offtop.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "gameplay/communication/offtop.h"
@@ -55,8 +57,9 @@ void do_offtop(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	ch->set_last_tell(argument);
 	if (ch->IsFlagged(EPlrFlag::kSpamer)) // а вот фиг, еще проверка :)
 		return;
-	snprintf(buf, kMaxStringLength, "[оффтоп] %s : '%s'\r\n", GET_NAME(ch), argument);
-	snprintf(buf1, kMaxStringLength, "&c%s&n", buf);
+	// Одна строка на всех: в буферном виде текст канала жил в buf, а его же цветная
+	// копия -- в buf1, и любой вызов внутри цикла мог затереть и то, и другое.
+	const std::string message = fmt::format("&c[оффтоп] {} : '{}'&n\r\n", GET_NAME(ch), argument);
 	for (DescriptorData *i = descriptor_list; i; i = i->next) {
 		// переплут как любитель почитывать логи за ночь очень хотел этот канал...
 		// а мы шо, не люди? даешь оффтоп 34-ым! кому не нравится - реж оффтоп...
@@ -67,11 +70,11 @@ void do_offtop(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			&& i->character->IsFlagged(EPrf::kOfftopMode)
 			&& !i->character->IsFlagged(EPrf::kStopOfftop)
 			&& !ignores(i->character.get(), ch, EIgnore::kOfftop)) {
-			SendMsgToChar(i->character.get(), "%s%s%s", kColorCyn, buf, kColorNrm);
-			i->character->remember_add(buf1, Remember::ALL);
+			SendMsgToChar(message, i->character.get());
+			i->character->remember_add(message, Remember::ALL);
 		}
 	}
-	ch->remember_add(buf1, Remember::OFFTOP);
+	ch->remember_add(message, Remember::OFFTOP);
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/ui/cmd/do_order.cpp
+++ b/src/engine/ui/cmd/do_order.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include "do_order.h"
 #include "administration/privilege.h"
 
@@ -45,8 +47,7 @@ void do_order(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			&& !utils::IsAbbr(name, "все")
 			&& !utils::IsAbbr(name, "всем")
 			&& !utils::IsAbbr(name, "followers")) {
-			sprintf(buf, "$N приказал$g вам '%s'", message);
-			act(buf, false, vict, 0, ch, kToChar | kToNotDeaf);
+			act(fmt::format("$N приказал$g вам '{}'", message), false, vict, 0, ch, kToChar | kToNotDeaf);
 			act("$n отдал$g приказ $N2.", false, ch, 0, vict, kToRoom | kToNotDeaf);
 
 			if (vict->get_master() != ch

--- a/src/engine/ui/cmd/do_say.cpp
+++ b/src/engine/ui/cmd/do_say.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "gameplay/core/constants.h"
 
@@ -23,7 +25,7 @@ void do_say(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (!*argument)
 		SendMsgToChar("Вы задумались: \"Чего бы такого сказать?\"\r\n", ch);
 	else {
-		sprintf(buf, "$n сказал$g : '%s'", argument);
+		const std::string to_room = fmt::format("$n сказал$g : '{}'", argument);
 
 // для возможности игнорирования теллов в клетку
 // пришлось изменить act в клетку на проход по клетке
@@ -31,15 +33,14 @@ void do_say(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			if (ch == to || ignores(to, ch, EIgnore::kSay)) {
 				continue;
 			}
-			act(buf, false, ch, nullptr, to, kToVict | DG_NO_TRIG | kToNotDeaf);
+			act(to_room, false, ch, nullptr, to, kToVict | DG_NO_TRIG | kToNotDeaf);
 		}
 
 		if (ch->IsFlagged(EPrf::kNoRepeat)) {
 			SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);
 		} else {
 			delete_doubledollar(argument);
-			sprintf(buf, "Вы сказали : '%s'\r\n", argument);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Вы сказали : '{}'\r\n", argument), ch);
 		}
 		speech_mtrigger(ch, argument);
 		speech_wtrigger(ch, argument);

--- a/src/engine/ui/cmd/do_sign.cpp
+++ b/src/engine/ui/cmd/do_sign.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include "engine/db/obj_prototypes.h"
 #include "engine/entities/char_data.h"
 #include "engine/core/target_resolver.h"
@@ -62,8 +64,7 @@ void DoSign(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		SendMsgToChar("На чем царапаем?\r\n", ch);
 	} else {
 		if (!(target = get_obj_in_list_vis(ch, objname, ch->carrying))) {
-			sprintf(buf, "У вас нет \'%s\'.\r\n", objname);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", objname), ch);
 		} else {
 			if (erase_only) {
 				target->remove_custom_label();

--- a/src/engine/ui/cmd/do_tell.cpp
+++ b/src/engine/ui/cmd/do_tell.cpp
@@ -29,18 +29,20 @@ void do_tell(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	}
 	*/
 
-	half_chop(argument, buf, buf2);
+	char name[kMaxInputLength];
+	char message[kMaxStringLength];
+	half_chop(argument, name, message);
 
-	if (!*buf || !*buf2) {
+	if (!*name || !*message) {
 		SendMsgToChar("Что и кому вы хотите сказать?\r\n", ch);
-	} else if (!(vict = target_resolver::FindPlayerVis(ch, buf))) {
+	} else if (!(vict = target_resolver::FindPlayerVis(ch, name))) {
 		SendMsgToChar(CommonMsg(ECommonMsg::kNoPerson) + "\r\n", ch);
 	} else if (vict->IsNpc())
 		SendMsgToChar(CommonMsg(ECommonMsg::kNoPerson) + "\r\n", ch);
 	else if (is_tell_ok(ch, vict)) {
 		if (ch->IsFlagged(EPrf::kNoTell))
 			SendMsgToChar("Ответить вам не смогут!\r\n", ch);
-		perform_tell(ch, vict, buf2);
+		perform_tell(ch, vict, message);
 	}
 }
 


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Шесть команд общения переведены на локальные строки: `сказать`, `оффтоп`, `шепнуть`, `приказать`, `орать`, `метка`.

Самое опасное место — оффтоп: текст канала жил в `buf`, его же цветная копия — в `buf1`, и оба переживали цикл по всем дескрипторам. Любой вызов внутри цикла мог их затереть, и часть игроков получила бы чужую строку. Теперь это одна локальная строка, она же уходит в `remember`.

В `do_say` и `do_mobshout` сообщение собиралось в `buf` до цикла по получателям — та же схема, тот же перенос в строку.

Цвет в оффтопе проставлен кодами `&c`/`&n` вместо констант `kColor*`: раньше в эфир уходил сырой ANSI, а в `remember` ложились коды — одна и та же строка хранилась в двух видах.

Тексты сообщений не менялись.

Сборка без предупреждений, 712 тестов проходят.
