### PR TITLE
refactor(mechanics): drop global buffers from weather, mounts and poison (#3814)

### DIFF
--- a/src/engine/ui/cmd/do_weather.cpp
+++ b/src/engine/ui/cmd/do_weather.cpp
@@ -6,6 +6,8 @@
 \detail Detail description.
 */
 
+#include <fmt/format.h>
+
 #include "engine/entities/char_data.h"
 #include "administration/privilege.h"
 #include "utils/grammar/declensions.h"
@@ -26,48 +28,49 @@ void do_weather(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) 
 							   "Убывающий серп луны."
 	};
 	if (OUTSIDE(ch)) {
-		*buf = '\0';
+		std::string out;
 		if (world[ch->in_room]->weather.duration > 0) {
 			sky = world[ch->in_room]->weather.sky;
 			weather_type = world[ch->in_room]->weather.weather_type;
 		}
-		sprintf(buf + strlen(buf),
-				"Небо %s. %s\r\n%s\r\n", sky_look[sky],
-				get_moon(sky) ? moon_look[get_moon(sky) - 1] : "",
-				(weather_info.change >=
-					0 ? "Атмосферное давление повышается." : "Атмосферное давление понижается."));
-		sprintf(buf + strlen(buf), "На дворе %d %s.\r\n",
-				weather_info.temperature, grammar::GetDeclensionInNumber(weather_info.temperature, grammar::EWhat::kDegree));
+		out += fmt::format("Небо {}. {}\r\n{}\r\n", sky_look[sky],
+						   get_moon(sky) ? moon_look[get_moon(sky) - 1] : "",
+						   weather_info.change >= 0 ? "Атмосферное давление повышается."
+													: "Атмосферное давление понижается.");
+		out += fmt::format("На дворе {} {}.\r\n", weather_info.temperature,
+						   grammar::GetDeclensionInNumber(weather_info.temperature, grammar::EWhat::kDegree));
 
 		if (IS_SET(weather_info.weather_type, kWeatherBigwind))
-			strcat(buf, "Сильный ветер.\r\n");
+			out += "Сильный ветер.\r\n";
 		else if (IS_SET(weather_info.weather_type, kWeatherMediumwind))
-			strcat(buf, "Умеренный ветер.\r\n");
+			out += "Умеренный ветер.\r\n";
 		else if (IS_SET(weather_info.weather_type, kWeatherLightwind))
-			strcat(buf, "Легкий ветерок.\r\n");
+			out += "Легкий ветерок.\r\n";
 
 		if (IS_SET(weather_type, kWeatherBigsnow))
-			strcat(buf, "Валит снег.\r\n");
+			out += "Валит снег.\r\n";
 		else if (IS_SET(weather_type, kWeatherMediumsnow))
-			strcat(buf, "Снегопад.\r\n");
+			out += "Снегопад.\r\n";
 		else if (IS_SET(weather_type, kWeatherLightsnow))
-			strcat(buf, "Легкий снежок.\r\n");
+			out += "Легкий снежок.\r\n";
 
 		if (IS_SET(weather_type, kWeatherHail))
-			strcat(buf, "Дождь с градом.\r\n");
+			out += "Дождь с градом.\r\n";
 		else if (IS_SET(weather_type, kWeatherBigrain))
-			strcat(buf, "Льет, как из ведра.\r\n");
+			out += "Льет, как из ведра.\r\n";
 		else if (IS_SET(weather_type, kWeatherMediumrain))
-			strcat(buf, "Идет дождь.\r\n");
+			out += "Идет дождь.\r\n";
 		else if (IS_SET(weather_type, kWeatherLightrain))
-			strcat(buf, "Моросит дождик.\r\n");
+			out += "Моросит дождик.\r\n";
 
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(out, ch);
 	} else {
 		SendMsgToChar("Вы ничего не можете сказать о погоде сегодня.\r\n", ch);
 	}
 	if (privilege::IsGod(ch)) {
-		sprintf(buf, "День: %d Месяц: %s Час: %d Такт = %d\r\n"
+		// Ширины полей у богов оставлены printf-формами: значения числовые, байт равен символу.
+		char out[kMaxStringLength];
+		snprintf(out, sizeof(out), "День: %d Месяц: %s Час: %d Такт = %d\r\n"
 					 "Температура =%-5d, за день = %-8d, за неделю = %-8d\r\n"
 					 "Давление    =%-5d, за день = %-8d, за неделю = %-8d\r\n"
 					 "Выпало дождя = %d(%d), снега = %d(%d). Лед = %d(%d). Погода = %08x(%08x).\r\n",
@@ -80,7 +83,7 @@ void do_weather(CharData *ch, char * /*argument*/, int/* cmd*/, int/* subcmd*/) 
 				world[ch->in_room]->weather.snowlevel, weather_info.icelevel,
 				world[ch->in_room]->weather.icelevel,
 				weather_info.weather_type, world[ch->in_room]->weather.weather_type);
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(out, ch);
 	}
 }
 

