### PR TITLE
fix(zones): treat an inverted room range as "zone has no rooms"

### DIFF
--- a/src/engine/db/db.cpp
+++ b/src/engine/db/db.cpp
@@ -3386,7 +3386,12 @@ int GetZoneRooms(ZoneRnum zrn, int *first, int *last) {
 	*first = zone_table[zrn].RnumRoomsLocation.first;
 	*last = zone_table[zrn].RnumRoomsLocation.second;
 
-	if (*first <= 0)
+	// Пустая зона выглядит не как first == -1, а как перевёрнутый диапазон. Каждой зоне
+	// AddVirtualRoomsToAllZones() добавляет виртуальную комнату X99, а CalculateFirstAndLastRooms()
+	// тут же выбрасывает её из диапазона (second--). Если своих комнат у зоны нет -- а у системных
+	// зон вроде книг заклинаний их нет, -- виртуалка была единственной, и после вычитания
+	// получается first == last + 1, причём last указывает в ПРЕДЫДУЩУЮ зону.
+	if (*first <= 0 || *first > *last)
 		return 0;
 	return 1;
 }

--- a/src/engine/ui/cmd_god/do_show.cpp
+++ b/src/engine/ui/cmd_god/do_show.cpp
@@ -334,12 +334,17 @@ std::string print_zone_exits(ZoneRnum zone) {
 void print_zone_to_buf(char **bufptr, ZoneRnum zone) {
 	const size_t BUFFER_SIZE = 1024;
 	int rfirst, rlast;
-	GetZoneRooms(zone, &rfirst, &rlast);
+	// У зоны без собственных комнат диапазон пуст, и его края показывать нельзя: rfirst -- это
+	// виртуальная комната X99, которую из диапазона выбросили, а rlast лежит уже в предыдущей
+	// зоне. Печатали их как есть, и системная зона 5 показывала "First: 599, Top: 499".
+	const std::string rooms_line = GetZoneRooms(zone, &rfirst, &rlast)
+								   ? fmt::format("First: {:7}, Top: {:7}", world[rfirst]->vnum, world[rlast]->vnum)
+								   : std::string("Собственных комнат нет");
 	char tmpstr[BUFFER_SIZE];
 	snprintf(tmpstr, BUFFER_SIZE,
 			 "%3d %s\r\n"
-			 "Уровнь зоны %2d, Средний уровень мобов: %2d; Type: %s; Age: %3d; Reset: %3d (%1d)(%1d)\r\n"
-			 "First: %7d, Top: %7d %s %s; ResetIdle: %s; Занято: %s; Активность: %.2f; Группа: %2d; \r\n"
+			 "Уровень зоны %2d, Средний уровень мобов: %2d; Type: %s; Age: %3d; Reset: %3d (%1d)(%1d)\r\n"
+			 "%s %s %s; ResetIdle: %s; Занято: %s; Активность: %.2f; Группа: %2d; \r\n"
 			 "Автор: %s, количество репопов зоны (с перезагрузки): %d, всего посещений: %d, вход в зону: %d\r\n",
 			 zone_table[zone].vnum,
 			 zone_table[zone].name.c_str(),
@@ -351,8 +356,7 @@ void print_zone_to_buf(char **bufptr, ZoneRnum zone) {
 			 zone_table[zone].age, zone_table[zone].lifespan,
 			 zone_table[zone].reset_mode,
 			 (zone_table[zone].reset_mode == 3) ? (CanBeReset(zone) ? 1 : 0) : (IsZoneEmpty(zone) ? 1 : 0),
-			 world[rfirst]->vnum,
-			 world[rlast]->vnum,
+			 rooms_line.c_str(),
 			 zone_table[zone].under_construction ? "&GТестовая!&n" : " ",
 			 zone_table[zone].locked ? "&RРедактирование запрещено!&n" : " ",
 			 zone_table[zone].reset_idle ? "Y" : "N",


### PR DESCRIPTION
## Что видно снаружи

```
  5 Системная зона 5 -- книги заклинаний #1
Уровнь зоны  1, Средний уровень мобов:  0; Type: Ингридиентов нет    ; Age:   0; Reset:  30 (0)(1)
First:     599, Top:     499
```

Верхняя граница меньше нижней, и обе не имеют отношения к зоне 5.

## Откуда берутся эти числа

Комнат у зоны 5 в мире нет вообще: `worlddata/world/zones/5/rooms.yaml` — 19 байт, одна строка комментария. Обе комнаты создаёт движок.

**Шаг 1.** `AddVirtualRoomsToAllZones()` (`db.cpp:1929`) добавляет **каждой** зоне комнату с внумом `зона*100 + 99`. Для зоны 5 это 599, для зоны 4 — 499. В мире их нет, это чисто движковые комнаты.

**Шаг 2.** `CalculateFirstAndLastRooms()` (`db.cpp:1904`) проходит по всем комнатам в порядке rnum и на каждой смене зоны закрывает предыдущую. Потом отдельным проходом:

```c
zone_data.RnumRoomsLocation.second--; //уберем виртуалки
```

Для обычной зоны верно: виртуалка с внумом `X99` — последняя по внуму, значит и последняя по rnum, вычитание её отрезает.

**Шаг 3.** Для зоны без собственных комнат виртуалка была единственной:

| | first | second |
|---|---|---|
| после основного цикла | rnum(599) | rnum(599) |
| после `second--` | rnum(599) | rnum(599)−1 = **rnum(499)** |

Диапазон стал пустым в форме `first = last + 1`, а его верхний край уехал в предыдущую зону.

**Шаг 4.** `GetZoneRooms` (`db.cpp:3385`) такой диапазон пустым не считала — проверка была только `*first <= 0`. `print_zone_to_buf` (`do_show.cpp:337`) печатала `world[first]->vnum` и `world[last]->vnum` как есть.

Заметьте: `First: 599` тоже неверно — это ровно та виртуалка, которую `second--` из диапазона выбрасывает. У пустой зоны бессмысленны оба конца.

## Замер на боевом мире

Поднял сервер на реальном `lib/` с временным логом границ по всем зонам:

```
zone=3 ret=0 rnum=[43..42] vnum=[399..299]
zone=4 ret=0 rnum=[44..43] vnum=[499..399]
zone=5 ret=0 rnum=[45..44] vnum=[599..499]     <- ровно то, что видно в игре
...
zone=30049 ret=1 rnum=[48022..48120] vnum=[3004900..3004998]
```

**Из 659 зон 39 не имеют собственных комнат** — и все они показывали в `Top` чужой внум.

## Данжи не затронуты

`CreateBlankRoomDungeon()` заводит каждой зоне данжа комнаты `X00..X98` — 99 штук, плюс виртуалка `X99`. После `second--` диапазон нормальный. По логу: **все 50 зон 30000..30049 дают ret=1**, границы `X00..X98`. Правка их не касается ни в одном месте.

Заодно проверил все девять вызовов `GetZoneRooms`. Циклы `for (r = start; r <= stop; ++r)` на пустом диапазоне и раньше не выполнялись — там ничего не меняется. Две ветки начнут наконец срабатывать: `ZoneCopy` (`dungeons.cpp:112`) с сообщением «Нет комнат в зоне» и `graph.cpp:112` с `kBfsError`. А `target_resolver.cpp:642` уже обходил это у себя:

```c
int n = rnum_stop - rnum_start + 1;
if (n <= 0) {
	return kNowhere;
}
```

то есть на пустой диапазон кто-то уже напарывался и чинил его в одном месте вызова вместо самой функции.

## Правка

```c
-	if (*first <= 0)
+	if (*first <= 0 || *first > *last)
 		return 0;
```

и в `print_zone_to_buf` — печать границ по возвращённому признаку, для зоны без комнат строка «Собственных комнат нет».

Заодно исправлена опечатка в той же строке вывода: «Уровнь зоны» → «Уровень зоны». Если не нужна — уберу.

Сборка без предупреждений, 712 тестов, сервер стартует на боевом мире.
