### PR TITLE
fix(ai): respect sneaking in the post-command aggro check (#3887)

### DIFF
--- a/src/engine/ui/interpreter.cpp
+++ b/src/engine/ui/interpreter.cpp
@@ -1224,7 +1224,11 @@ void command_interpreter(CharData *ch, char *argument) {
 		}
 		if (!ch->IsNpc() && ch->in_room != kNowhere && ch->check_aggressive) {
 			ch->check_aggressive = false;
-			mob_ai::do_aggressive_room(ch, false);
+			// Кражу здесь учитываем так же, как при самом шаге (#3887): иначе два вызова в одной
+			// команде отвечали по-разному -- движение сообщало "вам удалось прокрасться незаметно",
+			// а эта проверка тут же била игрока, потому что про кражу не знала. Пульс активности
+			// мобов кражу по-прежнему не смотрит, так что стоять в комнате с агром крадучись нельзя.
+			mob_ai::do_aggressive_room(ch, true);
 			if (ch->purged()) {
 				return;
 			}


### PR DESCRIPTION
Закрывает #3887. Вариант согласован там же с татями: «атака не должна прилетать в той же строке, что и „успешно прокрался“».

## Правка

```diff
 if (!ch->IsNpc() && ch->in_room != kNowhere && ch->check_aggressive) {
 	ch->check_aggressive = false;
-	mob_ai::do_aggressive_room(ch, false);
+	mob_ai::do_aggressive_room(ch, true);
 }
```

Проверка агра после команды звалась без учёта кражи, тогда как сама команда движения звала её с учётом. Два вызова подряд в одной команде давали противоположный ответ на один вопрос.

Спусковым крючком служил флаг `check_aggressive`: его взводит `MakeVisible` (`hide.cpp:127`) — то есть ровно то слетание хайда, которое происходит при шаге (#3886). Дальше интерпретатор видел взведённый флаг и перепроверял агр уже вслепую.

## Что не тронуто

* пульс активности мобов кражу по-прежнему не смотрит — стоять в комнате с агром крадучись нельзя, удар придёт на ближайшем пульсе;
* бегство, прятки, маскировка, видимость — без изменений.

## Тестеру

1. Тать с прятками и кражей, комната с агрессивным мобом или караульным за стенкой.
2. `прятаться`, `красться`, шаг в комнату с мобом.
3. Ожидаем: «Вам удалось прокрасться незаметно», удара в той же команде **нет**.
4. Контроль: постоять пару секунд — удар должен прийти на ближайшем пульсе мобов. Если не приходит, значит зацепили пульс, и правку надо вернуть.

Сборка без предупреждений, 712 тестов, сервер стартует на боевом мире.

Рядом лежит #3888 — переименование флагов агра, только читаемость; конфликтов между ними нет (разные файлы).
