### PR TITLE
refactor(cmd): drop global buffers from page, wimpy, write and steal (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_alias.cpp
+++ b/src/engine/ui/cmd/do_alias.cpp
@@ -17,9 +17,10 @@ void do_alias(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (ch->IsNpc())
 		return;
 
-	repl = one_argument(argument, arg);
+	char name[kMaxInputLength];
+	repl = one_argument(argument, name);
 
-	if (!*arg) {
+	if (!*name) {
 		SendMsgToChar("Определены следующие алиасы:\r\n", ch);
 		if ((a = GET_ALIASES(ch)) == nullptr)
 			SendMsgToChar(" Нет алиасов.\r\n", ch);
@@ -30,7 +31,7 @@ void do_alias(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			}
 		}
 	} else {
-		if ((a = FindAlias(GET_ALIASES(ch), arg)) != nullptr) {
+		if ((a = FindAlias(GET_ALIASES(ch), name)) != nullptr) {
 			REMOVE_FROM_LIST(a, GET_ALIASES(ch));
 			FreeAlias(a);
 		}
@@ -41,12 +42,12 @@ void do_alias(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			else
 				SendMsgToChar("Алиас успешно удален.\r\n", ch);
 		} else {
-			if (!str_cmp(arg, "alias")) {
+			if (!str_cmp(name, "alias")) {
 				SendMsgToChar("Вы не можете определить алиас 'alias'.\r\n", ch);
 				return;
 			}
 			CREATE(a, 1);
-			a->alias = str_dup(arg);
+			a->alias = str_dup(name);
 			delete_doubledollar(repl);
 			a->replacement = str_dup(repl);
 			if (strchr(repl, kAliasSepChar) || strchr(repl, kAliasVarChar))

--- a/src/engine/ui/cmd/do_mixture.cpp
+++ b/src/engine/ui/cmd/do_mixture.cpp
@@ -86,12 +86,13 @@ void do_mixture(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	}
 
 	// Find the target
-	if (!target_str.empty())
-		one_argument(target_str.data(), arg);
-	else
-		*arg = '\0';
+	char target_name[kMaxInputLength];
+	*target_name = '\0';
+	if (!target_str.empty()) {
+		one_argument(target_str.data(), target_name);
+	}
 
-	target = FindCastTarget(spell_id, arg, ch, &tch, &tobj, &troom);
+	target = FindCastTarget(spell_id, target_name, ch, &tch, &tobj, &troom);
 
 	if (target && (tch == ch) && MUD::Spell(spell_id).IsViolent()) {
 		SendMsgToChar("Лекари не рекомендуют использовать ЭТО на себя!\r\n", ch);

--- a/src/engine/ui/cmd/do_page.cpp
+++ b/src/engine/ui/cmd/do_page.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "engine/network/descriptor_data.h"
@@ -15,21 +17,24 @@ void do_page(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	DescriptorData *d;
 	CharData *vict;
 
-	half_chop(argument, arg, buf2);
+	char name[kMaxInputLength];
+	char message[kMaxStringLength];
+	half_chop(argument, name, message);
 
 	if (ch->IsNpc())
 		SendMsgToChar("Создания-не-персонажи этого не могут.. ступайте.\r\n", ch);
-	else if (!*arg)
+	else if (!*name)
 		SendMsgToChar("Whom do you wish to page?\r\n", ch);
 	else {
-		std::stringstream buffer;
-		buffer << "\007\007*$n*" << buf2;
-//		sprintf(buf, "\007\007*$n* %s", buf2);
-		if (!str_cmp(arg, "all") || !str_cmp(arg, "все")) {
+		// В ветке "page all" в эфир уходил глобальный buf, который в этой функции никто
+		// не заполнял: всем игрокам рассылалось то, что осталось в буфере от чужого кода.
+		// Пробел после *$n* был в исходном sprintf и потерялся при переводе на поток.
+		const std::string page_text = fmt::format("\007\007*$n* {}", message);
+		if (!str_cmp(name, "all") || !str_cmp(name, "все")) {
 			if (privilege::IsGrGod(ch)) {
 				for (d = descriptor_list; d; d = d->next) {
 					if (d->state == EConState::kPlaying && d->character) {
-						act(buf, false, ch, nullptr, d->character.get(), kToVict);
+						act(page_text, false, ch, nullptr, d->character.get(), kToVict);
 					}
 				}
 			} else {
@@ -37,13 +42,13 @@ void do_page(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			}
 			return;
 		}
-		vict = target_resolver::FindCharInWorld(ch, arg);
+		vict = target_resolver::FindCharInWorld(ch, name);
 		if ((vict != nullptr)) {
-			act(buffer.str().c_str(), false, ch, nullptr, vict, kToVict);
+			act(page_text, false, ch, nullptr, vict, kToVict);
 			if (ch->IsFlagged(EPrf::kNoRepeat))
 				SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);
 			else
-				act(buffer.str().c_str(), false, ch, nullptr, vict, kToChar);
+				act(page_text, false, ch, nullptr, vict, kToChar);
 		} else
 			SendMsgToChar("Такой игрок отсутствует!\r\n", ch);
 	}

--- a/src/engine/ui/cmd/do_steal.cpp
+++ b/src/engine/ui/cmd/do_steal.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "gameplay/mechanics/hide.h"
 #include "administration/privilege.h"
@@ -180,20 +182,15 @@ void go_steal(CharData *ch, CharData *vict, char *obj_name) {
 
 				if (gold > 0) {
 					if (gold > 1) {
-						sprintf(buf, "УР-Р-Р-А! Вы таки сперли %d %s.\r\n",
-								gold, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(gold, grammar::ECase::kNom).c_str());
-						SendMsgToChar(buf, ch);
+						SendMsgToChar(fmt::format("УР-Р-Р-А! Вы таки сперли {} {}.\r\n", gold,
+												  MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(gold, grammar::ECase::kNom)), ch);
 					} else {
 						SendMsgToChar("УРА-А-А ! Вы сперли :) 1 (одну) куну :(.\r\n", ch);
 					}
 					currencies::AddHand(*ch, currencies::kGold, gold);
-					sprintf(buf,
-							"<%s> {%d} нагло спер %d кун у %s.",
-							ch->get_name().c_str(),
-							GET_ROOM_VNUM(ch->in_room),
-							gold,
-							GET_PAD(vict, 0));
-					mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
+					mudlog(fmt::format("<{}> {{{}}} нагло спер {} кун у {}.",
+									   ch->get_name(), GET_ROOM_VNUM(ch->in_room), gold, GET_PAD(vict, 0)),
+						   NRM, kLvlGreatGod, MONEY_LOG, true);
 					split_or_clan_tax(ch, gold);
 					currencies::RemoveHand(*vict, currencies::kGold, gold);
 				} else

--- a/src/engine/ui/cmd/do_trample.cpp
+++ b/src/engine/ui/cmd/do_trample.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "gameplay/magic/magic_rooms.h"  // room_spells::ERoomAffect
 #include "administration/privilege.h"
@@ -24,9 +26,10 @@ void DoTrample(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	one_argument(argument, arg);
+	char target_arg[kMaxInputLength];
+	one_argument(argument, target_arg);
 
-	if ((!*arg) || ((tp = search_block(arg, targets, false)) == -1)) {
+	if ((!*target_arg) || ((tp = search_block(target_arg, targets, false)) == -1)) {
 		SendMsgToChar("Что вы хотите затоптать?\r\n", ch);
 		return;
 	}
@@ -90,10 +93,9 @@ void DoTrample(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 					caster = find_char(aff->caster_id);
 					if (caster && !group::same_group(ch, caster)) {
 						pk_thiefs_action(ch, caster);
-						sprintf(buf,
-								"Послышался далекий звук лопнувшей струны, и перед вами промельнул призрачный облик %s.\r\n",
-								GET_PAD(ch, 1));
-						SendMsgToChar(buf, caster);
+						SendMsgToChar(fmt::format("Послышался далекий звук лопнувшей струны, "
+												  "и перед вами промельнул призрачный облик {}.\r\n",
+												  GET_PAD(ch, 1)), caster);
 					}
 				}
 				room_spells::RoomRemoveAffect(world[ch->in_room], aff_i);

--- a/src/engine/ui/cmd/do_wimpy.cpp
+++ b/src/engine/ui/cmd/do_wimpy.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 
 void do_wimpy(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
@@ -15,20 +17,20 @@ void do_wimpy(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (ch->IsNpc())
 		return;
 
-	one_argument(argument, arg);
+	char level_arg[kMaxInputLength];
+	one_argument(argument, level_arg);
 
-	if (!*arg) {
+	if (!*level_arg) {
 		if (GET_WIMP_LEV(ch)) {
-			sprintf(buf, "Вы попытаетесь бежать при %d ХП.\r\n", GET_WIMP_LEV(ch));
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Вы попытаетесь бежать при {} ХП.\r\n", GET_WIMP_LEV(ch)), ch);
 			return;
 		} else {
 			SendMsgToChar("Вы будете драться, драться и драться (пока не помрете, ессно...).\r\n", ch);
 			return;
 		}
 	}
-	if (a_isdigit(*arg)) {
-		if ((wimp_lev = atoi(arg)) != 0) {
+	if (a_isdigit(*level_arg)) {
+		if ((wimp_lev = atoi(level_arg)) != 0) {
 			if (wimp_lev < 0)
 				SendMsgToChar("Да, перегрев похоже. С такими хитами вы и так помрете :)\r\n", ch);
 			else if (wimp_lev > ch->get_real_max_hit())
@@ -36,8 +38,7 @@ void do_wimpy(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			else if (wimp_lev > (ch->get_real_max_hit() / 2))
 				SendMsgToChar("Размечтались. Сбечь то можно, но не более половины максимальных ХП.\r\n", ch);
 			else {
-				sprintf(buf, "Ладушки. Вы сбегите (или сбежите) по достижению %d ХП.\r\n", wimp_lev);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("Ладушки. Вы сбегите (или сбежите) по достижению {} ХП.\r\n", wimp_lev), ch);
 				GET_WIMP_LEV(ch) = wimp_lev;
 			}
 		} else {

--- a/src/engine/ui/cmd/do_write.cpp
+++ b/src/engine/ui/cmd/do_write.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/core/target_resolver.h"
 #include "engine/entities/char_data.h"
 #include "gameplay/mechanics/sight.h"
@@ -30,19 +32,16 @@ void do_write(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	}
 	if (*penname) {
 		if (!(paper = get_obj_in_list_vis(ch, papername, ch->carrying))) {
-			sprintf(buf, "У вас нет %s.\r\n", papername);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("У вас нет {}.\r\n", papername), ch);
 			return;
 		}
 		if (!(pen = get_obj_in_list_vis(ch, penname, ch->carrying))) {
-			sprintf(buf, "У вас нет %s.\r\n", penname);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("У вас нет {}.\r\n", penname), ch);
 			return;
 		}
 	} else {
 		if (!(paper = get_obj_in_list_vis(ch, papername, ch->carrying))) {
-			sprintf(buf, "Вы не видите %s в инвентаре.\r\n", papername);
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Вы не видите {} в инвентаре.\r\n", papername), ch);
 			return;
 		}
 		if (paper->get_type() == EObjType::kPen)    // oops, a pen..
@@ -55,8 +54,7 @@ void do_write(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 
 		if (!GET_EQ(ch, kHold)) {
-			sprintf(buf, "Вам нечем писать!\r\n");
-			SendMsgToChar(buf, ch);
+			SendMsgToChar("Вам нечем писать!\r\n", ch);
 			return;
 		}
 		if (!sight::CanSeeObj(ch, GET_EQ(ch, kHold))) {


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Семь команд переведены на `fmt::format` и локальные строки: `вызвать`, `трус`, `писать`, `алиас`, `потоптать`, `смесь`, `украсть`.

## Ошибка в `вызвать все`

Текст вызова собирался в `std::stringstream`, но ветка «вызвать все» рассылала не его, а глобальный `buf`, который в этой функции никто не заполнял:

```c
std::stringstream buffer;
buffer << "\007\007*$n*" << buf2;
//		sprintf(buf, "\007\007*$n* %s", buf2);   <-- исходная строка, осталась в комментарии
if (!str_cmp(arg, "all") || !str_cmp(arg, "все")) {
    ...
    act(buf, false, ch, nullptr, d->character.get(), kToVict);   // <-- buf, а не buffer
```

То есть всем игрокам уходило то, что осталось в глобальном буфере от чужого кода. Из того же закомментированного `sprintf` видно, что при переводе на поток потерялся пробел после `*$n*` — восстановил.

Теперь строка одна, собирается через `fmt::format`; поток и мёртвый комментарий убраны.

Остальное — механика: буфер заменён локальной строкой, тексты не менялись.

Сборка без предупреждений, 712 тестов проходят.
