### PR TITLE
refactor(cmd): drop global buffers from pray, enter and hire (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_enter.cpp
+++ b/src/engine/ui/cmd/do_enter.cpp
@@ -5,6 +5,8 @@
 \brief 'Do enter' command.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "gameplay/mechanics/minions.h"
@@ -27,15 +29,16 @@ void DoEnter(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	const char *p_str = "пентаграмма";
 	char *pnumber;
 
-	one_argument(argument, smallBuf);
-	pnumber = smallBuf;
+	char name[kMaxInputLength];
+	one_argument(argument, name);
+	pnumber = name;
 	if (!(fnum = get_number(&pnumber))) {
 		SendMsgToChar("Здесь такой нет!\r\n", ch);
 		return;
 	}
 
-	if (*smallBuf) {
-		if (isname(smallBuf, p_str)) {
+	if (*name) {
+		if (isname(name, p_str)) {
 
 			int i = 0;
 			for (const auto &aff : world[ch->in_room]->affected) {
@@ -89,10 +92,12 @@ void DoEnter(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 						|| AFF_FLAGGED(ch, EAffect::kNoTeleport)
 						|| (room_spells::FindRoomPkPortalUid(world[door]) != 0
 							&& (ROOM_FLAGGED(door, ERoomFlag::kArena) || ROOM_FLAGGED(door, ERoomFlag::kHouse))))) {
-					sprintf(smallBuf, "%sПентаграмма ослепительно вспыхнула!%s\r\n",
-							kColorWht, kColorNrm);
-					act(smallBuf, true, ch, nullptr, nullptr, kToChar);
-					act(smallBuf, true, ch, nullptr, nullptr, kToRoom);
+					// Сообщение писалось в smallBuf поверх аргумента команды -- а ниже по
+					// функции этот же аргумент ещё нужен для приказа спутникам (#3814).
+					const std::string flash = fmt::format("{}Пентаграмма ослепительно вспыхнула!{}\r\n",
+														  kColorWht, kColorNrm);
+					act(flash, true, ch, nullptr, nullptr, kToChar);
+					act(flash, true, ch, nullptr, nullptr, kToRoom);
 
 					SendMsgToChar("Мощным ударом вас отшвырнуло от пентаграммы.\r\n", ch);
 					act("$n с визгом отлетел$g от пентаграммы.\r\n", true, ch,
@@ -148,12 +153,14 @@ void DoEnter(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 						!AFF_FLAGGED(k, EAffect::kHold) &&
 						k->GetPosition() == EPosition::kStand &&
 						k->in_room == from_room) {
+						// command_interpreter правит строку на месте, поэтому своя копия на каждого
+						char order[kMaxInputLength];
 						if (fnum > 1) {
-							snprintf(buf2, kMaxStringLength, "enter %d.%s", fnum, smallBuf);
+							snprintf(order, sizeof(order), "enter %d.%s", fnum, name);
 						} else {
-							snprintf(buf2, kMaxStringLength, "enter %s", smallBuf);
+							snprintf(order, sizeof(order), "enter %s", name);
 						}
-						command_interpreter(k, buf2);
+						command_interpreter(k, order);
 					}
 				}
 				if (ch->desc != nullptr)
@@ -162,14 +169,13 @@ void DoEnter(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		} else {    // an argument was supplied, search for door keyword
 			for (door = 0; door < EDirection::kMaxDirNum; door++) {
 				if (EXIT(ch, door)
-					&& (isname(smallBuf, EXIT(ch, door)->keyword)
-						|| isname(smallBuf, EXIT(ch, door)->vkeyword))) {
+					&& (isname(name, EXIT(ch, door)->keyword)
+						|| isname(name, EXIT(ch, door)->vkeyword))) {
 					PerformMove(ch, door, 1, true, nullptr);
 					return;
 				}
 			}
-			sprintf(buf2, "Вы не нашли здесь '%s'.\r\n", smallBuf);
-			SendMsgToChar(buf2, ch);
+			SendMsgToChar(fmt::format("Вы не нашли здесь '{}'.\r\n", name), ch);
 		}
 	} else if (ROOM_FLAGGED(ch->in_room, ERoomFlag::kIndoors))
 		SendMsgToChar("Вы уже внутри.\r\n", ch);

--- a/src/engine/ui/cmd/do_hire.cpp
+++ b/src/engine/ui/cmd/do_hire.cpp
@@ -135,9 +135,10 @@ void DoFindhelpee(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	argument = one_argument(argument, arg);
+	char name[kMaxInputLength];
+	argument = one_argument(argument, name);
 
-	if (!*arg) {
+	if (!*name) {
 		CharData *hired = nullptr;
 		for (auto *k : ch->followers) {
 			if (AFF_FLAGGED(k, EAffect::kHelper) && AFF_FLAGGED(k, EAffect::kCharmed)) {
@@ -156,7 +157,7 @@ void DoFindhelpee(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 	CharData *helpee = nullptr;
 
-	helpee = target_resolver::FindCharInRoom(ch, arg);
+	helpee = target_resolver::FindCharInRoom(ch, name);
 	if (!helpee) {
 		SendMsgToChar("Вы не видите никого похожего.\r\n", ch);
 		return;
@@ -192,15 +193,15 @@ void DoFindhelpee(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		// Вы издеваетесь? Блок else на три экрана, реально?
 		// Svent TODO: Вынести проверку на корректность чармиса в отдельную функицю.
 		char isbank[kMaxStringLength];
-		two_arguments(argument, arg, isbank);
+		two_arguments(argument, name, isbank);
 
 		unsigned int times = 0;
-		times = atoi(arg);
-		if (!*arg || times == 0) {
+		times = atoi(name);
+		if (!*name || times == 0) {
 			const auto cost = CalcHirePrice(ch, helpee);
-			sprintf(buf, "$n сказал$g вам : \"Один час моих услуг стоит %ld %s\".\r\n",
-					cost, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(cost, grammar::ECase::kNom).c_str());
-			act(buf, false, helpee, 0, ch, kToVict | kToNotDeaf);
+			act(fmt::format("$n сказал$g вам : \"Один час моих услуг стоит {} {}\".\r\n", cost,
+							MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(cost, grammar::ECase::kNom)),
+				false, helpee, 0, ch, kToVict | kToNotDeaf);
 			return;
 		}
 		if (hired && helpee != hired) {
@@ -219,11 +220,10 @@ void DoFindhelpee(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 		if ((!isname(isbank, "банк bank") && cost > currencies::GetHand(*ch, currencies::kGold)) ||
 			(isname(isbank, "банк bank") && cost > currencies::GetBank(*ch, currencies::kGold))) {
-			sprintf(buf,
-					"$n сказал$g вам : \" Мои услуги за %d %s стоят %ld %s - это тебе не по карману.\"",
-					times,
-					grammar::GetDeclensionInNumber(times, grammar::EWhat::kHour), cost, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(cost, grammar::ECase::kNom).c_str());
-			act(buf, false, helpee, 0, ch, kToVict | kToNotDeaf);
+			act(fmt::format("$n сказал$g вам : \" Мои услуги за {} {} стоят {} {} - это тебе не по карману.\"",
+							times, grammar::GetDeclensionInNumber(times, grammar::EWhat::kHour), cost,
+							MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(cost, grammar::ECase::kNom)),
+				false, helpee, 0, ch, kToVict | kToNotDeaf);
 			return;
 		}
 
@@ -284,8 +284,8 @@ void DoFindhelpee(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		af.battleflag = {kAfCharmBond};
 		affect_to_char(helpee, af);
 
-		sprintf(buf, "$n сказал$g вам : \"Приказывай, %s!\"", IsFemale(ch) ? "хозяйка" : "хозяин");
-		act(buf, false, helpee, 0, ch, kToVict | kToNotDeaf);
+		act(fmt::format("$n сказал$g вам : \"Приказывай, {}!\"", IsFemale(ch) ? "хозяйка" : "хозяин"),
+			false, helpee, 0, ch, kToVict | kToNotDeaf);
 
 		if (helpee->IsNpc()) {
 			for (auto i = 0; i < EEquipPos::kNumEquipPos; i++) {

--- a/src/engine/ui/cmd/do_pray.cpp
+++ b/src/engine/ui/cmd/do_pray.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/ui/cmd/do_pray.h"
 #include "administration/privilege.h"
 #include "gameplay/economics/currencies.h"
@@ -44,9 +46,11 @@ void do_pray(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 		return;
 	}
 
-	half_chop(argument, arg, buf);
+	char whom[kMaxInputLength];
+	char gift[kMaxStringLength];
+	half_chop(argument, whom, gift);
 
-	if (!*arg || (metter = search_block(arg, pray_whom, false)) < 0) {
+	if (!*whom || (metter = search_block(whom, pray_whom, false)) < 0) {
 		if (subcmd == SCMD_DONATE) {
 			SendMsgToChar("Вы можете принести жертву :\r\n", ch);
 			for (metter = 0; *(pray_metter[metter]) != '\n'; metter++) {
@@ -79,7 +83,7 @@ void do_pray(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	}
 
 	if (subcmd == SCMD_DONATE) {
-		if (!*buf || !(obj = get_obj_in_list_vis(ch, buf, ch->carrying))) {
+		if (!*gift || !(obj = get_obj_in_list_vis(ch, gift, ch->carrying))) {
 			SendMsgToChar("Вы должны пожертвовать что-то стоящее.\r\n", ch);
 			return;
 		}
@@ -129,16 +133,16 @@ void do_pray(CharData *ch, char *argument, int/* cmd*/, int subcmd) {
 	}
 
 	if (subcmd == SCMD_PRAY) {
-		sprintf(buf, "$n затеплил$g свечку и вознес$q молитву %s.", pray_whom[metter]);
-		act(buf, false, ch, nullptr, nullptr, kToRoom | kToArenaListen);
-		sprintf(buf, "Вы затеплили свечку и вознесли молитву %s.", pray_whom[metter]);
-		act(buf, false, ch, nullptr, nullptr, kToChar);
+		act(fmt::format("$n затеплил$g свечку и вознес$q молитву {}.", pray_whom[metter]),
+			false, ch, nullptr, nullptr, kToRoom | kToArenaListen);
+		act(fmt::format("Вы затеплили свечку и вознесли молитву {}.", pray_whom[metter]),
+			false, ch, nullptr, nullptr, kToChar);
 		currencies::RemoveHand(*ch, currencies::kGold, 10);
 	} else if (subcmd == SCMD_DONATE && obj) {
-		sprintf(buf, "$n принес$q $o3 в жертву %s.", pray_whom[metter]);
-		act(buf, false, ch, obj, nullptr, kToRoom | kToArenaListen);
-		sprintf(buf, "Вы принесли $o3 в жертву %s.", pray_whom[metter]);
-		act(buf, false, ch, obj, nullptr, kToChar);
+		act(fmt::format("$n принес$q $o3 в жертву {}.", pray_whom[metter]),
+			false, ch, obj, nullptr, kToRoom | kToArenaListen);
+		act(fmt::format("Вы принесли $o3 в жертву {}.", pray_whom[metter]),
+			false, ch, obj, nullptr, kToChar);
 		RemoveObjFromChar(obj);
 		ExtractObjFromWorld(obj);
 	}

--- a/src/engine/ui/cmd/do_pray_gods.cpp
+++ b/src/engine/ui/cmd/do_pray_gods.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "utils/grammar/gender.h"
@@ -43,8 +45,7 @@ void do_pray_gods(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	}
 
 	if (!*argument) {
-		sprintf(buf, "С чем вы хотите обратиться к Богам?\r\n");
-		SendMsgToChar(buf, ch);
+		SendMsgToChar("С чем вы хотите обратиться к Богам?\r\n", ch);
 		return;
 	}
 	if (ch->IsFlagged(EPrf::kNoRepeat))
@@ -52,34 +53,41 @@ void do_pray_gods(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	else {
 		if (ch->IsNpc())
 			return;
+		std::string echo;
 		if (privilege::IsImmortal(ch)) {
-			sprintf(buf, "&RВы одарили СЛОВОМ %s : '%s'&n\r\n", GET_PAD(victim, 3), argument);
+			echo = fmt::format("&RВы одарили СЛОВОМ {} : '{}'&n\r\n", GET_PAD(victim, 3), argument);
 		} else {
-			sprintf(buf, "&RВы воззвали к Богам с сообщением : '%s'&n\r\n", argument);
+			echo = fmt::format("&RВы воззвали к Богам с сообщением : '{}'&n\r\n", argument);
 			SetWait(ch, 3, false);
 		}
-		SendMsgToChar(buf, ch);
-		ch->remember_add(buf, Remember::PRAY_PERSONAL);
+		SendMsgToChar(echo, ch);
+		ch->remember_add(echo, Remember::PRAY_PERSONAL);
 	}
 
+	std::string to_gods;
 	if (privilege::IsImmortal(ch)) {
-		sprintf(buf, "&R%s ответил%s вам : '%s'&n\r\n", GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), argument);
-		SendMsgToChar(buf, victim);
-		victim->remember_add(buf, Remember::PRAY_PERSONAL);
+		const std::string to_victim =
+			fmt::format("&R{} ответил{} вам : '{}'&n\r\n",
+						GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), argument);
+		SendMsgToChar(to_victim, victim);
+		victim->remember_add(to_victim, Remember::PRAY_PERSONAL);
 
-		snprintf(buf1, kMaxStringLength, "&R%s ответил%s %s : '%s&n\r\n",
-				 GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), GET_PAD(victim, 2), argument);
-		ch->remember_add(buf1, Remember::PRAY);
+		ch->remember_add(fmt::format("&R{} ответил{} {} : '{}&n\r\n",
+									 GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1),
+									 GET_PAD(victim, 2), argument),
+						 Remember::PRAY);
 
-		snprintf(buf, kMaxStringLength, "&R%s ответил%s на воззвание %s : '%s'&n\r\n",
-				 GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), GET_PAD(victim, 1), argument);
+		to_gods = fmt::format("&R{} ответил{} на воззвание {} : '{}'&n\r\n",
+							  GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1),
+							  GET_PAD(victim, 1), argument);
 	} else {
-		snprintf(buf1, kMaxStringLength, "&R%s воззвал%s к богам : '%s&n\r\n",
-				 GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), argument);
-		ch->remember_add(buf1, Remember::PRAY);
+		ch->remember_add(fmt::format("&R{} воззвал{} к богам : '{}&n\r\n",
+									 GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), argument),
+						 Remember::PRAY);
 
-		snprintf(buf, kMaxStringLength, "&R[%7d] %s воззвал%s к богам с сообщением : '%s'&n\r\n",
-				 world[ch->in_room]->vnum, GET_NAME(ch), grammar::SexEnding((ch)->get_sex(), 1), argument);
+		to_gods = fmt::format("&R[{:7}] {} воззвал{} к богам с сообщением : '{}'&n\r\n",
+							  world[ch->in_room]->vnum, GET_NAME(ch),
+							  grammar::SexEnding((ch)->get_sex(), 1), argument);
 	}
 
 	for (i = descriptor_list; i; i = i->next) {
@@ -97,13 +105,13 @@ void do_pray_gods(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 				char ts[32];
 				const time_t now = time(nullptr);
 				strftime(ts, sizeof(ts), "[%d-%m-%Y %H:%M] ", localtime(&now));
-				std::string line = std::string(ts) + buf;
+				std::string line = std::string(ts) + to_gods;
 				if (!god->IsNpc() && god->player_specials->saved.stringLength > 0) {
 					// WrapText съедает хвостовой \r\n -- возвращаем его обратно
 					line = utils::WrapText(line, god->player_specials->saved.stringLength) + "\r\n";
 				}
 				SendMsgToChar(line.c_str(), god);
-				god->remember_add(buf, Remember::ALL);
+				god->remember_add(to_gods, Remember::ALL);
 			}
 		}
 	}


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

`молиться`, `воззвать`, `войти`, `нанять`.

## Ловушка в `do_enter`

Сообщение «Пентаграмма ослепительно вспыхнула!» писалось в `smallBuf` — **поверх аргумента команды**, который ниже по функции ещё нужен, чтобы отправить той же пентаграммой спутников (`enter 2.пентаграмма`):

```c
one_argument(argument, smallBuf);      // тут аргумент
...
sprintf(smallBuf, "%sПентаграмма ослепительно вспыхнула!%s\r\n", ...);   // а тут его затёрли
...
snprintf(buf2, kMaxStringLength, "enter %d.%s", fnum, smallBuf);        // и вот он нужен
```

Сейчас на этой ветке функция выходит раньше, так что до беды не доходило, но мина лежала взведённой. Аргумент и сообщение разведены.

Там же приказ спутнику собирался в общий `buf2` и отдавался в `command_interpreter`, который правит строку на месте — теперь каждому спутнику своя копия.

## Остальное

В `do_pray_gods` воззвание жило сразу в двух буферах (`buf` для рассылки богам, `buf1` для remember) и переживало цикл по всем дескрипторам.

Сборка без предупреждений, 712 тестов проходят.