### PR TITLE
refactor(mechanics): drop global buffers from parcels, locate and clones (#3814)

### DIFF
--- a/src/gameplay/ai/graph.cpp
+++ b/src/gameplay/ai/graph.cpp
@@ -12,6 +12,8 @@
 *  $Revision$                                                       *
 ************************************************************************ */
 
+#include <fmt/format.h>
+
 #include "engine/core/char_movement.h"
 #include "engine/entities/char_data.h"
 #include "utils/logger.h"
@@ -163,9 +165,9 @@ int find_first_step(RoomRnum src, RoomRnum target, CharData *ch, bool complain) 
 	}
 	bfs_queue.clear();
 	if (complain && ch->IsNpc()) {
-		sprintf(buf, "[%d] Mob (mob: %s vnum: %d) can't find path to room [%d].",
-				GET_ROOM_VNUM(ch->in_room), GET_NAME(ch), GET_MOB_VNUM(ch), GET_ROOM_VNUM(target));
-		mudlog(buf, NRM, kLvlBuilder, ERRLOG, true);
+		mudlog(fmt::format("[{}] Mob (mob: {} vnum: {}) can't find path to room [{}].",
+						   GET_ROOM_VNUM(ch->in_room), GET_NAME(ch), GET_MOB_VNUM(ch), GET_ROOM_VNUM(target)),
+			   NRM, kLvlBuilder, ERRLOG, true);
 	}
 	return (kBfsNoPath);
 }
