### PR TITLE
refactor(cmd): drop global buffers from the item and info commands (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_consider.cpp
+++ b/src/engine/ui/cmd/do_consider.cpp
@@ -13,9 +13,10 @@ void DoConsider(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	CharData *victim;
 	int diff;
 
-	one_argument(argument, buf);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
 
-	victim = target_resolver::FindCharInRoom(ch, buf);
+	victim = target_resolver::FindCharInRoom(ch, name);
 
 	if (!victim) {
 		SendMsgToChar("Кого вы хотите оценить?\r\n", ch);

--- a/src/engine/ui/cmd/do_equipment.cpp
+++ b/src/engine/ui/cmd/do_equipment.cpp
@@ -5,6 +5,8 @@
 \brief description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "utils/grammar/declensions.h"
 #include "engine/ui/color.h"
@@ -46,8 +48,7 @@ void DoEquipment(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 						continue;
 				}
 				SendMsgToChar(where[i], ch);
-				sprintf(buf, "%s[ Ничего ]%s\r\n", kColorBoldBlk, kColorNrm);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("{}[ Ничего ]{}\r\n", kColorBoldBlk, kColorNrm), ch);
 				found = true;
 			}
 		}

--- a/src/engine/ui/cmd/do_examine.cpp
+++ b/src/engine/ui/cmd/do_examine.cpp
@@ -27,9 +27,10 @@ void do_examine(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		return;
 	}
 
-	two_arguments(argument, arg, where);
+	char name[kMaxInputLength];
+	two_arguments(argument, name, where);
 
