### PR TITLE
fix(look): show what a book contains when examining it (#3877)

### DIFF
--- a/src/gameplay/mechanics/identify.cpp
+++ b/src/gameplay/mechanics/identify.cpp
@@ -57,7 +57,14 @@ static void ShowWeapon(CharData *ch, ObjData *obj) {
 	}
 }
 */
-std::string GetBookContents(const CObjectPrototype *obj) {
+// "Недоступно" здесь -- это про класс, а не про уровень: класс либо получает талант когда-нибудь,
+// либо не получает никогда. Нехватка уровня или ремортов временна, и молчать о ней честнее, чем
+// пугать игрока словом "недоступно" (#3877).
+static const char *UnavailableTail(bool unavailable) {
+	return unavailable ? " (вам недоступно)" : "";
+}
+
+std::string GetBookContents(const CObjectPrototype *obj, CharData *ch) {
 	if (!obj || obj->get_type() != EObjType::kBook) {
 		return "";
 	}
@@ -67,40 +74,54 @@ std::string GetBookContents(const CObjectPrototype *obj) {
 			if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
 				return "";
 			}
-			return fmt::format("содержит заклинание        : \"{}\"", MUD::Spell(spell_id).GetName());
+			const bool unavailable = ch && MUD::Class(ch->GetClass()).spells.IsUnavailable(spell_id);
+			return fmt::format("содержит заклинание        : \"{}\"{}",
+							   MUD::Spell(spell_id).GetName(), UnavailableTail(unavailable));
 		}
 		case EBook::kSkill: {
 			const auto skill_id = static_cast<ESkill>(GET_OBJ_VAL(obj, 1));
 			if (MUD::Skills().IsInvalid(skill_id)) {
 				return "";
 			}
-			return fmt::format("содержит секрет умения     : \"{}\"", MUD::Skill(skill_id).GetName());
+			const bool unavailable = ch && MUD::Class(ch->GetClass()).skills.IsUnavailable(skill_id);
+			return fmt::format("содержит секрет умения     : \"{}\"{}",
+							   MUD::Skill(skill_id).GetName(), UnavailableTail(unavailable));
 		}
 		case EBook::kSkillUpgrade: {
 			const auto skill_id = static_cast<ESkill>(GET_OBJ_VAL(obj, 1));
 			if (MUD::Skills().IsInvalid(skill_id)) {
 				return "";
 			}
+			const bool unavailable = ch && MUD::Class(ch->GetClass()).skills.IsUnavailable(skill_id);
 			if (GET_OBJ_VAL(obj, 3) > 0) {
-				return fmt::format("повышает умение            : \"{}\" (максимум {})",
-								   MUD::Skill(skill_id).GetName(), GET_OBJ_VAL(obj, 3));
+				return fmt::format("повышает умение            : \"{}\" (максимум {}){}",
+								   MUD::Skill(skill_id).GetName(), GET_OBJ_VAL(obj, 3),
+								   UnavailableTail(unavailable));
 			}
-			return fmt::format("повышает умение            : \"{}\" (не больше максимума текущего перевоплощения)",
-							   MUD::Skill(skill_id).GetName());
+			return fmt::format("повышает умение            : \"{}\" (не больше максимума текущего перевоплощения){}",
+							   MUD::Skill(skill_id).GetName(), UnavailableTail(unavailable));
 		}
 		case EBook::kReceipt: {
 			const int recipe = im_get_recipe(GET_OBJ_VAL(obj, 1));
 			if (recipe < 0) {
 				return "";
 			}
-			return fmt::format("содержит рецепт отвара     : \"{}\"", imrecipes[recipe].name);
+			const bool unavailable =
+				ch && !MUD::Class(ch->GetClass()).FindIngredientRecipe(imrecipes[recipe].str_id);
+			return fmt::format("содержит рецепт отвара     : \"{}\"{}",
+							   imrecipes[recipe].name, UnavailableTail(unavailable));
 		}
 		case EBook::kFeat: {
 			const auto feat_id = static_cast<EFeat>(GET_OBJ_VAL(obj, 1));
 			if (!MUD::Feat(feat_id).IsValid()) {
 				return "";
 			}
-			return fmt::format("содержит секрет способности: \"{}\"", MUD::Feat(feat_id).GetName());
+			// У способностей доступность даёт не только класс, но и раса -- как в CanGetFeat.
+			const bool unavailable = ch
+				&& MUD::Class(ch->GetClass()).feats.IsUnavailable(feat_id)
+				&& !MUD::PcRaces()[GET_RACE(ch)].HasFeature(feat_id);
+			return fmt::format("содержит секрет способности: \"{}\"{}",
+							   MUD::Feat(feat_id).GetName(), UnavailableTail(unavailable));
 		}
 		default: return "";
 	}

