### PR TITLE
refactor(comm): drop global buffers from the chat channels (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_gen_comm.cpp
+++ b/src/engine/ui/cmd/do_gen_comm.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "do_gen_comm.h"
 #include "administration/privilege.h"
 #include "utils/native_text.h"
@@ -121,10 +123,8 @@ void do_gen_comm(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	}
 
 	if (GetRealLevel(ch) < com_msgs[subcmd].min_lev && !remort::GetRealRemort(ch)) {
-		sprintf(buf1,
-				"Вам стоит достичь хотя бы %d уровня, чтобы вы могли %s.\r\n",
-				com_msgs[subcmd].min_lev, com_msgs[subcmd].action);
-		SendMsgToChar(buf1, ch);
+		SendMsgToChar(fmt::format("Вам стоит достичь хотя бы {} уровня, чтобы вы могли {}.\r\n",
+								  com_msgs[subcmd].min_lev, com_msgs[subcmd].action), ch);
 		return;
 	}
 
@@ -139,8 +139,7 @@ void do_gen_comm(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 
 	// make sure that there is something there to say!
 	if (!*argument && subcmd != kScmdAuction) {
-		sprintf(buf1, "ЛЕГКО! Но, Ярило вас побери, ЧТО %s???\r\n", com_msgs[subcmd].action);
-		SendMsgToChar(buf1, ch);
+		SendMsgToChar(fmt::format("ЛЕГКО! Но, Ярило вас побери, ЧТО {}???\r\n", com_msgs[subcmd].action), ch);
 		return;
 	}
 
@@ -193,7 +192,6 @@ void do_gen_comm(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 
 	// first, set up strings to be given to the communicator
 	if (subcmd == kScmdAuction) {
-		*buf = '\0';
 		auction_drive(ch, argument);
 		return;
 	} else {
@@ -207,13 +205,12 @@ void do_gen_comm(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		if (ch->IsFlagged(EPrf::kNoRepeat))
 			SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);
 		else {
-			snprintf(buf1, kMaxStringLength, "%sВы %s : '%s'%s", color_on,
-					 com_msgs[subcmd].you_action, argument, kColorNrm);
-			act(buf1, false, ch, nullptr, nullptr, kToChar | kToSleep);
+			const std::string echo = fmt::format("{}Вы {} : '{}'{}", color_on,
+												 com_msgs[subcmd].you_action, argument, kColorNrm);
+			act(echo, false, ch, nullptr, nullptr, kToChar | kToSleep);
 
 			if (!ch->IsNpc()) {
-				strcat(buf1, "\r\n");
-				ch->remember_add(buf1, Remember::ALL);
+				ch->remember_add(echo + "\r\n", Remember::ALL);
 			}
 		}
 		switch (subcmd) {
@@ -232,24 +229,13 @@ void do_gen_comm(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 			default: ign_flag = 0;
 		}
 		snprintf(out_str, kMaxStringLength, "$n %s : '%s'", com_msgs[subcmd].hi_action, argument);
-		if (IsFemale(ch)) {
-			if (!ch->IsNpc() && (subcmd == kScmdGossip)) {
-				snprintf(buf1, kMaxStringLength, "%s%s заметила :'%s'%s\r\n", color_on, GET_NAME(ch), argument, kColorNrm);
-				ch->remember_add(buf1, Remember::GOSSIP);
-			}
-			if (!ch->IsNpc() && (subcmd == kScmdHoller)) {
-				snprintf(buf1, kMaxStringLength, "%s%s заорала :'%s'%s\r\n", color_on, GET_NAME(ch), argument, kColorNrm);
-				ch->remember_add(buf1, Remember::GOSSIP);
-			}
-		} else {
-			if (!ch->IsNpc() && (subcmd == kScmdGossip)) {
-				snprintf(buf1, kMaxStringLength, "%s%s заметил :'%s'%s\r\n", color_on, GET_NAME(ch), argument, kColorNrm);
-				ch->remember_add(buf1, Remember::GOSSIP);
-			}
-			if (!ch->IsNpc() && (subcmd == kScmdHoller)) {
-				snprintf(buf1, kMaxStringLength, "%s%s заорал :'%s'%s\r\n", color_on, GET_NAME(ch), argument, kColorNrm);
-				ch->remember_add(buf1, Remember::GOSSIP);
-			}
+		if (!ch->IsNpc() && (subcmd == kScmdGossip || subcmd == kScmdHoller)) {
+			// Четыре почти одинаковые ветки (пол x канал) свёрнуты в одну: различаются
+			// только глагол и окончание.
+			const char *verb = subcmd == kScmdGossip ? "заметил" : "заорал";
+			ch->remember_add(fmt::format("{}{} {}{} :'{}'{}\r\n", color_on, GET_NAME(ch), verb,
+										 IsFemale(ch) ? "а" : "", argument, kColorNrm),
+							 Remember::GOSSIP);
 		}
 	}
 	// now send all the strings out

--- a/src/engine/ui/cmd/do_group_say.cpp
+++ b/src/engine/ui/cmd/do_group_say.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "gameplay/mechanics/sight.h"
 #include "utils/grammar/gender.h"
@@ -42,37 +44,37 @@ void do_gsay(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			k = ch;
 		}
 
-		sprintf(buf, "$n сообщил$g группе : '%s'", argument);
+		const std::string to_group = fmt::format("$n сообщил$g группе : '{}'", argument);
 
 		if (AFF_FLAGGED(k, EAffect::kGroup)
 			&& k != ch
 			&& !ignores(k, ch, EIgnore::kGroup)) {
-			act(buf, false, ch, nullptr, k, kToVict | kToSleep | kToNotDeaf);
+			act(to_group, false, ch, nullptr, k, kToVict | kToSleep | kToNotDeaf);
 			if (!AFF_FLAGGED(k, EAffect::kDeafness)
 				&& k->GetPosition() > EPosition::kDead) {
-				sprintf(buf1,
-						"%s сообщил%s группе : '%s'\r\n",
-						tell_can_see(ch, k) ? ch->get_name().c_str() : "Кто-то",
-						grammar::VisSexEnding(sight::CanSee((k), (ch)), (ch)->get_sex(), 1),
-						argument);
-				k->remember_add(buf1, Remember::ALL);
-				k->remember_add(buf1, Remember::GROUP);
+				const std::string remembered =
+					fmt::format("{} сообщил{} группе : '{}'\r\n",
+								tell_can_see(ch, k) ? ch->get_name() : "Кто-то",
+								grammar::VisSexEnding(sight::CanSee((k), (ch)), (ch)->get_sex(), 1),
+								argument);
+				k->remember_add(remembered, Remember::ALL);
+				k->remember_add(remembered, Remember::GROUP);
 			}
 		}
 		for (auto *f : k->followers) {
 			if (AFF_FLAGGED(f, EAffect::kGroup)
 				&& (f != ch)
 				&& !ignores(f, ch, EIgnore::kGroup)) {
-				act(buf, false, ch, nullptr, f, kToVict | kToSleep | kToNotDeaf);
+				act(to_group, false, ch, nullptr, f, kToVict | kToSleep | kToNotDeaf);
 				if (!AFF_FLAGGED(f, EAffect::kDeafness)
 					&& f->GetPosition() > EPosition::kDead) {
-					sprintf(buf1,
-							"%s сообщил%s группе : '%s'\r\n",
-							tell_can_see(ch, f) ? ch->get_name().c_str() : "Кто-то",
-							grammar::VisSexEnding(sight::CanSee((f), (ch)), (ch)->get_sex(), 1),
-							argument);
-					f->remember_add(buf1, Remember::ALL);
-					f->remember_add(buf1, Remember::GROUP);
+					const std::string remembered =
+						fmt::format("{} сообщил{} группе : '{}'\r\n",
+									tell_can_see(ch, f) ? ch->get_name() : "Кто-то",
+									grammar::VisSexEnding(sight::CanSee((f), (ch)), (ch)->get_sex(), 1),
+									argument);
+					f->remember_add(remembered, Remember::ALL);
+					f->remember_add(remembered, Remember::GROUP);
 				}
 			}
 		}
@@ -80,10 +82,10 @@ void do_gsay(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		if (ch->IsFlagged(EPrf::kNoRepeat))
 			SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);
 		else {
-			sprintf(buf, "Вы сообщили группе : '%s'\r\n", argument);
-			SendMsgToChar(buf, ch);
-			ch->remember_add(buf, Remember::ALL);
-			ch->remember_add(buf, Remember::GROUP);
+			const std::string echo = fmt::format("Вы сообщили группе : '{}'\r\n", argument);
+			SendMsgToChar(echo, ch);
+			ch->remember_add(echo, Remember::ALL);
+			ch->remember_add(echo, Remember::GROUP);
 		}
 	}
 }

--- a/src/engine/ui/cmd/do_spec_comm.cpp
+++ b/src/engine/ui/cmd/do_spec_comm.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "engine/core/target_resolver.h"
 
@@ -39,36 +41,31 @@ void do_spec_comm(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		action_others = "$n задал$g $N2 вопрос.";
 	}
 
-	half_chop(argument, buf, buf2);
+	char name[kMaxInputLength];
+	char message[kMaxStringLength];
+	half_chop(argument, name, message);
 
-	if (!*buf || !*buf2) {
-		sprintf(buf, "Что вы хотите %s.. и %s?\r\n", action_sing, vict1);
-		SendMsgToChar(buf, ch);
-	} else if (!(vict = target_resolver::FindCharInRoom(ch, buf)))
+	if (!*name || !*message) {
+		SendMsgToChar(fmt::format("Что вы хотите {}.. и {}?\r\n", action_sing, vict1), ch);
+	} else if (!(vict = target_resolver::FindCharInRoom(ch, name)))
 		SendMsgToChar(CommonMsg(ECommonMsg::kNoPerson) + "\r\n", ch);
 	else if (vict == ch)
 		SendMsgToChar("От ваших уст до ушей - всего одна ладонь...\r\n", ch);
 	else if (ignores(vict, ch, subcmd == kScmdWhisper ? EIgnore::kWhisper : EIgnore::kAsk)) {
-		sprintf(buf, "%s не желает вас слышать.\r\n", GET_NAME(vict));
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(fmt::format("{} не желает вас слышать.\r\n", GET_NAME(vict)), ch);
 	} else {
 		if (subcmd == kScmdWhisper)
 			sprintf(vict3, "%s", GET_PAD(vict, 2));
 		else
 			sprintf(vict3, "у %s", GET_PAD(vict, 1));
 
-		std::stringstream buffer;
-		buffer << "$n " << action_plur << "$g " << vict2 << " : " << buf2;
-//		sprintf(buf, "$n %s$g %s : '%s'", action_plur, vict2, buf2);
-		act(buffer.str().c_str(), false, ch, nullptr, vict, kToVict | kToNotDeaf);
+		act(fmt::format("$n {}$g {} : {}", action_plur, vict2, message),
+			false, ch, nullptr, vict, kToVict | kToNotDeaf);
 
 		if (ch->IsFlagged(EPrf::kNoRepeat))
 			SendMsgToChar(CommonMsg(ECommonMsg::kOk) + "\r\n", ch);
 		else {
-			std::stringstream buffer;
-			buffer << "Вы " << action_plur << "и " << vict3 << " : '" << buf2 << "'" << "\r\n";
-//			sprintf(buf, "Вы %sи %s : '%s'\r\n", action_plur, vict3, buf2);
-			SendMsgToChar(buffer.str(), ch);
+			SendMsgToChar(fmt::format("Вы {}и {} : '{}'\r\n", action_plur, vict3, message), ch);
 		}
 
 		act(action_others, false, ch, nullptr, vict, kToNotVict);

--- a/src/gameplay/communication/talk.cpp
+++ b/src/gameplay/communication/talk.cpp
@@ -80,6 +80,7 @@ int is_tell_ok(CharData *ch, CharData *vict) {
 }
 
 void perform_tell(CharData *ch, CharData *vict, char *arg) {
+	std::string tell_text;
 	if (vict->IsFlagged(EPrf::kNoInvistell)
 		&& !sight::CanSee(vict, ch)
 		&& GetRealLevel(ch) < kLvlImmortal
@@ -90,26 +91,26 @@ void perform_tell(CharData *ch, CharData *vict, char *arg) {
 
 	// TODO: если в act() останется показ иммов, то это и эхо ниже переделать на act()
 	if (tell_can_see(ch, vict)) {
-		snprintf(buf, kMaxStringLength, "%s сказал%s вам : '%s'", GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), arg);
+		tell_text = fmt::format("{} сказал{} вам : '{}'", GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), arg);
 	} else {
-		snprintf(buf, kMaxStringLength, "Кто-то сказал вам : '%s'", arg);
+		tell_text = fmt::format("Кто-то сказал вам : '{}'", arg);
 	}
 	// перенос длинного телла по словам на ширину экрана получателя
 	// (stringLength == 0 -- лимит не задан, не переносим; NPC -- player_specials нет)
-	std::string tell_line = utils::CAP(buf);
+	std::string tell_line = utils::CAP(tell_text);
 	if (!vict->IsNpc() && vict->player_specials->saved.stringLength > 0) {
 		tell_line = utils::OutWordsList(tell_line, vict->player_specials->saved.stringLength, " ");
 	}
-	snprintf(buf1, kMaxStringLength, "%s%s%s\r\n", kColorBoldCyn, tell_line.c_str(), kColorNrm);
-	SendMsgToChar(buf1, vict);
+	const std::string to_vict = fmt::format("{}{}{}\r\n", kColorBoldCyn, tell_line, kColorNrm);
+	SendMsgToChar(to_vict, vict);
 	if (!vict->IsNpc()) {
-		vict->remember_add(buf1, Remember::ALL);
+		vict->remember_add(to_vict, Remember::ALL);
 	}
 
 	if (!vict->IsNpc() && !ch->IsNpc()) {
-		snprintf(buf, kMaxStringLength, "%s%s : '%s'%s\r\n", kColorBoldCyn,
-				 tell_can_see(ch, vict) ? GET_NAME(ch) : "Кто-то", arg, kColorNrm);
-		vict->remember_add(buf, Remember::PERSONAL);
+		vict->remember_add(fmt::format("{}{} : '{}'{}\r\n", kColorBoldCyn,
+									   tell_can_see(ch, vict) ? GET_NAME(ch) : "Кто-то", arg, kColorNrm),
+						   Remember::PERSONAL);
 	}
 
 	if (ch->IsFlagged(EPrf::kNoRepeat)) {
@@ -125,10 +126,10 @@ void perform_tell(CharData *ch, CharData *vict, char *arg) {
 		if (!ch->IsNpc() && ch->player_specials->saved.stringLength > 0) {
 			echo = utils::OutWordsList(echo, ch->player_specials->saved.stringLength, " ");
 		}
-		snprintf(buf, kMaxStringLength, "%s%s%s\r\n", kColorBoldCyn, echo.c_str(), kColorNrm);
-		SendMsgToChar(buf, ch);
+		const std::string to_char = fmt::format("{}{}{}\r\n", kColorBoldCyn, echo, kColorNrm);
+		SendMsgToChar(to_char, ch);
 		if (!ch->IsNpc()) {
-			ch->remember_add(buf, Remember::ALL);
+			ch->remember_add(to_char, Remember::ALL);
 		}
 	}
 


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Каналы (`болтать`, `орать`, `кричать`), сообщение группе, `шепнуть`/`спросить` и `perform_tell` переведены на локальные строки.

Опасное место — `do_gen_comm`: строка канала лежала в `buf1` и переживала рассылку по всем дескрипторам, а под конец в тот же `buf1` писалась копия для `remember`. Любой вызов внутри цикла мог затереть и то, и другое.

Там же свёрнуты четыре почти одинаковые ветки (пол × канал) в одну — от женского варианта отличалось только окончание глагола. Тексты сообщений не изменились.

В `do_spec_comm` убраны два `std::stringstream` и закомментированные исходные `sprintf` рядом с ними.

Сборка без предупреждений, 712 тестов проходят.