-	if (!*arg) {
+	if (!*name) {
 		SendMsgToChar("Что вы желаете осмотреть?\r\n", ch);
 		return;
 	}
@@ -46,7 +47,7 @@ void do_examine(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	{
 		ObjData *supp_obj = nullptr;
 		CharData *supp_ch = nullptr;
-		generic_find(arg, where_bits, ch, &supp_ch, &supp_obj);
+		generic_find(name, where_bits, ch, &supp_ch, &supp_obj);
 		const bool did_look = sight::look_at_target(ch, argument, subcmd);
 		if (supp_obj && supp_obj->has_suppressed_affects()) {
 			// One suppressed affect per indented line -- a single comma-joined line is unreadable with 2+.
@@ -65,14 +66,14 @@ void do_examine(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		}
 	}
 
-	if (isname(arg, "пентаграмма") && IS_SET(where_bits, EFind::kObjRoom)) {
+	if (isname(name, "пентаграмма") && IS_SET(where_bits, EFind::kObjRoom)) {
 		for (const auto &aff : world[ch->in_room]->affected) {
 			if (aff->affect_type == room_spells::ERoomAffect::kNoPortalExit) {
 				return;
 			}
 		}
 	}
-	generic_find(arg, where_bits, ch, &tmp_char, &tmp_object);
+	generic_find(name, where_bits, ch, &tmp_char, &tmp_object);
 	if (tmp_object) {
 		if (tmp_object->get_type() == EObjType::kLiquidContainer
 			|| tmp_object->get_type() == EObjType::kFountain

--- a/src/engine/ui/cmd/do_gen_door.cpp
+++ b/src/engine/ui/cmd/do_gen_door.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "gameplay/mechanics/doors.h"
 #include "utils/utils.h"
@@ -23,8 +25,8 @@ void do_gen_door(CharData *ch, char *argument, int, int subcmd) {
 	}
 	skip_spaces(&argument);
 	if (!*argument) {
-		sprintf(buf, "%s что?\r\n", a_cmd_door[subcmd]);
-		SendMsgToChar(utils::CAP(buf), ch);
+		// CAP(std::string) возвращает копию, а не правит на месте
+		SendMsgToChar(utils::CAP(fmt::format("{} что?\r\n", a_cmd_door[subcmd])), ch);
 		return;
 	}
 	char type[kMaxInputLength], dir[kMaxInputLength];

--- a/src/engine/ui/cmd/do_gold.cpp
+++ b/src/engine/ui/cmd/do_gold.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "gameplay/economics/currencies.h"
 #include "engine/db/global_objects.h"
@@ -16,9 +18,8 @@ void do_gold(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	if (amount == 0) {
 		SendMsgToChar("Вы разорены!\r\n", ch);
 	} else {
-		sprintf(buf, "У Вас есть %ld %s.\r\n", amount,
-			MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kNom).c_str());
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("У Вас есть {} {}.\r\n", amount,
+								  MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(amount, grammar::ECase::kNom)), ch);
 	}
 }
 

--- a/src/engine/ui/cmd/do_levels.cpp
+++ b/src/engine/ui/cmd/do_levels.cpp
@@ -2,6 +2,8 @@
 // Created by Sventovit on 08.09.2024.
 //
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "gameplay/core/experience.h"
 #include "engine/ui/color.h"
@@ -11,28 +13,27 @@
 
 void do_levels(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	int i;
-	char *ptr = &buf[0];
 
 	if (ch->IsNpc()) {
 		SendMsgToChar("Боги уже придумали ваш уровень.\r\n", ch);
 		return;
 	}
-	*ptr = '\0';
 
-	ptr += sprintf(ptr, "Уровень          Опыт            Макс на урв.\r\n");
+	std::string out = "Уровень          Опыт            Макс на урв.\r\n";
 	for (i = 1; i < kLvlImmortal; i++) {
-		ptr += sprintf(ptr, "%s[%2d] %13s-%-13s %-13s%s\r\n", (GetRealLevel(ch) == i) ? kColorBoldCyn : "", i,
-					   thousands_sep(experience::GetExpUntilNextLvl(ch, i)).c_str(),
-					   thousands_sep(experience::GetExpUntilNextLvl(ch, i + 1) - 1).c_str(),
-					   thousands_sep((int) (experience::GetExpUntilNextLvl(ch, i + 1) - experience::GetExpUntilNextLvl(ch, i)) / (10 + remort::GetRealRemort(ch))).c_str(),
-					   (GetRealLevel(ch) == i) ? kColorNrm : "");
+		out += fmt::format("{}[{:2}] {:>13}-{:<13} {:<13}{}\r\n",
+						   (GetRealLevel(ch) == i) ? kColorBoldCyn : "", i,
+						   thousands_sep(experience::GetExpUntilNextLvl(ch, i)),
+						   thousands_sep(experience::GetExpUntilNextLvl(ch, i + 1) - 1),
+						   thousands_sep((int) (experience::GetExpUntilNextLvl(ch, i + 1) - experience::GetExpUntilNextLvl(ch, i)) / (10 + remort::GetRealRemort(ch))),
+						   (GetRealLevel(ch) == i) ? kColorNrm : "");
 	}
 
-	ptr += sprintf(ptr, "%s[%2d] %13s               (БЕССМЕРТИЕ)%s\r\n",
-				   (GetRealLevel(ch) >= kLvlImmortal) ? kColorBoldCyn : "", kLvlImmortal,
-				   thousands_sep(experience::GetExpUntilNextLvl(ch, kLvlImmortal)).c_str(),
-				   (GetRealLevel(ch) >= kLvlImmortal) ? kColorNrm : "");
-	page_string(ch->desc, buf, 1);
+	out += fmt::format("{}[{:2}] {:>13}               (БЕССМЕРТИЕ){}\r\n",
+					   (GetRealLevel(ch) >= kLvlImmortal) ? kColorBoldCyn : "", kLvlImmortal,
+					   thousands_sep(experience::GetExpUntilNextLvl(ch, kLvlImmortal)),
+					   (GetRealLevel(ch) >= kLvlImmortal) ? kColorNrm : "");
+	page_string(ch->desc, out);
 }
 
 // vim: ts=4 sw=4 tw=0 noet syntax=cpp :

--- a/src/engine/ui/cmd/do_put.cpp
+++ b/src/engine/ui/cmd/do_put.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include "gameplay/mechanics/depot.h"
 #include "engine/core/target_resolver.h"
 #include "gameplay/mechanics/sight.h"
@@ -179,13 +181,11 @@ void do_put(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	else if (cont_dotmode != kFindIndiv)
 		SendMsgToChar("Вы можете положить вещь только в один контейнер.\r\n", ch);
 	else if (!*thecont) {
-		sprintf(buf, "Куда вы хотите положить '%s'?\r\n", theobj);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Куда вы хотите положить '{}'?\r\n", theobj), ch);
 	} else {
 		generic_find(thecont, where_bits, ch, &tmp_char, &cont);
 		if (!cont) {
-			sprintf(buf, "Вы не видите здесь '%s'.\r\n", thecont);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Вы не видите здесь '{}'.\r\n", thecont), ch);
 		} else if (cont->get_type() != EObjType::kContainer) {
 			act("В $o3 нельзя ничего положить.", false, ch, cont, nullptr, kToChar);
 		} else if (IS_SET(GET_OBJ_VAL((cont), 1), (EContainerFlag::kShutted))) {
@@ -219,8 +219,7 @@ void do_put(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				} else {
 					auto obj = get_obj_in_list_vis(ch, theobj, ch->carrying);
 					if (!obj) {
-						sprintf(buf, "У вас нет '%s'.\r\n", theobj);
-						SendMsgToChar(buf, ch);
+						SendMsgToChar(fmt::format("У вас нет '{}'.\r\n", theobj), ch);
 					} else if (obj == cont) {
 						SendMsgToChar("Вам будет трудно запихнуть вещь саму в себя.\r\n", ch);
 					} else {
@@ -254,8 +253,7 @@ void do_put(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					if (obj_dotmode == kFindAll)
 						SendMsgToChar("Чтобы положить что-то ненужное нужно купить что-то ненужное.\r\n", ch);
 					else {
-						sprintf(buf, "Вы не видите ничего похожего на '%s'.\r\n", theobj);
-						SendMsgToChar(buf, ch);
+						SendMsgToChar(fmt::format("Вы не видите ничего похожего на '{}'.\r\n", theobj), ch);
 					}
 				}
 			}

--- a/src/engine/ui/cmd/do_quit.cpp
+++ b/src/engine/ui/cmd/do_quit.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/ui/cmd/do_quit.h"
 #include "engine/db/global_objects.h"
 #include "gameplay/economics/currencies.h"
@@ -62,8 +64,8 @@ void do_quit(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		}
 		if (!GET_INVIS_LEV(ch))
 			act("$n покинул$g игру.", true, ch, nullptr, nullptr, kToRoom | kToArenaListen);
-		sprintf(buf, "%s quit the game.", GET_NAME(ch));
-		mudlog(buf, NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
+		mudlog(fmt::format("{} quit the game.", GET_NAME(ch)),
+			   NRM, std::max(kLvlGod, GET_INVIS_LEV(ch)), SYSLOG, true);
 		SendMsgToChar("До свидания, странник... Мы ждем тебя снова!\r\n", ch);
 
 		long depot_cost = static_cast<long>(Depot::get_total_cost_per_day(ch));


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Восемь команд переведены на `fmt::format` и локальные строки: `положить`, `осмотреть`, `оценить`, `снаряжение`, `деньги`, `уровни`, `выход`, дверные (`открыть`/`закрыть`/`отпереть`/`взломать`).

Крупнее прочих `do_levels`: таблица уровней собиралась указателем по глобальному `buf` (`ptr += sprintf` в цикле по всем уровням), без единой проверки на переполнение. Теперь `std::string`. Ширины колонок перенесены в `fmt` как `{:>13}` и `{:<13}` — у `fmt` они считаются в символах, а не в байтах, но в этих колонках только цифры и разделители разрядов, так что вывод побайтово прежний.

Цветовые константы `kColor*` в `do_levels` и `do_equipment` оставлены как были — правка про буферы, вид вывода не меняется.

Тексты сообщений не менялись.

Сборка без предупреждений, 712 тестов проходят.