--- a/src/gameplay/mechanics/identify.cpp
+++ b/src/gameplay/mechanics/identify.cpp
@@ -57,6 +57,55 @@ static void ShowWeapon(CharData *ch, ObjData *obj) {
 	}
 }
 */
+std::string GetBookContents(const CObjectPrototype *obj) {
+	if (!obj || obj->get_type() != EObjType::kBook) {
+		return "";
+	}
+	switch (GET_OBJ_VAL(obj, 0)) {
+		case EBook::kSpell: {
+			const auto spell_id = static_cast<ESpell>(GET_OBJ_VAL(obj, 1));
+			if (spell_id < ESpell::kFirst || spell_id > ESpell::kLast) {
+				return "";
+			}
+			return fmt::format("содержит заклинание        : \"{}\"", MUD::Spell(spell_id).GetName());
+		}
+		case EBook::kSkill: {
+			const auto skill_id = static_cast<ESkill>(GET_OBJ_VAL(obj, 1));
+			if (MUD::Skills().IsInvalid(skill_id)) {
+				return "";
+			}
+			return fmt::format("содержит секрет умения     : \"{}\"", MUD::Skill(skill_id).GetName());
+		}
+		case EBook::kSkillUpgrade: {
+			const auto skill_id = static_cast<ESkill>(GET_OBJ_VAL(obj, 1));
+			if (MUD::Skills().IsInvalid(skill_id)) {
+				return "";
+			}
+			if (GET_OBJ_VAL(obj, 3) > 0) {
+				return fmt::format("повышает умение            : \"{}\" (максимум {})",
+								   MUD::Skill(skill_id).GetName(), GET_OBJ_VAL(obj, 3));
+			}
+			return fmt::format("повышает умение            : \"{}\" (не больше максимума текущего перевоплощения)",
+							   MUD::Skill(skill_id).GetName());
+		}
+		case EBook::kReceipt: {
+			const int recipe = im_get_recipe(GET_OBJ_VAL(obj, 1));
+			if (recipe < 0) {
+				return "";
+			}
+			return fmt::format("содержит рецепт отвара     : \"{}\"", imrecipes[recipe].name);
+		}
+		case EBook::kFeat: {
+			const auto feat_id = static_cast<EFeat>(GET_OBJ_VAL(obj, 1));
+			if (!MUD::Feat(feat_id).IsValid()) {
+				return "";
+			}
+			return fmt::format("содержит секрет способности: \"{}\"", MUD::Feat(feat_id).GetName());
+		}
+		default: return "";
+	}
+}
+
 static void PrintBookUpgradeSkill(CharData *ch, const ObjData *obj) {
 	const auto skill_id = static_cast<ESkill>(GET_OBJ_VAL(obj, 1));
 	if (MUD::Skills().IsInvalid(skill_id)) {

--- a/src/gameplay/mechanics/identify.h
+++ b/src/gameplay/mechanics/identify.h
@@ -7,8 +7,15 @@
 #ifndef BYLINS_SRC_GAMEPLAY_MECHANICS_IDENTIFY_H_
 #define BYLINS_SRC_GAMEPLAY_MECHANICS_IDENTIFY_H_
 
+#include <string>
+
 class CharData;
 class ObjData;
+class CObjectPrototype;
+
+// Что записано в книге (заклинание, умение, рецепт, способность) одной строкой.
+// Пусто, если предмет не книга или содержимое битое. Общая для опознания и осмотра (#3877).
+std::string GetBookContents(const CObjectPrototype *obj);
 
 // Render an object's full stat block to `ch` (detail level scaled by `fullness`).
 void MortShowObjValues(const ObjData *obj, CharData *ch, int fullness);

--- a/src/gameplay/mechanics/identify.h
+++ b/src/gameplay/mechanics/identify.h
@@ -15,7 +15,9 @@ class CObjectPrototype;
 
 // Что записано в книге (заклинание, умение, рецепт, способность) одной строкой.
 // Пусто, если предмет не книга или содержимое битое. Общая для опознания и осмотра (#3877).
-std::string GetBookContents(const CObjectPrototype *obj);
+// Если передан персонаж -- к строке добавляется "(вам недоступно)" для талантов, которых
+// его класс не получает вовсе.
+std::string GetBookContents(const CObjectPrototype *obj, CharData *ch = nullptr);
 
 // Render an object's full stat block to `ch` (detail level scaled by `fullness`).
 void MortShowObjValues(const ObjData *obj, CharData *ch, int fullness);

--- a/src/gameplay/mechanics/sight.cpp
+++ b/src/gameplay/mechanics/sight.cpp
@@ -1299,11 +1299,11 @@ std::string show_obj_to_char(ObjData *object, CharData *ch, int mode, int show_s
 		} else if (object->get_type() == EObjType::kBandage) {
 			out = fmt::format("Бинты для перевязки ран ('перевязать').\r\nОсталось применений: {}, восстановление: {}",
 							  object->get_weight(), GET_OBJ_VAL(object, 0) * 10);
-		} else if (object->get_type() == EObjType::kBook && !GetBookContents(object).empty()) {
+		} else if (object->get_type() == EObjType::kBook && !GetBookContents(object, ch).empty()) {
 			// issue #3877: осмотр книги не говорил о ней ничего -- что внутри, знало только
 			// опознание. Заголовок берём из общего справочника типов книг.
 			out = fmt::format("{}.\r\n{}", GetBookTypeName(static_cast<EBook>(GET_OBJ_VAL(object, 0))),
-							  GetBookContents(object));
+							  GetBookContents(object, ch));
 		} else if (object->get_type() != EObjType::kLiquidContainer) {
 			out = "Вы не видите ничего необычного.";
 		} else        // ITEM_TYPE == kLiquidContainer||FOUNTAIN

--- a/src/gameplay/mechanics/sight.cpp
+++ b/src/gameplay/mechanics/sight.cpp
@@ -10,6 +10,7 @@
 #include "utils/native_text.h"
 #include "engine/core/target_resolver.h"
 #include "sight.h"
+#include "gameplay/mechanics/identify.h"
 #include "gameplay/mechanics/hide.h"
 #include "gameplay/mechanics/minions.h"
 #include "administration/privilege.h"
@@ -1298,6 +1299,11 @@ std::string show_obj_to_char(ObjData *object, CharData *ch, int mode, int show_s
 		} else if (object->get_type() == EObjType::kBandage) {
 			out = fmt::format("Бинты для перевязки ран ('перевязать').\r\nОсталось применений: {}, восстановление: {}",
 							  object->get_weight(), GET_OBJ_VAL(object, 0) * 10);
+		} else if (object->get_type() == EObjType::kBook && !GetBookContents(object).empty()) {
+			// issue #3877: осмотр книги не говорил о ней ничего -- что внутри, знало только
+			// опознание. Заголовок берём из общего справочника типов книг.
+			out = fmt::format("{}.\r\n{}", GetBookTypeName(static_cast<EBook>(GET_OBJ_VAL(object, 0))),
+							  GetBookContents(object));
 		} else if (object->get_type() != EObjType::kLiquidContainer) {
 			out = "Вы не видите ничего необычного.";
 		} else        // ITEM_TYPE == kLiquidContainer||FOUNTAIN


### PR DESCRIPTION
Закрывает #3877.

## Почему осмотр молчал

В `sight.cpp` разбор типов предмета при осмотре (`look_at_target`, режим 5) выглядит так:

```c
if (object->get_type() == EObjType::kNote) {          // записка -- читаем текст
} else if (object->get_type() == EObjType::kBandage) { // бинты -- применения
} else if (object->get_type() != EObjType::kLiquidContainer) {
    out = "Вы не видите ничего необычного.";           // <-- сюда попадала книга
} else {
    out = "Это емкость для жидкости.";
}
```

Ветки на `EObjType::kBook` там не было никогда — по всему `sight.cpp` тип книги не упоминается ни разу. Что внутри книги, знали только опознание (`identify.cpp:119`) и божеский `vstat` (`do_stat.cpp:752`) — поэтому в отчёте `vstat` показывает «восстановить плетение», а `осм` не показывает ничего.

## Правка

Добавлена общая `GetBookContents` рядом с опознанием — одна строка о содержимом для всех пяти видов книг (заклинание, умение, повышение умения, рецепт отвара, способность). Осмотр печатает название вида из общего справочника `GetBookTypeName` плюс эту строку:

```
Книга заклинаний.
содержит заклинание        : "восстановить плетение"
Состояние: идеально.
```

**Уровень изучения «для вас» намеренно оставлен опознанию** — осмотр бесплатный, а опознание нет. Если хочешь, чтобы осмотр показывал и его, скажи, добавлю одной строкой.

## Проверка на боевом мире

Поднял сервер на реальном `lib/` с временным логом по всем прототипам книг: **из 442 книг строку получают 438**.

Оставшиеся четыре — битые данные мира, не код:

| внум | предмет | что не так |
|---|---|---|
| 1729, 40429 | книга о мерцании звезд | тип 3 (рецепт), а рецепта 29 в таблице нет |
| 11026 | покрытый пылью свиток | тип 0 (заклинание), номер заклинания 0 |
| 83051 | книга знаний | то же самое |

Для них осмотр покажет прежнее «Вы не видите ничего необычного» — ровно как и опознание сейчас. Чинить их надо в мире, а не в движке.

Сборка без предупреждений, 712 тестов, сервер стартует на боевом мире.
