### PR TITLE
refactor(mechanics): drop global buffers from titles, doors and cities (#3814)

### DIFF
--- a/src/administration/names.cpp
+++ b/src/administration/names.cpp
@@ -25,7 +25,7 @@ namespace NewNames {
 static void save();
 static void cache_add(CharData *ch);
 }
-extern void SendMsgToGods(char *text, bool demigod);
+extern void SendMsgToGods(const std::string &text, bool demigod);
 
 // Check if name agree (name must be parsed)
 int was_agree_name(DescriptorData *d) {

--- a/src/engine/core/comm.cpp
+++ b/src/engine/core/comm.cpp
@@ -2416,7 +2416,8 @@ void SendMsgToOutdoor(const char *msg, int control) {
 	}
 }
 
-void SendMsgToGods(char *text, bool include_demigod) {
+// Принимала char *: ей всегда передавали глобальный buf, и другого вызывающего не было (#3814).
+void SendMsgToGods(const std::string &text, bool include_demigod) {
 	DescriptorData *d;
 	for (d = descriptor_list; d; d = d->next) {
 		if (d->state == EConState::kPlaying) {

--- a/src/engine/core/comm.h
+++ b/src/engine/core/comm.h
@@ -34,6 +34,7 @@ void send_stat_char(const CharData *ch);
 void SendMsgToRoom(const char *msg, RoomRnum room, int to_awake);
 void SendMsgToOutdoor(const char *msg, int control);
 void SendMsgToGods(const char *msg);
+void SendMsgToGods(const std::string &text, bool include_demigod);
 void perform_to_all(const char *messg, CharData *ch);
 #ifdef HAS_EPOLL
 void close_socket(DescriptorData *d, int direct, int epoll, struct epoll_event *events, int n_ev);

--- a/src/gameplay/mechanics/cities.cpp
+++ b/src/gameplay/mechanics/cities.cpp
@@ -2,6 +2,8 @@
 // Created by Sventovit on 07.09.2024. Reworked for issue.cities (InfoContainer + cfg_manager).
 //
 
+#include <fmt/format.h>
+
 #include "cities.h"
 
 #include "cities_messages.h"
@@ -162,7 +164,7 @@ void DoCities(CharData *ch, char *, int, int) {
 			continue;
 		}
 		++n;
-		sprintf(buf, "%3d.", n);
+		std::string line = fmt::format("{:3}.", n);
 		if (privilege::IsImmortal(ch)) {
 			std::string rents;
 			for (const int rent_vnum : city.GetRentVnums()) {
@@ -171,15 +173,11 @@ void DoCities(CharData *ch, char *, int, int) {
 				}
 				rents += std::to_string(rent_vnum);
 			}
-			sprintf(buf1, " [vnum: %d, rent: %s]", city.GetId(), rents.c_str());
-			strcat(buf, buf1);
+			line += fmt::format(" [vnum: {}, rent: {}]", city.GetId(), rents);
 		}
-		sprintf(buf1,
-				" %s: %s\r\n",
-				city.GetName().c_str(),
-				(ch->check_city(city.GetTextId()) ? "&gВы были там.&n" : "&rВы еще не были там.&n"));
-		strcat(buf, buf1);
-		SendMsgToChar(buf, ch);
+		line += fmt::format(" {}: {}\r\n", city.GetName(),
+							ch->check_city(city.GetTextId()) ? "&gВы были там.&n" : "&rВы еще не были там.&n");
+		SendMsgToChar(line, ch);
 	}
 }
 

--- a/src/gameplay/mechanics/doors.cpp
+++ b/src/gameplay/mechanics/doors.cpp
@@ -9,6 +9,8 @@
  Тогда и scmd тут не понадобится и его можно будет либо убрать в do_gen_door, либо вообще удалить.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/obj_data.h"
 #include "gameplay/magic/magic.h"
 #include "engine/entities/room_data.h"
@@ -324,12 +326,10 @@ void do_doorcmd(CharData *ch, ObjData *obj, int door, EDoorScmd scmd) {
 			}
 			// вываливание и пурж кошелька
 			if (obj && system_obj::is_purse(obj)) {
-				sprintf(buf,
-						"<%s> {%d} открыл трупный кошелек %s.",
-						ch->get_name().c_str(),
-						GET_ROOM_VNUM(ch->in_room),
-						GetPlayerNameByUnique(GET_OBJ_VAL(obj, 3)).c_str());
-				mudlog(buf, NRM, kLvlGreatGod, MONEY_LOG, true);
+				mudlog(fmt::format("<{}> {{{}}} открыл трупный кошелек {}.",
+								   ch->get_name(), GET_ROOM_VNUM(ch->in_room),
+								   GetPlayerNameByUnique(GET_OBJ_VAL(obj, 3))),
+					   NRM, kLvlGreatGod, MONEY_LOG, true);
 				system_obj::process_open_purse(ch, obj);
 				return;
 			} else {
@@ -443,17 +443,17 @@ void go_gen_door(CharData *ch, char *type, char *dir, int where_bits, int subcmd
 			switch (door.error) {
 				case EDoorError::kWrongDir: SendMsgToChar("Уточните направление.\r\n", ch);
 					break;
-				case EDoorError::kWrongDirDoorName: sprintf(buf, "Вы не видите '%s' в этой комнате.\r\n", type);
-					SendMsgToChar(buf, ch);
+				case EDoorError::kWrongDirDoorName:
+					SendMsgToChar(fmt::format("Вы не видите '{}' в этой комнате.\r\n", type), ch);
 					break;
-				case EDoorError::kNoDoorGivenDir: sprintf(buf, "Вы не можете это '%s'.\r\n", a_cmd_door[subcmd]);
-					SendMsgToChar(buf, ch);
+				case EDoorError::kNoDoorGivenDir:
+					SendMsgToChar(fmt::format("Вы не можете это '{}'.\r\n", a_cmd_door[subcmd]), ch);
 					break;
-				case EDoorError::kDoorNameIsEmpty: sprintf(buf, "Что вы хотите '%s'?\r\n", a_cmd_door[subcmd]);
-					SendMsgToChar(buf, ch);
+				case EDoorError::kDoorNameIsEmpty:
+					SendMsgToChar(fmt::format("Что вы хотите '{}'?\r\n", a_cmd_door[subcmd]), ch);
 					break;
-				case EDoorError::kWrongDoorName: sprintf(buf, "Вы не видите здесь '%s'.\r\n", type);
-					SendMsgToChar(buf, ch);
+				case EDoorError::kWrongDoorName:
+					SendMsgToChar(fmt::format("Вы не видите здесь '{}'.\r\n", type), ch);
 					break;
 				default: SendMsgToChar("Что-то с дверью произошло непнятное, сообщите богам.", ch);
 					break;

--- a/src/gameplay/mechanics/liquid.cpp
+++ b/src/gameplay/mechanics/liquid.cpp
@@ -710,31 +710,29 @@ void identify(CharData *ch, const ObjData *obj) {
 	}
 	if (amount > 0) //если что-то плескается
 	{
-		sprintf(buf1, "Качество: %s \r\n", diag_liquid_timer(obj)); // состояние жижки
-		out += buf1;
+		out += fmt::format("Качество: {} \r\n", diag_liquid_timer(obj)); // состояние жижки
 	}
 	SendMsgToChar(out, ch);
 }
 
-char *daig_filling_drink(const ObjData *obj, const CharData *ch) {
+// Возвращала указатель на глобальный buf1: следующий вызов затирал ответ предыдущего,
+// а вызывающий в sight.cpp ещё и правил эту память на месте (#3814).
+std::string daig_filling_drink(const ObjData *obj, const CharData *ch) {
 	char tmp[256];
 	if (GET_OBJ_VAL(obj, 1) <= 0) {
-		sprintf(buf1, "Пусто");
-		return buf1;
+		return "Пусто";
 	}
 	else {
 		if (GET_OBJ_VAL(obj, 0) <= 0 || GET_OBJ_VAL(obj, 1) > GET_OBJ_VAL(obj, 0)) {
-			sprintf(buf1, "Заполнен%s вакуумом?!", grammar::ObjSexEnding((obj)->get_sex(), 6));    // BUG
-			return buf1;
+			return fmt::format("Заполнен{} вакуумом?!", grammar::ObjSexEnding((obj)->get_sex(), 6));    // BUG
 		}
 		else {
 			const char *msg = AFF_FLAGGED(ch, EAffect::kDetectPoison)
 				&& obj->GetPotionValueKey(ObjVal::EValueKey::kLiquidPoison) > 0 ? " *отравленной*" : "";
 			int amt = (GET_OBJ_VAL(obj, 1) * 5) / GET_OBJ_VAL(obj, 0);
 			sprinttype(GET_OBJ_VAL(obj, 2), color_liquid, tmp);
-			snprintf(buf1, kMaxStringLength,
-					 "Наполнен%s %s%s%s жидкостью", grammar::ObjSexEnding((obj)->get_sex(), 6), fullness[amt], tmp, msg);
-			return buf1;
+			return fmt::format("Наполнен{} {}{}{} жидкостью",
+							   grammar::ObjSexEnding((obj)->get_sex(), 6), fullness[amt], tmp, msg);
 		}
 	}
 }

--- a/src/gameplay/mechanics/liquid.h
+++ b/src/gameplay/mechanics/liquid.h
@@ -66,7 +66,7 @@ namespace drinkcon {
 void identify(CharData *ch, const ObjData *obj);
 std::string print_spells(const ObjData *obj);
 void copy_potion_values(const CObjectPrototype *from_obj, CObjectPrototype *to_obj);
-char *daig_filling_drink(const ObjData *obj, const CharData *ch);
+std::string daig_filling_drink(const ObjData *obj, const CharData *ch);
 const char *diag_liquid_timer(const ObjData *obj);
 void reset_potion_values(CObjectPrototype *obj);
 int check_equal_potions(ObjData *from_obj, ObjData *to_obj);

--- a/src/gameplay/mechanics/mem_queue.cpp
+++ b/src/gameplay/mechanics/mem_queue.cpp
@@ -5,6 +5,8 @@
 \details Весь код по работе с очередью заучивания заклинаний должен располагаться в данном модуле.
 */
 
+#include <fmt/format.h>
+
 #include "mem_queue.h"
 #include "utils/logger.h"
 #include "administration/privilege.h"
@@ -210,9 +212,8 @@ ESpell MemQ_learn(CharData *ch) {
 	i = ch->mem_queue.queue;
 	ch->mem_queue.queue = i->next;
 	free(i);
-	sprintf(buf, "Вы выучили заклинание \"%s%s%s\".\r\n",
-			kColorBoldCyn, MUD::Spell(spell_id).GetCName(), kColorNrm);
-	SendMsgToChar(buf, ch);
+	SendMsgToChar(fmt::format("Вы выучили заклинание \"{}{}{}\".\r\n",
+							  kColorBoldCyn, MUD::Spell(spell_id).GetName(), kColorNrm), ch);
 	return spell_id;
 }
 
@@ -232,13 +233,15 @@ void MemQ_remember(CharData *ch, ESpell spell_id) {
 		return;
 	}
 
-	if (GET_RELIGION(ch) == kReligionMono)
-		sprintf(buf, "Вы дописали заклинание \"%s%s%s\" в свой часослов.\r\n",
-				kColorBoldMag, MUD::Spell(spell_id).GetCName(), kColorNrm);
-	else
-		sprintf(buf, "Вы занесли заклинание \"%s%s%s\" в свои резы.\r\n",
-				kColorBoldMag, MUD::Spell(spell_id).GetCName(), kColorNrm);
-	SendMsgToChar(buf, ch);
+	// Формат у fmt должен быть известен на компиляции, поэтому ветвим не строку формата,
+	// а готовое сообщение.
+	if (GET_RELIGION(ch) == kReligionMono) {
+		SendMsgToChar(fmt::format("Вы дописали заклинание \"{}{}{}\" в свой часослов.\r\n",
+								  kColorBoldMag, MUD::Spell(spell_id).GetName(), kColorNrm), ch);
+	} else {
+		SendMsgToChar(fmt::format("Вы занесли заклинание \"{}{}{}\" в свои резы.\r\n",
+								  kColorBoldMag, MUD::Spell(spell_id).GetName(), kColorNrm), ch);
+	}
 
 	ch->mem_queue.total += CalcSpellManacost(ch, spell_id);
 	while (*pi)
@@ -267,10 +270,8 @@ void MemQ_forget(CharData *ch, ESpell spell_id) {
 		ptr = q[0];
 		q[0] = q[0]->next;
 		free(ptr);
-		sprintf(buf,
-				"Вы вычеркнули заклинание \"%s%s%s\" из списка для запоминания.\r\n",
-				kColorBoldMag, MUD::Spell(spell_id).GetCName(), kColorNrm);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("Вы вычеркнули заклинание \"{}{}{}\" из списка для запоминания.\r\n",
+								  kColorBoldMag, MUD::Spell(spell_id).GetName(), kColorNrm), ch);
 	}
 }
 

--- a/src/gameplay/mechanics/sight.cpp
+++ b/src/gameplay/mechanics/sight.cpp
@@ -1255,7 +1255,7 @@ void look_in_obj(CharData *ch, char *arg) {
 			}
 		} else {
 			// item must be a fountain or drink container
-			SendMsgToChar(ch, "%s.\r\n", drinkcon::daig_filling_drink(obj, ch));
+			SendMsgToChar(fmt::format("{}.\r\n", drinkcon::daig_filling_drink(obj, ch)), ch);
 
 		}
 	}
@@ -1330,8 +1330,8 @@ std::string show_obj_to_char(ObjData *object, CharData *ch, int mode, int show_s
 					// строку вдвое, а посмотреть её можно, осмотрев ёмкость.
 					if (object->get_type() == EObjType::kLiquidContainer
 						&& GET_OBJ_VAL(object, 1) <= 0) {
-						char *tmp = drinkcon::daig_filling_drink(object, ch);
-						native_text::copy_lower_char(tmp, tmp);
+						std::string tmp = drinkcon::daig_filling_drink(object, ch);
+						native_text::copy_lower_char(tmp.data(), tmp.data());
 						state += fmt::format(" ({})", tmp);
 					}
 				}

--- a/src/gameplay/mechanics/title.cpp
+++ b/src/gameplay/mechanics/title.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2006 Krodo
 // Part of Bylins http://www.bylins.su
 
+#include <fmt/format.h>
+
 #include "utils/native_text.h"
 #include "title.h"
 #include "gameplay/economics/currencies.h"
@@ -16,7 +18,7 @@
 #include "gameplay/core/remort.h"
 #include "gameplay/economics/currencies.h"
 
-extern void SendMsgToGods(char *text, bool demigod);
+extern void SendMsgToGods(const std::string &text, bool demigod);
 
 namespace TitleSystem {
 
@@ -99,8 +101,7 @@ void TitleSystem::do_title(CharData *ch, char *argument, int/* cmd*/, int/* subc
 				return;
 			}
 			if (!vict->GetTitleStr().empty()) {
-				sprintf(buf, "&c%s удалил титул игрока %s.&n\r\n", GET_NAME(ch), GET_NAME(vict));
-				SendMsgToGods(buf, true);
+				SendMsgToGods(fmt::format("&c{} удалил титул игрока {}.&n\r\n", GET_NAME(ch), GET_NAME(vict)), true);
 				vict->SetTitleStr("");
 				//SendMsgToChar("Титул удален.\r\n", ch);
 			} else
@@ -308,8 +309,7 @@ bool TitleSystem::manage_title_list(std::string &name, bool action, CharData *ch
 			// Что внизу за хрень ?
 			if (d) {
 				set_player_title(d->character.get(), it->second->pre_title, it->second->title, GET_NAME(ch));
-				sprintf(buf, "&c%s одобрил титул игрока %s!&n\r\n", GET_NAME(ch), GET_NAME(d->character));
-				SendMsgToGods(buf, true);
+				SendMsgToGods(fmt::format("&c{} одобрил титул игрока {}!&n\r\n", GET_NAME(ch), GET_NAME(d->character)), true);
 			} else {
 				Player victim;
 				if (LoadPlayerCharacter(it->first.c_str(), &victim, ELoadCharFlags::kFindId) < 0) {
@@ -318,8 +318,7 @@ bool TitleSystem::manage_title_list(std::string &name, bool action, CharData *ch
 					return TITLE_FIND_CHAR;
 				}
 				set_player_title(&victim, it->second->pre_title, it->second->title, GET_NAME(ch));
-				sprintf(buf, "&c%s одобрил титул игрока %s[ОФФЛАЙН].&n\r\n", GET_NAME(ch), GET_NAME(&victim));
-				SendMsgToGods(buf, true);
+				SendMsgToGods(fmt::format("&c{} одобрил титул игрока {}[ОФФЛАЙН].&n\r\n", GET_NAME(ch), GET_NAME(&victim)), true);
 				victim.save_char();
 			}
 		} else {
@@ -327,8 +326,7 @@ bool TitleSystem::manage_title_list(std::string &name, bool action, CharData *ch
 
 			DescriptorData *d = send_result_message(it->second->unique, action);
 			if (d) {
-				sprintf(buf, "&c%s запретил титул игрока %s.&n\r\n", GET_NAME(ch), GET_NAME(d->character));
-				SendMsgToGods(buf, true);
+				SendMsgToGods(fmt::format("&c{} запретил титул игрока {}.&n\r\n", GET_NAME(ch), GET_NAME(d->character)), true);
 			} else {
 				Player victim;
 				if (LoadPlayerCharacter(it->first.c_str(), &victim, ELoadCharFlags::kFindId) < 0) {
@@ -336,8 +334,7 @@ bool TitleSystem::manage_title_list(std::string &name, bool action, CharData *ch
 					title_list.erase(it);
 					return TITLE_FIND_CHAR;
 				}
-				sprintf(buf, "&c%s запретил титул игрока %s[ОФФЛАЙН].&n\r\n", GET_NAME(ch), GET_NAME(&victim));
-				SendMsgToGods(buf, true);
+				SendMsgToGods(fmt::format("&c{} запретил титул игрока {}[ОФФЛАЙН].&n\r\n", GET_NAME(ch), GET_NAME(&victim)), true);
 				victim.save_char();
 			}
 		}


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Титулы, двери, города, очередь заклинаний и ёмкости с жидкостью переведены на `fmt::format` и локальные строки. Заодно две функции перестали зависеть от общего буфера.

## `SendMsgToGods`

```c
-void SendMsgToGods(char *text, bool include_demigod);
+void SendMsgToGods(const std::string &text, bool include_demigod);
```

Она принимала `char *` ровно потому, что ей всегда передавали глобальный `buf`; другого вызывающего у неё не было. Объявление переехало в `comm.h` — раньше его дублировали `extern` по месту в двух файлах.

## `daig_filling_drink`

Возвращала указатель на глобальный `buf1`, так что следующий вызов затирал ответ предыдущего. Хуже: вызывающий в `sight.cpp` правил эту память на месте через `copy_lower_char`, то есть портил общий буфер ради одной строчки в списке предметов:

```c
char *tmp = drinkcon::daig_filling_drink(object, ch);
native_text::copy_lower_char(tmp, tmp);
```

Теперь функция возвращает `std::string`, а нижний регистр наводится в своей копии.

Тексты сообщений не менялись.

Сборка без предупреждений, 712 тестов проходят.