@@ -208,14 +210,15 @@ void do_sense(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 	if (!check_moves(ch, CanUseFeat(ch, EFeat::kTracker) ? kSenseMoves / 2 : kSenseMoves))
 		return;
 
-	one_argument(argument, arg);
+	char name[kMaxInputLength];
+	one_argument(argument, name);
 
-	if (!*arg) {
+	if (!*name) {
 		SendMsgToChar("Кого вы хотите найти?\r\n", ch);
 		return;
 	}
 	// The person can't see the victim.
-	vict = target_resolver::FindCharInWorld(ch, arg);
+	vict = target_resolver::FindCharInWorld(ch, name);
 	if (!vict) {
 		SendMsgToChar("Ваши чувства молчат.\r\n", ch);
 		return;
@@ -231,19 +234,20 @@ void do_sense(CharData *ch, char *argument, int/* cmd*/, int/* subcmd*/) {
 
 	dir = go_sense(ch, vict);
 
+	std::string message;
 	switch (dir) {
-		case kBfsError: strcpy(buf, "Хммм... Ваше чувство подвело вас.");
+		case kBfsError: message = "Хммм... Ваше чувство подвело вас.";
 			break;
-		case kBfsAlreadyThere: strcpy(buf, "Вы же в одной комнате с $N4!");
+		case kBfsAlreadyThere: message = "Вы же в одной комнате с $N4!";
 			break;
-		case kBfsNoPath: strcpy(buf, "Ваши чувства молчат.");
+		case kBfsNoPath: message = "Ваши чувства молчат.";
 			break;
 		default:        // Success!
 			ImproveSkill(ch, ESkill::kSense, true, vict);
-			sprintf(buf, "Чувство подсказало вам : \"Ступай %s.\"\r\n", DirsTo[dir]);
+			message = fmt::format("Чувство подсказало вам : \"Ступай {}.\"\r\n", DirsTo[dir]);
 			break;
 	}
-	act(buf, false, ch, 0, vict, kToChar);
+	act(message, false, ch, 0, vict, kToChar);
 }
 
 

--- a/src/gameplay/communication/parcel.cpp
+++ b/src/gameplay/communication/parcel.cpp
@@ -160,19 +160,17 @@ bool can_send(CharData *ch, CharData *mailman, ObjData *obj, long vict_uid) {
 		|| obj->is_unrentable()
 		|| obj->has_flag(EObjFlag::kDecay)
 		|| obj->get_owner()) {
-		snprintf(buf, kMaxStringLength, "$n сказал$g вам : '%s - мы не отправляем такие вещи!'\r\n",
-				 obj->get_PName(grammar::ECase::kNom).c_str());
-		act(buf, false, mailman, 0, ch, kToVict);
+		act(fmt::format("$n сказал$g вам : '{} - мы не отправляем такие вещи!'\r\n",
+						obj->get_PName(grammar::ECase::kNom)), false, mailman, 0, ch, kToVict);
 		return 0;
 	} else if (obj->get_type() == EObjType::kContainer
 		&& obj->get_contains()) {
-		snprintf(buf, kMaxStringLength, "$n сказал$g вам : 'В %s что-то лежит.'\r\n", obj->get_PName(grammar::ECase::kPre).c_str());
-		act(buf, false, mailman, 0, ch, kToVict);
+		act(fmt::format("$n сказал$g вам : 'В {} что-то лежит.'\r\n", obj->get_PName(grammar::ECase::kPre)),
+			false, mailman, 0, ch, kToVict);
 		return 0;
 	} else if (SetSystem::is_big_set(obj)) {
-		snprintf(buf, kMaxStringLength, "$n сказал$g вам : '%s является частью большого набора предметов.'\r\n",
-				 obj->get_PName(grammar::ECase::kNom).c_str());
-		act(buf, false, mailman, 0, ch, kToVict);
+		act(fmt::format("$n сказал$g вам : '{} является частью большого набора предметов.'\r\n",
+						obj->get_PName(grammar::ECase::kNom)), false, mailman, 0, ch, kToVict);
 		return 0;
 	}
 	Player t_vict;
@@ -244,8 +242,9 @@ void send_object(CharData *ch, CharData *mailman, long vict_uid, ObjData *obj) {
 	}
 	if (SetSystem::is_norent_set(ch, obj)
 		&& SetSystem::is_norent_set(GET_OBJ_VNUM(obj), get_objs(ch->get_uid()))) {
-		snprintf(buf, kMaxStringLength, "%s - требуется две и более вещи из набора.\r\n", obj->get_PName(grammar::ECase::kNom).c_str());
-		SendMsgToChar(utils::CAP(buf), ch);
+		// CAP(std::string) возвращает копию, а не правит на месте
+		SendMsgToChar(utils::CAP(fmt::format("{} - требуется две и более вещи из набора.\r\n",
+											 obj->get_PName(grammar::ECase::kNom))), ch);
 		return;
 	}
 	name_convert(name);
@@ -253,8 +252,7 @@ void send_object(CharData *ch, CharData *mailman, long vict_uid, ObjData *obj) {
 	if (send_buffer.empty())
 		send_buffer += "Адресат: " + name + ", отправлено:\r\n";
 
-	snprintf(buf, sizeof(buf), "%s%s%s\r\n", kColorWht, obj->get_PName(grammar::ECase::kNom).c_str(), kColorNrm);
-	send_buffer += buf;
+	send_buffer += fmt::format("{}{}{}\r\n", kColorWht, obj->get_PName(grammar::ECase::kNom), kColorNrm);
 	obj = dungeons::SwapOriginalObject(obj);
 	const auto object_ptr = world_objects.get_by_raw_ptr(obj);
 	Node tmp_node(reserved_cost, object_ptr);
@@ -353,10 +351,11 @@ void send(CharData *ch, CharData *mailman, long vict_uid, char *arg) {
 	}
 
 	if (!send_buffer.empty()) {
-		snprintf(buf, sizeof(buf), "с вас удержано %d %s и еще %d %s зарезервировано на 3 дня хранения.\r\n",
-				 send_cost_buffer, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(send_cost_buffer, grammar::ECase::kNom).c_str(),
-				 send_reserved_buffer, MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(send_reserved_buffer, grammar::ECase::kNom).c_str());
-		send_buffer += buf;
+		send_buffer += fmt::format("с вас удержано {} {} и еще {} {} зарезервировано на 3 дня хранения.\r\n",
+								   send_cost_buffer,
+								   MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(send_cost_buffer, grammar::ECase::kNom),
+								   send_reserved_buffer,
+								   MUD::Currency(currencies::kGoldVnum).GetNameWithAmount(send_reserved_buffer, grammar::ECase::kNom));
 		SendMsgToChar(send_buffer.c_str(), ch);
 
 		send_buffer = "";
@@ -525,8 +524,7 @@ void receive(CharData *ch, CharData *mailman) {
 			return_money(name, money, RETURN_WITH_MONEY);
 
 			PlaceObjToInventory(obj, ch);
-			snprintf(buf, kMaxStringLength, "$n дал$g вам посылку (отправитель %s).", name.c_str());
-			act(buf, false, mailman, 0, ch, kToVict);
+			act(fmt::format("$n дал$g вам посылку (отправитель {}).", name), false, mailman, 0, ch, kToVict);
 			act("$N дал$G $n2 посылку.", false, ch, 0, mailman, kToRoom);
 			++was_sended;
 		}
@@ -574,11 +572,11 @@ void return_parcel() {
 
 // * Дикей предмета на почте и уведомление об этом отправителя и получателя через письма.
 void extract_parcel(int sender_uid, int target_uid, const std::list<Node>::iterator &it) {
-	snprintf(buf, kMaxStringLength, "С прискорбием сообщаем вам: %s рассыпал%s в прах.\r\n",
-			 it->obj_->get_short_description().c_str(),
-			 grammar::ObjSexEnding((it->obj_)->get_sex(), 2));
+	const std::string notice = fmt::format("С прискорбием сообщаем вам: {} рассыпал{} в прах.\r\n",
+										   it->obj_->get_short_description(),
+										   grammar::ObjSexEnding((it->obj_)->get_sex(), 2));
 
-	char *tmp = str_dup(buf);
+	char *tmp = str_dup(notice.c_str());
 	// -1 в качестве ид отправителя при получении подставит в имя почтовую службу
 	create_mail(sender_uid, -1, tmp);
 	create_mail(target_uid, -1, tmp);
@@ -596,9 +594,9 @@ void extract_parcel(int sender_uid, int target_uid, const std::list<Node>::itera
 
 // * Генерация письма о возврате посылки.
 void return_invoice(int uid, ObjData *obj) {
-	snprintf(buf, kMaxStringLength, "Посылка возвращена отправителю: %s.\r\n",
-			 obj->get_short_description().c_str());
-	char *tmp = str_dup(buf);
+	const std::string notice = fmt::format("Посылка возвращена отправителю: {}.\r\n",
+										   obj->get_short_description());
+	char *tmp = str_dup(notice.c_str());
 	create_mail(uid, -1, tmp);
 	free(tmp);
 }
@@ -921,8 +919,7 @@ void bring_back(CharData *ch, CharData *mailman) {
 			PlaceObjIntoObj(l->obj_.get(), obj);
 		}
 		PlaceObjToInventory(obj, ch);
-		snprintf(buf, kMaxStringLength, "$n дал$g вам посылку.");
-		act(buf, false, mailman, 0, ch, kToVict);
+		act("$n дал$g вам посылку.", false, mailman, 0, ch, kToVict);
 		act("$N дал$G $n2 посылку.", false, ch, 0, mailman, kToRoom);
 
 		i->second.erase(k);

--- a/src/gameplay/handlers/clone_cascade.cpp
+++ b/src/gameplay/handlers/clone_cascade.cpp
@@ -3,6 +3,8 @@
  \brief issue.spellhandlers: CloneCascade kClone post-spawn handler (extracted from magic.cpp).
 */
 
+#include <fmt/format.h>
+
 #include "gameplay/handlers/spell_handlers.h"
 #include "gameplay/economics/currencies.h"
 #include "engine/entities/char_data.h"
@@ -15,23 +17,15 @@
 
 // ApplyCloneCosmetics: single-use helper for CloneCascade (kept file-local).
 static void ApplyCloneCosmetics(CharData *ch, CharData *mob) {
-	sprintf(buf2, "двойник %s %s", GET_PAD(ch, 1), GET_NAME(ch));
-	mob->SetCharAliases(buf2);
-	sprintf(buf2, "двойник %s", GET_PAD(ch, 1));
-	mob->set_npc_name(buf2);
+	mob->SetCharAliases(fmt::format("двойник {} {}", GET_PAD(ch, 1), GET_NAME(ch)));
+	mob->set_npc_name(fmt::format("двойник {}", GET_PAD(ch, 1)));
 	mob->player_data.long_descr = "";
-	sprintf(buf2, "двойник %s", GET_PAD(ch, 1));
-	mob->player_data.PNames[grammar::ECase::kNom] = std::string(buf2);
-	sprintf(buf2, "двойника %s", GET_PAD(ch, 1));
-	mob->player_data.PNames[grammar::ECase::kGen] = std::string(buf2);
-	sprintf(buf2, "двойнику %s", GET_PAD(ch, 1));
-	mob->player_data.PNames[grammar::ECase::kDat] = std::string(buf2);
-	sprintf(buf2, "двойника %s", GET_PAD(ch, 1));
-	mob->player_data.PNames[grammar::ECase::kAcc] = std::string(buf2);
-	sprintf(buf2, "двойником %s", GET_PAD(ch, 1));
-	mob->player_data.PNames[grammar::ECase::kIns] = std::string(buf2);
-	sprintf(buf2, "двойнике %s", GET_PAD(ch, 1));
-	mob->player_data.PNames[grammar::ECase::kPre] = std::string(buf2);
+	mob->player_data.PNames[grammar::ECase::kNom] = fmt::format("двойник {}", GET_PAD(ch, 1));
+	mob->player_data.PNames[grammar::ECase::kGen] = fmt::format("двойника {}", GET_PAD(ch, 1));
+	mob->player_data.PNames[grammar::ECase::kDat] = fmt::format("двойнику {}", GET_PAD(ch, 1));
+	mob->player_data.PNames[grammar::ECase::kAcc] = fmt::format("двойника {}", GET_PAD(ch, 1));
+	mob->player_data.PNames[grammar::ECase::kIns] = fmt::format("двойником {}", GET_PAD(ch, 1));
+	mob->player_data.PNames[grammar::ECase::kPre] = fmt::format("двойнике {}", GET_PAD(ch, 1));
 
 	mob->set_str(ch->get_str());
 	mob->set_dex(ch->get_dex());

--- a/src/gameplay/handlers/spell_locate_object.cpp
+++ b/src/gameplay/handlers/spell_locate_object.cpp
@@ -3,6 +3,8 @@
  \brief issue.spellhandlers: SpellLocateObject manual-cast handler (extracted from spells.cpp).
 */
 
+#include <fmt/format.h>
+
 #include "gameplay/handlers/spell_handlers.h"
 #include "administration/privilege.h"
 #include "utils/grammar/gender.h"
@@ -43,8 +45,7 @@ EStageResult SpellLocateObject(ActionContext &ctx) {
 	const auto result = world_objects.find_if_and_dec_number([ch, name, &bloody_corpse](const ObjData::shared_ptr &i) {
 		const auto obj_ptr = world_objects.get_by_raw_ptr(i.get());
 		if (!obj_ptr) {
-			sprintf(buf, "SYSERR: Illegal object iterator while locate");
-			mudlog(buf, BRF, kLvlImplementator, SYSLOG, true);
+			mudlog("SYSERR: Illegal object iterator while locate", BRF, kLvlImplementator, SYSLOG, true);
 
 			return false;
 		}
@@ -77,17 +78,15 @@ EStageResult SpellLocateObject(ActionContext &ctx) {
 			const auto carried_by_ptr = character_list.get_character_by_address(carried_by);
 
 			if (!carried_by_ptr) {
-				sprintf(buf, "SYSERR: Illegal carried_by ptr. Создана кора для исследований");
-				mudlog(buf, BRF, kLvlImplementator, SYSLOG, true);
+				mudlog("SYSERR: Illegal carried_by ptr. Создана кора для исследований",
+					   BRF, kLvlImplementator, SYSLOG, true);
 				return false;
 			}
 
 			if (!ValidRnum(carried_by->in_room)) {
-				sprintf(buf,
-						"SYSERR: Illegal room %d, char %s. Создана кора для исследований",
-						carried_by->in_room,
-						carried_by->get_name().c_str());
-				mudlog(buf, BRF, kLvlImplementator, SYSLOG, true);
+				mudlog(fmt::format("SYSERR: Illegal room {}, char {}. Создана кора для исследований",
+								   carried_by->in_room, carried_by->get_name()),
+					   BRF, kLvlImplementator, SYSLOG, true);
 				return false;
 			}
 
@@ -100,13 +99,14 @@ EStageResult SpellLocateObject(ActionContext &ctx) {
 			return false;
 		}
 		std::string locate_msg;
+		std::string where;
 
 		if (i->get_carried_by()) {
 			const auto carried_by = i->get_carried_by();
 			const auto same_zone = world[ch->in_room]->zone_rn == world[carried_by->in_room]->zone_rn;
 			if (!carried_by->IsNpc() || same_zone || bloody_corpse) {
-				sprintf(buf, "%s наход%sся у %s в инвентаре.\r\n", i->get_short_description().c_str(),
-						grammar::ObjPluralVerbEnding((i)->get_sex()), sight::PersonName(carried_by, ch, 1));
+				where = fmt::format("{} наход{}ся у {} в инвентаре.\r\n", i->get_short_description(),
+									grammar::ObjPluralVerbEnding((i)->get_sex()), sight::PersonName(carried_by, ch, 1));
 			} else {
 				return false;
 			}
@@ -114,8 +114,10 @@ EStageResult SpellLocateObject(ActionContext &ctx) {
 			const auto room = i->get_in_room();
 			const auto same_zone = world[ch->in_room]->zone_rn == world[room]->zone_rn;
 			if (same_zone) {
-				sprintf(buf, "%s наход%sся в комнате '%s'\r\n",
-						i->get_short_description().c_str(), grammar::ObjPluralVerbEnding((i)->get_sex()), world[room]->name);
+				// Имя комнаты бывает нулевым, а fmt на нуле бросает исключение
+				where = fmt::format("{} наход{}ся в комнате '{}'\r\n",
+									i->get_short_description(), grammar::ObjPluralVerbEnding((i)->get_sex()),
+									world[room]->name ? world[room]->name : "");
 			} else {
 				return false;
 			}
@@ -142,17 +144,17 @@ EStageResult SpellLocateObject(ActionContext &ctx) {
 						}
 					}
 				}
-				sprintf(buf, "%s наход%sся в %s.\r\n",
-						i->get_short_description().c_str(),
-						grammar::ObjPluralVerbEnding((i)->get_sex()),
-						i->get_in_obj()->get_PName(grammar::ECase::kPre).c_str());
+				where = fmt::format("{} наход{}ся в {}.\r\n",
+									i->get_short_description(),
+									grammar::ObjPluralVerbEnding((i)->get_sex()),
+									i->get_in_obj()->get_PName(grammar::ECase::kPre));
 			}
 		} else if (i->get_worn_by()) {
 			const auto worn_by = i->get_worn_by();
 			const auto same_zone = world[ch->in_room]->zone_rn == world[worn_by->in_room]->zone_rn;
 			if (!worn_by->IsNpc() || same_zone || bloody_corpse) {
-				sprintf(buf, "%s надет%s на %s.\r\n", i->get_short_description().c_str(),
-						grammar::ObjSexEnding((i)->get_sex(), 6), sight::PersonName(worn_by, ch, 3));
+				where = fmt::format("{} надет{} на {}.\r\n", i->get_short_description(),
+									grammar::ObjSexEnding((i)->get_sex(), 6), sight::PersonName(worn_by, ch, 3));
 			} else {
 				return false;
 			}
@@ -163,9 +165,9 @@ EStageResult SpellLocateObject(ActionContext &ctx) {
 			SendMsgToChar(locate_msg.c_str(), ch);
 			return true;
 		} else {
-			sprintf(buf, "Местоположение %s неопределимо.\r\n", OBJN(i.get(), ch, grammar::ECase::kGen));
+			where = fmt::format("Местоположение {} неопределимо.\r\n", OBJN(i.get(), ch, grammar::ECase::kGen));
 		}
-		SendMsgToChar(buf, ch);
+		SendMsgToChar(where, ch);
 		return true;
 	}, count);
 


### PR DESCRIPTION
Продолжение #3814 (слой 1 из #3807).

Посылки, заклинание поиска предмета, двойники, поиск пути.

В `parcel` текст квитанции накапливался в `std::string`, но каждая строчка перед этим собиралась в общий `buf`.

В `clone_cascade` восемь падежей двойника писались по очереди в один и тот же `buf2` и оттуда копировались в имена.

В `spell_locate_object` строка «где лежит» собиралась в `buf` в пяти ветках, а между ними вызывались `Depot` и `Parcel`, которые тоже пишут в общие буферы. Заодно добавлена проверка на пустое имя комнаты: printf печатал `(null)`, а fmt на нуле бросает исключение.

Сборка без предупреждений, 712 тестов проходят, сервер стартует на боевом мире.