--- a/src/gameplay/mechanics/celebrates.cpp
+++ b/src/gameplay/mechanics/celebrates.cpp
@@ -114,8 +114,7 @@ void ParseTrigList(DataNode node, TrigList *triggers) {
 	for (auto &trig : node.Children("trig")) {
 		int vnum = AttrInt(trig, "vnum");
 		if (!vnum) {
-			snprintf(buf, kMaxStringLength, "...celebrates - bad trig (node = %s)", node.GetName());
-			mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
+			mudlog(fmt::format("...celebrates - bad trig (node = %s)", node.GetName()), CMP, kLvlImmortal, SYSLOG, true);
 			return;
 		}
 		triggers->push_back(vnum);
@@ -126,8 +125,7 @@ void ParseLoadData(const DataNode &node, const LoadPtr &node_data) {
 	int vnum = AttrInt(node, "vnum");
 	int max = AttrInt(node, "max");
 	if (!vnum || !max) {
-		snprintf(buf, kMaxStringLength, "...celebrates - bad data (node = %s)", node.GetName());
-		mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
+		mudlog(fmt::format("...celebrates - bad data (node = %s)", node.GetName()), CMP, kLvlImmortal, SYSLOG, true);
 		return;
 	}
 	node_data->vnum = vnum;
@@ -138,11 +136,8 @@ void ParseLoadSection(DataNode node, const CelebrateDataPtr &holiday) {
 	for (auto &room : node.Children("room")) {
 		int vnum = AttrInt(room, "vnum");
 		if (!vnum) {
-			snprintf(buf,
-					 kMaxStringLength,
-					 "...celebrates - bad room (celebrate = %s)",
-					 node.GetValue("name"));
-			mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
+			mudlog(fmt::format("...celebrates - bad room (celebrate = {})", node.GetValue("name")),
+				   CMP, kLvlImmortal, SYSLOG, true);
 			return;
 		}
 		CelebrateRoomPtr tmp_room(new CelebrateRoom);
@@ -183,8 +178,7 @@ void ParseAttachSection(DataNode node, const CelebrateDataPtr &holiday) {
 	for (auto &mob : node.Children("mob")) {
 		vnum = AttrInt(mob, "vnum");
 		if (!vnum) {
-			snprintf(buf, kMaxStringLength, "...celebrates - bad attach data (node = %s)", node.GetName());
-			mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
+			mudlog(fmt::format("...celebrates - bad attach data (node = %s)", node.GetName()), CMP, kLvlImmortal, SYSLOG, true);
 			return;
 		}
 		ParseTrigList(mob, &holiday->mobsToAttach[vnum / 100][vnum]);
@@ -192,8 +186,7 @@ void ParseAttachSection(DataNode node, const CelebrateDataPtr &holiday) {
 	for (auto &obj : node.Children("obj")) {
 		vnum = AttrInt(obj, "vnum");
 		if (!vnum) {
-			snprintf(buf, kMaxStringLength, "...celebrates - bad attach data (node = %s)", node.GetName());
-			mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
+			mudlog(fmt::format("...celebrates - bad attach data (node = %s)", node.GetName()), CMP, kLvlImmortal, SYSLOG, true);
 			return;
 		}
 		ParseTrigList(obj, &holiday->objsToAttach[vnum / 100][vnum]);
@@ -231,8 +224,7 @@ void LoadCelebrates(DataNode node_list, CelebrateList &celebrates, bool is_real)
 		std::string name = name_attr ? name_attr : "";
 		int baseDay;
 		if (!day || !month || name.empty()) {
-			snprintf(buf, kMaxStringLength, "...celebrates - bad node struct");
-			mudlog(buf, CMP, kLvlImmortal, SYSLOG, true);
+			mudlog("...celebrates - bad node struct", CMP, kLvlImmortal, SYSLOG, true);
 			return;
 		}
 		CelebrateDataPtr tmp_holiday(new CelebrateData);

--- a/src/gameplay/mechanics/mount.cpp
+++ b/src/gameplay/mechanics/mount.cpp
@@ -1,5 +1,7 @@
 // обслуживание функций езды на всяческих жовтоне
 //
+#include <fmt/format.h>
+
 #include "mount.h"
 #include "administration/privilege.h"
 #include "utils/grammar/gender.h"
@@ -66,8 +68,8 @@ bool DropFromHorse(CharData *ch) {
 	} else {  // не лошадь и не всадник
 		return false;
 	}
-	sprintf(buf, "%s свалил%s со своего скакуна.", GET_PAD(plr, 0), grammar::SexEnding((plr)->get_sex(), 2));
-	act(buf, false, plr, 0, 0, kToRoom | kToArenaListen);
+	act(fmt::format("{} свалил{} со своего скакуна.", GET_PAD(plr, 0), grammar::SexEnding((plr)->get_sex(), 2)),
+		false, plr, 0, 0, kToRoom | kToArenaListen);
 	AFF_FLAGS(plr).unset(EAffect::kHorse);
 	SetBattleLag(plr, 3);
 	if (plr->GetPosition() > EPosition::kSit) {
@@ -199,9 +201,10 @@ void do_horseon(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	one_argument(argument, arg);
-	if (*arg)
-		horse = target_resolver::FindCharInRoom(ch, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
+	if (*name)
+		horse = target_resolver::FindCharInRoom(ch, name);
 	else
 		horse = mount::GetHorse(ch);
 
@@ -267,9 +270,10 @@ void do_horseget(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	one_argument(argument, arg);
-	if (*arg)
-		horse = target_resolver::FindCharInRoom(ch, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
+	if (*name)
+		horse = target_resolver::FindCharInRoom(ch, name);
 	else
 		horse = mount::GetHorse(ch);
 
@@ -305,9 +309,10 @@ void do_horseput(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	one_argument(argument, arg);
-	if (*arg)
-		horse = target_resolver::FindCharInRoom(ch, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
+	if (*name)
+		horse = target_resolver::FindCharInRoom(ch, name);
 	else
 		horse = mount::GetHorse(ch);
 	if (horse == nullptr)
@@ -338,9 +343,10 @@ void do_horsetake(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		return;
 	}
 
-	one_argument(argument, arg);
-	if (*arg) {
-		horse = target_resolver::FindCharInRoom(ch, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
+	if (*name) {
+		horse = target_resolver::FindCharInRoom(ch, name);
 	}
 
 	if (horse == nullptr) {
@@ -393,12 +399,13 @@ void do_givehorse(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 		SendMsgToChar("Ваш скакун далеко от вас.\r\n", ch);
 		return;
 	}
-	one_argument(argument, arg);
-	if (!*arg) {
+	char name[kMaxInputLength];
+	one_argument(argument, name);
+	if (!*name) {
 		SendMsgToChar("Кому вы хотите передать скакуна?\r\n", ch);
 		return;
 	}
-	victim = target_resolver::FindCharInRoom(ch, arg);
+	victim = target_resolver::FindCharInRoom(ch, name);
 	if (!victim) {
 		SendMsgToChar("Вам некому передать скакуна.\r\n", ch);
 		return;

--- a/src/gameplay/mechanics/poison.cpp
+++ b/src/gameplay/mechanics/poison.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2009 Krodo
 // Part of Bylins http://www.mud.ru
 
+#include <fmt/format.h>
+
 #include "poison.h"
 #include "gameplay/affects/obj_affects.h"
 #include "administration/privilege.h"
@@ -369,10 +371,8 @@ void PerformToxicate(CharData *ch, CharData *vict, int modifier) {
 		ImposeAffect(vict, i, false, false, false, false);
 	}
 
-	snprintf(buf, sizeof(buf), "%sВы отравили $N3.%s", kColorBoldGrn, kColorCyn);
-	act(buf, false, ch, nullptr, vict, kToChar);
-	snprintf(buf, sizeof(buf), "%s$n отравил$g вас.%s", kColorBoldRed, kColorCyn);
-	act(buf, false, ch, nullptr, vict, kToVict);
+	act(fmt::format("{}Вы отравили $N3.{}", kColorBoldGrn, kColorCyn), false, ch, nullptr, vict, kToChar);
+	act(fmt::format("{}$n отравил$g вас.{}", kColorBoldRed, kColorCyn), false, ch, nullptr, vict, kToVict);
 }
 
 // issue.obj-affects: weapon-poison is now the first obj-affect trigger. The kPoisoned affect on the
@@ -414,20 +414,18 @@ void PerformPoisonedWeapom(CharData *ch, CharData *vict, ESpell spell_id) {
 				SendMsgToChar(ch, "Кровоточащие язвы покрыли тело %s.\r\n",
 							  sight::PersonName(vict, ch, 1));
 			} else if (spell_id == ESpell::kScopolaPoison) {
-				strcpy(buf1, sight::PersonName(vict, ch, 0));
-				utils::CAP(buf1);
-				SendMsgToChar(ch, "%s скрючил%s от нестерпимой боли.\r\n",
-							  buf1, grammar::VisSexEnding(sight::CanSee((ch), (vict)), (vict)->get_sex(), 2));
+				// CAP(std::string) возвращает копию, а не правит на месте
+				SendMsgToChar(fmt::format("{} скрючил{} от нестерпимой боли.\r\n",
+										  utils::CAP(sight::PersonName(vict, ch, 0)),
+										  grammar::VisSexEnding(sight::CanSee((ch), (vict)), (vict)->get_sex(), 2)), ch);
 				vict->battle_affects.set(kEafFirstPoison);
 			} else if (spell_id == ESpell::kBelenaPoison) {
-				strcpy(buf1, sight::PersonName(vict, ch, 3));
-				utils::CAP(buf1);
-				SendMsgToChar(ch, "%s перестали слушаться руки.\r\n", buf1);
+				SendMsgToChar(fmt::format("{} перестали слушаться руки.\r\n",
+										  utils::CAP(sight::PersonName(vict, ch, 3))), ch);
 				vict->battle_affects.set(kEafFirstPoison);
 			} else if (spell_id == ESpell::kDaturaPoison) {
-				strcpy(buf1, sight::PersonName(vict, ch, 2));
-				utils::CAP(buf1);
-				SendMsgToChar(ch, "%s стало труднее плести заклинания.\r\n", buf1);
+				SendMsgToChar(fmt::format("{} стало труднее плести заклинания.\r\n",
+										  utils::CAP(sight::PersonName(vict, ch, 2))), ch);
 				vict->battle_affects.set(kEafFirstPoison);
 			} else {
 				SendMsgToChar(ch, "Вы отравили %s.\r\n", sight::PersonName(ch, vict, 3));


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Погода, скакуны, яды и загрузка праздников.

В `do_weather` сводка собиралась в общий `buf` десятком `strcat` подряд — теперь `std::string`. Отладочная таблица для богов оставлена на printf: там числовые поля с ширинами, байт равен символу, перевод на fmt ничего не даёт.

В `poison` имя жертвы копировалось в `buf1` и правилось на месте через `CAP` ради одной строки сообщения — взята строковая форма `CAP`, возвращающая копию.

В `celebrates` восемь однотипных сборок сообщения в буфер перед `mudlog` заменены на `fmt::format` по месту.

Сборка без предупреждений, 712 тестов проходят.