### PR TITLE
refactor(ai): make the aggro stealth flags read the way they work (#3887)

### DIFF
--- a/src/gameplay/ai/mob_memory.cpp
+++ b/src/gameplay/ai/mob_memory.cpp
@@ -97,7 +97,7 @@ void clearMemory(CharData *ch) {
 	MEMORY(ch) = nullptr;
 }
 
-CharData *FimdRememberedEnemyInRoom(CharData *mob, int check_sneak, bool skip_hide_camouflage_checks) {
+CharData *FimdRememberedEnemyInRoom(CharData *mob, bool respect_sneak, bool respect_hide_and_camouflage) {
 	if (!mob->mob_specials.memory) {
 		return nullptr;
 	}
@@ -115,7 +115,7 @@ CharData *FimdRememberedEnemyInRoom(CharData *mob, int check_sneak, bool skip_hi
 				if (!sight::MaySee(mob, mob, vict) || !may_kill_here(mob, vict, NoArgument)) {
 					continue;
 				}
-				if (check_sneak) {
+				if (respect_sneak) {
 					SkipSneaking(vict, mob);
 					if ((vict)->Temporary.get(ECharExtraFlag::kFailSneak)) {
 						AFF_FLAGS(vict).unset(EAffect::kSneak);
@@ -123,7 +123,7 @@ CharData *FimdRememberedEnemyInRoom(CharData *mob, int check_sneak, bool skip_hi
 					if (AFF_FLAGGED(vict, EAffect::kSneak))
 						continue;
 				}
-				if (!skip_hide_camouflage_checks) {
+				if (respect_hide_and_camouflage) {
 					SkipHiding(vict, mob);
 					if ((vict)->Temporary.get(ECharExtraFlag::kFailHide)) {
 						AFF_FLAGS(vict).unset(EAffect::kHide);

--- a/src/gameplay/ai/mob_memory.h
+++ b/src/gameplay/ai/mob_memory.h
@@ -22,7 +22,7 @@ void mobRemember(CharData *ch, CharData *victim);
 void mobForget(CharData *ch, CharData *victim);
 void clearMemory(CharData *ch);
 void update_mob_memory(CharData *ch, CharData *victim);
-CharData *FimdRememberedEnemyInRoom(CharData *mob, int check_sneak, bool skip_hide_camouflage_checks);
+CharData *FimdRememberedEnemyInRoom(CharData *mob, bool respect_sneak, bool respect_hide_and_camouflage);
 void AttackToRememberedVictim(CharData *mob, CharData *victim);
 
 } //namespace mob_ai

--- a/src/gameplay/ai/mobact.cpp
+++ b/src/gameplay/ai/mobact.cpp
@@ -265,9 +265,12 @@ int attack_best(CharData *ch, CharData *victim, bool do_mode) {
 
 #define KILL_FIGHTING   (1 << 0)
 #define CHECK_HITS      (1 << 10)
-#define SKIP_HIDING     (1 << 11)
-#define SKIP_CAMOUFLAGE (1 << 12)
-#define SKIP_SNEAKING   (1 << 13)
+// Эти три флага значат "проверить маскировку такого-то вида и уважить её результат", а не
+// "пропустить проверку", как читались прежние имена SKIP_*. Крадущегося при CHECK_SNEAK моб
+// обходит стороной; спрятавшегося защищает не отдельная ветка, а проверка видимости ниже.
+#define CHECK_HIDE      (1 << 11)
+#define CHECK_CAMOUFLAGE (1 << 12)
+#define CHECK_SNEAK     (1 << 13)
 #define CHECK_OPPONENT  (1 << 14)
 #define GUARD_ATTACK    (1 << 15)
 
@@ -408,7 +411,7 @@ CharData *find_best_stupidmob_victim(CharData *ch, int extmode) {
 		}
 
 		// skip sneaking, hiding and camouflaging pc
-		if (IS_SET(extmode, SKIP_SNEAKING)) {
+		if (IS_SET(extmode, CHECK_SNEAK)) {
 			SkipSneaking(vict, ch);
 			if (((vict)->Temporary.get(ECharExtraFlag::kFailSneak))) {
 				AFF_FLAGS(vict).unset(EAffect::kSneak);
@@ -417,14 +420,14 @@ CharData *find_best_stupidmob_victim(CharData *ch, int extmode) {
 				continue;
 		}
 
-		if (IS_SET(extmode, SKIP_HIDING)) {
+		if (IS_SET(extmode, CHECK_HIDE)) {
 			SkipHiding(vict, ch);
 			if ((vict)->Temporary.get(ECharExtraFlag::kFailHide)) {
 				AFF_FLAGS(vict).unset(EAffect::kHide);
 			}
 		}
 
-		if (IS_SET(extmode, SKIP_CAMOUFLAGE)) {
+		if (IS_SET(extmode, CHECK_CAMOUFLAGE)) {
 			SkipCamouflage(vict, ch);
 			if ((vict)->Temporary.get(ECharExtraFlag::kFailCamouflage)) {
 				AFF_FLAGS(vict).unset(EAffect::kDisguise);
@@ -556,7 +559,7 @@ bool filter_victim (CharData *ch, CharData *vict, int extmode) {
 			return false;
 		}
 	}
-	if (IS_SET(extmode, SKIP_SNEAKING)) {
+	if (IS_SET(extmode, CHECK_SNEAK)) {
 		SkipSneaking(vict, ch);
 		if ((vict)->Temporary.get(ECharExtraFlag::kFailSneak)) {
 			AFF_FLAGS(vict).unset(EAffect::kSneak);
@@ -566,14 +569,14 @@ bool filter_victim (CharData *ch, CharData *vict, int extmode) {
 			return false;
 		}
 	}
-	if (IS_SET(extmode, SKIP_HIDING)) {
+	if (IS_SET(extmode, CHECK_HIDE)) {
 		SkipHiding(vict, ch);
 		if ((vict)->Temporary.get(ECharExtraFlag::kFailHide)) {
 			AFF_FLAGS(vict).unset(EAffect::kHide);
 		}
 	}
 
-	if (IS_SET(extmode, SKIP_CAMOUFLAGE)) {
+	if (IS_SET(extmode, CHECK_CAMOUFLAGE)) {
 		SkipCamouflage(vict, ch);
 		if ((vict)->Temporary.get(ECharExtraFlag::kFailCamouflage)) {
 			AFF_FLAGS(vict).unset(EAffect::kDisguise);
@@ -775,7 +778,7 @@ int perform_best_horde_attack(CharData *ch, int extmode) {
 
 int perform_mob_switch(CharData *ch) {
 	CharData *best;
-	best = find_best_mob_victim(ch, SKIP_HIDING | SKIP_CAMOUFLAGE | SKIP_SNEAKING | CHECK_OPPONENT);
+	best = find_best_mob_victim(ch, CHECK_HIDE | CHECK_CAMOUFLAGE | CHECK_SNEAK | CHECK_OPPONENT);
 
 	if (!best)
 		return false;
@@ -798,14 +801,17 @@ int perform_mob_switch(CharData *ch) {
 	return true;
 }
 
-void do_aggressive_mob(CharData *ch, int check_sneak, bool skip_hide_camouflage_checks) {
+// respect_sneak / respect_hide_and_camouflage: оба параметра положительные -- true значит
+// "учитывать". Раньше второй был инвертирован (skip_hide_camouflage_checks), и вызов
+// do_aggressive_mob(vict, check_sneak, false) читался как "не проверять", хотя проверял.
+void do_aggressive_mob(CharData *ch, bool respect_sneak, bool respect_hide_and_camouflage) {
 	if (!ch || ch->in_room == kNowhere || !ch->IsNpc() || !MayAttack(ch) || AFF_FLAGGED(ch, EAffect::kBlind)) {
 		return;
 	}
 
-	int mode = check_sneak ? SKIP_SNEAKING : 0;
-	if (!skip_hide_camouflage_checks) {
-		mode |= SKIP_HIDING | SKIP_CAMOUFLAGE;
+	int mode = respect_sneak ? CHECK_SNEAK : 0;
+	if (respect_hide_and_camouflage) {
+		mode |= CHECK_HIDE | CHECK_CAMOUFLAGE;
 	}
 	// ****************  Horde
 	if (ch->IsFlagged(EMobFlag::kHorde)) {
@@ -833,16 +839,16 @@ void do_aggressive_mob(CharData *ch, int check_sneak, bool skip_hide_camouflage_
 	}
 
 	if (ch->IsFlagged(EMobFlag::kCityGuardian)) {
-		int guard_mode = GUARD_ATTACK | SKIP_SNEAKING;
-		if (!skip_hide_camouflage_checks) {
-			guard_mode |= SKIP_HIDING | SKIP_CAMOUFLAGE;
+		int guard_mode = GUARD_ATTACK | CHECK_SNEAK;
+		if (respect_hide_and_camouflage) {
+			guard_mode |= CHECK_HIDE | CHECK_CAMOUFLAGE;
 		}
 		perform_best_mob_attack(ch, guard_mode);
 		return;
 	}
 
 	if (ch->IsFlagged(EMobFlag::kMemory)) {
-		auto victim = FimdRememberedEnemyInRoom(ch, check_sneak, skip_hide_camouflage_checks);
+		auto victim = FimdRememberedEnemyInRoom(ch, respect_sneak, respect_hide_and_camouflage);
 		AttackToRememberedVictim(ch, victim);
 		return;
 	}
@@ -859,7 +865,7 @@ void do_aggressive_mob(CharData *ch, int check_sneak, bool skip_hide_camouflage_
 * в результате агра на себя кого-то в комнате и начале атаки
 * например с глуша.
 */
-void do_aggressive_room(CharData *ch, int check_sneak) {
+void do_aggressive_room(CharData *ch, bool respect_sneak) {
 	if (!ch || ch->in_room == kNowhere) {
 		return;
 	}
@@ -869,7 +875,8 @@ void do_aggressive_room(CharData *ch, int check_sneak) {
 	for (const auto &vict : people) {
 		// здесь не надо преварително запоминать next_in_room, потому что как раз
 		// он то и может быть спуржен по ходу do_aggressive_mob, а вот атакующий нет
-		do_aggressive_mob(vict, check_sneak, vict == ch);
+		// Себе самому прятки и маскировку не проверяем -- третий аргумент сменил полярность
+		do_aggressive_mob(vict, respect_sneak, vict != ch);
 	}
 }
 
@@ -1059,7 +1066,7 @@ void mobile_activity(int activity_level, int missed_pulses) {
 	  }
 
 	  // look at room before moving
-	  do_aggressive_mob(ch.get(), false, false);
+	  do_aggressive_mob(ch.get(), false, true);
 
 	  // if mob attack something
 	  if (ch->GetEnemy()
@@ -1183,7 +1190,7 @@ void mobile_activity(int activity_level, int missed_pulses) {
 	  }
 
 	  if (door == kBfsAlreadyThere) {
-		  do_aggressive_mob(ch.get(), false, false);
+		  do_aggressive_mob(ch.get(), false, true);
 		  continue;
 	  }
 

--- a/src/gameplay/ai/mobact.h
+++ b/src/gameplay/ai/mobact.h
@@ -18,7 +18,8 @@ extern const short kCharacterHpForMobPriorityAttack;
 
 void mobile_activity(int activity_level, int missed_pulses);
 int perform_mob_switch(CharData *ch);
-void do_aggressive_room(CharData *ch, int check_sneak);
+// respect_sneak: true -- крадущихся моб пропускает, false -- кража не учитывается вовсе.
+void do_aggressive_room(CharData *ch, bool respect_sneak);
 bool find_master_charmice(CharData *charmice);
 int attack_best(CharData *ch, CharData *victim, bool do_mode = false);
 bool drop_mob_objects_to_box(CharData *ch);

--- a/src/gameplay/skills/charge.cpp
+++ b/src/gameplay/skills/charge.cpp
@@ -158,5 +158,5 @@ void GoCharge(CharData *ch, int direction) {
 			break;
 		}
 	}
-	mob_ai::do_aggressive_room(ch,1);
+	mob_ai::do_aggressive_room(ch, true);
 }


### PR DESCRIPTION
Подготовка к #3887: сделать код агра читаемым **до** того, как трогать в нём баланс. Поведение не меняется ни в одной ветке.

## Имена врали

```c
#define SKIP_SNEAKING   (1 << 13)
```

Читается «пропустить проверку кражи», значит — «пропускать крадущегося игрока», то есть защиту для него. Переименовано в `CHECK_SNEAK`, `CHECK_HIDE`, `CHECK_CAMOUFLAGE`, рядом написано, чем кража отличается от пряток: крадущегося моб обходит явным `continue`, а спрятавшегося защищает проверка видимости ниже по функции (в ветке пряток `continue` нет вовсе).

## Два параметра с обратной полярностью

```c
-void do_aggressive_mob(CharData *ch, int check_sneak, bool skip_hide_camouflage_checks) {
-	int mode = check_sneak ? SKIP_SNEAKING : 0;
-	if (!skip_hide_camouflage_checks) {
+void do_aggressive_mob(CharData *ch, bool respect_sneak, bool respect_hide_and_camouflage) {
+	int mode = respect_sneak ? CHECK_SNEAK : 0;
+	if (respect_hide_and_camouflage) {
```

`check_sneak` значил «проверять», соседний `skip_hide_camouflage_checks` — «не проверять». Из-за этого вызов `do_aggressive_mob(vict, check_sneak, vict == ch)` читался как «для себя не проверять», а на деле именно для себя и не проверял, но через двойное отрицание.

Третий аргумент во всех вызовах инвертирован, значения сохранены один в один:

| было | стало |
|---|---|
| `do_aggressive_mob(vict, ..., vict == ch)` | `(vict, ..., vict != ch)` |
| `do_aggressive_mob(ch.get(), false, false)` | `(ch.get(), false, true)` |

То же приведение у `FimdRememberedEnemyInRoom`; в `charge.cpp` числовая `1` заменена на `true`.

## Проверка

Сборка без предупреждений, 712 тестов, сервер стартует на боевом мире. Изменений в поведении нет — тестеру здесь ловить нечего, это и есть цель правки.

После этого правка из #3887 (учитывать кражу в проверке после команды) становится изменением одного аргумента в читаемом вызове.
