### PR TITLE
refactor(cmd): drop global buffers from skills, forget, toggle and remove (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_forget.cpp
+++ b/src/engine/ui/cmd/do_forget.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include "do_forget.h"
 #include "administration/privilege.h"
 
@@ -21,22 +23,23 @@ void do_forget(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	int is_in_mem;
 
 	// проверка на аргумент рецепт|отвар
-	one_argument(argument, arg);
+	char what[kMaxInputLength];
+	one_argument(argument, what);
 
-	if (!*arg) {
+	if (!*what) {
 		SendMsgToChar("Что вы хотите забыть?\r\n", ch);
 		return;
 	}
 
-	if (utils::IsAbbr(arg, "recipe") || utils::IsAbbr(arg, "рецепт") ||
-		utils::IsAbbr(arg, "отвар")) {
+	if (utils::IsAbbr(what, "recipe") || utils::IsAbbr(what, "рецепт") ||
+		utils::IsAbbr(what, "отвар")) {
 		forget_recipe(ch, argument, 0);
 		return;
 	}
 
-	if (utils::IsAbbr(arg, "все") || utils::IsAbbr(arg, "all")) {
+	if (utils::IsAbbr(what, "все") || utils::IsAbbr(what, "all")) {
 		char arg2[kMaxInputLength];
-		two_arguments(argument, arg, arg2);
+		two_arguments(argument, what, arg2);
 		if (in_mem(arg2)) {
 			MemQ_flush(ch);
 			SendMsgToChar("Вы вычеркнули все заклинания из своего списка для запоминания.\r\n", ch);
@@ -44,10 +47,8 @@ void do_forget(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			for (auto spell_id = ESpell::kFirst ; spell_id <= ESpell::kLast; ++spell_id) {
 				GET_SPELL_MEM(ch, spell_id) = 0;
 			}
-			sprintf(buf,
-					"Вы удалили все заклинания из %s.\r\n",
-					GET_RELIGION(ch) == kReligionMono ? "своего часослова" : "своих рез");
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Вы удалили все заклинания из {}.\r\n",
+									  GET_RELIGION(ch) == kReligionMono ? "своего часослова" : "своих рез"), ch);
 		}
 		return;
 	}
@@ -85,8 +86,8 @@ void do_forget(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (quote2 != std::string::npos && quote2 + 1 < arg_str.size()) {
 		std::string rest_str = arg_str.substr(quote2 + 1);
 		utils::TrimLeft(rest_str);
-		one_argument(rest_str.data(), arg);
-		is_in_mem = in_mem(arg);
+		one_argument(rest_str.data(), what);
+		is_in_mem = in_mem(what);
 	}
 	if (!is_in_mem)
 		if (!GET_SPELL_MEM(ch, spell_id)) {
@@ -95,10 +96,9 @@ void do_forget(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		} else {
 			--GET_SPELL_MEM(ch, spell_id);
 			ch->caster_level -= MUD::Spell(spell_id).GetDanger();
-			sprintf(buf, "Вы удалили заклинание '%s%s%s' из %s.\r\n",
-					kColorBoldCyn, MUD::Spell(spell_id).GetCName(),
-					kColorNrm, GET_RELIGION(ch) == kReligionMono ? "своего часослова" : "своих рез");
-			SendMsgToChar(buf, ch);
+			SendMsgToChar(fmt::format("Вы удалили заклинание '{}{}{}' из {}.\r\n",
+									  kColorBoldCyn, MUD::Spell(spell_id).GetName(), kColorNrm,
+									  GET_RELIGION(ch) == kReligionMono ? "своего часослова" : "своих рез"), ch);
 		}
 	else
 		MemQ_forget(ch, spell_id);

--- a/src/engine/ui/cmd/do_remove.cpp
+++ b/src/engine/ui/cmd/do_remove.cpp
@@ -1,3 +1,5 @@
+#include <fmt/format.h>
+
 #include "engine/ui/cmd/do_remove.h"
 #include "gameplay/mechanics/sight.h"
 
@@ -45,13 +47,14 @@ void do_remove(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	int i, dotmode, found;
 	ObjData *obj;
 
-	one_argument(argument, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
 
-	if (!*arg) {
+	if (!*name) {
 		SendMsgToChar("Снять что?\r\n", ch);
 		return;
 	}
-	dotmode = ParseAllPrefix(arg);
+	dotmode = ParseAllPrefix(name);
 
 	if (dotmode == kFindAll) {
 		found = 0;
@@ -68,7 +71,7 @@ void do_remove(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		ch->obj_bonus().update(ch);
 		affect_total(ch);
 	} else if (dotmode == kFindAlldot) {
-		if (!*arg) {
+		if (!*name) {
 			SendMsgToChar("Снять все вещи какого типа?\r\n", ch);
 			return;
 		} else {
@@ -76,15 +79,14 @@ void do_remove(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 			for (i = 0; i < EEquipPos::kNumEquipPos; i++) {
 				if (GET_EQ(ch, i)
 					&& sight::CanSeeObj(ch, GET_EQ(ch, i))
-					&& (isname(arg, GET_EQ(ch, i)->get_aliases())
-						|| CHECK_CUSTOM_LABEL(arg, GET_EQ(ch, i), ch))) {
+					&& (isname(name, GET_EQ(ch, i)->get_aliases())
+						|| CHECK_CUSTOM_LABEL(name, GET_EQ(ch, i), ch))) {
 					RemoveEquipment(ch, i, true);
 					found = 1;
 				}
 			}
 			if (!found) {
-				snprintf(buf, kMaxStringLength, "Вы не используете ни одного '%s'.\r\n", arg);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("Вы не используете ни одного '{}'.\r\n", name), ch);
 				return;
 			}
 			ch->obj_bonus().update(ch);
@@ -92,22 +94,21 @@ void do_remove(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		}
 	} else        // Returns object pointer but we don't need it, just true/false.
 	{
-		if (!get_object_in_equip_vis(ch, arg, ch->equipment, &i)) {
+		if (!get_object_in_equip_vis(ch, name, ch->equipment, &i)) {
 			// если предмет не найден, то возможно игрок ввел "левая" или "правая"
-			if (!str_cmp("правая", arg)) {
+			if (!str_cmp("правая", name)) {
 				if (!GET_EQ(ch, EEquipPos::kWield)) {
 					SendMsgToChar("В правой руке ничего нет.\r\n", ch);
 				} else {
 					RemoveEquipment(ch, EEquipPos::kWield);
 				}
-			} else if (!str_cmp("левая", arg)) {
+			} else if (!str_cmp("левая", name)) {
 				if (!GET_EQ(ch, EEquipPos::kHold))
 					SendMsgToChar("В левой руке ничего нет.\r\n", ch);
 				else
 					RemoveEquipment(ch, EEquipPos::kHold);
 			} else {
-				snprintf(buf, kMaxInputLength, "Вы не используете '%s'.\r\n", arg);
-				SendMsgToChar(buf, ch);
+				SendMsgToChar(fmt::format("Вы не используете '{}'.\r\n", name), ch);
 				return;
 			}
 		} else {

--- a/src/engine/ui/cmd/do_skills.cpp
+++ b/src/engine/ui/cmd/do_skills.cpp
@@ -36,9 +36,9 @@ void DoSkills(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 void DisplaySkills(CharData *ch, CharData *vict, const char *filter/* = nullptr*/) {
 	int i = 0;
+	std::string line;
 
-	sprintf(buf, "Вы владеете следующими умениями:\r\n");
-	strcpy(buf2, buf);
+	std::string out = "Вы владеете следующими умениями:\r\n";
 	std::list<std::string> skills_names;
 
 	for (const auto &skill : MUD::Skills()) {
@@ -53,12 +53,12 @@ void DisplaySkills(CharData *ch, CharData *vict, const char *filter/* = nullptr*
 			auto skill_id = skill.GetId();
 			switch (skill_id) {
 				case ESkill::kWarcry:
-					sprintf(buf, "[-%d-] ", (kHoursPerDay - IsTimedBySkill(ch, skill_id)) / kHoursPerWarcry);
+					line = fmt::format("[-{}-] ", (kHoursPerDay - IsTimedBySkill(ch, skill_id)) / kHoursPerWarcry);
 					break;
 				case ESkill::kTurnUndead: {
 					auto bonus = CanUseFeat(ch, EFeat::kExorcist) ? -2 : 0;
 					bonus = std::max(1, kHoursPerTurnUndead + bonus);
-					sprintf(buf, "[-%d-] ", (kHoursPerDay - IsTimedBySkill(ch, skill_id)) / bonus);
+					line = fmt::format("[-{}-] ", (kHoursPerDay - IsTimedBySkill(ch, skill_id)) / bonus);
 					break;
 				}
 				case ESkill::kFirstAid:
@@ -71,46 +71,34 @@ void DisplaySkills(CharData *ch, CharData *vict, const char *filter/* = nullptr*
 				case ESkill::kStun:
 				case ESkill::kRepair:
 					if (IsTimedBySkill(ch, skill_id) > 0)
-						sprintf(buf, "[%3d] ", IsTimedBySkill(ch, skill_id));
+						line = fmt::format("[{:3}] ", IsTimedBySkill(ch, skill_id));
 					else
-						sprintf(buf, "[-!-] ");
+						line = "[-!-] ";
 					break;
-				default: sprintf(buf, "      ");
+				default: line = "      ";
 			}
 
 			// Ширина колонки - в символах, а не в байтах (issue #3681).
-			strcat(buf, fmt::format("{:<23} {} ({}){} \r\n",
+			line += fmt::format("{:<23} {} ({}){} \r\n",
 					skill.GetName(),
 					how_good(GetSkill(ch, skill_id), CalcSkillHardCap(ch, skill_id)),
 					GetTrainedSkill(ch, skill_id) == 0 ? GetEquippedSkill(ch, skill_id) : 
 					std::min(CalcSkillMinCap(ch, skill_id) + GetEquippedSkill(ch, skill_id), MUD::Skill(skill_id).cap),
-					kColorNrm).c_str());
-			skills_names.emplace_back(buf);
+					kColorNrm);
+			skills_names.emplace_back(line);
 			i++;
 		}
 	}
 
 	if (!i) {
-		if (nullptr == filter) {
-			sprintf(buf2 + strlen(buf2), "Нет умений.\r\n");
-		} else {
-			sprintf(buf2 + strlen(buf2), "Нет умений, удовлетворяющих фильтру.\r\n");
-		}
+		out += (nullptr == filter) ? "Нет умений.\r\n" : "Нет умений, удовлетворяющих фильтру.\r\n";
 	} else {
-		// output set of skills
-		size_t buf2_length = strlen(buf2);
+		// Сторож переполнения снят вместе с буфером: список умений растёт сам.
 		for (const auto &skill_name : skills_names) {
-			// why 60?
-			if (buf2_length + skill_name.length() >= kMaxStringLength - 60) {
-				strcat(buf2, "***ПЕРЕПОЛНЕНИЕ***\r\n");
-				break;
-			}
-
-			strncat(buf2 + buf2_length, skill_name.c_str(), skill_name.length());
-			buf2_length += skill_name.length();
+			out += skill_name;
 		}
 	}
-	SendMsgToChar(buf2, vict);
+	SendMsgToChar(out, vict);
 
 }
 

--- a/src/engine/ui/cmd/do_toggle.cpp
+++ b/src/engine/ui/cmd/do_toggle.cpp
@@ -12,13 +12,17 @@ const char *BoolToOnOffStr(bool value);
 void do_toggle(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 	if (ch->IsNpc())
 		return;
+	// Вёрстка таблицы считается printf'ом в байтах; перевод на fmt сдвинул бы колонки,
+	// поэтому здесь меняются только буферы -- формат оставлен как есть (#3814).
+	char out[kMaxStringLength];
+	char wimpy[kMaxInputLength];
 	if (GET_WIMP_LEV(ch) == 0)
-		strcpy(buf2, "нет");
+		strcpy(wimpy, "нет");
 	else
-		sprintf(buf2, "%-3d", GET_WIMP_LEV(ch));
+		snprintf(wimpy, sizeof(wimpy), "%-3d", GET_WIMP_LEV(ch));
 
 	if (GetRealLevel(ch) >= kLvlImmortal || ch->IsFlagged(EPrf::kCoderinfo)) {
-		snprintf(buf, kMaxStringLength,
+		snprintf(out, sizeof(out),
 				 " Нет агров     : %-3s     "
 				 " Супервидение  : %-3s     "
 				 " Флаги комнат  : %-3s \r\n"
@@ -33,10 +37,10 @@ void do_toggle(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 				 BoolToOnOffStr(nameserver_is_slow),
 				 BoolToOnOffStr(ch->IsFlagged(EPrf::kCoderinfo)),
 				 BoolToOnOffStr(ch->IsFlagged(EPrf::kShowUnread)));
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(out, ch);
 	}
 
-	snprintf(buf, kMaxStringLength,
+	snprintf(out, sizeof(out),
 			 " Автовыходы    : %-3s     "
 			 " Краткий режим : %-3s     "
 			 " Сжатый режим  : %-3s \r\n"
@@ -92,7 +96,7 @@ void do_toggle(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 			 ch->IsFlagged(EPrf::kAutoloot) ? ch->IsFlagged(EPrf::kNoIngrLoot) ? "NO-INGR" : "ALL    " : "OFF    ",
 			 BoolToOnOffStr(ch->IsFlagged(EPrf::kAutomoney)),
 			 BoolToOnOffStr(!ch->IsFlagged(EPrf::kNoArena)),
-			 buf2,
+			 wimpy,
 			 (ch)->player_specials->saved.stringLength,
 			 (ch)->player_specials->saved.stringWidth,
 #if defined(HAVE_ZLIB)
@@ -111,14 +115,14 @@ void do_toggle(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 			 BoolToOnOffStr(ch->IsFlagged(EPrf::kAntiDcMode)),
 			 BoolToOnOffStr(ch->IsFlagged(EPrf::kNoIngrMode)),
 			 ch->remember_get_num());
-	SendMsgToChar(buf, ch);
+	SendMsgToChar(out, ch);
 	if ((ch)->player_specials->saved.ntfyExchangePrice > 0) {
-		sprintf(buf, " Уведомления   : %-7ld ", (ch)->player_specials->saved.ntfyExchangePrice);
+		snprintf(out, sizeof(out), " Уведомления   : %-7ld ", (ch)->player_specials->saved.ntfyExchangePrice);
 	} else {
-		sprintf(buf, " Уведомления   : %s ", native_text::pad_right("Нет", 7).c_str());
+		snprintf(out, sizeof(out), " Уведомления   : %s ", native_text::pad_right("Нет", 7).c_str());
 	}
-	SendMsgToChar(buf, ch);
-	snprintf(buf, kMaxStringLength,
+	SendMsgToChar(out, ch);
+	snprintf(out, sizeof(out),
 			 " Карта         : %-3s     "
 			 " Вход в зону   : %-3s   \r\n"
 			 " Магщиты (вид) : %s"
@@ -131,12 +135,12 @@ void do_toggle(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) {
 			 BoolToOnOffStr(ch->IsFlagged(EPrf::kAutonosummon)),
 			 BoolToOnOffStr(ch->IsFlagged(EPrf::kMapper)),
 			 BoolToOnOffStr(ch->IsFlagged(EPrf::kIpControl)));
-	SendMsgToChar(buf, ch);
+	SendMsgToChar(out, ch);
 	if (GET_GOD_FLAG(ch, EGf::kAllowTesterMode))
-		sprintf(buf, " Тестер        : %-3s\r\n", BoolToOnOffStr(ch->IsFlagged(EPrf::kTester)));
+		snprintf(out, sizeof(out), " Тестер        : %-3s\r\n", BoolToOnOffStr(ch->IsFlagged(EPrf::kTester)));
 	else
-		sprintf(buf, "\r\n");
-	SendMsgToChar(buf, ch);
+		snprintf(out, sizeof(out), "\r\n");
+	SendMsgToChar(out, ch);
 }
 
 const char *BoolToOnOffStr(bool value) {


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

`умения`, `забыть`, `режим`, `снять`.

В `do_skills` список собирался в `buf2` через `strcat` со сторожем на `kMaxStringLength - 60` и припиской `***ПЕРЕПОЛНЕНИЕ***` при нехватке места. Теперь это `std::string`, сторож не нужен — у кого умений много, тот увидит их все. Каждая строка списка тоже собиралась в `buf` и оттуда копировалась в список.

В `do_toggle` вёрстка таблицы настроек считается printf'ом **в байтах**, поэтому формат не тронут: заменены только буферы на локальные. Перевод этой таблицы на `fmt` сдвинул бы колонки и должен идти отдельной правкой.

Сборка без предупреждений, 712 тестов проходят.